### PR TITLE
Always apply Kourier manifest in the reconcile loop

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
+++ b/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
@@ -39,14 +39,22 @@ func Apply(instance *servingv1alpha1.KnativeServing, api client.Client, scheme *
 	}
 	if err := checkDeployments(&manifest, instance, api); err != nil {
 		log.Error(err, "")
+		prev := instance.Status.GetCondition(servingv1alpha1.DependenciesInstalled)
 		instance.Status.MarkDependencyInstalling("Kourier")
+		if prev == instance.Status.GetCondition(servingv1alpha1.DependenciesInstalled) {
+			return err
+		}
 		if apiErr := api.Status().Update(context.TODO(), instance); apiErr != nil {
 			return fmt.Errorf("failed to update KnativeServing status: %w", err)
 		}
 		return err
 	}
 	log.Info("Kourier is ready")
+	prev := instance.Status.GetCondition(servingv1alpha1.DependenciesInstalled)
 	instance.Status.MarkDependenciesInstalled()
+	if prev.Status == instance.Status.GetCondition(servingv1alpha1.DependenciesInstalled).Status {
+		return nil
+	}
 	return api.Status().Update(context.TODO(), instance)
 }
 

--- a/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
+++ b/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
@@ -39,11 +39,6 @@ func Apply(instance *servingv1alpha1.KnativeServing, api client.Client, scheme *
 	}
 	if err := checkDeployments(&manifest, instance, api); err != nil {
 		log.Error(err, "")
-		if !instance.Status.IsFullySupported() {
-			// If the instance is already DependencyInstalling status, do not update it.
-			// This avoids frequent LastTransitionTimestamp update.
-			return err
-		}
 		instance.Status.MarkDependencyInstalling("Kourier")
 		if apiErr := api.Status().Update(context.TODO(), instance); apiErr != nil {
 			return fmt.Errorf("failed to update KnativeServing status: %w", err)

--- a/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
+++ b/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
@@ -39,6 +39,11 @@ func Apply(instance *servingv1alpha1.KnativeServing, api client.Client, scheme *
 	}
 	if err := checkDeployments(&manifest, instance, api); err != nil {
 		log.Error(err, "")
+		if !instance.Status.IsFullySupported() {
+			// If the instance is already DependencyInstalling status, do not update it.
+			// This avoids frequent LastTransitionTimestamp update.
+			return err
+		}
 		instance.Status.MarkDependencyInstalling("Kourier")
 		if apiErr := api.Status().Update(context.TODO(), instance); apiErr != nil {
 			return fmt.Errorf("failed to update KnativeServing status: %w", err)


### PR DESCRIPTION
This patch changes to apply Kourier manifest always in the reconcile loop.

Part of SRVKS-454.