### PR TITLE
[SRVKS-468] Support nightly versions of OCP4.3 too.

### DIFF
--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
@@ -43,6 +43,21 @@ func TestInvalidVersion(t *testing.T) {
 	}
 }
 
+func TestPreReleaseVersionConstraint(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("MIN_OPENSHIFT_VERSION", "4.3.0-0")
+
+	for _, version := range []string{"4.3.0", "4.3.5", "4.3.0-0.ci-2020-03-11-221411", "4.3.0+build"} {
+		validator := KnativeServingValidator{}
+		validator.InjectDecoder(&mockDecoder{})
+		validator.InjectClient(fake.NewFakeClient(mockClusterVersion(version)))
+		result := validator.Handle(context.TODO(), types.Request{})
+		if !result.Response.Allowed {
+			t.Errorf("Version %q was supposed to pass but didn't", version)
+		}
+	}
+}
+
 func mockClusterVersion(version string) *configv1.ClusterVersion {
 	return &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{

--- a/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
@@ -270,7 +270,7 @@ spec:
                     - name: OPERATOR_NAME
                       value: "knative-serving-openshift"
                     - name: MIN_OPENSHIFT_VERSION
-                      value: "4.3.0"
+                      value: "4.3.0-0"
                     - name: REQUIRED_NAMESPACE
                       value: "knative-serving"
                     - name: KOURIER_MANIFEST_PATH


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVKS-468 for more context. This allows any prerelease versions to pass the version check as well, which is what we want.