### PR TITLE
Depend on ServiceMesh operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ should apply its output in the namespace where the other
 e.g. `openshift-marketplace`:
 
 ```
-./hack/catalog.sh | kubectl apply -n openshift-marketplace -f -
+CS_NS=$(kubectl get catalogsources --all-namespaces | tail -1 | awk '{print $1}')
+./hack/catalog.sh | kubectl apply -n $CS_NS -f -
 ```
 
 ### Create a Subscription
@@ -28,6 +29,7 @@ e.g. `openshift-marketplace`:
 To install the operator, create a subscription:
 
 ```
+CS_NS=$(kubectl get catalogsources --all-namespaces | tail -1 | awk '{print $1}')
 OPERATOR_NS=$(kubectl get og --all-namespaces | grep global-operators | awk '{print $1}')
 
 cat <<-EOF | kubectl apply -f -
@@ -39,7 +41,7 @@ metadata:
   namespace: $OPERATOR_NS
 spec:
   source: serverless-operator
-  sourceNamespace: openshift-marketplace
+  sourceNamespace: $CS_NS
   name: serverless-operator
   channel: techpreview
 EOF
@@ -53,8 +55,8 @@ installing OLM on it:
 
 ```
 minikube start
-kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.11.0/crds.yaml
-kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.11.0/olm.yaml
+kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.12.0/crds.yaml
+kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.12.0/olm.yaml
 ```
 
 Once all the pods in the `olm` namespace are running, install the

--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ The [catalog.sh](hack/catalog.sh) script should yield a valid
 `ConfigMap` and `CatalogSource` comprised of the
 `ClusterServiceVersions`, `CustomResourceDefinitions`, and package
 manifest in the bundle beneath [olm-catalog/](olm-catalog/). You
-should apply its output in the OLM namespace:
+should apply its output in the namespace where the other
+`CatalogSources` live on your cluster,
+e.g. `openshift-marketplace`:
 
 ```
-OLM_NS=$(kubectl get deploy --all-namespaces | grep olm-operator | awk '{print $1}')
-./hack/catalog.sh | kubectl apply -n $OLM_NS -f -
+./hack/catalog.sh | kubectl apply -n openshift-marketplace -f -
 ```
 
 ### Create a Subscription
@@ -27,7 +28,6 @@ OLM_NS=$(kubectl get deploy --all-namespaces | grep olm-operator | awk '{print $
 To install the operator, create a subscription:
 
 ```
-OLM_NS=$(kubectl get og --all-namespaces | grep olm-operators | awk '{print $1}')
 OPERATOR_NS=$(kubectl get og --all-namespaces | grep global-operators | awk '{print $1}')
 
 cat <<-EOF | kubectl apply -f -
@@ -39,7 +39,7 @@ metadata:
   namespace: $OPERATOR_NS
 spec:
   source: serverless-operator
-  sourceNamespace: $OLM_NS
+  sourceNamespace: openshift-marketplace
   name: serverless-operator
   channel: techpreview
 EOF

--- a/olm-catalog/serverless-operator/1.2.0/serverless-operator.v1.2.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.2.0/serverless-operator.v1.2.0.clusterserviceversion.yaml
@@ -84,6 +84,17 @@ spec:
         displayName: Version
         path: version
       version: v1alpha1
+    required:
+    - description: A list of namespaces in Service Mesh
+      displayName: Istio Service Mesh Member Roll
+      kind: ServiceMeshMemberRoll
+      name: servicemeshmemberrolls.maistra.io
+      version: v1
+    - description: An Istio control plane installation
+      displayName: Istio Service Mesh Control Plane
+      kind: ServiceMeshControlPlane
+      name: servicemeshcontrolplanes.maistra.io
+      version: v1
   description: |-
     The Red Hat Serverless Operator provides a collection of API's to
     install various "serverless" services.


### PR DESCRIPTION
It seems we no longer are expected to install CatalogSources in the
OLM namespace. On OCP 4.2, it seems they should go in
`openshift-marketplace`.

With the `required` stanza added, installing the Serverless operator results in the following operators being installed as well: ServiceMesh, Kiali, and Jaeger. I believe this may allow us to remove some of the subscriptions in the test scripts as well. But I'm not entirely sure why the Elastic Search operator is needed since it's not among the required CRD's in the SM CSV.