### PR TITLE
Assorted fixes for our OLM metadata.

### DIFF
--- a/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
@@ -47,6 +47,14 @@ spec:
     - Routing and network programming for Istio components
     - Point-in-time snapshots of deployed code and configurations
 
+    ## Prerequisites
+
+    The Serverless Operator's provided APIs such as Knative Serving
+    have certain requirements with regards to the size of the underlying
+    cluster and a working installation of Service Mesh. See the [installation
+    section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#installing-openshift-serverless)
+    of the Serverless documentation for more info.
+
     ## Further Information
 
     For documentation on using Knative Serving, see the

--- a/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
       Provides a collection of API's to support deploying and serving
       of serverless applications and functions.
     repository: https://github.com/openshift-knative/serverless-operator
-    support: Red Hat
+    support: Red Hat, Inc.
   name: serverless-operator.v1.1.0
   namespace: placeholder
 spec:
@@ -285,6 +285,6 @@ spec:
     name: Serverless Team
   maturity: alpha
   provider:
-    name: Red Hat
+    name: Red Hat, Inc.
   replaces: serverless-operator.v1.0.0
   version: 1.1.0

--- a/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
@@ -32,6 +32,8 @@ spec:
     The Red Hat Serverless Operator provides a collection of API's to
     install various "serverless" services.
 
+    This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
     # Knative Serving
 
     Knative Serving builds on Kubernetes to support deploying and


### PR DESCRIPTION
This fixes some minor inconveniences in our Operator metadata to increase usability and visibility of Tech Preview status.

**Proposed changes:**

- [SRVKS-243] Change 'Red Hat' to 'Red Hat, Inc.'
- [SRVKS-251] Clearly state TP status.
- [SRVKS-253] Add prerequisites section and link to docs.