### PR TITLE
Update status of KnativeServing at the end of each reconcile cycle.

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -71,8 +71,8 @@ func (r *ReconcileKnativeServing) Reconcile(request reconcile.Request) (reconcil
 	reqLogger.Info("Reconciling KnativeServing")
 
 	// Fetch the KnativeServing instance
-	instance := &servingv1alpha1.KnativeServing{}
-	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	original := &servingv1alpha1.KnativeServing{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, original)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return reconcile.Result{}, nil
@@ -80,10 +80,22 @@ func (r *ReconcileKnativeServing) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
-	if instance.GetDeletionTimestamp() != nil {
-		return reconcile.Result{}, r.delete(instance)
+	if original.GetDeletionTimestamp() != nil {
+		return reconcile.Result{}, r.delete(original)
 	}
 
+	instance := original.DeepCopy()
+	reconcileErr := r.reconcileKnativeServing(instance)
+
+	if !equality.Semantic.DeepEqual(original.Status, instance.Status) {
+		if err := r.updateStatus(instance); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to update status: %w", err)
+		}
+	}
+	return reconcile.Result{}, reconcileErr
+}
+
+func (r *ReconcileKnativeServing) reconcileKnativeServing(instance *servingv1alpha1.KnativeServing) error {
 	stages := []func(*servingv1alpha1.KnativeServing) error{
 		r.configure,
 		r.ensureFinalizers,
@@ -94,11 +106,10 @@ func (r *ReconcileKnativeServing) Reconcile(request reconcile.Request) (reconcil
 	}
 	for _, stage := range stages {
 		if err := stage(instance); err != nil {
-			return reconcile.Result{}, err
+			return err
 		}
 	}
-
-	return reconcile.Result{}, nil
+	return nil
 }
 
 // configure default settings for OpenShift
@@ -211,4 +222,21 @@ func finalizerName() string {
 		panic(err)
 	}
 	return name
+}
+
+func (r *ReconcileKnativeServing) updateStatus(desired *servingv1alpha1.KnativeServing) error {
+	ks := &servingv1alpha1.KnativeServing{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, ks)
+	if err != nil {
+		return err
+	}
+
+	// If there's nothing to update, just return.
+	if equality.Semantic.DeepEqual(ks.Status, desired.Status) {
+		return nil
+	}
+	// Don't modify the informers copy
+	existing := ks.DeepCopy()
+	existing.Status = desired.Status
+	return r.client.Status().Update(context.TODO(), existing)
 }

--- a/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
+++ b/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
@@ -38,24 +38,12 @@ func Apply(instance *servingv1alpha1.KnativeServing, api client.Client, scheme *
 		return fmt.Errorf("failed to apply kourier manifest: %w", err)
 	}
 	if err := checkDeployments(&manifest, instance, api); err != nil {
-		log.Error(err, "")
-		prev := instance.Status.GetCondition(servingv1alpha1.DependenciesInstalled)
 		instance.Status.MarkDependencyInstalling("Kourier")
-		if prev == instance.Status.GetCondition(servingv1alpha1.DependenciesInstalled) {
-			return err
-		}
-		if apiErr := api.Status().Update(context.TODO(), instance); apiErr != nil {
-			return fmt.Errorf("failed to update KnativeServing status: %w", err)
-		}
-		return err
+		return fmt.Errorf("failed to check deployments: %w", err)
 	}
 	log.Info("Kourier is ready")
-	prev := instance.Status.GetCondition(servingv1alpha1.DependenciesInstalled)
 	instance.Status.MarkDependenciesInstalled()
-	if prev.Status == instance.Status.GetCondition(servingv1alpha1.DependenciesInstalled).Status {
-		return nil
-	}
-	return api.Status().Update(context.TODO(), instance)
+	return nil
 }
 
 // Check for deployments in knative-serving-ingress


### PR DESCRIPTION
Instead of updating the status during the reconcile cycle multiple times, we unconditionally (regardless of error or not) do it at the end of each reconcile cycle for a much easier to reason about path of execution.