### PR TITLE
Require at least ocp 4.2, k8s 1.14.0 [SRVKS-371]

### DIFF
--- a/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ spec:
       kind: ServiceMeshControlPlane
       name: servicemeshcontrolplanes.maistra.io
       version: v1
-  minKubeVersion: 1.14.6
+  minKubeVersion: 1.14.0
   description: |-
     The Red Hat Serverless Operator provides a collection of API's to
     install various "serverless" services.

--- a/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
@@ -100,6 +100,7 @@ spec:
       kind: ServiceMeshControlPlane
       name: servicemeshcontrolplanes.maistra.io
       version: v1
+  minKubeVersion: 1.14.6
   description: |-
     The Red Hat Serverless Operator provides a collection of API's to
     install various "serverless" services.


### PR DESCRIPTION
I've confirmed that a virgin install of this will fail if the required min version isn't available, but it is not clear how this will work for upgrading existing operators because OLM doesn't seem to distinguish versions when updating operators, i.e. only an "uninstall" option is provided when you attempt to install the upgraded CatalogSource, even after deleting the older CatalogSource first.