### PR TITLE
Delete the new CR when the old CR is removed and vice versa.

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleclidownload"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/servicemesh"
+	obsolete "github.com/openshift-knative/serverless-operator/serving/operator/pkg/apis/serving/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/predicate"
 	corev1 "k8s.io/api/core/v1"
@@ -193,6 +194,14 @@ func (r *ReconcileKnativeServing) delete(instance *servingv1alpha1.KnativeServin
 	if len(instance.GetFinalizers()) == 0 || instance.GetFinalizers()[0] != finalizerName() {
 		return nil
 	}
+
+	// Try to delete the "old" CR, if it's still there. Ignore any errors.
+	old := &obsolete.KnativeServing{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, old); err == nil {
+		// Oh, it actually still exists. Remove it, but ignore all errors!
+		r.client.Delete(context.TODO(), old)
+	}
+
 	if err := servicemesh.RemoveServiceMesh(instance, r.client); err != nil {
 		return err
 	}

--- a/knative-operator/pkg/controller/knativeservingobsolete/knativeservingobsolete_controller.go
+++ b/knative-operator/pkg/controller/knativeservingobsolete/knativeservingobsolete_controller.go
@@ -128,8 +128,9 @@ func (r *ReconcileKnativeServingObsolete) reconcileNewResource(old *obsolete.Kna
 	if errors.IsNotFound(err) {
 		new := &servingv1alpha1.KnativeServing{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      old.Name,
-				Namespace: old.Namespace,
+				Name:            old.Name,
+				Namespace:       old.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(old.GetObjectMeta(), obsolete.SchemeGroupVersion.WithKind("KnativeServing"))},
 			},
 			Spec: servingv1alpha1.KnativeServingSpec{
 				Config: old.Spec.Config,


### PR DESCRIPTION
To make behavior a little bit less surprising, we now delete the entire system when either the old or the new CR is removed. We also remove the respective "brother" CR if either of them is removed.