### PR TITLE
Fix replacement chain for skipping 1.4.0.

### DIFF
--- a/olm-catalog/serverless-operator/1.4.1/serverless-operator.v1.4.1.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.4.1/serverless-operator.v1.4.1.clusterserviceversion.yaml
@@ -445,7 +445,7 @@ spec:
       image: $IMAGE_KNATIVE_OPERATOR
     - name: knative-openshift-ingress
       image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
-  replaces: serverless-operator.v1.3.0
+  replaces: serverless-operator.v1.4.0
   skips:
     - serverless-operator.v1.4.0
   version: 1.4.1


### PR DESCRIPTION
The OLM team told us that we actually need to both replace and skip 1.4.0.