### PR TITLE
Fix 4.1 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
   for more information.
 - HTTPS based routes are now available for all Knative Services.
 - Fixed a bug where Routes have non-correct cross-namespaced OwnerReferences.
+- Dropped support for OpenShift 4.1

--- a/hack/lib/common.bash
+++ b/hack/lib/common.bash
@@ -35,7 +35,7 @@ function timeout {
       echo -n '.'
     fi
     sleep $interval
-    [[ $seconds -gt $timeout ]] && logger.error "Timed out of ${timeout} exceeded" && return 1
+    [[ $seconds -gt $timeout ]] && logger.error "Time out of ${timeout} exceeded" && return 1
   done
   if [[ "${LOG_LEVEL}" != 'DEBUG' ]] && [[ "$seconds" != '0' ]]; then
     echo ''

--- a/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ spec:
       kind: ServiceMeshControlPlane
       name: servicemeshcontrolplanes.maistra.io
       version: v1
-  minKubeVersion: 1.14.6
+  minKubeVersion: 1.14.0
   description: |-
     The Red Hat Serverless Operator provides a collection of API's to
     install various "serverless" services.

--- a/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
@@ -100,6 +100,7 @@ spec:
       kind: ServiceMeshControlPlane
       name: servicemeshcontrolplanes.maistra.io
       version: v1
+  minKubeVersion: 1.14.6
   description: |-
     The Red Hat Serverless Operator provides a collection of API's to
     install various "serverless" services.

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -127,7 +127,7 @@ function run_knative_serving_rolling_upgrade_tests {
     local upgrade_to=$(${rootdir}/hack/catalog.sh | grep currentCSV | awk '{ print $2 }')
 
     if [[ ${HOSTNAME} = e2e-aws-ocp-41* ]]; then
-      approve_csv $upgrade_to && return 1 # Upgrade should fail on OCP 4.1
+      approve_csv $upgrade_to && return 1 || true # Upgrade should fail on OCP 4.1
       # Check we got RequirementsNotMet error
       [[ $(oc get ClusterServiceVersion $upgrade_to -n $OPERATORS_NAMESPACE -o=jsonpath="{.status.requirementStatus[?(@.name==\"$upgrade_to\")].message}") =~ "requirement not met: minKubeVersion" ]] || return 1
       # Check KnativeServing still has the old version
@@ -146,7 +146,7 @@ function run_knative_serving_rolling_upgrade_tests {
     end_prober_test ${PROBER_PID}
 
     local latest_cluster_version=$(oc adm upgrade | sed -ne '/VERSION/,$ p' | grep -v VERSION | awk '{print $1}')
-    [[ $latest_cluster_version == "" ]] && return 1
+    [[ $latest_cluster_version != "" ]] || return 1
 
     oc adm upgrade --to-latest=true
 

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -127,7 +127,9 @@ function run_knative_serving_rolling_upgrade_tests {
     local upgrade_to=$(${rootdir}/hack/catalog.sh | grep currentCSV | awk '{ print $2 }')
 
     if [[ ${HOSTNAME} = e2e-aws-ocp-41* ]]; then
-      approve_csv $upgrade_to && return 1 || true # Upgrade should fail on OCP 4.1
+      if approve_csv "$upgrade_to" ; then # Upgrade should fail on OCP 4.1
+        return 1
+      fi
       # Check we got RequirementsNotMet error
       [[ $(oc get ClusterServiceVersion $upgrade_to -n $OPERATORS_NAMESPACE -o=jsonpath="{.status.requirementStatus[?(@.name==\"$upgrade_to\")].message}") =~ "requirement not met: minKubeVersion" ]] || return 1
       # Check KnativeServing still has the old version

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/lib.bash"
 
-set -Eeuo pipefail
+set -Eeuox pipefail
 
 register_teardown || exit $?
 scale_up_workers || exit $?

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/lib.bash"
 
-set -Eeuox pipefail
+set -Eeuo pipefail
 
 register_teardown || exit $?
 scale_up_workers || exit $?


### PR DESCRIPTION
This PR includes commits from https://github.com/openshift-knative/serverless-operator/pull/56 and modifies upgrade tests to pass on OCP 4.1