### PR TITLE
Move client role setup into t.Run()

### DIFF
--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -193,6 +193,7 @@ func testUserPermissions(t *testing.T) {
 	editCtx := test.SetupEdit(t)
 	viewCtx := test.SetupView(t)
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(paCtx, editCtx, viewCtx) })
+	defer test.CleanupAll(paCtx, editCtx, viewCtx)
 
 	tests := []struct {
 		name        string

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -32,11 +32,8 @@ const (
 
 func TestKnativeServing(t *testing.T) {
 	caCtx := test.SetupClusterAdmin(t)
-	paCtx := test.SetupProjectAdmin(t)
-	editCtx := test.SetupEdit(t)
-	viewCtx := test.SetupView(t)
 
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(caCtx, paCtx, editCtx, viewCtx) })
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(caCtx) })
 
 	t.Run("create subscription and wait for CSV to succeed", func(t *testing.T) {
 		if _, err := test.WithOperatorReady(caCtx, "serverless-operator-subscription"); err != nil {
@@ -71,7 +68,7 @@ func TestKnativeServing(t *testing.T) {
 	})
 
 	t.Run("user permissions", func(t *testing.T) {
-		testUserPermissions(t, paCtx, editCtx, viewCtx)
+		testUserPermissions(t)
 	})
 
 	t.Run("deploy knative and kubernetes service in same namespace", func(t *testing.T) {
@@ -191,7 +188,12 @@ func testKnativeVersusKubeServicesInOneNamespace(t *testing.T, caCtx *test.Conte
 	caCtx.Clients.Serving.ServingV1beta1().Services(testNamespace2).Delete(ksvc.Name, &metav1.DeleteOptions{})
 }
 
-func testUserPermissions(t *testing.T, paCtx *test.Context, editCtx *test.Context, viewCtx *test.Context) {
+func testUserPermissions(t *testing.T) {
+	paCtx := test.SetupProjectAdmin(t)
+	editCtx := test.SetupEdit(t)
+	viewCtx := test.SetupView(t)
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(paCtx, editCtx, viewCtx) })
+
 	tests := []struct {
 		name        string
 		userContext *test.Context


### PR DESCRIPTION
When testing TestKnativeServing on local, we have to setup kubeclient
with roles beforehand. Otherwise, the test failed by setup phase:

```
=== RUN   TestKnativeServing
time="2020-03-12T17:35:09+09:00" level=info msg="Loading kube client config from path \"/home/knakayam/.kube/config\""
--- FAIL: TestKnativeServing (0.00s)
    clients.go:95: kubeconfig for user with ProjectAdmin role not present
FAIL
FAIL	github.com/openshift-knative/serverless-operator/test/e2e	0.029s
FAIL
```

This patch moves the test into t.Run(), so even if it failed with setup
issue, all test could be executed.