### PR TITLE
Remove quay.io image references.

### DIFF
--- a/olm-catalog/serverless-operator/1.0.0/serverless-operator.v1.0.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.0.0/serverless-operator.v1.0.0.clusterserviceversion.yaml
@@ -162,19 +162,19 @@ spec:
                 - name: OPERATOR_NAME
                   value: knative-serving-operator
                 - name: IMAGE_QUEUE
-                  value: quay.io/openshift-knative/knative-serving-queue:v0.7.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.7.1:knative-serving-queue
                 - name: IMAGE_activator
-                  value: quay.io/openshift-knative/knative-serving-activator:v0.7.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.7.1:knative-serving-activator
                 - name: IMAGE_autoscaler
-                  value: quay.io/openshift-knative/knative-serving-autoscaler:v0.7.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.7.1:knative-serving-autoscaler
                 - name: IMAGE_controller
-                  value: quay.io/openshift-knative/knative-serving-controller:v0.7.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.7.1:knative-serving-controller
                 - name: IMAGE_networking-certmanager
-                  value: quay.io/openshift-knative/knative-serving-certmanager:v0.7.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.7.1:knative-serving-certmanager
                 - name: IMAGE_networking-istio
-                  value: quay.io/openshift-knative/knative-serving-istio:v0.7.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.7.1:knative-serving-istio
                 - name: IMAGE_webhook
-                  value: quay.io/openshift-knative/knative-serving-webhook:v0.7.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.7.1:knative-serving-webhook
                 image: quay.io/openshift-knative/knative-serving-operator:v0.7.1-TP1-04
                 imagePullPolicy: Always
                 name: knative-serving-operator

--- a/olm-catalog/serverless-operator/1.1.0/serverless-operator.v1.1.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.1.0/serverless-operator.v1.1.0.clusterserviceversion.yaml
@@ -172,19 +172,19 @@ spec:
                 - name: OPERATOR_NAME
                   value: knative-serving-operator
                 - name: IMAGE_QUEUE
-                  value: quay.io/openshift-knative/knative-serving-queue:v0.8.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.8.1:knative-serving-queue
                 - name: IMAGE_activator
-                  value: quay.io/openshift-knative/knative-serving-activator:v0.8.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.8.1:knative-serving-activator
                 - name: IMAGE_autoscaler
-                  value: quay.io/openshift-knative/knative-serving-autoscaler:v0.8.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.8.1:knative-serving-autoscaler
                 - name: IMAGE_autoscaler-hpa
-                  value: quay.io/openshift-knative/knative-serving-autoscaler-hpa:v0.8.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.8.1:knative-serving-autoscaler-hpa
                 - name: IMAGE_controller
-                  value: quay.io/openshift-knative/knative-serving-controller:v0.8.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.8.1:knative-serving-controller
                 - name: IMAGE_networking-istio
-                  value: quay.io/openshift-knative/knative-serving-istio:v0.8.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.8.1:knative-serving-istio
                 - name: IMAGE_webhook
-                  value: quay.io/openshift-knative/knative-serving-webhook:v0.8.1
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.8.1:knative-serving-webhook
                 image: quay.io/openshift-knative/knative-serving-operator:v0.8.1-1.1.0-05
                 imagePullPolicy: Always
                 name: knative-serving-operator

--- a/olm-catalog/serverless-operator/1.2.0/serverless-operator.v1.2.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.2.0/serverless-operator.v1.2.0.clusterserviceversion.yaml
@@ -256,19 +256,19 @@ spec:
                 - name: OPERATOR_NAME
                   value: knative-serving-operator
                 - name: IMAGE_QUEUE
-                  value: quay.io/openshift-knative/knative-serving-queue:v0.9.0
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.9.0:knative-serving-queue
                 - name: IMAGE_activator
-                  value: quay.io/openshift-knative/knative-serving-activator:v0.9.0
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.9.0:knative-serving-activator
                 - name: IMAGE_autoscaler
-                  value: quay.io/openshift-knative/knative-serving-autoscaler:v0.9.0
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.9.0:knative-serving-autoscaler
                 - name: IMAGE_autoscaler-hpa
-                  value: quay.io/openshift-knative/knative-serving-autoscaler-hpa:v0.9.0
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.9.0:knative-serving-autoscaler-hpa
                 - name: IMAGE_controller
-                  value: quay.io/openshift-knative/knative-serving-controller:v0.9.0
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.9.0:knative-serving-controller
                 - name: IMAGE_networking-istio
-                  value: quay.io/openshift-knative/knative-serving-istio:v0.9.0
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.9.0:knative-serving-istio
                 - name: IMAGE_webhook
-                  value: quay.io/openshift-knative/knative-serving-webhook:v0.9.0
+                  value: registry.svc.ci.openshift.org/openshift/knative-v0.9.0:knative-serving-webhook
                 image: quay.io/openshift-knative/knative-serving-operator:v0.9.0-1.2.0-05
                 imagePullPolicy: Always
                 name: knative-serving-operator


### PR DESCRIPTION
Replace quay.io references to the knative-serving images with references to the openshift CI registry. These are public as well and can be pulled via the internet (for example from your local machine). This removes the need for us to mirror images from the knative-serving repository.