### PR TITLE
Update Knative Serving + operator to 0.13.

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -19,6 +19,6 @@ create_namespaces || exit $?
 exitcode=0
 
 (( !exitcode )) && ensure_catalogsource_installed || exitcode=3
-(( !exitcode )) && ensure_serverless_installed "operator" ${INSTALL_PREVIOUS_VERSION} || exitcode=4
+(( !exitcode )) && ensure_serverless_installed ${INSTALL_PREVIOUS_VERSION} || exitcode=4
 
 exit $exitcode

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -2,9 +2,8 @@
 
 function ensure_serverless_installed {
   logger.info 'Check if Serverless is installed'
-  local group=${1:-operator}
-  local prev=${2:-false}
-  if oc get knativeserving.${group}.knative.dev knative-serving -n "${SERVING_NAMESPACE}" >/dev/null 2>&1; then
+  local prev=${1:-false}
+  if oc get knativeserving.operator.knative.dev knative-serving -n "${SERVING_NAMESPACE}" >/dev/null 2>&1; then
     logger.success 'Serverless is already installed.'
     return 0
   fi
@@ -115,7 +114,7 @@ metadata:
   namespace: ${SERVING_NAMESPACE}
 EOF
 
-  timeout 900 '[[ $(oc get knativeserving knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
+  timeout 900 '[[ $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
 
   logger.success 'Serverless has been installed sucessfully.'
 }
