### PR TITLE
Remove -l from the array of kubeconfigs

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -27,7 +27,7 @@ function register_teardown {
 }
 
 function run_e2e_tests {
-  declare -al kubeconfigs
+  declare -a kubeconfigs
   local kubeconfigs_str
 
   logger.info "Running tests"


### PR DESCRIPTION
* in some cases the paths to kubeconfigs can be case sensitive

..e.g. when we use a generated temporary gopath