### PR TITLE
Using OLM namespace for CatalogSource does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ manifest in the bundle beneath [olm-catalog/](olm-catalog/). You
 should apply its output in the OLM namespace:
 
 ```
-OLM_NS=$(kubectl get deploy --all-namespaces | grep olm-operator | awk '{print $1}')
-./hack/catalog.sh | kubectl apply -n $OLM_NS -f -
+OPERATOR_NS=$(kubectl get og --all-namespaces | grep global-operators | awk '{print $1}')
+./hack/catalog.sh | kubectl apply -n $OPERATOR_NS -f -
 ```
 
 ### Create a Subscription
@@ -27,7 +27,6 @@ OLM_NS=$(kubectl get deploy --all-namespaces | grep olm-operator | awk '{print $
 To install the operator, create a subscription:
 
 ```
-OLM_NS=$(kubectl get og --all-namespaces | grep olm-operators | awk '{print $1}')
 OPERATOR_NS=$(kubectl get og --all-namespaces | grep global-operators | awk '{print $1}')
 
 cat <<-EOF | kubectl apply -f -
@@ -39,7 +38,7 @@ metadata:
   namespace: $OPERATOR_NS
 spec:
   source: serverless-operator
-  sourceNamespace: $OLM_NS
+  sourceNamespace: $OPERATOR_NS
   name: serverless-operator
   channel: techpreview
 EOF


### PR DESCRIPTION
Using openshift-operator-lifecycle-manager for internal CatalogSource does not work.   Subscription will not be able to find the it.  We should use openshift-operators instead.