### PR TITLE
Add Dockerfile for productization

### DIFF
--- a/serving/ingress/Dockerfile.productization
+++ b/serving/ingress/Dockerfile.productization
@@ -1,0 +1,33 @@
+FROM registry-proxy.engineering.redhat.com/rh-osbs/rhel8-go-toolset:1.13.4 AS builder
+
+WORKDIR /opt/app-root/src/go/src/github.com/openshift-knative/serverless-operator/serving/ingress
+
+COPY . .
+
+ENV GOFLAGS="-mod=vendor"
+RUN go build -o /tmp/knative-openshift-ingress ./cmd/manager
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/ubi8-minimal:8-released
+
+ENV OPERATOR=/usr/local/bin/knative-openshift-ingress \
+    USER_UID=1001 \
+    USER_NAME=knative-openshift-ingress
+
+# install operator binary
+COPY --from=builder /tmp/knative-openshift-ingress ${OPERATOR}
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-tech-preview-ingress-rhel8-operator-container" \
+      name="openshift-serverless-1-tech-preview/ingress-rhel8-operator" \
+      version="v1.5.0" \
+      summary="Red Hat OpenShift Serverless 1 Ingress Operator" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Ingress Operator" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Ingress Operator"
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}


### PR DESCRIPTION
FYI, there are some pretty significant differences between the existing `Dockerfile` and new `Dockerfile.productization` in `serving/ingress`.

Of note, the existing `Dockerfile`:

1) builds the binary using go `1.12` vs. `1.13.4`.
2) copies deploy to the image, while the new one does not. How would we notice this in production?
3) does not use `ENV GOFLAGS="-mod=vendor"`.