### PR TITLE
Make the repository testable against arbitrary clusters.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
-#This makefile is used by ci-operator
+# Useful for local development
+publish-images:
+	./hack/publish.sh $(DOCKER_REPO_OVERRIDE)
+.PHONY: publish-images
 
+# Test targets for CI operator
 test-unit:
 	go test ./serving/ingress/...
 .PHONY: test-e2e
@@ -7,10 +11,6 @@ test-unit:
 test-e2e:
 	./test/e2e-tests.sh
 .PHONY: test-e2e
-
-install:
-	# Do nothing right now. Required by ci-operator.
-.PHONY: install
 
 # Generates a ci-operator configuration for a specific branch.
 generate-ci-config:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 Provides a collection of API's to support deploying and serving of
 serverless applications and functions.
 
+## Local/Private cluster testing
+
+To test the Serverless Operator against your private Openshift cluster
+you first need to push the necessary images to a publicly available location.
+To do that, make sure the `DOCKER_REPO_OVERRIDE` environment variable is set
+to a docker repository you can push to (for example `docker.io/markusthoemmes`)
+and then run `make publish-images`. All images in this repository will now be
+built and pushed to your docker repository.
+
+After that is done, all the scripts in the `hack` directory are at your disposal
+to install and test the system. `make test-e2e` in particular runs the entirety
+of the end-to-end tests against the system.
+
 ## Operator Framework
 
 This repository contains the metadata required by the [Operator

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ serverless applications and functions.
 To test the Serverless Operator against your private Openshift cluster
 you first need to push the necessary images to a publicly available location.
 To do that, make sure the `DOCKER_REPO_OVERRIDE` environment variable is set
-to a docker repository you can push to (for example `docker.io/markusthoemmes`)
-and then run `make publish-images`. All images in this repository will now be
-built and pushed to your docker repository.
+to a docker repository you can push to, for example `docker.io/markusthoemmes`.
+You might need to run `docker login` to be able to push images. Now run
+`make publish-images` and all images in this repository will now be built and
+pushed to your docker repository.
 
 After that is done, all the scripts in the `hack` directory are at your disposal
 to install and test the system. `make test-e2e` in particular runs the entirety

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -13,7 +13,7 @@ function install_catalogsource {
   logger.info "Installing CatalogSource"
 
   # Determine if we're running locally or in CI.
-  if [[ -v OPENSHIFT_BUILD_NAMESPACE ]]; then
+  if [ -z "$OPENSHIFT_BUILD_NAMESPACE" ]; then
     export IMAGE_KNATIVE_SERVING_OPERATOR="${DOCKER_REPO_OVERRIDE}/knative-serving-operator"
     export IMAGE_KNATIVE_OPENSHIFT_INGRESS="${DOCKER_REPO_OVERRIDE}/knative-openshift-ingress"
   else

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -9,6 +9,7 @@ readonly CATALOG_SOURCE_FILENAME="${CATALOG_SOURCE_FILENAME:-catalogsource-ci.ya
 readonly DOCKER_REPO_OVERRIDE="${DOCKER_REPO_OVERRIDE:-}"
 readonly INTERACTIVE="${INTERACTIVE:-$(test -z "${GDMSESSION}"; echo $?)}"
 readonly KUBECONFIG="${KUBECONFIG:-$(realpath ~/.kube/config)}"
+readonly OPENSHIFT_BUILD_NAMESPACE="${OPENSHIFT_BUILD_NAMESPACE:-}"
 readonly OPERATOR="${OPERATOR:-serverless-operator}"
 readonly SCALE_UP="${SCALE_UP:-6}"
 

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -5,16 +5,17 @@ readonly BUILD_NUMBER=${BUILD_NUMBER:-$(uuidgen)}
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/../../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh"
 
+readonly CATALOG_SOURCE_FILENAME="${CATALOG_SOURCE_FILENAME:-catalogsource-ci.yaml}"
+readonly DOCKER_REPO_OVERRIDE="${DOCKER_REPO_OVERRIDE:-}"
+readonly INTERACTIVE="${INTERACTIVE:-$(test -z "${GDMSESSION}"; echo $?)}"
 readonly KUBECONFIG="${KUBECONFIG:-$(realpath ~/.kube/config)}"
-readonly OPENSHIFT_REGISTRY="${OPENSHIFT_REGISTRY:-"registry.svc.ci.openshift.org"}"
-readonly INTERNAL_REGISTRY="${INTERNAL_REGISTRY:-"image-registry.openshift-image-registry.svc:5000"}"
-readonly SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
+readonly OPERATOR="${OPERATOR:-serverless-operator}"
+readonly SCALE_UP="${SCALE_UP:-6}"
+
 readonly OPERATORS_NAMESPACE="${OPERATORS_NAMESPACE:-openshift-operators}"
 readonly SERVERLESS_NAMESPACE="${SERVERLESS_NAMESPACE:-serverless}"
-readonly OPERATOR="${OPERATOR:-serverless-operator}"
-readonly CATALOG_SOURCE_FILENAME="${CATALOG_SOURCE_FILENAME:-catalogsource-ci.yaml}"
-readonly INTERACTIVE="${INTERACTIVE:-$(test -z "${GDMSESSION}"; echo $?)}"
-readonly SCALE_UP="${SCALE_UP:-6}"
+readonly SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
+
 declare -a NAMESPACES
 NAMESPACES=("${SERVING_NAMESPACE}" "${SERVERLESS_NAMESPACE}")
 export NAMESPACES

--- a/hack/publish.sh
+++ b/hack/publish.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This script can be used to publish all images built by
+# this repository to the specified docker repository.
+
+repo=$1
+
+(
+cd serving/operator || exit 1
+docker build -t "$repo/knative-serving-operator" .
+docker push "$repo/knative-serving-operator"
+)
+
+(
+cd serving/ingress || exit 1
+docker build -t "$repo/knative-openshift-ingress" .
+docker push "$repo/knative-openshift-ingress"
+)

--- a/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
@@ -269,7 +269,7 @@ spec:
                   value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-istio
                 - name: IMAGE_webhook
                   value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-webhook
-                image: registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-serving-operator
+                image: $IMAGE_KNATIVE_SERVING_OPERATOR
                 imagePullPolicy: Always
                 name: knative-serving-operator
                 resources: {}
@@ -288,7 +288,7 @@ spec:
               serviceAccountName: knative-openshift-ingress
               containers:
                 - name: knative-openshift-ingress
-                  image: registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-openshift-ingress
+                  image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
                   command:
                   - knative-openshift-ingress
                   imagePullPolicy: Always

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -90,7 +90,7 @@ function run_knative_serving_tests {
 }
 
 function teardown {
-  if [[ -v OPENSHIFT_BUILD_NAMESPACE ]]; then
+  if [ -z "$OPENSHIFT_BUILD_NAMESPACE" ]; then
     logger.warn 'Skipping teardown as we are running on Openshift CI'
     return 0
   fi


### PR DESCRIPTION
As the title states, this makes the repository usable in local environments and against arbitrary clusters in general to make development as easy as possible.