### PR TITLE
hide the knativeservings APIs

### DIFF
--- a/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
@@ -68,6 +68,7 @@ metadata:
       Provides a collection of API's based on Knative to support deploying and serving
       of serverless applications and functions.
     repository: https://github.com/openshift-knative/serverless-operator
+    operators.operatorframework.io/internal-objects: '["knativeservings.operator.knative.dev", "knativeservings.serving.knative.dev"]'
     support: Red Hat, Inc.
   name: serverless-operator.v1.5.0
   namespace: placeholder


### PR DESCRIPTION
Addressing [SRVKS-317](https://issues.redhat.com/browse/SRVKS-317), to hide the `KnativeServings` APIs from the `Developer Console`

* `knativeservings.operator.knative.dev`
* `knativeservings.serving.knative.dev`

are hidden.  Soon, once we land (for 1.6.0), we will need to do the same for Eventing