### PR TITLE
Bootstrap 1.5.0, upgrade to Serving 0.12.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Openshift Serverless v1.5.0
+
+- Update Knative Serving to v0.12.1. See
+  [upstream release notes](https://github.com/knative/serving/releases/tag/v0.12.1)
+  for more information.
+
 # Openshift Serverless v1.4.0
 
 - Update Knative Serving to v0.11.1. See

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -5,7 +5,7 @@ readonly BUILD_NUMBER=${BUILD_NUMBER:-$(uuidgen)}
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/../../test/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh"
 
-readonly KNATIVE_VERSION="${KNATIVE_VERSION:-v0.11.1}"
+readonly KNATIVE_VERSION="${KNATIVE_VERSION:-v0.12.1}"
 
 readonly CATALOG_SOURCE_FILENAME="${CATALOG_SOURCE_FILENAME:-catalogsource-ci.yaml}"
 readonly DOCKER_REPO_OVERRIDE="${DOCKER_REPO_OVERRIDE:-}"

--- a/olm-catalog/serverless-operator/1.4.1/serverless-operator.v1.4.1.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.4.1/serverless-operator.v1.4.1.clusterserviceversion.yaml
@@ -289,7 +289,7 @@ spec:
               serviceAccountName: knative-serving-operator
               containers:
                 - name: knative-serving-openshift
-                  image: $IMAGE_KNATIVE_OPERATOR
+                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
                   command:
                   - knative-serving-openshift
                   imagePullPolicy: Always
@@ -334,7 +334,7 @@ spec:
               serviceAccountName: knative-openshift-ingress
               containers:
                 - name: knative-openshift-ingress
-                  image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
+                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
                   command:
                   - knative-openshift-ingress
                   imagePullPolicy: Always
@@ -442,9 +442,9 @@ spec:
     - name: IMAGE_webhook
       image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-webhook
     - name: knative-operator
-      image: $IMAGE_KNATIVE_OPERATOR
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
     - name: knative-openshift-ingress
-      image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
   replaces: serverless-operator.v1.3.0
   skips:
     - serverless-operator.v1.4.0

--- a/olm-catalog/serverless-operator/1.5.0/operator_v1alpha1_knativeserving_crd.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/operator_v1alpha1_knativeserving_crd.yaml
@@ -1,0 +1,158 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: knativeservings.operator.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.version
+    name: Version
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+    name: Reason
+    type: string
+  group: operator.knative.dev
+  names:
+    kind: KnativeServing
+    listKind: KnativeServingList
+    plural: knativeservings
+    shortNames:
+    - ks
+    singular: knativeserving
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Schema for the knativeservings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec defines the desired state of KnativeServing
+          properties:
+            cluster-local-gateway:
+              description: A means to override the cluster-local-gateway
+              properties:
+                selector:
+                  additionalProperties:
+                    type: string
+                  description: The selector for the ingress-gateway.
+                  type: object
+              type: object
+            config:
+              additionalProperties:
+                additionalProperties:
+                  type: string
+                type: object
+              description: A means to override the corresponding entries in the upstream
+                configmaps
+              type: object
+            controller-custom-certs:
+              description: Enabling the controller to trust registries with self-signed
+                certificates
+              properties:
+                name:
+                  description: The name of the ConfigMap or Secret
+                  type: string
+                type:
+                  description: One of ConfigMap or Secret
+                  enum:
+                  - ConfigMap
+                  - Secret
+                  - ""
+                  type: string
+              type: object
+            knative-ingress-gateway:
+              description: A means to override the knative-ingress-gateway
+              properties:
+                selector:
+                  additionalProperties:
+                    type: string
+                  description: The selector for the ingress-gateway.
+                  type: object
+              type: object
+            registry:
+              description: A means to override the corresponding deployment images
+                in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+              properties:
+                default:
+                  description: The default image reference template to use for all
+                    knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                  type: string
+                imagePullSecrets:
+                  description: A list of secrets to be used when pulling the knative
+                    images. The secret must be created in the same namespace as the
+                    knative-serving deployments, and not the namespace of this resource.
+                  items:
+                    properties:
+                      name:
+                        description: The name of the secret.
+                        type: string
+                    type: object
+                  type: array
+                override:
+                  additionalProperties:
+                    type: string
+                  description: A map of a container name or image name to the full
+                    image location of the individual knative image.
+                  type: object
+              type: object
+          type: object
+        status:
+          description: Status defines the observed state of KnativeServing
+          properties:
+            conditions:
+              description: The latest available observations of a resource's current
+                state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the last time the condition
+                      transitioned from one status to another. We use VolatileTime
+                      in place of metav1.Time to exclude this from creating equality.Semantic
+                      differences (all other things held constant).
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  severity:
+                    description: Severity with which to treat failures of this type
+                      of condition. When this is not specified, it defaults to Error.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition.
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            version:
+              description: The version of the installed release
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
@@ -114,7 +114,7 @@ spec:
       kind: ServiceMeshControlPlane
       name: servicemeshcontrolplanes.maistra.io
       version: v1
-  minKubeVersion: 1.14.0
+  minKubeVersion: 1.15.0
   description: |-
     The Red Hat Serverless Operator provides a collection of API's to
     install various "serverless" services.
@@ -303,7 +303,7 @@ spec:
                     - name: OPERATOR_NAME
                       value: "knative-serving-openshift"
                     - name: MIN_OPENSHIFT_VERSION
-                      value: "4.1.13"
+                      value: "4.3.0"
                     - name: REQUIRED_NAMESPACE
                       value: "knative-serving"
                     - name: IMAGE_queue-proxy

--- a/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
@@ -62,14 +62,14 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
     certified: "false"
-    containerImage: quay.io/openshift-knative/serverless-operator:v1.4.0
+    containerImage: quay.io/openshift-knative/serverless-operator:v1.5.0
     createdAt: "2019-07-27T17:00:00Z"
     description: |-
       Provides a collection of API's based on Knative to support deploying and serving
       of serverless applications and functions.
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat, Inc.
-  name: serverless-operator.v1.4.0
+  name: serverless-operator.v1.5.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -267,7 +267,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: METRICS_DOMAIN
                   value: knative.dev/serving-operator
-                image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-operator
+                image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-operator
                 imagePullPolicy: IfNotPresent
                 name: knative-serving-operator
                 ports:
@@ -289,7 +289,7 @@ spec:
               serviceAccountName: knative-serving-operator
               containers:
                 - name: knative-serving-openshift
-                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
+                  image: $IMAGE_KNATIVE_OPERATOR
                   command:
                   - knative-serving-openshift
                   imagePullPolicy: Always
@@ -307,19 +307,19 @@ spec:
                     - name: REQUIRED_NAMESPACE
                       value: "knative-serving"
                     - name: IMAGE_queue-proxy
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-queue
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-queue
                     - name: IMAGE_networking-istio
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-istio
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-istio
                     - name: IMAGE_activator
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-activator
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-activator
                     - name: IMAGE_autoscaler
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler
                     - name: IMAGE_autoscaler-hpa
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler-hpa
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler-hpa
                     - name: IMAGE_controller
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-controller
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-controller
                     - name: IMAGE_webhook
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-webhook
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-webhook
       - name: knative-openshift-ingress
         spec:
           replicas: 1
@@ -334,7 +334,7 @@ spec:
               serviceAccountName: knative-openshift-ingress
               containers:
                 - name: knative-openshift-ingress
-                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
+                  image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
                   command:
                   - knative-openshift-ingress
                   imagePullPolicy: Always
@@ -428,22 +428,22 @@ spec:
     name: Red Hat, Inc.
   relatedImages:
     - name: IMAGE_QUEUE
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-queue
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-queue
     - name: IMAGE_activator
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-activator
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-activator
     - name: IMAGE_autoscaler
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler
     - name: IMAGE_autoscaler-hpa
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler-hpa
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler-hpa
     - name: IMAGE_controller
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-controller
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-controller
     - name: IMAGE_networking-istio
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-istio
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-istio
     - name: IMAGE_webhook
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-webhook
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-webhook
     - name: knative-operator
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
+      image: $IMAGE_KNATIVE_OPERATOR
     - name: knative-openshift-ingress
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
-  replaces: serverless-operator.v1.3.0
-  version: 1.4.0
+      image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
+  replaces: serverless-operator.v1.4.1
+  version: 1.5.0

--- a/olm-catalog/serverless-operator/1.5.0/serving_v1alpha1_knativeserving_crd.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serving_v1alpha1_knativeserving_crd.yaml
@@ -1,0 +1,99 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: knativeservings.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.version
+    name: Version
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    name: Reason
+    type: string
+  group: serving.knative.dev
+  names:
+    kind: KnativeServing
+    listKind: KnativeServingList
+    plural: knativeservings
+    singular: knativeserving
+    shortNames:
+    - ks
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Schema for the knativeservings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec defines the desired state of KnativeServing
+          properties:
+            config:
+              additionalProperties:
+                additionalProperties:
+                  type: string
+                type: object
+              description: A means to override the corresponding entries in the upstream
+                configmaps
+              type: object
+          type: object
+        status:
+          description: Status defines the observed state of KnativeServing
+          properties:
+            conditions:
+              description: The latest available observations of a resource's current
+                state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the last time the condition
+                      transitioned from one status to another. We use VolatileTime
+                      in place of metav1.Time to exclude this from creating equality.Semantic
+                      differences (all other things held constant).
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  severity:
+                    description: Severity with which to treat failures of this type
+                      of condition. When this is not specified, it defaults to Error.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition.
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            version:
+              description: The version of the installed release
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/olm-catalog/serverless-operator/serverless-operator.package.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: serverless-operator
 channels:
 - name: techpreview
-  currentCSV: serverless-operator.v1.4.1
+  currentCSV: serverless-operator.v1.5.0

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -115,7 +115,7 @@ function run_knative_serving_e2e_and_conformance_tests {
     parallel=2
   fi
 
-  go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel ./test/e2e ./test/conformance/... \
+  go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     --resolvabledomain --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$image_template" || failed=1
 


### PR DESCRIPTION
As the title says. This upgrade our latest CSV to 1.5.0 and uses 0.12 images for upstream operator and upstream itself.