### PR TITLE
[DO NOT SUBMIT] Replace OwnerRefs on Routes with Finalizer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Openshift Serverless v1.2.1
+
+- Fixed a bug where Routes have non-correct cross-namespaced OwnerReferences.

--- a/serving/ingress/pkg/controller/resources/route.go
+++ b/serving/ingress/pkg/controller/resources/route.go
@@ -9,7 +9,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -130,11 +129,10 @@ func makeRoute(ci networkingv1alpha1.IngressAccessor, host string, rule networki
 
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            name,
-			Namespace:       namespace,
-			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ci)},
-			Labels:          labels,
-			Annotations:     annotations,
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: routev1.RouteSpec{
 			Host: host,

--- a/serving/ingress/pkg/controller/resources/route_test.go
+++ b/serving/ingress/pkg/controller/resources/route_test.go
@@ -9,7 +9,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -27,8 +26,6 @@ const (
 	routeName0 = "route-" + uid + "-323531366235"
 	routeName1 = "route-" + uid + "-663738313063"
 )
-
-var ownerRef = *kmeta.NewControllerRef(ingress())
 
 func TestMakeRoute(t *testing.T) {
 	tests := []struct {
@@ -56,7 +53,6 @@ func TestMakeRoute(t *testing.T) {
 			),
 			want: []*routev1.Route{{
 				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "ingress",
 						serving.RouteLabelKey:          "route1",
@@ -101,7 +97,6 @@ func TestMakeRoute(t *testing.T) {
 			),
 			want: []*routev1.Route{{
 				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "ingress",
 						serving.RouteLabelKey:          "route1",
@@ -133,7 +128,6 @@ func TestMakeRoute(t *testing.T) {
 			)),
 			want: []*routev1.Route{{
 				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "ingress",
 						serving.RouteLabelKey:          "route1",
@@ -157,7 +151,6 @@ func TestMakeRoute(t *testing.T) {
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "ingress",
 						serving.RouteLabelKey:          "route1",
@@ -189,7 +182,6 @@ func TestMakeRoute(t *testing.T) {
 			)),
 			want: []*routev1.Route{{
 				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "ingress",
 						serving.RouteLabelKey:          "route1",
@@ -227,7 +219,6 @@ func TestMakeRoute(t *testing.T) {
 			),
 			want: []*routev1.Route{{
 				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "ingress",
 						serving.RouteLabelKey:          "route1",


### PR DESCRIPTION
This is a PR that showcases how the monorepo + the newly setup CI works. 

This entire change is validated by the operator tests and then run through the integration tests of Knative Serving. If it passes, confidence is high that the entire system would still work after this change has been merged.

In addition, it also runs the unit tests that we currently have for extra confidence.