### PR TITLE
Bump k-s-o version to v0.8.1-1.1.0-05

### DIFF
--- a/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.v1.1.0.clusterserviceversion.yaml
@@ -185,7 +185,7 @@ spec:
                   value: quay.io/openshift-knative/knative-serving-istio:v0.8.1
                 - name: IMAGE_webhook
                   value: quay.io/openshift-knative/knative-serving-webhook:v0.8.1
-                image: quay.io/openshift-knative/knative-serving-operator:v0.8.1-1.1.0-04
+                image: quay.io/openshift-knative/knative-serving-operator:v0.8.1-1.1.0-05
                 imagePullPolicy: Always
                 name: knative-serving-operator
                 resources: {}


### PR DESCRIPTION
The knative-serving-operator is bumped to `v0.8.1-1.1.0-05`.