### PR TITLE
API separation in tests

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -97,14 +97,11 @@ function deploy_knativeserving_v1alpha1 {
   # Wait for the CRD to appear
   timeout 900 "[[ \$(oc get crd | grep -c knativeservings) -eq 0 ]]" || return 6
 
+  local rootdir
+  rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
+
   # Install Knative Serving
-  cat <<EOF | oc apply -f - || return $?
-apiVersion: serving.knative.dev/v1alpha1
-kind: KnativeServing
-metadata:
-  name: knative-serving
-  namespace: ${SERVING_NAMESPACE}
-EOF
+  oc apply -n "${SERVING_NAMESPACE}" -f "${rootdir}/serving/operator/deploy/crds/serving_v1alpha1_knativeserving_cr.yaml" || return $?
 
   timeout 900 '[[ $(oc get knativeserving knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
 

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -20,7 +20,7 @@ function install_serverless_previous {
 
   previous_csv=$("${rootdir}/hack/catalog.sh" | grep replaces: | tail -n1 | awk '{ print $2 }')
   deploy_serverless_operator "$previous_csv"  || return $?
-  deploy_knativeserving_cr || return $?
+  deploy_knativeserving_v1alpha1 || return $?
 }
 
 function remove_installplan {
@@ -33,7 +33,7 @@ function remove_installplan {
 
 function install_serverless_latest {
   deploy_serverless_operator_latest || return $?
-  deploy_knativeserving_cr || return $?
+  deploy_knativeserving_v1alpha1 || return $?
 }
 
 function deploy_serverless_operator_latest {
@@ -91,7 +91,7 @@ function find_install_plan {
   echo ""
 }
 
-function deploy_knativeserving_cr {
+function deploy_knativeserving_v1alpha1 {
   logger.info 'Deploy Knative Serving'
 
   # Wait for the CRD to appear

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -20,7 +20,7 @@ function install_serverless_previous {
 
   previous_csv=$("${rootdir}/hack/catalog.sh" | grep replaces: | tail -n1 | awk '{ print $2 }')
   deploy_serverless_operator "$previous_csv"  || return $?
-  deploy_knativeserving_v1alpha1 || return $?
+  deploy_knativeserving_v1alpha1_1.3.0 || return $?
 }
 
 function remove_installplan {
@@ -33,7 +33,7 @@ function remove_installplan {
 
 function install_serverless_latest {
   deploy_serverless_operator_latest || return $?
-  deploy_knativeserving_v1alpha1 || return $?
+  deploy_knativeserving_v1alpha1_1.3.0 || return $?
 }
 
 function deploy_serverless_operator_latest {
@@ -91,7 +91,7 @@ function find_install_plan {
   echo ""
 }
 
-function deploy_knativeserving_v1alpha1 {
+function deploy_knativeserving_v1alpha1_1.3.0 {
   logger.info 'Deploy Knative Serving'
 
   # Wait for the CRD to appear
@@ -101,7 +101,7 @@ function deploy_knativeserving_v1alpha1 {
   rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
 
   # Install Knative Serving
-  oc apply -n "${SERVING_NAMESPACE}" -f "${rootdir}/serving/operator/deploy/crds/serving_v1alpha1_knativeserving_cr.yaml" || return $?
+  oc apply -n "${SERVING_NAMESPACE}" -f "${rootdir}/serving/operator/deploy/crds/serving_v1alpha1_1.3.0_knativeserving_cr.yaml" || return $?
 
   timeout 900 '[[ $(oc get knativeserving knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
 

--- a/serving/operator/deploy/crds/serving_v1alpha1_1.3.0_knativeserving_cr.yaml
+++ b/serving/operator/deploy/crds/serving_v1alpha1_1.3.0_knativeserving_cr.yaml
@@ -1,0 +1,42 @@
+# Warning: This file is used for backward compatibility tests and
+# should work with future versions of Serverless (after 1.3.0).
+# Do not update this file after Serverles 1.3.0 is released.
+
+apiVersion: serving.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    defaults:
+      revision-timeout-seconds: "300"  # 5 minutes
+    autoscaler:
+      container-concurrency-target-percentage: "1.0"
+      container-concurrency-target-default: "100"
+      stable-window: "60s"
+      panic-window-percentage: "10.0"
+      panic-window: "6s"
+      panic-threshold-percentage: "200.0"
+      max-scale-up-rate: "10"
+      enable-scale-to-zero: "true"
+      tick-interval: "2s"
+      scale-to-zero-grace-period: "30s"
+    deployment:
+      registriesSkippingTagResolving: "ko.local,dev.local"
+    gc:
+      stale-revision-create-delay: "24h"
+      stale-revision-timeout: "15h"
+      stale-revision-minimum-generations: "1"
+      stale-revision-lastpinned-debounce: "5h"
+    logging:
+      loglevel.controller: "info"
+      loglevel.autoscaler: "info"
+      loglevel.queueproxy: "info"
+      loglevel.webhook: "info"
+      loglevel.activator: "info"
+    observability:
+      logging.enable-var-log-collection: "false"
+      metrics.backend-destination: "prometheus"
+    tracing:
+      backend: "none"
+      sample-rate: "0.1"

--- a/serving/operator/deploy/crds/serving_v1alpha1_knativeserving_cr.yaml
+++ b/serving/operator/deploy/crds/serving_v1alpha1_knativeserving_cr.yaml
@@ -6,10 +6,6 @@ spec:
   config:
     defaults:
       revision-timeout-seconds: "300"  # 5 minutes
-      revision-cpu-request: "400m"     # 0.4 of a CPU (aka 400 milli-CPU)
-      revision-memory-request: "100M"  # 100 megabytes of memory
-      revision-cpu-limit: "1000m"      # 1 CPU (aka 1000 milli-CPU)
-      revision-memory-limit: "200M"    # 200 megabytes of memory
     autoscaler:
       container-concurrency-target-percentage: "1.0"
       container-concurrency-target-default: "100"

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
+	v1a1test "github.com/openshift-knative/serverless-operator/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +39,7 @@ func TestKnativeServing(t *testing.T) {
 	})
 
 	t.Run("deploy knativeserving cr and wait for it to be ready", func(t *testing.T) {
-		_, err := test.WithKnativeServingReady(caCtx, knativeServing, knativeServing)
+		_, err := v1a1test.WithKnativeServingReady(caCtx, knativeServing, knativeServing)
 		if err != nil {
 			t.Fatal("Failed to deploy KnativeServing", err)
 		}
@@ -60,7 +61,7 @@ func TestKnativeServing(t *testing.T) {
 	})
 
 	t.Run("remove knativeserving cr", func(t *testing.T) {
-		if err := test.DeleteKnativeServing(caCtx, knativeServing, knativeServing); err != nil {
+		if err := v1a1test.DeleteKnativeServing(caCtx, knativeServing, knativeServing); err != nil {
 			t.Fatal("Failed to remove Knative Serving", err)
 		}
 

--- a/test/v1alpha1/knativeserving.go
+++ b/test/v1alpha1/knativeserving.go
@@ -1,6 +1,7 @@
-package test
+package v1alpha1
 
 import (
+	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/pkg/errors"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +18,7 @@ func KnativeServing(name, namespace string) *servingoperatorv1alpha1.KnativeServ
 	}
 }
 
-func WithKnativeServingReady(ctx *Context, name, namespace string) (*servingoperatorv1alpha1.KnativeServing, error) {
+func WithKnativeServingReady(ctx *test.Context, name, namespace string) (*servingoperatorv1alpha1.KnativeServing, error) {
 	serving, err := CreateKnativeServing(ctx, name, namespace)
 	if err != nil {
 		return nil, err
@@ -29,7 +30,7 @@ func WithKnativeServingReady(ctx *Context, name, namespace string) (*servingoper
 	return serving, nil
 }
 
-func CreateKnativeServing(ctx *Context, name, namespace string) (*servingoperatorv1alpha1.KnativeServing, error) {
+func CreateKnativeServing(ctx *test.Context, name, namespace string) (*servingoperatorv1alpha1.KnativeServing, error) {
 	serving, err := ctx.Clients.ServingOperator.KnativeServings(namespace).Create(KnativeServing(name, namespace))
 	if err != nil {
 		return nil, err
@@ -40,7 +41,7 @@ func CreateKnativeServing(ctx *Context, name, namespace string) (*servingoperato
 	return serving, nil
 }
 
-func DeleteKnativeServing(ctx *Context, name, namespace string) error {
+func DeleteKnativeServing(ctx *test.Context, name, namespace string) error {
 	if err := ctx.Clients.ServingOperator.KnativeServings(namespace).Delete(name, &metav1.DeleteOptions{}); err != nil {
 		return err
 	}
@@ -56,10 +57,10 @@ func DeleteKnativeServing(ctx *Context, name, namespace string) error {
 	return err
 }
 
-func WaitForKnativeServingState(ctx *Context, name, namespace string, inState func(s *servingoperatorv1alpha1.KnativeServing, err error) (bool, error)) (*servingoperatorv1alpha1.KnativeServing, error) {
+func WaitForKnativeServingState(ctx *test.Context, name, namespace string, inState func(s *servingoperatorv1alpha1.KnativeServing, err error) (bool, error)) (*servingoperatorv1alpha1.KnativeServing, error) {
 	var lastState *servingoperatorv1alpha1.KnativeServing
 	var err error
-	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
+	waitErr := wait.PollImmediate(test.Interval, test.Timeout, func() (bool, error) {
 		lastState, err = ctx.Clients.ServingOperator.KnativeServings(namespace).Get(name, metav1.GetOptions{})
 		return inState(lastState, err)
 	})


### PR DESCRIPTION
This is related to "Backwards compatibility for installation" in https://issues.redhat.com/browse/SRVLS-199

The idea is that we explicitly choose version of KnativeServing CR for the tests. There are two two types of tests:
* serverless-operator tests in test/e2e/ folder

    These tests are deploying KnativeServing from test/v1alpha1 package using Go. In the future they could deploy a newer version to test new features (e.g. v1beta1, v1, etc.)

* knative-serving tests in which are pulled from github.com/openshift/knative-serving on the fly when running `e2e-tests.sh`

  Before these tests run, the KnativeServing CR is deployed from Bash. Now that it is versioned we could make sure this KnativeServing CR stays at version v1alpha1 even for future releases and we could test backwards compatibility through it. Basically, making sure that this old CR can still be used with newer releases and doesn't break installation.