### PR TITLE
[SRVKS-427] Override all configuration we set as we have authority. Apply mutations on update.

### DIFF
--- a/knative-operator/deploy/resources/kourier/download.sh
+++ b/knative-operator/deploy/resources/kourier/download.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-KOURIER_VERSION=v0.3.9
+KOURIER_VERSION=v0.3.10
 DOWNLOAD_URL=https://raw.githubusercontent.com/3scale/kourier/${KOURIER_VERSION}/deploy/kourier-knative.yaml
 
 if [ -f "kourier-${KOURIER_VERSION}.yaml" ]; then

--- a/knative-operator/deploy/resources/kourier/kourier-latest.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier-latest.yaml
@@ -1,1 +1,1 @@
-kourier-v0.3.9.yaml
+kourier-v0.3.10.yaml

--- a/knative-operator/deploy/resources/kourier/kourier-v0.3.10.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier-v0.3.10.yaml
@@ -40,17 +40,10 @@ metadata:
   name: 3scale-kourier-gateway
   namespace: kourier-system
 spec:
-  progressDeadlineSeconds: 600
   replicas: 1
-  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: 3scale-kourier-gateway
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -71,9 +64,6 @@ spec:
             - name: https
               containerPort: 8443
               protocol: TCP
-          resources: {}
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
           volumeMounts:
             - name: config-volume
               mountPath: /tmp/config
@@ -91,11 +81,7 @@ spec:
         - name: config-volume
           configMap:
             name: kourier-bootstrap
-      dnsPolicy: ClusterFirst
       restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
-      terminationGracePeriodSeconds: 30
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -103,29 +89,19 @@ metadata:
   name: 3scale-kourier-control
   namespace: kourier-system
 spec:
-  progressDeadlineSeconds: 600
   replicas: 1
-  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: 3scale-kourier-control
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
   template:
     metadata:
       labels:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: quay.io/3scale/kourier:v0.3.9
+        - image: quay.io/3scale/kourier:v0.3.10
           imagePullPolicy: Always
           name: kourier-control
-          resources: {}
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
           env:
             - name: CERTS_SECRET_NAMESPACE
               value: ""
@@ -135,12 +111,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-      dnsPolicy: ClusterFirst
       restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
       serviceAccountName: 3scale-kourier
-      terminationGracePeriodSeconds: 30
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole

--- a/knative-operator/pkg/common/openshift.go
+++ b/knative-operator/pkg/common/openshift.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -24,7 +23,6 @@ func Mutate(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 		configureLogURLTemplate,
 		ensureCustomCerts,
 		imagesFromEnviron,
-		annotateTimestamp,
 	}
 	for _, stage := range stages {
 		if err := stage(ks, c); err != nil {
@@ -130,16 +128,5 @@ func imagesFromEnviron(ks *servingv1alpha1.KnativeServing, _ client.Client) erro
 		}
 	}
 	log.Info("Setting", "registry", ks.Spec.Registry)
-	return nil
-}
-
-// Mark the time when instance configured for OpenShift
-func annotateTimestamp(ks *servingv1alpha1.KnativeServing, _ client.Client) error {
-	annotations := ks.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	annotations[MutationTimestampKey] = time.Now().Format(time.RFC3339)
-	ks.SetAnnotations(annotations)
 	return nil
 }

--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -9,18 +9,22 @@ const MutationTimestampKey = "knative-serving-openshift/mutation"
 
 var Log = logf.Log.WithName("knative").WithName("openshift")
 
-// config helper to set value for key if not already set
+// Configure is a  helper to set a value for a key, potentially overriding existing contents.
 func Configure(ks *servingv1alpha1.KnativeServing, cm, key, value string) bool {
 	if ks.Spec.Config == nil {
 		ks.Spec.Config = map[string]map[string]string{}
 	}
-	if _, found := ks.Spec.Config[cm][key]; !found {
-		if ks.Spec.Config[cm] == nil {
-			ks.Spec.Config[cm] = map[string]string{}
-		}
-		ks.Spec.Config[cm][key] = value
-		Log.Info("Configured", "map", cm, key, value)
-		return true
+
+	old, found := ks.Spec.Config[cm][key]
+	if found && value == old {
+		return false
 	}
-	return false
+
+	if ks.Spec.Config[cm] == nil {
+		ks.Spec.Config[cm] = map[string]string{}
+	}
+
+	ks.Spec.Config[cm][key] = value
+	Log.Info("Configured", "map", cm, key, value, "old value", old)
+	return true
 }

--- a/knative-operator/pkg/webhook/knativeserving/webhook_mutating.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_mutating.go
@@ -26,7 +26,7 @@ func MutatingWebhook(mgr manager.Manager) (webhook.Webhook, error) {
 	return builder.NewWebhookBuilder().
 		Name("mutating.knativeserving.openshift.io").
 		Mutating().
-		Operations(admissionregistrationv1beta1.Create).
+		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
 		WithManager(mgr).
 		ForType(&servingv1alpha1.KnativeServing{}).
 		Handlers(&KnativeServingConfigurator{}).

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -194,8 +194,9 @@ function run_knative_serving_rolling_upgrade_tests {
 
     local cluster_version
     cluster_version=$(oc get clusterversion -o=jsonpath="{.items[0].status.history[?(@.state==\"Completed\")].version}")
-    if [[ "$cluster_version" = 4.1.* || "${HOSTNAME}" = *ocp-41* ]]; then
-      if approve_csv "$upgrade_to" ; then # Upgrade should fail on OCP 4.1
+    if [[ "$cluster_version" = 4.1.* || "${HOSTNAME}" = *ocp-41* || \
+          "$cluster_version" = 4.2.* || "${HOSTNAME}" = *ocp-42* ]]; then
+      if approve_csv "$upgrade_to" ; then # Upgrade should fail on OCP 4.1, 4.2
         return 1
       fi
       # Check we got RequirementsNotMet error
@@ -209,6 +210,9 @@ function run_knative_serving_rolling_upgrade_tests {
         timeout 900 '[[ ! ( $(oc get knativeserving.serving.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") != $serving_version && $(oc get knativeserving.serving.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
       fi
       timeout 900 '[[ ! ( $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") != $serving_version && $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
+
+      # Assert that the old image references eventually fade away
+      timeout 900 "oc get pod -n $SERVING_NAMESPACE -o yaml | grep image: | uniq | grep $serving_version" || return 1
     fi
     end_prober_test ${PROBER_PID}
   fi


### PR DESCRIPTION
Currently, when we update the operator, we will try to override the image setting in the respective config maps. Our `Configure` helper is too conservative though, and only writes config that was not set before.

All configs that we actively set are subject to our authority though. For now, we should always override all of these settings as they are integral to our integration.