### PR TITLE
Add IMAGE_3scale-* env values to replace Kourier images

### DIFF
--- a/knative-operator/deploy/resources/kourier/download.sh
+++ b/knative-operator/deploy/resources/kourier/download.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 KOURIER_VERSION=v0.3.10
-DOWNLOAD_URL=https://raw.githubusercontent.com/3scale/kourier/${KOURIER_VERSION}/deploy/kourier-knative.yaml
+DOWNLOAD_URL=https://raw.githubusercontent.com/openshift-knative/kourier/${KOURIER_VERSION}/deploy/kourier-knative.yaml
 
 if [ -f "kourier-${KOURIER_VERSION}.yaml" ]; then
   echo "kourier-${KOURIER_VERSION}.yaml already exists"

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -156,7 +156,7 @@ func (r *ReconcileKnativeServing) ensureCustomCertsConfigMap(instance *servingv1
 // Install Kourier Ingress Gateway
 func (r *ReconcileKnativeServing) installKourier(instance *servingv1alpha1.KnativeServing) error {
 	// install Kourier
-	return kourier.Apply(instance, r.client)
+	return kourier.Apply(instance, r.client, r.scheme)
 }
 
 // Uninstall obsolete SMCP deployed by previous version

--- a/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
@@ -318,6 +318,10 @@ spec:
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-controller
                     - name: IMAGE_webhook
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-webhook
+                    - name: IMAGE_3scale-kourier-gateway
+                      value: docker.io/maistra/proxyv2-ubi8:1.0.4
+                    - name: IMAGE_3scale-kourier-control
+                      value: quay.io/3scale/kourier:v0.3.8
       - name: knative-openshift-ingress
         spec:
           replicas: 1

--- a/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
@@ -321,7 +321,7 @@ spec:
                     - name: IMAGE_3scale-kourier-gateway
                       value: docker.io/maistra/proxyv2-ubi8:1.0.4
                     - name: IMAGE_3scale-kourier-control
-                      value: quay.io/3scale/kourier:v0.3.9
+                      value: quay.io/3scale/kourier:v0.3.10
       - name: knative-openshift-ingress
         spec:
           replicas: 1

--- a/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
@@ -321,7 +321,7 @@ spec:
                     - name: IMAGE_3scale-kourier-gateway
                       value: docker.io/maistra/proxyv2-ubi8:1.0.4
                     - name: IMAGE_3scale-kourier-control
-                      value: quay.io/3scale/kourier:v0.3.8
+                      value: quay.io/3scale/kourier:v0.3.9
       - name: knative-openshift-ingress
         spec:
           replicas: 1


### PR DESCRIPTION
This patch introduces `IMAGE_3scale-kourier-gateway` and `IMAGE_3scale-kourier-control` env values to replace Kourier images.

It is basically same logic with usage of other `IMAGE_` values.