### PR TITLE
[WIP] [SRVKS-157] Create our own ingress class that has kourier as a child.

### DIFF
--- a/knative-operator/pkg/common/openshift.go
+++ b/knative-operator/pkg/common/openshift.go
@@ -32,7 +32,7 @@ func Mutate(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 }
 
 func ingressClass(ks *servingv1alpha1.KnativeServing, c client.Client) error {
-	Configure(ks, "network", "ingress.class", "kourier.ingress.networking.knative.dev")
+	Configure(ks, "network", "ingress.class", "openshift.kourier.ingress.networking.knative.dev")
 	return nil
 }
 

--- a/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
@@ -291,7 +291,7 @@ spec:
                     - name: IMAGE_3scale-kourier-gateway
                       value: docker.io/maistra/proxyv2-ubi8:1.0.8
                     - name: IMAGE_3scale-kourier-control
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:kourier
+                      value: markusthoemmes/kourier:srvks-157
       - name: knative-openshift-ingress
         spec:
           replicas: 1
@@ -412,7 +412,7 @@ spec:
     - name: IMAGE_webhook
       image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-serving-webhook
     - name: IMAGE_3scale-kourier-control
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:kourier
+      image: markusthoemmes/kourier:srvks-157
     - name: IMAGE_3scale-kourier-gateway
       image: docker.io/maistra/proxyv2-ubi8:1.0.8
     - name: knative-serving-operator


### PR DESCRIPTION
To be able to collapse both our ingress state (encoded in Openshift Routes) and the Kourier ingress state (as surfaced in the ingress' status) we're creating a parent-child relationship between the two, where we are in charge of the "openshift" parent and create a non-Openshift child, that is reconciled as usual. Once all routes are ready and the child is ready too, the parent will reflect readiness.