### PR TITLE
Fix teardown condition to skip in CI builds properly.

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -90,7 +90,7 @@ function run_knative_serving_tests {
 }
 
 function teardown {
-  if [ -z "$OPENSHIFT_BUILD_NAMESPACE" ]; then
+  if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
     logger.warn 'Skipping teardown as we are running on Openshift CI'
     return 0
   fi


### PR DESCRIPTION
I broke this by moving the conditions to use `-z`. This should've been `-n`.