### PR TITLE
WIP Adds kourier as a postInstall step for openshift

### DIFF
--- a/knative-operator/deploy/resources/kourier/kourier.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kourier-system
+  name: knative-serving-ingress
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/knative-operator/deploy/resources/kourier/kourier.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier.yaml
@@ -1,8 +1,8 @@
-#apiVersion: v1
-#kind: Namespace
-#metadata:
-#  name: kourier-system
-#---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kourier-system
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/knative-operator/deploy/resources/kourier/kourier.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier.yaml
@@ -1,0 +1,275 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kourier-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: kourier-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: kourier-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier
+  namespace: kourier-system
+spec:
+  ports:
+    - name: http2
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app: 3scale-kourier-gateway
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: 3scale-kourier-gateway
+  namespace: kourier-system
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: 3scale-kourier-gateway
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: 3scale-kourier-gateway
+    spec:
+      containers:
+        - command: ["/usr/local/bin/envoy"]
+          args:
+            - -c
+            - /tmp/config/envoy-bootstrap.yaml
+          image: docker.io/maistra/proxyv2-ubi8:1.0.4
+          imagePullPolicy: Always
+          name: kourier-gateway
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - name: config-volume
+              mountPath: /tmp/config
+          readinessProbe:
+            exec:
+              command: ['bash','-c','curl -H "Host: internalkourier" localhost:8081/__internalkouriersnapshot']
+            initialDelaySeconds: 5
+            periodSeconds: 2
+      volumes:
+        - name: config-volume
+          configMap:
+            name: kourier-bootstrap
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: 3scale-kourier-control
+  namespace: kourier-system
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: 3scale-kourier-control
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: 3scale-kourier-control
+    spec:
+      containers:
+        - image: quay.io/3scale/kourier:v0.3.6
+          imagePullPolicy: Always
+          name: kourier-control
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          env:
+            - name: CERTS_SECRET_NAMESPACE
+              value: ""
+            - name: CERTS_SECRET_NAME
+              value: ""
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccountName: 3scale-kourier
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: 3scale-kourier
+  namespace: kourier-system
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "endpoints", "namespaces", "services", "secrets", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.internal.knative.dev"]
+    resources: ["clusteringresses","ingresses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.internal.knative.dev"]
+    resources: ["ingresses/status","clusteringresses/status"]
+    verbs: ["update"]
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: 3scale-kourier
+  namespace: kourier-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: 3scale-kourier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 3scale-kourier
+subjects:
+  - kind: ServiceAccount
+    name: 3scale-kourier
+    namespace: kourier-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-internal
+  namespace: kourier-system
+spec:
+  ports:
+    - name: http2
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: 3scale-kourier-gateway
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-control
+  namespace: kourier-system
+spec:
+  ports:
+    - port: 18000
+      protocol: TCP
+      targetPort: 18000
+  selector:
+    app: 3scale-kourier-control
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kourier-bootstrap
+  namespace: kourier-system
+data:
+  envoy-bootstrap.yaml: |
+    dynamic_resources:
+      ads_config:
+        api_type: GRPC
+        grpc_services:
+          - envoy_grpc:
+              cluster_name: xds_cluster
+      cds_config:
+        ads: {}
+      lds_config:
+        ads: {}
+    node:
+      cluster: kourier-knative
+      id: 3scale-kourier-gateway
+    static_resources:
+      listeners:
+        - name: stats_listener
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9000
+          filter_chains:
+            - filters:
+                - name: envoy.http_connection_manager
+                  config:
+                    stat_prefix: stats_server
+                    route_config:
+                      virtual_hosts:
+                        - name: admin_interface
+                          domains:
+                            - "*"
+                          routes:
+                            - match:
+                                regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
+                                headers:
+                                  - name: ':method'
+                                    exact_match: GET
+                              route:
+                                cluster: service_stats
+                    http_filters:
+                      - name: envoy.router
+                        config: {}
+      clusters:
+        - name: service_stats
+          connect_timeout: 0.250s
+          type: static
+          load_assignment:
+            cluster_name: service_stats
+            endpoints:
+              lb_endpoints:
+                endpoint:
+                  address:
+                    pipe:
+                      path: /tmp/envoy.admin
+        - name: xds_cluster
+          connect_timeout: 1s
+          hosts:
+            - socket_address:
+                address: "kourier-control"
+                port_value: 18000
+          http2_protocol_options: {}
+          type: STRICT_DNS
+    admin:
+      access_log_path: "/dev/stdout"
+      address:
+        pipe:
+          path: /tmp/envoy.admin

--- a/knative-operator/deploy/resources/kourier/kourier.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier.yaml
@@ -111,7 +111,7 @@ spec:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: quay.io/3scale/kourier:v0.3.6
+        - image: quay.io/3scale/kourier:v0.3.7
           imagePullPolicy: Always
           name: kourier-control
           resources: {}

