### PR TITLE
[WIP] POC for https://github.com/openshift-knative/serving-operator/pull/4

### DIFF
--- a/knative-operator/deploy/resources/networkpolicies.yaml
+++ b/knative-operator/deploy/resources/networkpolicies.yaml
@@ -67,17 +67,3 @@ spec:
       app: networking-certmanager
   ingress:
   - {}
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: networking-istio
-  namespace: knative-serving
-  labels:
-    app: networking-istio
-spec:
-  podSelector:
-    matchLabels:
-      app: networking-istio
-  ingress:
-  - {}

--- a/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
@@ -308,8 +308,6 @@ spec:
                       value: "knative-serving"
                     - name: IMAGE_queue-proxy
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-queue
-                    - name: IMAGE_networking-istio
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-istio
                     - name: IMAGE_activator
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-activator
                     - name: IMAGE_autoscaler
@@ -437,8 +435,6 @@ spec:
       image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler-hpa
     - name: IMAGE_controller
       image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-controller
-    - name: IMAGE_networking-istio
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-istio
     - name: IMAGE_webhook
       image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-webhook
     - name: knative-operator

--- a/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
@@ -267,7 +267,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: METRICS_DOMAIN
                   value: knative.dev/serving-operator
-                image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-operator
+                image: quay.io/nak3/knative-v0.12.1:knative-serving-operator
                 imagePullPolicy: IfNotPresent
                 name: knative-serving-operator
                 ports:


### PR DESCRIPTION
This is a POC for https://github.com/openshift-knative/serving-operator/pull/4.
It is supposed to pass e2e tests and prove that we can remove netwroking-istio now.