### PR TITLE
Add failfast option to openshift specific e2e test

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -39,7 +39,7 @@ function run_e2e_tests {
 
   local failed=0
 
-  go_test_e2e -tags=e2e -timeout=30m -parallel=1 ./test/e2e \
+  go_test_e2e -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2e \
     --kubeconfig "${kubeconfigs[0]}" \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@" || failed=1


### PR DESCRIPTION
This patch is similar to pull/121, but it adds same option to
openshift specific e2e test.

I found that [this test failure](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/122/pull-ci-openshift-knative-serverless-operator-master-4.3-e2e-aws-ocp-43/316) in https://github.com/openshift-knative/serverless-operator/pull/122 did not stop and so `TestKnativeServing/remove_knativeserving_cr` cleaned up all resources.
