### PR TITLE
Upgrades: Choose the latest OCP version if there are more options

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -183,7 +183,7 @@ function run_knative_serving_rolling_upgrade_tests {
     # End the prober test now before we start cluster upgrade, up until now we should have zero failed requests
     end_prober_test ${PROBER_PID}
 
-    local latest_cluster_version=$(oc adm upgrade | sed -ne '/VERSION/,$ p' | grep -v VERSION | awk '{print $1}')
+    local latest_cluster_version=$(oc adm upgrade | sed -ne '/VERSION/,$ p' | grep -v VERSION | awk '{print $1}' | sort -r | head -n 1)
     [[ $latest_cluster_version != "" ]] || return 1
 
     oc adm upgrade --to-latest=true


### PR DESCRIPTION
At times there are more available versions, e.g. when we're installing a version 2 releases back and then doing an upgrade. This change will make sure we pick just the latest.

The tests in this CI won't use this code. It's only used in downstream testing where we re-use the code.