### PR TITLE
Fix log format

### DIFF
--- a/serving/ingress/pkg/controller/common/reconciler.go
+++ b/serving/ingress/pkg/controller/common/reconciler.go
@@ -209,7 +209,7 @@ func (r *BaseIngressReconciler) reconcileDeletion(ctx context.Context, ci networ
 		}
 	}
 
-	logger.Info("Removing finalizer for ingress %q", ci.GetName())
+	logger.Infof("Removing finalizer for ingress %q", ci.GetName())
 	ci.SetFinalizers(ci.GetFinalizers()[1:])
 	return r.Client.Update(ctx, ci)
 }


### PR DESCRIPTION
This is a super tiny change to fix log format. Current log prints invalid `%q` as:

`{"level":"info","ts":1583814627.2499268,"logger":"fallback","caller":"common/reconciler.go:212","msg":"Removing finalizer for ingress %qannotation-propagation-wykmpqgt"}`