### PR TITLE
Make subscription source and channel configurable in e2e test

### DIFF
--- a/test/flags.go
+++ b/test/flags.go
@@ -14,6 +14,8 @@ var Flags = initializeFlags()
 // FlagsStruct is struct that defines testing options
 type FlagsStruct struct {
 	Kubeconfigs string // Path to .kube/config
+	CatalogSource string // CatalogSource in the openshift-marketplace namespace for the serverless-operator Subscription
+	Channel string // serverless-operator Subscription channel
 }
 
 func initializeFlags() *FlagsStruct {
@@ -25,6 +27,10 @@ func initializeFlags() *FlagsStruct {
 	}
 	flag.StringVar(&f.Kubeconfigs, "kubeconfigs", defaultKubeconfig,
 		"Provide the path to the `kubeconfig` file you'd like to use for these tests. The `current-context` will be used.")
+	flag.StringVar(&f.CatalogSource, "catalogsource", "serverless-operator",
+		"CatalogSource in the openshift-marketplace namespace for the serverless-operator Subscription, \"serverless-operator\" by default")
+	flag.StringVar(&f.Channel, "channel", "techpreview",
+		"serverless-operator Subscription channel, \"techpreview\" by default.")
 
 	return &f
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -40,6 +40,7 @@ function run_e2e_tests {
   go_test_e2e -tags=e2e -timeout=30m -parallel=1 ./test/e2e \
     --kubeconfig "${kubeconfigs[0]}" \
     --kubeconfigs "${kubeconfigs_str}" \
+    "$@" \
     && logger.success 'Tests has passed' && return 0 \
     || logger.error 'Tests have failures!' \
     && return 1

--- a/test/subscription.go
+++ b/test/subscription.go
@@ -31,10 +31,10 @@ func Subscription(subscriptionName string) *v1alpha1.Subscription {
 			Name:      subscriptionName,
 		},
 		Spec: &v1alpha1.SubscriptionSpec{
-			CatalogSource:          ServerlessOperatorPackage,
+			CatalogSource:          Flags.CatalogSource,
 			CatalogSourceNamespace: OLMNamespace,
 			Package:                ServerlessOperatorPackage,
-			Channel:                "techpreview",
+			Channel:                Flags.Channel,
 			InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 		},
 	}


### PR DESCRIPTION
also, make run_e2e_tests pass its arguments as $@ so we can use run_e2e_tests to pass the flags.