### PR TITLE
Update Kourier version to v0.3.9

### DIFF
--- a/knative-operator/deploy/resources/kourier/download.sh
+++ b/knative-operator/deploy/resources/kourier/download.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-KOURIER_VERSION=v0.3.8
+KOURIER_VERSION=v0.3.9
 DOWNLOAD_URL=https://raw.githubusercontent.com/3scale/kourier/${KOURIER_VERSION}/deploy/kourier-knative.yaml
 
 if [ -f "kourier-${KOURIER_VERSION}.yaml" ]; then
@@ -20,4 +20,4 @@ fi
 
 ln -s kourier-${KOURIER_VERSION}.yaml kourier-latest.yaml
 
-# patch kourier-${KOURIER_VERSION}.yaml proxyv2-image.patch
+patch kourier-${KOURIER_VERSION}.yaml proxyv2-image.patch

--- a/knative-operator/deploy/resources/kourier/kourier-latest.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier-latest.yaml
@@ -1,1 +1,1 @@
-kourier-v0.3.8.yaml
+kourier-v0.3.9.yaml

--- a/knative-operator/deploy/resources/kourier/kourier-v0.3.9.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier-v0.3.9.yaml
@@ -57,10 +57,11 @@ spec:
         app: 3scale-kourier-gateway
     spec:
       containers:
-        - args:
+        - command: ["/usr/local/bin/envoy"]
+          args:
             - -c
             - /tmp/config/envoy-bootstrap.yaml
-          image: quay.io/3scale/kourier-gateway:v0.1.3
+          image: docker.io/maistra/proxyv2-ubi8:1.0.4
           imagePullPolicy: Always
           name: kourier-gateway
           ports:
@@ -119,7 +120,7 @@ spec:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: quay.io/3scale/kourier:v0.3.8
+        - image: quay.io/3scale/kourier:v0.3.9
           imagePullPolicy: Always
           name: kourier-control
           resources: {}
@@ -247,9 +248,7 @@ data:
                             - "*"
                           routes:
                             - match:
-                                safe_regex:
-                                  google_re2: {}
-                                  regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
+                                regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
                                 headers:
                                   - name: ':method'
                                     exact_match: GET


### PR DESCRIPTION
This patch updates Kourier controller image to v0.3.9 and back to proxyv2-ubi8 for Kourier gateway.

This is supposed to fix https://issues.redhat.com/browse/MAISTRA-1175.