### PR TITLE
Replace OwnerRefs on Routes with Finalizer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Openshift Serverless v1.3.0
+
+- Fixed a bug where Routes have non-correct cross-namespaced OwnerReferences.

--- a/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
+++ b/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -168,11 +167,10 @@ func TestRouteMigration(t *testing.T) {
 		}},
 		want: []routev1.Route{{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            routeName0,
-				Namespace:       serviceMeshNamespace,
-				Labels:          map[string]string{networking.IngressLabelKey: name, serving.RouteLabelKey: name, serving.RouteNamespaceLabelKey: namespace},
-				Annotations:     map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
-				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(defaultIngress)},
+				Name:        routeName0,
+				Namespace:   serviceMeshNamespace,
+				Labels:      map[string]string{networking.IngressLabelKey: name, serving.RouteLabelKey: name, serving.RouteNamespaceLabelKey: namespace},
+				Annotations: map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
 			},
 			Spec: routev1.RouteSpec{
 				Host: domainName,
@@ -264,7 +262,19 @@ func TestRouteMigration(t *testing.T) {
 			t.Fatalf("failed to get ServiceMeshMemberRole: (%v)", err)
 		}
 		// Check if namespace has been removed from smmr.
-		assert.Equal(t, len([]string{}), len(smmrDelete.Spec.Members))
+		assert.Empty(t, len(smmrDelete.Spec.Members))
+
+		// check openshift routes has been removed.
+		routeListdelete := &routev1.RouteList{}
+		err = cl.List(context.TODO(), &client.ListOptions{}, routeListdelete)
+		assert.Nil(t, err)
+		assert.Empty(t, routeListdelete.Items)
+
+		// check finalizers has been removed from ingress.
+		ingressListdelete := &networkingv1alpha1.IngressList{}
+		err = cl.List(context.TODO(), &client.ListOptions{}, ingressListdelete)
+		assert.Nil(t, err)
+		assert.Empty(t, len(ingressListdelete.Items[0].Finalizers))
 	})
 }
 

--- a/serving/ingress/pkg/controller/resources/route.go
+++ b/serving/ingress/pkg/controller/resources/route.go
@@ -9,7 +9,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -121,11 +120,10 @@ func makeRoute(ci networkingv1alpha1.IngressAccessor, host string, rule networki
 
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            name,
-			Namespace:       namespace,
-			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ci)},
-			Labels:          labels,
-			Annotations:     annotations,
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: routev1.RouteSpec{
 			Host: host,

--- a/serving/ingress/pkg/controller/resources/route_test.go
+++ b/serving/ingress/pkg/controller/resources/route_test.go
@@ -9,7 +9,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -27,8 +26,6 @@ const (
 	routeName0 = "route-" + uid + "-323531366235"
 	routeName1 = "route-" + uid + "-663738313063"
 )
-
-var ownerRef = *kmeta.NewControllerRef(ingress())
 
 func TestMakeRoute(t *testing.T) {
 	tests := []struct {
@@ -56,7 +53,6 @@ func TestMakeRoute(t *testing.T) {
 			),
 			want: []*routev1.Route{{
 				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "ingress",
 						serving.RouteLabelKey:          "route1",
@@ -105,7 +101,6 @@ func TestMakeRoute(t *testing.T) {
 			),
 			want: []*routev1.Route{{
 				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "ingress",
 						serving.RouteLabelKey:          "route1",
@@ -141,7 +136,6 @@ func TestMakeRoute(t *testing.T) {
 			)),
 			want: []*routev1.Route{{
 				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "ingress",
 						serving.RouteLabelKey:          "route1",
@@ -169,7 +163,6 @@ func TestMakeRoute(t *testing.T) {
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "ingress",
 						serving.RouteLabelKey:          "route1",
@@ -206,7 +199,6 @@ func TestMakeRoute(t *testing.T) {
 			)),
 			want: []*routev1.Route{{
 				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
 					Labels: map[string]string{
 						networking.IngressLabelKey:     "ingress",
 						serving.RouteLabelKey:          "route1",


### PR DESCRIPTION
**Note:** This code was written by @savitaashture. I took it to showcase how a change PR to the new monorepo looks and works.

Title says it all really. Cross namespace OwnerRefs are bad!