### PR TITLE
Adding a cluster-local-gateway hack/fix policy for ksi namespace

### DIFF
--- a/serving/ingress/deploy/networkpolicies.yaml
+++ b/serving/ingress/deploy/networkpolicies.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: knative-cluster-local-gateway-hack
+  namespace: knative-serving-ingress
+spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      istio: cluster-local-gateway
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
@jcrossley3 we talked about this policy ... but if we dont want to embed it here ... ok

we already ship in via the eventing operator... but it ends up in the `knative-eventing` namespace, not in the required `knative-serving-ingress` call 