### PR TITLE
Hide Serving CRDs in developer catalog

### DIFF
--- a/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
@@ -68,6 +68,7 @@ metadata:
       Provides a collection of API's based on Knative to support deploying and serving
       of serverless applications and functions.
     repository: https://github.com/openshift-knative/serverless-operator
+    operators.operatorframework.io/internal-objects: '["knativeservings.operator.knative.dev"]'
     support: Red Hat, Inc.
   name: serverless-operator.v1.6.0
   namespace: placeholder


### PR DESCRIPTION
Doing the same thing as https://github.com/openshift-knative/serverless-operator/pull/160/files, but for 1.6