### PR TITLE
Remove skips directive as it has been found to be unreliable.

### DIFF
--- a/olm-catalog/serverless-operator/1.4.1/serverless-operator.v1.4.1.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.4.1/serverless-operator.v1.4.1.clusterserviceversion.yaml
@@ -445,7 +445,5 @@ spec:
       image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
     - name: knative-openshift-ingress
       image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
-  replaces: serverless-operator.v1.3.0
-  skips:
-    - serverless-operator.v1.4.0
+  replaces: serverless-operator.v1.4.0
   version: 1.4.1


### PR DESCRIPTION
This is already in the release-1.4 branch, but we should update here as well to not accidentally ship it again.