### PR TITLE
Add network policy for cluster-local-gateway

### DIFF
--- a/serving/operator/deploy/resources/serviceMesh/network_policies.yaml
+++ b/serving/operator/deploy/resources/serviceMesh/network_policies.yaml
@@ -1,0 +1,12 @@
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: cluster-local-gateway
+  namespace: knative-serving-ingress
+spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      istio: cluster-local-gateway


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVKS-378

```
kubectl get NetworkPolicy -n knative-serving-ingress cluster-local-gateway -o yaml
apiVersion: extensions/v1beta1
kind: NetworkPolicy
metadata:
  annotations:
    manifestival: new
  creationTimestamp: "2020-01-16T21:23:19Z"
  generation: 1
  name: cluster-local-gateway
  namespace: knative-serving-ingress
  ownerReferences:
  - apiVersion: maistra.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: ServiceMeshControlPlane
    name: basic-install
    uid: 2dce7bf1-38a6-11ea-8cf9-52fdfc072182
  resourceVersion: "153229"
  selfLink: /apis/extensions/v1beta1/namespaces/knative-serving-ingress/networkpolicies/cluster-local-gateway
  uid: 6af24170-38a6-11ea-8cf9-52fdfc072182
spec:
  ingress:
  - from:
    - namespaceSelector: {}
  podSelector:
    matchLabels:
      istio: cluster-local-gateway
  policyTypes:
  - Ingress
```