### PR TITLE
Invocation of upstream knative/serving-operator e2e tests

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -10,37 +10,45 @@ function ensure_serverless_installed {
 }
 
 function install_serverless_previous {
-  local rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
+  local rootdir current_csv previous_csv
+  rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
 
   # Remove installplan from previous installations, leaving this would make the operator
   # upgrade to the latest version immediately
-  local current_csv=$(${rootdir}/hack/catalog.sh | grep currentCSV | awk '{ print $2 }')
-  remove_installplan $current_csv
+  current_csv=$("${rootdir}/hack/catalog.sh" | grep currentCSV | awk '{ print $2 }')
+  remove_installplan "$current_csv"
 
-  local previous_csv=$(${rootdir}/hack/catalog.sh | grep replaces: | tail -n1 | awk '{ print $2 }')
-  deploy_serverless_operator $previous_csv  || return $?
+  previous_csv=$("${rootdir}/hack/catalog.sh" | grep replaces: | tail -n1 | awk '{ print $2 }')
+  deploy_serverless_operator "$previous_csv"  || return $?
   deploy_knativeserving_cr || return $?
 }
 
 function remove_installplan {
-  local install_plan=$(find_install_plan $1)
+  local install_plan
+  install_plan=$(find_install_plan $1)
   if [[ -n $install_plan ]]; then
-    oc delete $install_plan -n ${OPERATORS_NAMESPACE}
+    oc delete "$install_plan" -n "${OPERATORS_NAMESPACE}"
   fi
 }
 
 function install_serverless_latest {
-  local rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
-  # Get the current/latest CSV
-  local csv=$(${rootdir}/hack/catalog.sh | grep currentCSV | awk '{ print $2 }')
-
-  deploy_serverless_operator $csv || return $?
+  deploy_serverless_operator_latest || return $?
   deploy_knativeserving_cr || return $?
+}
+
+function deploy_serverless_operator_latest {
+  local rootdir csv
+  rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
+  # Get the current/latest CSV
+  csv=$("${rootdir}/hack/catalog.sh" | grep currentCSV | awk '{ print $2 }')
+
+  deploy_serverless_operator "${csv}"
 }
 
 function deploy_serverless_operator {
   logger.info 'Install the Serverless Operator'
-  local csv=$1
+  local csv
+  csv="$1"
 
   cat <<EOF | oc apply -f - || return $?
 apiVersion: operators.coreos.com/v1alpha1
@@ -58,16 +66,17 @@ spec:
 EOF
 
   # Approve the initial installplan automatically
-  approve_csv $csv || return 5
+  approve_csv "$csv" || return 5
 }
 
 function approve_csv {
-  local csv_version=$1
+  local csv_version install_plan
+  csv_version=$1
 
   # Wait for the installplan to be available
   timeout 900 "[[ -z \$(find_install_plan $csv_version) ]]" || return 1
 
-  local install_plan=$(find_install_plan $csv_version)
+  install_plan=$(find_install_plan $csv_version)
   oc get $install_plan -n ${OPERATORS_NAMESPACE} -o yaml | sed 's/\(.*approved:\) false/\1 true/' | oc replace -f -
 
   timeout 300 "[[ \$(oc get ClusterServiceVersion $csv_version -n ${OPERATORS_NAMESPACE} -o jsonpath='{.status.phase}') != Succeeded ]]" || return 1
@@ -86,7 +95,7 @@ function deploy_knativeserving_cr {
   logger.info 'Deploy Knative Serving'
 
   # Wait for the CRD to appear
-  timeout 900 '[[ $(oc get crd | grep -c knativeservings) -eq 0 ]]' || return 6
+  timeout 900 "[[ \$(oc get crd | grep -c knativeservings) -eq 0 ]]" || return 6
 
   # Install Knative Serving
   cat <<EOF | oc apply -f - || return $?

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -19,13 +19,18 @@ failed=0
 # Run serverless-operator specific tests.
 (( !failed )) && run_e2e_tests || failed=4
 
-# Run upstream knative serving tests
-RUN_KNATIVE_SERVING_UPGRADE_TESTS=false
-RUN_KNATIVE_SERVING_E2E=true
+RUN_KNATIVE_SERVING_UPGRADE_TESTS=${RUN_KNATIVE_SERVING_UPGRADE_TESTS:-false}
+RUN_KNATIVE_SERVING_E2E=${RUN_KNATIVE_SERVING_E2E:-true}
+export RUN_KNATIVE_SERVING_UPGRADE_TESTS RUN_KNATIVE_SERVING_E2E
 
-(( !failed )) && ensure_serverless_installed || failed=5
-(( !failed )) && run_knative_serving_tests "v0.10.0" || failed=6
-(( !failed )) && teardown_serverless || failed=7
+# Run upstream knative serving operator tests
+(( !failed )) && deploy_serverless_operator_latest || failed=11
+(( !failed )) && run_knative_serving_operator_tests 'support/v0.9.0' 'cardil' || failed=12
+
+# Run upstream knative serving tests
+(( !failed )) && ensure_serverless_installed || failed=6
+(( !failed )) && run_knative_serving_tests "v0.10.0" || failed=7
+(( !failed )) && teardown_serverless || failed=8
 
 (( failed )) && dump_state
 (( failed )) && exit $failed

--- a/test/patches/SRVKS-241-knative-serving-operator-skip-configure.patch
+++ b/test/patches/SRVKS-241-knative-serving-operator-skip-configure.patch
@@ -1,0 +1,14 @@
+diff --git test/e2e/knativeservingdeployment_test.go test/e2e/knativeservingdeployment_test.go
+index ed985a1..20deb22 100644
+--- test/e2e/knativeservingdeployment_test.go
++++ test/e2e/knativeservingdeployment_test.go
+@@ -58,8 +58,7 @@ func TestKnativeServingDeployment(t *testing.T) {
+ 	})
+ 
+ 	t.Run("configure", func(t *testing.T) {
+-		knativeServingVerify(t, clients, names)
+-		knativeServingConfigure(t, clients, names)
++		t.Skip("Skip due to SRVKS-241")
+ 	})
+ 
+ 	// Delete the deployments one by one to see if they will be recreated.


### PR DESCRIPTION
A bash version of test invocation of upstream `knative/serving-operator`. Previous proposition is #32.

There is a patch that skips `TestKnativeServingDeployment/configure` due to SRVKS-241.

There is a `0.9.0` version of `knative/serving-operator` used, as current serverless operator do not handle `knativeservings.operator.knative.dev` definitions yet. After supporting that, versions should be set to `support/v0.10.0`. 

For `0.11+` we can use knative instead of fork (cardil), as master has configurable test namespace knative/serving-operator#223.