### PR TITLE
WIP Adds kourier as a postInstall step for openshift

### DIFF
--- a/serving/operator/deploy/resources/kourier/kourier.yaml
+++ b/serving/operator/deploy/resources/kourier/kourier.yaml
@@ -1,0 +1,273 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier
+  namespace: knative-serving
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: 3scale-kourier-gateway
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: 3scale-kourier-gateway
+  namespace: knative-serving
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: 3scale-kourier-gateway
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: 3scale-kourier-gateway
+    spec:
+      containers:
+        - args:
+            - -c
+            - /tmp/config/envoy-bootstrap.yaml
+          image: quay.io/3scale/kourier-gateway:v0.1.3
+          imagePullPolicy: Always
+          name: kourier-gateway
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - name: config-volume
+              mountPath: /tmp/config
+          readinessProbe:
+            exec:
+              command: ['ash','-c','(printf "GET /__internalkouriersnapshot HTTP/1.1\r\nHost: internalkourier\r\n\r\n"; sleep 1) | nc -n localhost 8081 | grep "HTTP/1.1 200 OK"']
+            initialDelaySeconds: 5
+            periodSeconds: 2
+      volumes:
+        - name: config-volume
+          configMap:
+            name: kourier-bootstrap
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: 3scale-kourier-control
+  namespace: knative-serving
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: 3scale-kourier-control
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: 3scale-kourier-control
+    spec:
+      containers:
+        - image: quay.io/3scale/kourier:v0.3.4
+          imagePullPolicy: Always
+          name: kourier-control
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          env:
+            - name: CERTS_SECRET_NAMESPACE
+              value: ""
+            - name: CERTS_SECRET_NAME
+              value: ""
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccountName: 3scale-kourier
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: 3scale-kourier
+  namespace: knative-serving
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "endpoints", "namespaces", "services", "secrets", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.internal.knative.dev"]
+    resources: ["clusteringresses","ingresses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.internal.knative.dev"]
+    resources: ["ingresses/status","clusteringresses/status"]
+    verbs: ["update"]
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: 3scale-kourier
+  namespace: knative-serving
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: 3scale-kourier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 3scale-kourier
+subjects:
+  - kind: ServiceAccount
+    name: 3scale-kourier
+    namespace: knative-serving
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-internal
+  namespace: knative-serving
+spec:
+  ports:
+    - name: http2
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: 3scale-kourier-gateway
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-external
+  namespace: knative-serving
+spec:
+  ports:
+    - name: http2
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: 3scale-kourier-gateway
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-control
+  namespace: knative-serving
+spec:
+  ports:
+    - port: 18000
+      protocol: TCP
+      targetPort: 18000
+  selector:
+    app: 3scale-kourier-control
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kourier-bootstrap
+  namespace: knative-serving
+data:
+  envoy-bootstrap.yaml: |
+    dynamic_resources:
+      ads_config:
+        api_type: GRPC
+        grpc_services:
+          - envoy_grpc:
+              cluster_name: xds_cluster
+      cds_config:
+        ads: {}
+      lds_config:
+        ads: {}
+    node:
+      cluster: kourier-knative
+      id: 3scale-kourier-gateway
+    static_resources:
+      listeners:
+        - name: stats_listener
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9000
+          filter_chains:
+            - filters:
+                - name: envoy.http_connection_manager
+                  config:
+                    stat_prefix: stats_server
+                    route_config:
+                      virtual_hosts:
+                        - name: admin_interface
+                          domains:
+                            - "*"
+                          routes:
+                            - match:
+                                safe_regex:
+                                  google_re2: {}
+                                  regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
+                                headers:
+                                  - name: ':method'
+                                    exact_match: GET
+                              route:
+                                cluster: service_stats
+                    http_filters:
+                      - name: envoy.router
+                        config: {}
+      clusters:
+        - name: service_stats
+          connect_timeout: 0.250s
+          type: static
+          load_assignment:
+            cluster_name: service_stats
+            endpoints:
+              lb_endpoints:
+                endpoint:
+                  address:
+                    pipe:
+                      path: /tmp/envoy.admin
+        - name: xds_cluster
+          connect_timeout: 1s
+          hosts:
+            - socket_address:
+                address: "kourier-control"
+                port_value: 18000
+          http2_protocol_options: {}
+          type: STRICT_DNS
+    admin:
+      access_log_path: "/dev/stdout"
+      address:
+        pipe:
+          path: /tmp/envoy.admin
+---
+
+---

--- a/serving/operator/deploy/resources/kourier/kourier.yaml
+++ b/serving/operator/deploy/resources/kourier/kourier.yaml
@@ -40,7 +40,7 @@ spec:
           args:
             - -c
             - /tmp/config/envoy-bootstrap.yaml
-          image: quay.io/3scale/kourier-gateway:vMaistra
+          image: docker.io/maistra/proxyv2-ubi8:1.0.2
           imagePullPolicy: Always
           name: kourier-gateway
           ports:

--- a/serving/operator/deploy/resources/kourier/kourier.yaml
+++ b/serving/operator/deploy/resources/kourier/kourier.yaml
@@ -36,10 +36,11 @@ spec:
         app: 3scale-kourier-gateway
     spec:
       containers:
-        - args:
+        - command: ["/usr/local/bin/envoy"]
+          args:
             - -c
             - /tmp/config/envoy-bootstrap.yaml
-          image: quay.io/3scale/kourier-gateway:v0.1.3
+          image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:1.0.3-1
           imagePullPolicy: Always
           name: kourier-gateway
           ports:
@@ -53,7 +54,7 @@ spec:
               mountPath: /tmp/config
           readinessProbe:
             exec:
-              command: ['ash','-c','(printf "GET /__internalkouriersnapshot HTTP/1.1\r\nHost: internalkourier\r\n\r\n"; sleep 1) | nc -n localhost 8081 | grep "HTTP/1.1 200 OK"']
+              command: ['bash','-c','curl -H "Host: internalkourier" localhost:8081/__internalkouriersnapshot']
             initialDelaySeconds: 5
             periodSeconds: 2
       volumes:
@@ -268,6 +269,3 @@ data:
       address:
         pipe:
           path: /tmp/envoy.admin
----
-
----

--- a/serving/operator/deploy/resources/kourier/kourier.yaml
+++ b/serving/operator/deploy/resources/kourier/kourier.yaml
@@ -40,7 +40,7 @@ spec:
           args:
             - -c
             - /tmp/config/envoy-bootstrap.yaml
-          image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:1.0.3-1
+          image: quay.io/3scale/kourier-gateway:vMaistra
           imagePullPolicy: Always
           name: kourier-gateway
           ports:


### PR DESCRIPTION
Adds kourier as a postinstall step (requires Knative crd's to be created before)

To enable kourier adding the proper ingress.class to the KnativeServing object is enough: 

```yaml
apiVersion: serving.knative.dev/v1alpha1
kind: KnativeServing
metadata:
  name: knative-serving
  namespace: knative-serving
spec:
  config:
   (..)
    network:
      ingress.class: kourier.ingress.networking.knative.dev

```

Currently kourier will always be installed, but we could add an specific trigger to enable/disable it's installation.

