### PR TITLE
Fix rolling upgrade wait condition - master

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -192,8 +192,10 @@ function run_knative_serving_rolling_upgrade_tests {
       [[ $(oc get knativeserving.serving.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") == "$serving_version" ]] || return 1
     else
       approve_csv "$upgrade_to" || return 1
-      # Both knativeserving CRs should be updated now
-      timeout 900 '[[ ! ( $(oc get knativeserving.serving.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") != $serving_version && $(oc get knativeserving.serving.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
+      # If we used old CR for installing Serverless both knativeserving CRs should be updated now
+      if oc get knativeserving.serving.knative.dev knative-serving -n "$SERVING_NAMESPACE" >/dev/null 2>&1; then
+        timeout 900 '[[ ! ( $(oc get knativeserving.serving.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") != $serving_version && $(oc get knativeserving.serving.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
+      fi
       timeout 900 '[[ ! ( $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") != $serving_version && $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
     fi
     end_prober_test ${PROBER_PID}


### PR DESCRIPTION
* take into account both cases when we installed previous version via
old CR and also via new CR

Similar to https://github.com/openshift-knative/serverless-operator/pull/117, just for master