### PR TITLE
Rewrite openshift/knative-serving test suite execution to Golang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 catalogsource-ci.yaml
 user*.kubeconfig
 users.htpasswd
+.idea

--- a/test/clients.go
+++ b/test/clients.go
@@ -173,7 +173,7 @@ func CleanupAll(contexts ...*Context) {
 	}
 }
 
-// Cleanup iterates through the list of registered CleanupFunc functions and calls them
+// Cleanup iterates through the list of registered CleanupFunc functions in reverse order and calls them
 func (ctx *Context) Cleanup() {
 	for _, f := range ctx.CleanupList {
 		f()

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -19,11 +19,6 @@ failed=0
 # Run serverless-operator specific tests.
 (( !failed )) && run_e2e_tests || failed=4
 
-# Setup serverless and run upstream e2e and conformance tests.
-(( !failed )) && ensure_serverless_installed || failed=5
-(( !failed )) && run_knative_serving_tests "v0.9.0" || failed=6
-(( !failed )) && teardown_serverless || failed=7
-
 (( failed )) && dump_state
 (( failed )) && exit $failed
 

--- a/test/e2e/errors.go
+++ b/test/e2e/errors.go
@@ -1,0 +1,9 @@
+package e2e
+
+import "testing"
+
+func ensureNoError(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/e2e/git.go
+++ b/test/e2e/git.go
@@ -1,0 +1,49 @@
+package e2e
+
+import (
+	"fmt"
+	"github.com/openshift-knative/serverless-operator/test"
+	"os"
+	"path"
+	"testing"
+)
+
+type repository struct {
+	source    string
+	scmserver string
+	name      []string
+	branch    string
+	version   string
+}
+
+func checkout(t *testing.T, ctx *test.Context, repo repository, gopath string) string {
+	target := target(repo, gopath)
+	parent := path.Dir(target)
+
+	wd, err := os.Getwd()
+	ensureNoError(t, err)
+	ctx.AddToCleanup(func() error {
+		return os.Chdir(wd)
+	})
+
+	t.Run("git checkout", func(t *testing.T) {
+		ensureNoError(t, os.MkdirAll(parent, os.ModePerm))
+		command := fmt.Sprintf(
+			"git clone --branch '%s' --single-branch %s %s",
+			repo.branch,
+			repo.source,
+			target)
+		execute(command, t)
+	})
+
+	return target
+}
+
+func target(repo repository, gopath string) string {
+	parent := path.Join(gopath, "src", repo.scmserver)
+	target := parent
+	for _, name := range repo.name {
+		target = path.Join(target, name)
+	}
+	return target
+}

--- a/test/e2e/openshift_knative_serving_test.go
+++ b/test/e2e/openshift_knative_serving_test.go
@@ -1,0 +1,85 @@
+// +build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"github.com/openshift-knative/serverless-operator/test"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestOpenshiftKnativeServing(t *testing.T) {
+	version := "v0.9.0"
+	repo := repository{
+		source:    "https://github.com/openshift/knative-serving.git",
+		scmserver: "knative.dev",
+		name:      []string{"serving"},
+		branch:    "release-" + version,
+		version:   version,
+	}
+	ctx := test.SetupClusterAdmin(t)
+
+	deployServerlessOperator(t, ctx)
+	deployKnativeServingResource(t, ctx)
+
+	gopath := createTemporaryGopath(t, ctx)
+	target := checkout(t, ctx, repo, gopath)
+	hackOnOpenshiftKnativeServingRepo(t, target)
+	createTestResourcesForOpenshiftKnativeServing(t, target, ctx)
+
+	r := repositoryInTempGopath{
+		gopath: gopath,
+		repo:   repo,
+	}
+
+	t.Run("run e2e tests", func(t *testing.T) {
+		testOpenshiftKnativeServing(r, t, "./test/e2e")
+	})
+	t.Run("run conformance-runtime tests", func(t *testing.T) {
+		testOpenshiftKnativeServing(r, t, "./test/conformance/runtime/...")
+	})
+	t.Run("run conformance-api tests", func(t *testing.T) {
+		testOpenshiftKnativeServing(r, t, "./test/conformance/api/...")
+	})
+
+	removeKnativeServingResource(t, ctx)
+	removeServerlessOperator(t, ctx)
+}
+
+func testOpenshiftKnativeServing(r repositoryInTempGopath, t *testing.T, scope string) {
+	r.test(t, func(dir string) string {
+		envs := fmt.Sprintf(
+			"env GATEWAY_NAMESPACE_OVERRIDE='knative-serving-ingress' GOPATH='%s'",
+			r.gopath)
+		imageTemplate := fmt.Sprintf(
+			"registry.svc.ci.openshift.org/openshift/knative-%s:knative-serving-test-{{.Name}}",
+			r.repo.version)
+		kubeconfigs := strings.Split(test.Flags.Kubeconfigs, ",")
+		kubeconfig := kubeconfigs[0]
+		return fmt.Sprintf("%s go test -v "+
+			"-tags=e2e -count=1 -timeout=30m -parallel=3 %s "+
+			"--resolvabledomain --kubeconfig '%s' "+
+			"--imagetemplate '%s'",
+			envs, scope, kubeconfig, imageTemplate)
+	})
+}
+
+// namespaces, configMaps, secrets
+func createTestResourcesForOpenshiftKnativeServing(t *testing.T, target string, ctx *test.Context) {
+	t.Run("create test resources for openshift-knativeserving", func(t *testing.T) {
+		ensureNoError(t, os.Chdir(target))
+		execute("oc apply -f test/config", t)
+		execute("oc adm policy add-scc-to-user privileged -z default -n serving-tests", t)
+		execute("oc adm policy add-scc-to-user privileged -z default -n serving-tests-alt", t)
+		execute("oc adm policy add-scc-to-user anyuid -z default -n serving-tests", t)
+	})
+}
+
+func hackOnOpenshiftKnativeServingRepo(t *testing.T, target string) {
+	t.Run("hack on openshift-knativeserving repo", func(t *testing.T) {
+		ensureNoError(t, os.Chdir(target))
+		execute("rm -vf test/config/100-istio-default-domain.yaml", t)
+	})
+}

--- a/test/e2e/serverless_lifecycle.go
+++ b/test/e2e/serverless_lifecycle.go
@@ -1,0 +1,94 @@
+package e2e
+
+import (
+	"github.com/openshift-knative/serverless-operator/test"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	knativeServing = "knative-serving"
+)
+
+func deployServerlessOperator(t *testing.T, ctx *test.Context) {
+	t.Run("deploy Serverless operator", func(t *testing.T) {
+		_, err := test.WithOperatorReady(ctx, "serverless-operator-subscription")
+		if err != nil {
+			t.Fatal("Failed", err)
+		}
+	})
+}
+
+func removeServerlessOperator(t *testing.T, ctx *test.Context) {
+	if t.Failed() && runsOnOpenshiftCI() {
+		t.Log("Skipping removal of Serverless as tests failed and we are running on Openshift CI")
+		return
+	}
+	t.Run("remove Serverless operator", func(t *testing.T) {
+		ctx.Cleanup()
+		err := test.WaitForOperatorDepsDeleted(ctx)
+		if err != nil {
+			t.Fatalf("Operators still running: %v", err)
+		}
+	})
+}
+
+func deployKnativeServingResource(t *testing.T, ctx *test.Context) {
+	t.Run("deploy KnativeServing resource", func(t *testing.T) {
+		_, err := test.WithKnativeServingReady(ctx, knativeServing, knativeServing)
+		if err != nil {
+			t.Fatal("Failed to deploy KnativeServing resource", err)
+		}
+	})
+}
+
+func removeKnativeServingResource(t *testing.T, ctx *test.Context) {
+	if t.Failed() && runsOnOpenshiftCI() {
+		t.Log("Skipping removal of KnativeServing resource as tests failed and we are running on Openshift CI")
+		return
+	}
+	t.Run("remove KnativeServing resource", func(t *testing.T) {
+		if err := test.DeleteKnativeServing(ctx, knativeServing, knativeServing); err != nil {
+			t.Fatal("Failed to remove Knative Serving resource", err)
+		}
+
+		ns, err := ctx.Clients.Kube.CoreV1().Namespaces().Get(
+			knativeServing + "-ingress", metav1.GetOptions{})
+		if apierrs.IsNotFound(err) {
+			// Namespace is already gone, all good!
+			return
+		} else if err != nil {
+			t.Fatal("Failed fetching ingress namespace", err)
+		}
+
+		// If the namespace is not gone yet, check if it's terminating.
+		if ns.Status.Phase != corev1.NamespaceTerminating {
+			t.Fatalf("Ingress namespace phase = %v, want %v",
+				ns.Status.Phase, corev1.NamespaceTerminating)
+		}
+	})
+}
+
+func cleanupOnInterrupt(t *testing.T, contexts ...*test.Context) {
+	if runsOnOpenshiftCI() {
+		t.Log("Skipping register of CleanUp on interrupt as we are running on Openshift CI")
+	}
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(contexts...) })
+}
+
+func cleanupAll(t *testing.T, contexts ...*test.Context) {
+	if t.Failed() && runsOnOpenshiftCI() {
+		t.Log("Skipping cleanup as test have failed and we are running on Openshift CI")
+		return
+	}
+	test.CleanupAll(contexts...)
+}
+
+func runsOnOpenshiftCI() bool {
+	_, ok := os.LookupEnv("OPENSHIFT_BUILD_NAMESPACE")
+	return ok
+}

