### PR TITLE
[SRKVS-462] Skip proxy e2e test.

### DIFF
--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -79,6 +79,7 @@ func TestKnativeServing(t *testing.T) {
 	})
 
 	t.Run("update global proxy and verify calls goes through proxy server", func(t *testing.T) {
+		t.Skip("SRKVS-462: This test needs thorough hardening")
 		testKnativeServingForGlobalProxy(t, caCtx)
 	})
 


### PR DESCRIPTION
This seems to greatly destabilize our tests currently. Let's skip this to flesh out what we need to do exactly.