### PR TITLE
SRVKS-411 remove IMAGE_default env

### DIFF
--- a/olm-catalog/serverless-operator/1.4.0/serverless-operator.v1.4.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.4.0/serverless-operator.v1.4.0.clusterserviceversion.yaml
@@ -292,8 +292,6 @@ spec:
                       value: "4.1.13"
                     - name: REQUIRED_NAMESPACE
                       value: "knative-serving"
-                    - name: IMAGE_default
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-${NAME}
                     - name: IMAGE_queue-proxy
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-queue
                     - name: IMAGE_networking-istio


### PR DESCRIPTION
Hoping at least Jim would know if we can safely remove this...

(also assuming the serverless-operator.v1.4.0.clusterserviceversion.yaml is not magically generated from somewhere else... )