### PR TITLE
[WIP][SRVKS-364] Replace networking-istio with networking-openshift

### DIFF
--- a/hack/images.sh
+++ b/hack/images.sh
@@ -10,3 +10,6 @@ docker push "$repo/knative-serving-operator"
 
 docker build -t "$repo/knative-openshift-ingress" serving/ingress
 docker push "$repo/knative-openshift-ingress"
+
+#docker build -t "$repo/knative-networking-openshift" serving/networking-openshift
+#docker push "$repo/knative-networking-openshift"

--- a/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
@@ -267,7 +267,7 @@ spec:
                 - name: IMAGE_controller
                   value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-controller
                 - name: IMAGE_networking-istio
-                  value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-istio
+                  value: quay.io/nak3/knative-networking-openshift
                 - name: IMAGE_webhook
                   value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-webhook
                 image: $IMAGE_KNATIVE_SERVING_OPERATOR
@@ -275,33 +275,6 @@ spec:
                 name: knative-serving-operator
                 resources: {}
               serviceAccountName: knative-serving-operator
-      - name: knative-openshift-ingress
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              name: knative-openshift-ingress
-          template:
-            metadata:
-              labels:
-                name: knative-openshift-ingress
-            spec:
-              serviceAccountName: knative-openshift-ingress
-              containers:
-                - name: knative-openshift-ingress
-                  image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
-                  command:
-                  - knative-openshift-ingress
-                  imagePullPolicy: Always
-                  env:
-                    - name: WATCH_NAMESPACE
-                      value: "" # watch all namespaces for ClusterIngress
-                    - name: POD_NAME
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: metadata.name
-                    - name: OPERATOR_NAME
-                      value: "knative-openshift-ingress"
       permissions:
       - rules:
         - apiGroups:

--- a/serving/operator/deploy/operator.yaml
+++ b/serving/operator/deploy/operator.yaml
@@ -43,6 +43,6 @@ spec:
             - name: IMAGE_controller
               value: quay.io/openshift-knative/knative-serving-controller:v0.10.0
             - name: IMAGE_networking-istio
-              value: quay.io/openshift-knative/knative-serving-istio:v0.10.0
+              value: quay.io/nak3/knative-networking-openshift
             - name: IMAGE_webhook
               value: quay.io/openshift-knative/knative-serving-webhook:v0.10.0

--- a/serving/operator/deploy/resources/knative-serving-0.10.0.yaml
+++ b/serving/operator/deploy/resources/knative-serving-0.10.0.yaml
@@ -188,6 +188,34 @@ rules:
   - delete
   - patch
   - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  - routes/status
+  - routes/finalizers
+  verbs:
+  - "*"
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - knativeservings
+  - knativeservings/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - maistra.io
+  resources:
+  - servicemeshmemberrolls
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - "*"
 
 ---
 apiVersion: v1


### PR DESCRIPTION
__NOTE:__ This change will be applied to release-1.4. release-1.3 branch is just a testing purpose.

This patch still needs following tasks:

- [x] Add necessary permissions to knative-serving-core clusterrole.
- [ ] Complete https://github.com/openshift-knative/knative-serving-networking-openshift/pull/4
- [ ] Add networking-openshift codes and removes git submodule
- [ ] Clean up k-o-i configs completely.