### PR TITLE
Dump CSVs on failure

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -85,7 +85,10 @@ function approve_csv {
   install_plan=$(find_install_plan $csv_version)
   oc get $install_plan -n ${OPERATORS_NAMESPACE} -o yaml | sed 's/\(.*approved:\) false/\1 true/' | oc replace -f -
 
-  timeout 300 "[[ \$(oc get ClusterServiceVersion $csv_version -n ${OPERATORS_NAMESPACE} -o jsonpath='{.status.phase}') != Succeeded ]]" || return 1
+  if ! timeout 300 "[[ \$(oc get ClusterServiceVersion $csv_version -n ${OPERATORS_NAMESPACE} -o jsonpath='{.status.phase}') != Succeeded ]]" ; then
+    oc get ClusterServiceVersion "$csv_version" -n "${OPERATORS_NAMESPACE}" -o yaml || true
+    return 1
+  fi
 }
 
 function find_install_plan {

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -328,8 +328,6 @@ function dump_openshift_olm_state {
   logger.info "Dump of subscriptions.operators.coreos.com"
   # This is for status checking.
   oc get subscriptions.operators.coreos.com -o yaml --all-namespaces || true
-  logger.info "Dump of clusterserviceversion.operators.coreos.com"
-  oc get clusterserviceversion.operators.coreos.com -o yaml --all-namespaces || true
   logger.info "Dump of catalog operator log"
   oc logs -n openshift-operator-lifecycle-manager deployment/catalog-operator || true
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -328,6 +328,8 @@ function dump_openshift_olm_state {
   logger.info "Dump of subscriptions.operators.coreos.com"
   # This is for status checking.
   oc get subscriptions.operators.coreos.com -o yaml --all-namespaces || true
+  logger.info "Dump of clusterserviceversion.operators.coreos.com"
+  oc get clusterserviceversion.operators.coreos.com -o yaml --all-namespaces || true
   logger.info "Dump of catalog operator log"
   oc logs -n openshift-operator-lifecycle-manager deployment/catalog-operator || true
 }


### PR DESCRIPTION
This will help analyze CI failures like the second one in https://issues.redhat.com/browse/SRVKS-394
The test failed because of a timeout waiting for CSV to be ready, but the current dump doesn't print CSVs and Subscription didn't have enough info about the failure.