### PR TITLE
Don't check the upgrade probe for readiness.

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -232,7 +232,8 @@ function run_knative_serving_rolling_upgrade_tests {
     logger.info "New cluster version\n: $(oc get clusterversion)"
   fi
 
-  for kservice in `oc get ksvc -n serving-tests --no-headers -o name`; do
+  # Wait for all services to become ready again. Exclude the upgrade-probe as that'll be removed by the prober test above.
+  for kservice in $(oc get ksvc -n serving-tests --no-headers -o name | grep -v "upgrade-probe"); do
     timeout 900 '[[ $(oc get $kservice -n serving-tests -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]' || return 1
   done
 


### PR DESCRIPTION
It seems like the list operation can still contain the upgrade probe service, which will never become ready because it got actually deleted.

Happened here for example: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/152/pull-ci-openshift-knative-serverless-operator-master-4.3-upgrade-tests-aws-ocp-43/332