--- a/test/e2e/shell_exec.go
+++ b/test/e2e/shell_exec.go
@@ -1,0 +1,46 @@
+package e2e
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func execute(command string, t *testing.T) {
+	t.Logf("Running command: %s", command)
+	err, out, errout := shell(command)
+	if out != "" {
+		t.Log("--- stdout ---")
+		t.Log(out)
+	}
+	if errout != "" {
+		t.Log("--- stderr ---")
+		t.Log(errout)
+	}
+	if err != nil {
+		t.Fatalf("Error while running command: %v", err)
+	}
+}
+
+func streamExecutionAndFailLate(command string, t *testing.T) {
+	cmd := exec.Command("bash", "-c", command)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		t.Errorf("Error while running command: %v", err)
+	}
+}
+
+func shell(command string) (error, string, string) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.Command("bash", "-c", command)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return err, stdout.String(), stderr.String()
+}
+
+

--- a/test/e2e/temp_gopath.go
+++ b/test/e2e/temp_gopath.go
@@ -1,0 +1,41 @@
+package e2e
+
+import (
+	"fmt"
+	"github.com/openshift-knative/serverless-operator/test"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+type repositoryInTempGopath struct {
+	gopath string
+	repo   repository
+}
+
+func createTemporaryGopath(t *testing.T, ctx *test.Context) string {
+	gopath, err := ioutil.TempDir("", "test-gopath")
+	ensureNoError(t, err)
+	ctx.AddToCleanup(func() error {
+		if ctx.T.Failed() && runsOnOpenshiftCI() {
+			ctx.T.Logf("Tests have failed, so let's leave temp GOPATH for inspection: %s", gopath)
+			return nil
+		}
+		return os.RemoveAll(gopath)
+	})
+
+	t.Run("create temporary gopath", func(t *testing.T) {
+		ensureNoError(t, os.MkdirAll(path.Join(gopath, "bin"), os.ModePerm))
+		execute(fmt.Sprintf("cp -rv \"$(go env GOPATH)/bin\" '%s'", gopath), t)
+	})
+
+	return gopath
+}
+
+func (r repositoryInTempGopath) test(t *testing.T, commandSupplier func(dir string) string) {
+	dir := target(r.repo, r.gopath)
+	ensureNoError(t, os.Chdir(dir))
+	command := commandSupplier(dir)
+	streamExecutionAndFailLate(command, t)
+}


### PR DESCRIPTION
That will be better in number of ways:
* It will be easier to understand and write properly as bash isn't well understood
* test reports will be the same as in other test
* It will be easier to reuse in different tests
* It's easier to select what tests should be run, with build tags
* In future when we rewrite cluster setup to go, we will be able to run and DEBUG single test directly from IDE

The last point is biggest for me. That's what I would like to see. To be able to run everything just from IDE. Just as you run Spring Test or Arquillian!