### PR TITLE
Remove CI-namespace references.

### DIFF
--- a/hack/catalog.sh
+++ b/hack/catalog.sh
@@ -24,8 +24,8 @@ find $OLM_DIR -name '*_crd.yaml' | sort -n | xargs -I{} cp {} $CRD_DIR/
 
 # Determine if we're running locally or in CI.
 if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
-  export IMAGE_KNATIVE_OPERATOR="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-operator"
-  export IMAGE_KNATIVE_OPENSHIFT_INGRESS="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-openshift-ingress"
+  export IMAGE_KNATIVE_OPERATOR="${IMAGE_FORMAT//\$\{component\}/knative-operator}"
+  export IMAGE_KNATIVE_OPENSHIFT_INGRESS="${IMAGE_FORMAT//\$\{component\}/knative-openshift-ingress}"
 elif [ -n "$DOCKER_REPO_OVERRIDE" ]; then
   export IMAGE_KNATIVE_OPERATOR="${DOCKER_REPO_OVERRIDE}/knative-operator"
   export IMAGE_KNATIVE_OPENSHIFT_INGRESS="${DOCKER_REPO_OVERRIDE}/knative-openshift-ingress"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -8,6 +8,7 @@ set -Eeuo pipefail
 # Enable extra verbosity if running in CI.
 if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
   set -x
+  env
 fi
 
 register_teardown || exit $?

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -8,6 +8,7 @@ set -Eeuo pipefail
 # Enable extra verbosity if running in CI.
 if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
   set -x
+  env
 fi
 
 scale_up_workers || exit $?


### PR DESCRIPTION
See https://issues.redhat.com/browse/SRVKS-423 for more information. In theory, these image references should already be set, so we might get lucky. Printing `env` though just to be sure.