### PR TITLE
Add KOURIER_MANIFEST_PATH env var to specify Kourier manifest.

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -12,11 +12,11 @@ function ensure_catalogsource_installed {
 function install_catalogsource {
   logger.info "Installing CatalogSource"
 
-  # Use kourier manifest with debug patch.
-  export KOURIER_MANIFEST_PATH="deploy/resources/kourier/kourier-latest-debug.yaml"
 
   local rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
-  ${rootdir}/hack/catalog.sh | envsubst | oc apply -n "$OLM_NAMESPACE" -f - || return 1
+  ${rootdir}/hack/catalog.sh |\
+     sed -e "s|deploy/resources/kourier/kourier-latest.yaml|deploy/resources/kourier/kourier-latest-debug.yaml|g" |\
+     oc apply -n "$OLM_NAMESPACE" -f - || return 1
 
   logger.success "CatalogSource installed successfully"
 }

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -12,8 +12,11 @@ function ensure_catalogsource_installed {
 function install_catalogsource {
   logger.info "Installing CatalogSource"
 
+  # Use kourier manifest with debug patch.
+  export KOURIER_MANIFEST_PATH="deploy/resources/kourier/kourier-latest-debug.yaml"
+
   local rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
-  ${rootdir}/hack/catalog.sh | oc apply -n "$OLM_NAMESPACE" -f - || return 1
+  ${rootdir}/hack/catalog.sh | envsubst | oc apply -n "$OLM_NAMESPACE" -f - || return 1
 
   logger.success "CatalogSource installed successfully"
 }

--- a/knative-operator/deploy/resources/kourier/download.sh
+++ b/knative-operator/deploy/resources/kourier/download.sh
@@ -4,7 +4,8 @@ KOURIER_VERSION=v0.3.10
 DOWNLOAD_URL=https://raw.githubusercontent.com/openshift-knative/kourier/${KOURIER_VERSION}/deploy/kourier-knative.yaml
 
 if [ -f "kourier-${KOURIER_VERSION}.yaml" ]; then
-  echo "kourier-${KOURIER_VERSION}.yaml already exists"
+  echo "kourier-${KOURIER_VERSION}.yaml already exists. Please remove it."
+  echo -e "Run:\n   rm kourier-${KOURIER_VERSION}.yaml"
   exit 1
 fi
 
@@ -14,11 +15,20 @@ if [ $? != 0 ]; then
   exit 1
 fi
 
+cp kourier-${KOURIER_VERSION}.yaml kourier-${KOURIER_VERSION}-debug.yaml
+
 if [ -L "kourier-latest.yaml" ]; then
   unlink kourier-latest.yaml
 fi
+if [ -L "kourier-latest-debug.yaml" ]; then
+  unlink kourier-latest-debug.yaml
+fi
 
-ln -s kourier-${KOURIER_VERSION}.yaml kourier-latest.yaml
+ln -s kourier-${KOURIER_VERSION}.yaml       kourier-latest.yaml
+ln -s kourier-${KOURIER_VERSION}-debug.yaml kourier-latest-debug.yaml
 
-patch kourier-${KOURIER_VERSION}.yaml proxyv2-image.patch
-patch kourier-${KOURIER_VERSION}.yaml debug-log.patch
+patch kourier-${KOURIER_VERSION}.yaml       proxyv2-image.patch
+patch kourier-${KOURIER_VERSION}-debug.yaml proxyv2-image.patch
+
+# Apply debug log enable path to -debug.yaml only
+patch kourier-${KOURIER_VERSION}-debug.yaml debug-log.patch

--- a/knative-operator/deploy/resources/kourier/kourier-latest-debug.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier-latest-debug.yaml
@@ -1,0 +1,1 @@
+kourier-v0.3.10-debug.yaml

--- a/knative-operator/deploy/resources/kourier/kourier-v0.3.10-debug.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier-v0.3.10-debug.yaml
@@ -8,6 +8,28 @@ kind: ConfigMap
 metadata:
   name: config-logging
   namespace: kourier-system
+data:
+      zap-logger-config: |
+        {
+          "level": "debug",
+          "development": false,
+          "outputPaths": ["stdout"],
+          "errorOutputPaths": ["stderr"],
+          "encoding": "json",
+          "encoderConfig": {
+            "timeKey": "ts",
+            "levelKey": "level",
+            "nameKey": "logger",
+            "callerKey": "caller",
+            "messageKey": "msg",
+            "stacktraceKey": "stacktrace",
+            "lineEnding": "",
+            "levelEncoder": "",
+            "timeEncoder": "iso8601",
+            "durationEncoder": "",
+            "callerEncoder": ""
+          }
+        }
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -52,6 +74,8 @@ spec:
       containers:
         - command: ["/usr/local/bin/envoy"]
           args:
+            - -l
+            - debug
             - -c
             - /tmp/config/envoy-bootstrap.yaml
           image: docker.io/maistra/proxyv2-ubi8:1.0.4

--- a/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
+++ b/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
@@ -17,13 +17,13 @@ import (
 )
 
 var (
-	log             = common.Log.WithName("kourier")
-	defaultManifest = "deploy/resources/kourier/kourier-latest.yaml"
+	log  = common.Log.WithName("kourier")
+	path = os.Getenv("KOURIER_MANIFEST_PATH")
 )
 
 // Apply applies Kourier resources.
 func Apply(instance *servingv1alpha1.KnativeServing, api client.Client, scheme *runtime.Scheme) error {
-	manifest, err := mf.NewManifest(manifestPath(), false, api)
+	manifest, err := mf.NewManifest(path, false, api)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func checkDeployments(manifest *mf.Manifest, instance *servingv1alpha1.KnativeSe
 // Delete deletes Kourier resources.
 func Delete(instance *servingv1alpha1.KnativeServing, api client.Client) error {
 	log.Info("Deleting Kourier Ingress")
-	manifest, err := mf.NewManifest(manifestPath(), false, api)
+	manifest, err := mf.NewManifest(path, false, api)
 	if err != nil {
 		return err
 	}
@@ -133,14 +133,4 @@ func replaceImageFromEnvironment(prefix string, scheme *runtime.Scheme) mf.Trans
 		}
 		return nil
 	}
-}
-
-// manifestPath returns Kourier manifest path specified by KOURIER_MANIFEST_PATH.
-// If KOURIER_MANIFEST_PATH is empty returns default path.
-func manifestPath() string {
-	path := os.Getenv("KOURIER_MANIFEST_PATH")
-	if path != "" {
-		return path
-	}
-	return defaultManifest
 }

--- a/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
+++ b/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
@@ -17,13 +17,13 @@ import (
 )
 
 var (
-	log  = common.Log.WithName("kourier")
-	path = "deploy/resources/kourier/kourier-latest.yaml"
+	log             = common.Log.WithName("kourier")
+	defaultManifest = "deploy/resources/kourier/kourier-latest.yaml"
 )
 
 // Apply applies Kourier resources.
 func Apply(instance *servingv1alpha1.KnativeServing, api client.Client, scheme *runtime.Scheme) error {
-	manifest, err := mf.NewManifest(path, false, api)
+	manifest, err := mf.NewManifest(manifestPath(), false, api)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func checkDeployments(manifest *mf.Manifest, instance *servingv1alpha1.KnativeSe
 // Delete deletes Kourier resources.
 func Delete(instance *servingv1alpha1.KnativeServing, api client.Client) error {
 	log.Info("Deleting Kourier Ingress")
-	manifest, err := mf.NewManifest(path, false, api)
+	manifest, err := mf.NewManifest(manifestPath(), false, api)
 	if err != nil {
 		return err
 	}
@@ -133,4 +133,14 @@ func replaceImageFromEnvironment(prefix string, scheme *runtime.Scheme) mf.Trans
 		}
 		return nil
 	}
+}
+
+// manifestPath returns Kourier manifest path specified by KOURIER_MANIFEST_PATH.
+// If KOURIER_MANIFEST_PATH is empty returns default path.
+func manifestPath() string {
+	path := os.Getenv("KOURIER_MANIFEST_PATH")
+	if path != "" {
+		return path
+	}
+	return defaultManifest
 }

--- a/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
@@ -305,6 +305,8 @@ spec:
                       value: docker.io/maistra/proxyv2-ubi8:1.0.4
                     - name: IMAGE_3scale-kourier-control
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:kourier
+                    - name: KOURIER_MANIFEST_PATH
+                      value: $KOURIER_MANIFEST_PATH
       - name: knative-openshift-ingress
         spec:
           replicas: 1

--- a/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
@@ -306,7 +306,7 @@ spec:
                     - name: IMAGE_3scale-kourier-control
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:kourier
                     - name: KOURIER_MANIFEST_PATH
-                      value: $KOURIER_MANIFEST_PATH
+                      value: deploy/resources/kourier/kourier-latest.yaml
       - name: knative-openshift-ingress
         spec:
           replicas: 1


### PR DESCRIPTION
This PR supports `KOURIER_MANIFEST_PATH` to allow to switch Kourier's
manifest file. If the value is empty, default path is used.

This is implemented for switching the manifest between CI and production. 