### PR TITLE
[SRVKS-479] Delete orphaned VirtualService

### DIFF
--- a/knative-operator/pkg/apis/addtoscheme_serving_v1alpha1.go
+++ b/knative-operator/pkg/apis/addtoscheme_serving_v1alpha1.go
@@ -1,11 +1,12 @@
 package apis
 
 import (
+	"knative.dev/pkg/apis/istio/v1alpha3"
 	"knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 )
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
 	// Adds schema for knative serving
-	AddToSchemes = append(AddToSchemes, v1alpha1.AddToScheme)
+	AddToSchemes = append(AddToSchemes, v1alpha1.AddToScheme, v1alpha3.AddToScheme)
 }

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -153,7 +153,6 @@ func (r *ReconcileKnativeServing) deleteVirtualService(instance *servingv1alpha1
 	ctx := context.TODO()
 	if err := r.client.List(ctx, listOpts, list); err != nil {
 		if meta.IsNoMatchError(err) {
-			log.Info("failed to list VirtualServices")
 			// VirtualService CRD is not installed.
 			return nil
 		}


### PR DESCRIPTION
This patch deletes orphaned VirtualService, which has:
- `serving.knative.dev/route` label key with any value.
- `networking.knative.dev/ingress.class: istio.ingress.networking.knative.dev` annotation.

Fixes https://issues.redhat.com/browse/SRVKS-479