### PR TITLE
Do not use serverless-operator image in tests

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -12,25 +12,11 @@ function ensure_catalogsource_installed {
 function install_catalogsource {
   logger.info "Installing CatalogSource"
 
-  local operator_image rootdir
-  rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
-  operator_image=$(tag_operator_image)
-  if [[ -n "${operator_image}" ]]; then
-    "${rootdir}/hack/catalog.sh" | sed -e "s+\(.* containerImage:\)\(.*\)+\1 ${operator_image}+g" > "$CATALOG_SOURCE_FILENAME"
-  else
-    "${rootdir}/hack/catalog.sh" > "$CATALOG_SOURCE_FILENAME"
-  fi
-  oc apply -n "$OPERATORS_NAMESPACE" -f "$CATALOG_SOURCE_FILENAME" || return 1
+  local rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
+
+  ${rootdir}/hack/catalog.sh | oc apply -n "$OPERATORS_NAMESPACE" -f - || return 1
 
   logger.success "CatalogSource installed successfully"
-}
-
-function tag_operator_image {
-  if [[ -n "${OPENSHIFT_BUILD_NAMESPACE:-}" ]]; then
-    oc policy add-role-to-group system:image-puller "system:serviceaccounts:${OPERATORS_NAMESPACE}" --namespace="${OPENSHIFT_BUILD_NAMESPACE}" >/dev/null
-    oc tag --insecure=false -n "${OPERATORS_NAMESPACE}" "${OPENSHIFT_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:${OPERATOR} ${OPERATOR}:latest" >/dev/null
-    echo "$INTERNAL_REGISTRY/$OPERATORS_NAMESPACE/$OPERATOR"
-  fi
 }
 
 function delete_catalog_source {


### PR DESCRIPTION
The image is not used even if it's part of the catalog source. Only the metadata is consumed from the catalog source.