### PR TITLE
Remove obsoleted egress setting

### DIFF
--- a/knative-operator/pkg/common/openshift.go
+++ b/knative-operator/pkg/common/openshift.go
@@ -18,7 +18,6 @@ var log = Log
 func Mutate(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 	stages := []func(*servingv1alpha1.KnativeServing, client.Client) error{
 		ingressClass,
-		egress,
 		ingress,
 		configureLogURLTemplate,
 		ensureCustomCerts,
@@ -34,21 +33,6 @@ func Mutate(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 
 func ingressClass(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 	Configure(ks, "network", "ingress.class", "kourier.ingress.networking.knative.dev")
-	return nil
-}
-
-// configure egress
-func egress(ks *servingv1alpha1.KnativeServing, c client.Client) error {
-	networkConfig := &configv1.Network{}
-	if err := c.Get(context.TODO(), client.ObjectKey{Name: "cluster"}, networkConfig); err != nil {
-		if !meta.IsNoMatchError(err) {
-			return err
-		}
-		log.Info("No OpenShift cluster network config available")
-		return nil
-	}
-	network := strings.Join(networkConfig.Spec.ServiceNetwork, ",")
-	Configure(ks, "network", "istio.sidecar.includeOutboundIPRanges", network)
 	return nil
 }
 

--- a/knative-operator/pkg/common/openshift_test.go
+++ b/knative-operator/pkg/common/openshift_test.go
@@ -38,7 +38,6 @@ func TestMutate(t *testing.T) {
 		t.Error(err)
 	}
 
-	verifyEgress(t, ks, networks)
 	verifyIngress(t, ks, domain)
 	verifyImageOverride(t, ks, image)
 	verifyCerts(t, ks)
@@ -48,18 +47,16 @@ func TestMutate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	verifyEgress(t, ks, networks)
 	verifyIngress(t, ks, domain)
 	verifyImageOverride(t, ks, image)
 	verifyCerts(t, ks)
 
 	// Force a change and rerun
-	ks.Spec.Config["network"]["istio.sidecar.includeOutboundIPRanges"] = "foo"
+	ks.Spec.Config["network"]["ingress.class"] = "foo"
 	err = common.Mutate(ks, client)
 	if err != nil {
 		t.Error(err)
 	}
-	verifyEgress(t, ks, networks)
 	verifyIngress(t, ks, domain)
 	verifyImageOverride(t, ks, image)
 	verifyCerts(t, ks)
@@ -84,13 +81,6 @@ func mockIngressConfig(domain string) *configv1.Ingress {
 		Spec: configv1.IngressSpec{
 			Domain: domain,
 		},
-	}
-}
-
-func verifyEgress(t *testing.T, ks *servingv1alpha1.KnativeServing, expected string) {
-	actual := ks.Spec.Config["network"]["istio.sidecar.includeOutboundIPRanges"]
-	if actual != expected {
-		t.Errorf("Expected '%v', got '%v'", expected, actual)
 	}
 }
 


### PR DESCRIPTION
https://github.com/knative/serving/pull/6597 made `istio.sidecar.includeOutboundIPRanges`
obsoleted. This patch removes it from codes.