### PR TITLE
Simplify logging utitilities and enable -x in CI.

### DIFF
--- a/hack/lib/common.bash
+++ b/hack/lib/common.bash
@@ -31,15 +31,9 @@ function timeout {
   while eval $*; do
     seconds=$(( seconds + interval ))
     logger.debug "Execution failed: ${*}. Waiting ${interval} sec ($seconds/${timeout})..."
-    if [[ "${LOG_LEVEL}" != 'DEBUG' ]]; then
-      echo -n '.'
-    fi
     sleep $interval
     [[ $seconds -gt $timeout ]] && logger.error "Time out of ${timeout} exceeded" && return 1
   done
-  if [[ "${LOG_LEVEL}" != 'DEBUG' ]] && [[ "$seconds" != '0' ]]; then
-    echo ''
-  fi
   return 0
 }
 

--- a/hack/lib/ui.bash
+++ b/hack/lib/ui.bash
@@ -1,105 +1,21 @@
 #!/usr/bin/env bash
 
-if [ -t 1 ]; then 
-  IS_TTY=true
-else
-  IS_TTY=false
-fi
-readonly IS_TTY
-
-readonly FORCE_COLOR="${FORCE_COLOR:-false}"
-
-SHOULD_COLOR="$(if [[ "${FORCE_COLOR}" == "true" ]] || [[ "${IS_TTY}" == "true" ]]; then echo true; else echo false; fi)"
-readonly SHOULD_COLOR
-
-readonly COLOR_NC='\e[0m' # No Color
-readonly COLOR_BLUE='\e[0;34m'
-readonly COLOR_GREEN='\e[0;32m'
-readonly COLOR_LIGHT_GREEN='\e[1;32m'
-readonly COLOR_CYAN='\e[0;36m'
-readonly COLOR_LIGHT_RED='\e[1;31m'
-readonly COLOR_LIGHT_YELLOW='\e[1;33m'
-readonly COLOR_GRAY='\e[0;39m'
-
-readonly LOG_LEVEL=${LOG_LEVEL:-INFO}
-declare -ar LOG_LEVELS=('DEBUG' 'INFO' 'SUCCESS' 'WARNING' 'ERROR')
-declare -Ar LOG_LEVEL_VALUES=( ['DEBUG']=1 ['INFO']=2 ['SUCCESS']=3 ['WARNING']=4 ['ERROR']=5 )
-
 function logger.debug {
-  local message
-  message="$*"
-  if logger.__should-print 'DEBUG'; then
-    logger.__log 'DEBUG' "${COLOR_BLUE}" "${message}"
-  fi
+  printf "%7s %s %s\n" "DEBUG" "$(date '+%H:%M:%S.%3N')" "$*" 1>&2
 }
 
 function logger.info {
-  local message
-  message="$*"
-  if logger.__should-print 'INFO'; then
-    logger.__log 'INFO' "${COLOR_GREEN}" "${message}"
-  fi
+  printf "%7s %s %s\n" "INFO" "$(date '+%H:%M:%S.%3N')" "$*" 1>&2
 }
 
 function logger.success {
-  local message
-  message="$*"
-  if logger.__should-print 'SUCCESS'; then
-    logger.__log 'SUCCESS' "${COLOR_LIGHT_GREEN}" "${message}"
-  fi
+  printf "%7s %s %s\n" "SUCCESS" "$(date '+%H:%M:%S.%3N')" "$*" 1>&2
 }
 
 function logger.warn {
-  local message
-  message="$*"
-  if logger.__should-print 'WARNING'; then
-    logger.__log 'WARNING' "${COLOR_LIGHT_YELLOW}" "${message}"
-  fi
+  printf "%7s %s %s\n" "WARNING" "$(date '+%H:%M:%S.%3N')" "$*" 1>&2
 }
 
 function logger.error {
-  local message
-  message="$*"
-  if logger.__should-print 'ERROR'; then
-    logger.__log 'ERROR' "${COLOR_LIGHT_RED}" "${message}"
-  fi
+  printf "%7s %s %s\n" "ERROR" "$(date '+%H:%M:%S.%3N')" "$*" 1>&2
 }
-
-function logger.__log {
-  local message level now color
-  level="$1"
-  color="$2"
-  message="$3"
-  if [[ "${SHOULD_COLOR}" == "true" ]]; then
-    now="$(date '+%H:%M:%S.%3N')"
-    printf "${color}%7s ${COLOR_CYAN}%s ${color}%s${COLOR_NC}\n" "${level}" "${now}" "${message}" 1>&2
-  else
-    now="$(date --rfc-3339=ns)"
-    printf "%7s %s %s\n" "${level}" "${now}" "${message}" 1>&2
-  fi
-}
-
-function logger.__check-level {
-  local level check_level level_int check_level_int
-  level="$1"
-  check_level="$2"
-
-  if ! array.contains "$LOG_LEVEL" "${LOG_LEVELS[@]}"; then
-    echo "Given invalid log level: ${LOG_LEVEL}, possible values are: ${LOG_LEVELS[*]}" 1>&2
-    exit 1
-  fi
-  
-  level_int=${LOG_LEVEL_VALUES[$level]}
-  check_level_int=${LOG_LEVEL_VALUES[$check_level]}
-
-  (( level_int >= check_level_int ))
-}
-
-function logger.__should-print {
-  local level
-  level="$1"
-
-  logger.__check-level "$level" "$LOG_LEVEL"
-}
-
-logger.info "Actual log level is: ${LOG_LEVEL}. Configure logging by setting LOG_LEVEL env variable."

