### PR TITLE
[SRVKS-438] Adjust channel names to the proposal and make the new one the default.

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -27,4 +27,4 @@ readonly UPGRADE_SERVERLESS="${UPGRADE_SERVERLESS:-"true"}"
 readonly UPGRADE_CLUSTER="${UPGRADE_CLUSTER:-"false"}"
 
 readonly INSTALL_PREVIOUS_VERSION="${INSTALL_PREVIOUS_VERSION:-"false"}"
-readonly CHANNEL="${CHANNEL:-"techpreview"}"
+readonly CHANNEL="${CHANNEL:-"preview-4.3"}"

--- a/olm-catalog/serverless-operator/serverless-operator.package.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.package.yaml
@@ -1,9 +1,7 @@
 packageName: serverless-operator
-defaultChannel: techpreview
+defaultChannel: preview-4.3
 channels:
 - name: techpreview
-  currentCSV: serverless-operator.v1.6.0
-- name: techpreview-4.3
-  currentCSV: serverless-operator.v1.6.0
-- name: techpreview-4.4
+  currentCSV: serverless-operator.v1.5.0
+- name: preview-4.3
   currentCSV: serverless-operator.v1.6.0


### PR DESCRIPTION
As per title, this adjusts the channel names to be preview-MAJOR-MINOR as proposed. It also sets us up for moving to the new channel format (as a test for GA) by switching the default channel. The old techpreview channel will not get the new release either.