### PR TITLE
Remove shortname ks from knativeservings.serving.knative.dev CRD

### DIFF
--- a/olm-catalog/serverless-operator/1.5.0/serving_v1alpha1_knativeserving_crd.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serving_v1alpha1_knativeserving_crd.yaml
@@ -19,8 +19,6 @@ spec:
     listKind: KnativeServingList
     plural: knativeservings
     singular: knativeserving
-    shortNames:
-    - ks
   scope: Namespaced
   subresources:
     status: {}


### PR DESCRIPTION
When we run `oc get ks`, it hits `knative.serving.knative.dev` instead
of `knative.operator.knative.dev`.

Since we expect `knative.operator.knative.dev` now, this patch removes
ks from `knative.serving.knative.dev` CRD.

BEFORE
```
$ oc get ks -n knative-serving -o yaml  |grep apiVersion | head -2
apiVersion: v1
- apiVersion: serving.knative.dev/v1alpha1
```

AFTER
```
$ oc get ks -n knative-serving -o yaml  |grep apiVersion | head -2
apiVersion: v1
- apiVersion: operator.knative.dev/v1alpha1
```
