### PR TITLE
Update k-o-i version to 0.0.9 and k-s-o to 1.1.0-05.

### DIFF
--- a/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
@@ -185,7 +185,7 @@ spec:
                   value: quay.io/openshift-knative/knative-serving-istio:v0.8.1
                 - name: IMAGE_webhook
                   value: quay.io/openshift-knative/knative-serving-webhook:v0.8.1
-                image: quay.io/openshift-knative/knative-serving-operator:v0.8.1-1.1.0-04
+                image: quay.io/openshift-knative/knative-serving-operator:v0.8.1-1.1.0-05
                 imagePullPolicy: Always
                 name: knative-serving-operator
                 resources: {}

--- a/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
@@ -204,7 +204,7 @@ spec:
               serviceAccountName: knative-openshift-ingress
               containers:
                 - name: knative-openshift-ingress
-                  image: quay.io/openshift-knative/knative-openshift-ingress:v0.0.7
+                  image: quay.io/openshift-knative/knative-openshift-ingress:v0.0.9
                   command:
                   - knative-openshift-ingress
                   imagePullPolicy: Always


### PR DESCRIPTION
As per title. This contains fixes for the CVE.

The diff can be seen here: https://github.com/openshift-knative/knative-openshift-ingress/compare/v0.0.7...v0.0.9