### PR TITLE
Print error log when Cleanup func failed

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -189,16 +189,18 @@ func newOpenShiftProxyClient(cfg *rest.Config) (configV1.ConfigV1Interface, erro
 }
 
 // Cleanup for all contexts
-func CleanupAll(contexts ...*Context) {
+func CleanupAll(t *testing.T, contexts ...*Context) {
 	for _, ctx := range contexts {
-		ctx.Cleanup()
+		ctx.Cleanup(t)
 	}
 }
 
 // Cleanup iterates through the list of registered CleanupFunc functions and calls them
-func (ctx *Context) Cleanup() {
+func (ctx *Context) Cleanup(t *testing.T) {
 	for _, f := range ctx.CleanupList {
-		f()
+		if err := f(); err != nil {
+			t.Logf("Failed to clean up: %v", err)
+		}
 	}
 }
 

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -33,7 +33,7 @@ const (
 func TestKnativeServing(t *testing.T) {
 	caCtx := test.SetupClusterAdmin(t)
 
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(caCtx) })
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
 
 	t.Run("create subscription and wait for CSV to succeed", func(t *testing.T) {
 		if _, err := test.WithOperatorReady(caCtx, "serverless-operator-subscription"); err != nil {
@@ -100,7 +100,7 @@ func TestKnativeServing(t *testing.T) {
 	})
 
 	t.Run("undeploy serverless operator and check dependent operators removed", func(t *testing.T) {
-		caCtx.Cleanup()
+		caCtx.Cleanup(t)
 		if err := test.WaitForOperatorDepsDeleted(caCtx); err != nil {
 			t.Fatalf("Operators still running: %v", err)
 		}
@@ -193,8 +193,8 @@ func testUserPermissions(t *testing.T) {
 	paCtx := test.SetupProjectAdmin(t)
 	editCtx := test.SetupEdit(t)
 	viewCtx := test.SetupView(t)
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(paCtx, editCtx, viewCtx) })
-	defer test.CleanupAll(paCtx, editCtx, viewCtx)
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, paCtx, editCtx, viewCtx) })
+	defer test.CleanupAll(t, paCtx, editCtx, viewCtx)
 
 	tests := []struct {
 		name        string


### PR DESCRIPTION
This patch prints error log when `Cleanup` functions failed.

Part of [SRVKS-459](https://issues.redhat.com/browse/SRVKS-459)