### PR TITLE
Add Service Mesh as an OLM dependency in Serverless Operator CSV

### DIFF
--- a/olm-catalog/serverless-operator/serverless-operator.v1.2.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.v1.2.0.clusterserviceversion.yaml
@@ -89,7 +89,12 @@ spec:
         displayName: Istio Service Mesh Member Roll
         kind: ServiceMeshMemberRoll
         name: servicemeshmemberrolls.maistra.io
-        version: v1      
+        version: v1     
+      - description: An Istio control plane installation
+        displayName: Istio Service Mesh Control Plane
+        kind: ServiceMeshControlPlane
+        name: servicemeshcontrolplanes.maistra.io
+        version: v1         
   description: |-
     The Red Hat Serverless Operator provides a collection of API's to
     install various "serverless" services.

--- a/olm-catalog/serverless-operator/serverless-operator.v1.2.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.v1.2.0.clusterserviceversion.yaml
@@ -84,6 +84,12 @@ spec:
         displayName: Version
         path: version
       version: v1alpha1
+    required:
+      - description: A list of namespaces in Service Mesh
+        displayName: Istio Service Mesh Member Roll
+        kind: ServiceMeshMemberRoll
+        name: servicemeshmemberrolls.maistra.io
+        version: v1      
   description: |-
     The Red Hat Serverless Operator provides a collection of API's to
     install various "serverless" services.


### PR DESCRIPTION
Fix https://jira.coreos.com/browse/SRVKS-284

Add Service Mesh as an OLM dependency in Serverless Operator CSV
