### PR TITLE
Enable debug log for Kourier

### DIFF
--- a/knative-operator/deploy/resources/kourier/debug-log.patch
+++ b/knative-operator/deploy/resources/kourier/debug-log.patch
@@ -1,0 +1,42 @@
+diff --git a/knative-operator/deploy/resources/kourier/kourier-v0.3.9.yaml b/knative-operator/deploy/resources/kourier/kourier-v0.3.9.yaml
+index 23d5aa79..3f840c53 100644
+--- a/knative-operator/deploy/resources/kourier/kourier-v0.3.9.yaml
++++ b/knative-operator/deploy/resources/kourier/kourier-v0.3.9.yaml
+@@ -8,6 +8,28 @@ kind: ConfigMap
+ metadata:
+   name: config-logging
+   namespace: kourier-system
++data:
++      zap-logger-config: |
++        {
++          "level": "debug",
++          "development": false,
++          "outputPaths": ["stdout"],
++          "errorOutputPaths": ["stderr"],
++          "encoding": "json",
++          "encoderConfig": {
++            "timeKey": "ts",
++            "levelKey": "level",
++            "nameKey": "logger",
++            "callerKey": "caller",
++            "messageKey": "msg",
++            "stacktraceKey": "stacktrace",
++            "lineEnding": "",
++            "levelEncoder": "",
++            "timeEncoder": "iso8601",
++            "durationEncoder": "",
++            "callerEncoder": ""
++          }
++        }
+ ---
+ apiVersion: v1
+ kind: ConfigMap
+@@ -59,6 +81,8 @@ spec:
+       containers:
+         - command: ["/usr/local/bin/envoy"]
+           args:
++            - -l
++            - debug
+             - -c
+             - /tmp/config/envoy-bootstrap.yaml
+           image: docker.io/maistra/proxyv2-ubi8:1.0.4

--- a/knative-operator/deploy/resources/kourier/download.sh
+++ b/knative-operator/deploy/resources/kourier/download.sh
@@ -21,3 +21,4 @@ fi
 ln -s kourier-${KOURIER_VERSION}.yaml kourier-latest.yaml
 
 patch kourier-${KOURIER_VERSION}.yaml proxyv2-image.patch
+patch kourier-${KOURIER_VERSION}.yaml debug-log.patch

--- a/knative-operator/deploy/resources/kourier/kourier-v0.3.9.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier-v0.3.9.yaml
@@ -8,6 +8,28 @@ kind: ConfigMap
 metadata:
   name: config-logging
   namespace: kourier-system
+data:
+      zap-logger-config: |
+        {
+          "level": "debug",
+          "development": false,
+          "outputPaths": ["stdout"],
+          "errorOutputPaths": ["stderr"],
+          "encoding": "json",
+          "encoderConfig": {
+            "timeKey": "ts",
+            "levelKey": "level",
+            "nameKey": "logger",
+            "callerKey": "caller",
+            "messageKey": "msg",
+            "stacktraceKey": "stacktrace",
+            "lineEnding": "",
+            "levelEncoder": "",
+            "timeEncoder": "iso8601",
+            "durationEncoder": "",
+            "callerEncoder": ""
+          }
+        }
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -59,6 +81,8 @@ spec:
       containers:
         - command: ["/usr/local/bin/envoy"]
           args:
+            - -l
+            - debug
             - -c
             - /tmp/config/envoy-bootstrap.yaml
           image: docker.io/maistra/proxyv2-ubi8:1.0.4

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -99,9 +99,8 @@ func TestKnativeServing(t *testing.T) {
 			t.Fatalf("Operators still running: %v", err)
 		}
 	})
-
-	// Do not clean up by defer as we want to collect logs when failed.
-	test.CleanupAll(caCtx, paCtx, editCtx, viewCtx)
+	// Do not clean up by as we want to collect logs when failed.
+	// test.CleanupAll(caCtx, paCtx, editCtx, viewCtx)
 }
 
 func testKnativeVersusKubeServicesInOneNamespace(t *testing.T, caCtx *test.Context) {


### PR DESCRIPTION
This patch enables debug log on Kourier.

Reconciler reconciles the settings, so this enable
on manifest, but it should be improved in the future.
It is tracked in https://issues.redhat.com/browse/SRVKS-428.