--- a/knative-operator/deploy/resources/kourier/kourier.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier.yaml
@@ -1,20 +1,20 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kourier-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: kourier-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: kourier-system
----
+#apiVersion: v1
+#kind: Namespace
+#metadata:
+#  name: kourier-system
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: config-logging
+#  namespace: kourier-system
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: config-observability
+#  namespace: kourier-system
+#---
 apiVersion: v1
 kind: Service
 metadata:

--- a/knative-operator/deploy/resources/kourier/kourier.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier.yaml
@@ -1,9 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: knative-serving-ingress
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-logging

--- a/knative-operator/deploy/resources/kourier/kourier.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier.yaml
@@ -3,18 +3,18 @@
 #metadata:
 #  name: kourier-system
 #---
-#apiVersion: v1
-#kind: ConfigMap
-#metadata:
-#  name: config-logging
-#  namespace: kourier-system
-#---
-#apiVersion: v1
-#kind: ConfigMap
-#metadata:
-#  name: config-observability
-#  namespace: kourier-system
-#---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: kourier-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: kourier-system
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/knative-operator/deploy/resources/kourier/kourier.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier.yaml
@@ -111,7 +111,7 @@ spec:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: quay.io/3scale/kourier:v0.3.7
+        - image: quay.io/3scale/kourier:v0.3.8
           imagePullPolicy: Always
           name: kourier-control
           resources: {}

