### PR TITLE
Create ConsoleCLIDownload CR for kn CLI

### DIFF
--- a/knative-operator/deploy/resources/console_cli_download_kn.yaml
+++ b/knative-operator/deploy/resources/console_cli_download_kn.yaml
@@ -1,0 +1,14 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleCLIDownload
+metadata:
+  name: kn
+spec:
+  description: The OpenShift Serverless client `kn` is a CLI tool that allows you to fully manage OpenShift Serverless Serving and Eventing resources without writing a single line of YAML.
+  displayName: kn - OpenShift Serverless CLI
+  links:
+  - href: https://mirror.openshift.com/pub/openshift-v4/clients/serverless/0.11.0/kn-linux-amd64-0.11.0.tar.gz
+    text: Download kn for Linux
+  - href: https://mirror.openshift.com/pub/openshift-v4/clients/serverless/0.11.0/kn-macos-amd64-0.11.0.tar.gz
+    text: Download kn for macOS
+  - href: https://mirror.openshift.com/pub/openshift-v4/clients/serverless/0.11.0/kn-windows-amd64-0.11.0.zip
+    text: Download kn for Windows

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -1,0 +1,35 @@
+package consoleclidownload
+
+import (
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
+	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
+
+	mf "github.com/jcrossley3/manifestival"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const knConsoleCLIDownload = "deploy/resources/console_cli_download_kn.yaml"
+
+var log = common.Log.WithName("consoleclidownload")
+
+// Create creates ConsoleCLIDownload for kn CLI download links
+func Create(instance *servingv1alpha1.KnativeServing, apiclient client.Client) error {
+	log.Info("Creating ConsoleCLIDownload CR for kn")
+	manifest, err := mf.NewManifest(knConsoleCLIDownload, false, apiclient)
+	if err != nil {
+		return err
+	}
+
+	return manifest.ApplyAll()
+}
+
+// Delete deletes ConsoleCLIDownload for kn CLI download links
+func Delete(instance *servingv1alpha1.KnativeServing, apiclient client.Client) error {
+	log.Info("Deleting ConsoleCLIDownload CR for kn")
+	manifest, err := mf.NewManifest(knConsoleCLIDownload, false, apiclient)
+	if err != nil {
+		return err
+	}
+
+	return manifest.DeleteAll()
+}


### PR DESCRIPTION
Fixes #37 

- Create ConsoleCLIDownload instance part of openshift-specific knative operator
install to create ConsoleCLIDownload for kn.
- Add ConsoleCLIDownload resource YAML knative-operator/deploy/resources/console_cli_download_kn.yaml
- Create and Delete functions for ConsoleCLIDownload added as separate package under knative-operator/pkg/controller/knativeserving/consoleclidownload
- Creation of ConsoleCLIDownload treated as stage like others stages in operator
- Update link for kn v0.11.0 version download from mirror

![image](https://user-images.githubusercontent.com/2510184/72429066-12aa9980-37b5-11ea-9313-4a47236beabe.png)
