### PR TITLE
Update base maistra image to 1.0.8 for consistency.

### DIFF
--- a/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.5.0/serverless-operator.v1.5.0.clusterserviceversion.yaml
@@ -427,7 +427,7 @@ spec:
     - name: IMAGE_3scale-kourier-control
       image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:kourier
     - name: IMAGE_3scale-kourier-gateway
-      image: docker.io/maistra/proxyv2-ubi8:1.0.4
+      image: docker.io/maistra/proxyv2-ubi8:1.0.8
     - name: knative-operator
       image: $IMAGE_KNATIVE_OPERATOR
     - name: knative-openshift-ingress


### PR DESCRIPTION
Kourier now uses this for their testing and it's closest to the latest released version.