--- a/knative-operator/pkg/common/openshift.go
+++ b/knative-operator/pkg/common/openshift.go
@@ -18,6 +18,7 @@ var log = Log
 
 func Mutate(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 	stages := []func(*servingv1alpha1.KnativeServing, client.Client) error{
+		ingressClass,
 		egress,
 		ingress,
 		configureLogURLTemplate,
@@ -30,6 +31,11 @@ func Mutate(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func ingressClass(ks *servingv1alpha1.KnativeServing, c client.Client) error {
+	Configure(ks, "network", "ingress.class", "kourier.ingress.networking.knative.dev")
 	return nil
 }
 

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -97,6 +97,7 @@ func (r *ReconcileKnativeServing) Reconcile(request reconcile.Request) (reconcil
 		r.createConsoleCLIDownload,
 		r.installKourier,
 	}
+
 	for _, stage := range stages {
 		if err := stage(instance); err != nil {
 			return reconcile.Result{}, err
@@ -166,6 +167,8 @@ func (a *ReconcileKnativeServing) installKourier(instance *servingv1alpha1.Knati
 		return err
 	}
 	transforms := []mf.Transformer{mf.InjectOwner(instance)}
+	// let's hardcode this for now.
+	transforms = append(transforms, mf.InjectNamespace("knative-serving-ingress"))
 
 	if err := manifest.Transform(transforms...); err != nil {
 		log.Error(err, "Unable to transform Kourier Ingress manifest")

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -93,9 +93,9 @@ func (r *ReconcileKnativeServing) Reconcile(request reconcile.Request) (reconcil
 		r.ensureFinalizers,
 		r.ensureCustomCertsConfigMap,
 		r.installNetworkPolicies,
-		r.installServiceMesh,
-		r.createConsoleCLIDownload,
 		r.installKourier,
+		//r.installServiceMesh,
+		r.createConsoleCLIDownload,
 	}
 
 	for _, stage := range stages {
@@ -160,6 +160,8 @@ func (r *ReconcileKnativeServing) ensureCustomCertsConfigMap(instance *servingv1
 func (a *ReconcileKnativeServing) installKourier(instance *servingv1alpha1.KnativeServing) error {
 	log.Info("Installing Kourier Ingress")
 	const path = "deploy/resources/kourier/kourier.yaml"
+	// Having a race condition. We need this before the knative controller is running...
+	common.Configure(instance, "network", "ingress.class", "kourier.ingress.networking.knative.dev")
 
 	manifest, err := mf.NewManifest(path, false, a.client)
 	if err != nil {

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -93,8 +93,8 @@ func (r *ReconcileKnativeServing) Reconcile(request reconcile.Request) (reconcil
 		r.ensureFinalizers,
 		r.ensureCustomCertsConfigMap,
 		r.installNetworkPolicies,
-		r.installKourier,
 		r.installServiceMesh,
+		r.installKourier,
 		r.createConsoleCLIDownload,
 	}
 

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -95,6 +95,7 @@ func (r *ReconcileKnativeServing) Reconcile(request reconcile.Request) (reconcil
 		r.installNetworkPolicies,
 		r.installServiceMesh,
 		r.createConsoleCLIDownload,
+		r.installKourier,
 	}
 	for _, stage := range stages {
 		if err := stage(instance); err != nil {
@@ -149,6 +150,29 @@ func (r *ReconcileKnativeServing) ensureCustomCertsConfigMap(instance *servingv1
 			}
 			return nil
 		}
+		return err
+	}
+	return nil
+}
+
+// Install Kourier Ingress Gateway
+func (a *ReconcileKnativeServing) installKourier(instance *servingv1alpha1.KnativeServing) error {
+	log.Info("Installing Kourier Ingress")
+	const path = "deploy/resources/kourier/kourier.yaml"
+
+	manifest, err := mf.NewManifest(path, false, a.client)
+	if err != nil {
+		log.Error(err, "Unable to create Kourier Ingress install manifest")
+		return err
+	}
+	transforms := []mf.Transformer{mf.InjectOwner(instance)}
+
+	if err := manifest.Transform(transforms...); err != nil {
+		log.Error(err, "Unable to transform Kourier Ingress manifest")
+		return err
+	}
+	if err := manifest.ApplyAll(); err != nil {
+		log.Error(err, "Unable to install Kourier Ingress")
 		return err
 	}
 	return nil

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -94,7 +94,7 @@ func (r *ReconcileKnativeServing) Reconcile(request reconcile.Request) (reconcil
 		r.ensureCustomCertsConfigMap,
 		r.installNetworkPolicies,
 		r.installKourier,
-		//r.installServiceMesh,
+		r.installServiceMesh,
 		r.createConsoleCLIDownload,
 	}
 
@@ -155,6 +155,7 @@ func (r *ReconcileKnativeServing) ensureCustomCertsConfigMap(instance *servingv1
 	}
 	return nil
 }
+
 
 // Install Kourier Ingress Gateway
 func (a *ReconcileKnativeServing) installKourier(instance *servingv1alpha1.KnativeServing) error {

--- a/knative-operator/pkg/controller/knativeserving/servicemesh/servicemesh.go
+++ b/knative-operator/pkg/controller/knativeserving/servicemesh/servicemesh.go
@@ -45,9 +45,9 @@ func ApplyServiceMesh(instance *servingv1alpha1.KnativeServing, api client.Clien
 	if err := api.Status().Update(context.TODO(), instance); err != nil {
 		return err
 	}
-	if err := configureIstio(instance, api); err != nil {
-		return err
-	}
+	//if err := configureIstio(instance, api); err != nil {
+	//	return err
+	//}
 	if err := createIngressNamespace(instance.GetNamespace(), api); err != nil {
 		return err
 	}

--- a/knative-operator/pkg/controller/knativeserving/servicemesh/servicemesh.go
+++ b/knative-operator/pkg/controller/knativeserving/servicemesh/servicemesh.go
@@ -3,8 +3,6 @@ package servicemesh
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
@@ -45,9 +43,9 @@ func ApplyServiceMesh(instance *servingv1alpha1.KnativeServing, api client.Clien
 	if err := api.Status().Update(context.TODO(), instance); err != nil {
 		return err
 	}
-	if err := configureIstio(instance, api); err != nil {
-		return err
-	}
+	//if err := configureIstio(instance, api); err != nil {
+	//	return err
+	//}
 	if err := createIngressNamespace(instance.GetNamespace(), api); err != nil {
 		return err
 	}
@@ -62,20 +60,20 @@ func ApplyServiceMesh(instance *servingv1alpha1.KnativeServing, api client.Clien
 		return nil
 	}
 	log.Info("ServiceMeshControlPlane is ready")
-	if err := selectGateways(instance, api); err != nil {
-		return err
-	}
-	if err := installServiceMeshMemberRoll(instance, api); err != nil {
-		// ref for substring https://github.com/Maistra/istio-operator/blob/maistra-1.0/pkg/controller/servicemesh/validation/memberroll.go#L95
-		if strings.Contains(err.Error(), "one or more members are already defined in another ServiceMeshMemberRoll") {
-			log.Info(fmt.Sprintf("failed to update ServiceMeshMemberRole because namespace %s is already a member of another ServiceMeshMemberRoll", instance.GetNamespace()))
-			msg := "Could not add '%s' to ServiceMeshMemberRoll (SMMR) because it's already part of another SMMR, " +
-				"likely one in 'istio-system' (check with 'oc get smmr --all-namespaces'). " +
-				"Remove '%s' and all namespaces that contain Knative Services from that other SMMR"
-			return fmt.Errorf(msg, instance.GetNamespace(), instance.GetNamespace())
-		}
-		return err
-	}
+	//if err := selectGateways(instance, api); err != nil {
+	//	return err
+	//}
+	//if err := installServiceMeshMemberRoll(instance, api); err != nil {
+	//	// ref for substring https://github.com/Maistra/istio-operator/blob/maistra-1.0/pkg/controller/servicemesh/validation/memberroll.go#L95
+	//	if strings.Contains(err.Error(), "one or more members are already defined in another ServiceMeshMemberRoll") {
+	//		log.Info(fmt.Sprintf("failed to update ServiceMeshMemberRole because namespace %s is already a member of another ServiceMeshMemberRoll", instance.GetNamespace()))
+	//		msg := "Could not add '%s' to ServiceMeshMemberRoll (SMMR) because it's already part of another SMMR, " +
+	//			"likely one in 'istio-system' (check with 'oc get smmr --all-namespaces'). " +
+	//			"Remove '%s' and all namespaces that contain Knative Services from that other SMMR"
+	//		return fmt.Errorf(msg, instance.GetNamespace(), instance.GetNamespace())
+	//	}
+	//	return err
+	//}
 	ready, err = isServiceMeshMemberRollReady(instance.GetNamespace(), api)
 	if err != nil {
 		return err

--- a/knative-operator/pkg/controller/knativeserving/servicemesh/servicemesh.go
+++ b/knative-operator/pkg/controller/knativeserving/servicemesh/servicemesh.go
@@ -3,16 +3,15 @@ package servicemesh
 import (
 	"context"
 	"fmt"
+	mf "github.com/jcrossley3/manifestival"
 	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
-
-	mf "github.com/jcrossley3/manifestival"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -49,17 +48,17 @@ func ApplyServiceMesh(instance *servingv1alpha1.KnativeServing, api client.Clien
 	if err := createIngressNamespace(instance.GetNamespace(), api); err != nil {
 		return err
 	}
-	if err := installServiceMeshControlPlane(instance, api); err != nil {
-		return err
-	}
-	ready, err := isServiceMeshControlPlaneReady(instance.GetNamespace(), api)
-	if err != nil {
-		return err
-	}
-	if !ready {
-		return nil
-	}
-	log.Info("ServiceMeshControlPlane is ready")
+	//if err := installServiceMeshControlPlane(instance, api); err != nil {
+	//	return err
+	//}
+	//ready, err := isServiceMeshControlPlaneReady(instance.GetNamespace(), api)
+	//if err != nil {
+	//	return err
+	//}
+	//if !ready {
+	//	return nil
+	//}
+	//log.Info("ServiceMeshControlPlane is ready")
 	//if err := selectGateways(instance, api); err != nil {
 	//	return err
 	//}
@@ -74,17 +73,17 @@ func ApplyServiceMesh(instance *servingv1alpha1.KnativeServing, api client.Clien
 	//	}
 	//	return err
 	//}
-	ready, err = isServiceMeshMemberRollReady(instance.GetNamespace(), api)
-	if err != nil {
-		return err
-	}
-	if ready {
-		log.Info(fmt.Sprintf("Successfully configured %s namespace into configured members", instance.GetNamespace()))
-		// TODO: instance.Status.MarkDependenciesInstalled()
-	}
-	if err := installNetworkPolicies(instance.GetNamespace(), api); err != nil {
-		return err
-	}
+	//ready, err = isServiceMeshMemberRollReady(instance.GetNamespace(), api)
+	//if err != nil {
+	//	return err
+	//}
+	//if ready {
+	//	log.Info(fmt.Sprintf("Successfully configured %s namespace into configured members", instance.GetNamespace()))
+	//	// TODO: instance.Status.MarkDependenciesInstalled()
+	//}
+	//if err := installNetworkPolicies(instance.GetNamespace(), api); err != nil {
+	//	return err
+	//}
 	instance.Status.MarkDependenciesInstalled()
 	if err := api.Status().Update(context.TODO(), instance); err != nil {
 		return err

--- a/knative-operator/pkg/controller/knativeserving/servicemesh/servicemesh.go
+++ b/knative-operator/pkg/controller/knativeserving/servicemesh/servicemesh.go
@@ -45,9 +45,9 @@ func ApplyServiceMesh(instance *servingv1alpha1.KnativeServing, api client.Clien
 	if err := api.Status().Update(context.TODO(), instance); err != nil {
 		return err
 	}
-	//if err := configureIstio(instance, api); err != nil {
-	//	return err
-	//}
+	if err := configureIstio(instance, api); err != nil {
+		return err
+	}
 	if err := createIngressNamespace(instance.GetNamespace(), api); err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds kourier as a postinstall step (requires Knative crd's to be created before)

To enable kourier adding the proper ingress.class to the KnativeServing object is enough:

```yaml
apiVersion: operator.knative.dev/v1alpha1
kind: KnativeServing
metadata:
  name: knative-serving
  namespace: knative-serving
spec:
  config:
   (..)
    network:
      ingress.class: kourier.ingress.networking.knative.dev
```

Currently kourier will always be installed, but we could add an specific trigger to enable/disable it's installation.