### PR TITLE
Fix condition for checking loadbalancers

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -59,10 +59,10 @@ function wait_for_knative_serving_ingress_ns_deleted {
   timeout 180 '[[ $(oc get project knative-serving-ingress -ojsonpath="{.status.phase}") == Terminating ]]' || true
   # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1798282 on Azure - if loadbalancer status is empty
   # it's safe to remove the finalizer.
-  if oc -n knative-serving-ingress get svc istio-ingressgateway >/dev/null 2>&1 && [ $(oc -n knative-serving-ingress get svc istio-ingressgateway -ojsonpath="{.status.loadBalancer.*}") = "" ]; then
+  if oc -n knative-serving-ingress get svc istio-ingressgateway >/dev/null 2>&1 && [ "$(oc -n knative-serving-ingress get svc istio-ingressgateway -ojsonpath="{.status.loadBalancer.*}")" = "" ]; then
     oc -n knative-serving-ingress patch services/istio-ingressgateway --type=json --patch='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
   fi
-  if oc -n knative-serving-ingress get svc kourier >/dev/null 2>&1 && [ $(oc -n knative-serving-ingress get svc kourier -ojsonpath="{.status.loadBalancer.*}") = "" ]; then
+  if oc -n knative-serving-ingress get svc kourier >/dev/null 2>&1 && [ "$(oc -n knative-serving-ingress get svc kourier -ojsonpath="{.status.loadBalancer.*}")" = "" ]; then
     oc -n knative-serving-ingress patch services/kourier --type=json --patch='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
   fi
   timeout 180 '[[ $(oc get project knative-serving-ingress -ojsonpath="{.status.phase}") == Terminating ]]' || return 1


### PR DESCRIPTION
* when the command returns nothing and is not enclosed in parentheses it
results in syntax error:
'[' = '' ']'
./test/lib.bash: line 62: [: =: unary operator expected

* I've just checked it on Azure