### PR TITLE
Add OLM Status Descriptor for displaying installed serving conditions

### DIFF
--- a/olm-catalog/serverless-operator/1.2.0/serverless-operator.v1.2.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.2.0/serverless-operator.v1.2.0.clusterserviceversion.yaml
@@ -83,6 +83,11 @@ spec:
       - description: The version of Knative Serving installed
         displayName: Version
         path: version
+      - description: Conditions of Knative Serving installed
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes.conditions'	        
       version: v1alpha1
     required:
     - description: A list of namespaces in Service Mesh


### PR DESCRIPTION
Fix: https://jira.coreos.com/browse/SRVKS-257

Add OLM Status Descriptor for displaying installed serving conditions