--- a/hack/lib/ui.bash
+++ b/hack/lib/ui.bash
@@ -1,21 +1,73 @@
 #!/usr/bin/env bash
 
+if [ -t 1 ]; then 
+  IS_TTY=true
+else
+  IS_TTY=false
+fi
+readonly IS_TTY
+
+readonly FORCE_COLOR="${FORCE_COLOR:-false}"
+
+SHOULD_COLOR="$(if [[ "${FORCE_COLOR}" == "true" ]] || [[ "${IS_TTY}" == "true" ]]; then echo true; else echo false; fi)"
+readonly SHOULD_COLOR
+
+readonly COLOR_NC='\e[0m' # No Color
+readonly COLOR_BLUE='\e[0;34m'
+readonly COLOR_GREEN='\e[0;32m'
+readonly COLOR_LIGHT_GREEN='\e[1;32m'
+readonly COLOR_CYAN='\e[0;36m'
+readonly COLOR_LIGHT_RED='\e[1;31m'
+readonly COLOR_LIGHT_YELLOW='\e[1;33m'
+
 function logger.debug {
-  printf "%7s %s %s\n" "DEBUG" "$(date '+%H:%M:%S.%3N')" "$*" 1>&2
+  logger.__log 'DEBUG' "${COLOR_BLUE}" "$*"
 }
 
 function logger.info {
-  printf "%7s %s %s\n" "INFO" "$(date '+%H:%M:%S.%3N')" "$*" 1>&2
+  logger.__log 'INFO' "${COLOR_GREEN}" "$*"
 }
 
 function logger.success {
-  printf "%7s %s %s\n" "SUCCESS" "$(date '+%H:%M:%S.%3N')" "$*" 1>&2
+  logger.__log 'SUCCESS' "${COLOR_LIGHT_GREEN}" "$*"
 }
 
 function logger.warn {
-  printf "%7s %s %s\n" "WARNING" "$(date '+%H:%M:%S.%3N')" "$*" 1>&2
+  logger.__log 'WARNING' "${COLOR_LIGHT_YELLOW}" "$*"
 }
 
 function logger.error {
-  printf "%7s %s %s\n" "ERROR" "$(date '+%H:%M:%S.%3N')" "$*" 1>&2
+  logger.__log 'ERROR' "${COLOR_LIGHT_RED}" "$*"
 }
+
+function logger.__log {
+  local message level now color
+  level="$1"
+  color="$2"
+  message="$3"
+  now="$(date '+%H:%M:%S.%3N')"
+  
+  printf "${color}%7s ${COLOR_CYAN}%s ${color}%s${COLOR_NC}\n" "${level}" "${now}" "${message}" 1>&2
+}
+
+if [[ "${SHOULD_COLOR}" == "false" ]]; then
+  function logger.debug {
+    echo 'DEBUG' "$(date '+%H:%M:%S.%3N')" "$*"
+  }
+
+  function logger.info {
+    echo 'INFO' "$(date '+%H:%M:%S.%3N')" "$*"
+  }
+
+  function logger.success {
+    echo 'SUCCESS' "$(date '+%H:%M:%S.%3N')" "$*"
+  }
+
+  function logger.warn {
+    echo 'WARNING' "$(date '+%H:%M:%S.%3N')" "$*"
+  }
+
+  function logger.error {
+    echo 'ERROR' "$(date '+%H:%M:%S.%3N')" "$*"
+  }
+fi

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -26,11 +26,11 @@ failed=0
 
 # Run upstream knative serving operator tests
 (( !failed )) && deploy_serverless_operator_latest || failed=11
-(( !failed )) && run_knative_serving_operator_tests $KNATIVE_VERSION || failed=12
+(( !failed )) && run_knative_serving_operator_tests "$KNATIVE_VERSION" || failed=12
 
 # Run upstream knative serving tests
 (( !failed )) && ensure_serverless_installed || failed=6
-(( !failed )) && run_knative_serving_e2e_and_conformance_tests $KNATIVE_VERSION || failed=7
+(( !failed )) && run_knative_serving_e2e_and_conformance_tests "$KNATIVE_VERSION" || failed=7
 (( !failed )) && teardown_serverless || failed=8
 
 (( failed )) && dump_state

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -5,6 +5,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.bash"
 
 set -Eeuo pipefail
 
+# Enable extra verbosity if running in CI.
+if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
+  set -x
+fi
+
 register_teardown || exit $?
 scale_up_workers || exit $?
 create_namespaces || exit $?

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -5,6 +5,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.bash"
 
 set -Eeuo pipefail
 
+# Enable extra verbosity if running in CI.
+if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
+  set -x
+fi
+
 register_teardown || exit $?
 scale_up_workers || exit $?
 create_namespaces || exit $?

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -22,7 +22,7 @@ failed=0
 (( !failed )) && logger.success 'Cluster prepared for testing.'
 
 (( !failed )) && install_serverless_previous || failed=5
-(( !failed )) && run_knative_serving_rolling_upgrade_tests $KNATIVE_VERSION || failed=6
+(( !failed )) && run_knative_serving_rolling_upgrade_tests "$KNATIVE_VERSION" || failed=6
 
 (( !failed )) && teardown_serverless || failed=7
 


### PR DESCRIPTION
As the title says, this reduces the complexity of the logging utitilities to not produce too much noise when being run with `-x`.