@@ -123,9 +122,9 @@ EOF
 function teardown_serverless {
   logger.warn '😭  Teardown Serverless...'
 
-  if oc get knativeserving knative-serving -n "${SERVING_NAMESPACE}" >/dev/null 2>&1; then
+  if oc get knativeserving.operator.knative.dev knative-serving -n "${SERVING_NAMESPACE}" >/dev/null 2>&1; then
     logger.info 'Removing KnativeServing CR'
-    oc delete knativeserving knative-serving -n "${SERVING_NAMESPACE}" || return $?
+    oc delete knativeserving.operator.knative.dev knative-serving -n "${SERVING_NAMESPACE}" || return $?
   fi
   logger.info 'Ensure no knative serving pods running'
   timeout 600 "[[ \$(oc get pods -n ${SERVING_NAMESPACE} -o jsonpath='{.items}') != '[]' ]]" || return 9

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -5,7 +5,7 @@ readonly BUILD_NUMBER=${BUILD_NUMBER:-$(uuidgen)}
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/../../test/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh"
 
-readonly KNATIVE_VERSION="${KNATIVE_VERSION:-v0.12.1}"
+readonly KNATIVE_VERSION="${KNATIVE_VERSION:-v0.13.0}"
 
 readonly CATALOG_SOURCE_FILENAME="${CATALOG_SOURCE_FILENAME:-catalogsource-ci.yaml}"
 readonly DOCKER_REPO_OVERRIDE="${DOCKER_REPO_OVERRIDE:-}"

--- a/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
@@ -234,7 +234,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: METRICS_DOMAIN
                   value: knative.dev/serving-operator
-                image: markusthoemmes/knative-serving-operator:v0.13.0
+                image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-operator
                 imagePullPolicy: IfNotPresent
                 name: knative-serving-operator
                 ports:
@@ -413,7 +413,9 @@ spec:
     - name: IMAGE_3scale-kourier-control
       image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:kourier
     - name: IMAGE_3scale-kourier-gateway
-      image: docker.io/maistra/proxyv2-ubi8:1.0.4
+      image: docker.io/maistra/proxyv2-ubi8:1.0.8
+    - name: knative-serving-operator
+      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-operator
     - name: knative-operator
       image: $IMAGE_KNATIVE_OPERATOR
     - name: knative-openshift-ingress

--- a/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
@@ -234,7 +234,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: METRICS_DOMAIN
                   value: knative.dev/serving-operator
-                image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-operator
+                image: markusthoemmes/knative-serving-operator:v0.13.0
                 imagePullPolicy: IfNotPresent
                 name: knative-serving-operator
                 ports:
@@ -276,17 +276,17 @@ spec:
                     - name: KOURIER_MANIFEST_PATH
                       value: deploy/resources/kourier/kourier-latest.yaml
                     - name: IMAGE_queue-proxy
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-queue
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-queue
                     - name: IMAGE_activator
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-activator
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-activator
                     - name: IMAGE_autoscaler
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-autoscaler
                     - name: IMAGE_autoscaler-hpa
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler-hpa
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-autoscaler-hpa
                     - name: IMAGE_controller
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-controller
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-controller
                     - name: IMAGE_webhook
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-webhook
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-webhook
                     - name: IMAGE_3scale-kourier-gateway
                       value: docker.io/maistra/proxyv2-ubi8:1.0.8
                     - name: IMAGE_3scale-kourier-control
@@ -399,17 +399,17 @@ spec:
     name: Red Hat, Inc.
   relatedImages:
     - name: IMAGE_QUEUE
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-queue
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-queue
     - name: IMAGE_activator
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-activator
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-activator
     - name: IMAGE_autoscaler
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-autoscaler
     - name: IMAGE_autoscaler-hpa
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler-hpa
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-autoscaler-hpa
     - name: IMAGE_controller
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-controller
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-controller
     - name: IMAGE_webhook
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-webhook
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-webhook
     - name: IMAGE_3scale-kourier-control
       image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:kourier
     - name: IMAGE_3scale-kourier-gateway

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -261,7 +261,7 @@ function run_knative_serving_operator_tests {
   (
   local version target serverless_rootdir exitstatus patchfile fork gitdesc
   version=$1
-  fork="${2:-knative}"
+  fork="${2:-openshift-knative}"
   serverless_rootdir="$(pwd)"
   make_temporary_gopath
 

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -186,7 +186,7 @@ function run_knative_serving_rolling_upgrade_tests {
 
   if [[ $UPGRADE_SERVERLESS == true ]]; then
     local serving_version
-    serving_version=$(oc get knativeserving knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}")
+    serving_version=$(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}")
 
     # Get the current/latest CSV
     local upgrade_to
@@ -202,10 +202,10 @@ function run_knative_serving_rolling_upgrade_tests {
       # Check we got RequirementsNotMet error
       [[ $(oc get ClusterServiceVersion $upgrade_to -n $OPERATORS_NAMESPACE -o=jsonpath="{.status.requirementStatus[?(@.name==\"$upgrade_to\")].message}") =~ "requirement not met: minKubeVersion" ]] || return 1
       # Check KnativeServing still has the old version
-      [[ $(oc get knativeserving knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") == "$serving_version" ]] || return 1
+      [[ $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") == "$serving_version" ]] || return 1
     else
       approve_csv "$upgrade_to" || return 1
-      timeout 900 '[[ ! ( $(oc get knativeserving knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") != $serving_version && $(oc get knativeserving knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
+      timeout 900 '[[ ! ( $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") != $serving_version && $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
 
       # Assert that the old image references eventually fade away
       timeout 900 "oc get pod -n $SERVING_NAMESPACE -o yaml | grep image: | uniq | grep $serving_version" || return 1
@@ -344,7 +344,7 @@ function dump_openshift_ingress_state {
 
 function dump_knative_state {
   logger.info 'Dump of knative state'
-  oc describe knativeserving knative-serving -n "$SERVING_NAMESPACE" || true
+  oc describe knativeserving.operator.knative.dev knative-serving -n "$SERVING_NAMESPACE" || true
   oc get smcp --all-namespaces || true
   oc get smmr --all-namespaces || true
   oc get pods -n "$SERVING_NAMESPACE" || true

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -26,7 +26,7 @@ failed=0
 (( !failed )) && run_knative_serving_rolling_upgrade_tests "$KNATIVE_VERSION" || failed=6
 
 echo ">>> Knative Servings"
-oc get knativeserving --all-namespaces -o yaml
+oc get knativeserving.operator.knative.dev --all-namespaces -o yaml
 
 echo ">>> Knative Services"
 oc get ksvc --all-namespaces
@@ -42,7 +42,7 @@ echo "Sleeping so GC can run"
 sleep 120
 
 echo ">>> Knative Servings"
-oc get knativeserving --all-namespaces -o yaml
+oc get knativeserving.operator.knative.dev --all-namespaces -o yaml
 
 echo ">>> Knative Services"
 oc get ksvc --all-namespaces


### PR DESCRIPTION
Let's see what happens. Still waiting for the actual operator to release but this **should** work.

This reverts us not using the fully qualified api group for cli commands regarding knativeserving because the upgrade test still needs to deal with the "old" version.