### PR TITLE
Add previous version install option to make install-previous 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ images:
 	./hack/images.sh $(DOCKER_REPO_OVERRIDE)
 
 install:
-	./hack/install.sh
+	./hack/install.sh $(PREVIOUS_SERVERLESS_VERSION)
 
 teardown:
 	./hack/teardown.sh

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ images:
 	./hack/images.sh $(DOCKER_REPO_OVERRIDE)
 
 install:
-	./hack/install.sh $(PREVIOUS_SERVERLESS_VERSION)
+	./hack/install.sh
+
+install-previous:
+	INSTALL_PREVIOUS_VERSION="true" ./hack/install.sh
 
 teardown:
 	./hack/teardown.sh

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Use the appropriate make targets or scripts in `hack`:
 - `make dev`: Deploys the serverless-operator without deploying Knative Serving.
 - `make install`: Scales the cluster appropriately, deploys serverless-operator
   and Knative Serving.
+- `make install-previous`: same with `make install` but deploy previous serverless-operator
+  version.
 - `make test-e2e`: Scales, installs and runs all tests.
 
 **Note:** Don't forget you can chain `make` targets. `make images dev` is handy
@@ -73,3 +75,31 @@ spec:
   channel: techpreview
 EOF
 ```
+
+### Test upgrade from previous version
+
+To test upgrade from previous version, deploy serverless operator by `make install-previous`
+
+```
+make install-previous
+```
+
+Then, you can see the installplans that the latest version has APPROVED `false`.
+
+```
+$ oc get installplan -n openshift-operators
+NAME            CSV                          APPROVAL    APPROVED
+install-ck6jl   serverless-operator.v1.4.1   Manual      true
+install-hrzzn   serverless-operator.v1.5.0   Manual      false
+```
+
+For example, v1.5.0 is the latest version in this case. To upgrade v1.5.0, you can edit
+`spec.approved` to true manually.
+
+```
+spec:
+  approval: Manual
+  approved: true
+```
+
+After a few minutes, operators will be upgraded automatically.

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -11,7 +11,9 @@
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/lib/__sources__.bash"
 
-set -Eeuo pipefail
+set -Eeo pipefail
+
+install_prev="$1"
 
 scale_up_workers || exit $?
 create_namespaces || exit $?
@@ -20,6 +22,6 @@ exitcode=0
 
 (( !exitcode )) && install_service_mesh_operator || exitcode=2
 (( !exitcode )) && ensure_catalogsource_installed || exitcode=3
-(( !exitcode )) && ensure_serverless_installed || exitcode=4
+(( !exitcode )) && ensure_serverless_installed "operator" $install_prev || exitcode=4
 
 exit $exitcode

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -11,9 +11,7 @@
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/lib/__sources__.bash"
 
-set -Eeo pipefail
-
-install_prev="$1"
+set -Eeuo pipefail
 
 scale_up_workers || exit $?
 create_namespaces || exit $?
@@ -22,6 +20,6 @@ exitcode=0
 
 (( !exitcode )) && install_service_mesh_operator || exitcode=2
 (( !exitcode )) && ensure_catalogsource_installed || exitcode=3
-(( !exitcode )) && ensure_serverless_installed "operator" $install_prev || exitcode=4
+(( !exitcode )) && ensure_serverless_installed "operator" ${INSTALL_PREVIOUS_VERSION} || exitcode=4
 
 exit $exitcode

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -3,11 +3,16 @@
 function ensure_serverless_installed {
   logger.info 'Check if Serverless is installed'
   local group=${1:-operator}
+  local prev=${2}
   if oc get knativeserving.${group}.knative.dev knative-serving -n "${SERVING_NAMESPACE}" >/dev/null 2>&1; then
     logger.success 'Serverless is already installed.'
     return 0
   fi
-  install_serverless_latest
+  if [[ -n $prev ]]; then
+    install_serverless_previous
+  else
+    install_serverless_latest
+  fi
 }
 
 function install_serverless_previous {

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -3,12 +3,12 @@
 function ensure_serverless_installed {
   logger.info 'Check if Serverless is installed'
   local group=${1:-operator}
-  local prev=${2}
+  local prev=${2:-false}
   if oc get knativeserving.${group}.knative.dev knative-serving -n "${SERVING_NAMESPACE}" >/dev/null 2>&1; then
     logger.success 'Serverless is already installed.'
     return 0
   fi
-  if [[ -n $prev ]]; then
+  if [[ $prev == "true" ]]; then
     install_serverless_previous
   else
     install_serverless_latest


### PR DESCRIPTION
This patch adds the support of previous version installation by `make install-previous`.

For example, to Install previous version:

```
DOCKER_REPO_OVERRIDE=quay.io/nak3 make install-previous 
```