### PR TITLE
Always handle a finalizer if in the list.

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -188,8 +189,11 @@ func (r *ReconcileKnativeServing) createConsoleCLIDownload(instance *servingv1al
 
 // general clean-up, mostly resources in different namespaces from servingv1alpha1.KnativeServing.
 func (r *ReconcileKnativeServing) delete(instance *servingv1alpha1.KnativeServing) error {
-	if len(instance.GetFinalizers()) == 0 || instance.GetFinalizers()[0] != finalizerName() {
-		log.Info("Finalizer is not first in line", "finalizers", instance.GetFinalizers())
+	finalizer := finalizerName()
+	finalizers := sets.NewString(instance.GetFinalizers()...)
+
+	if !finalizers.Has(finalizer) {
+		log.Info("Finalizer has already been removed, nothing to do")
 		return nil
 	}
 
@@ -204,12 +208,17 @@ func (r *ReconcileKnativeServing) delete(instance *servingv1alpha1.KnativeServin
 		return fmt.Errorf("failed to delete ConsoleCLIDownload: %w", err)
 	}
 
-	// The deletionTimestamp might've changed. Fetch the resource again.
+	// The above might take a while, so we refetch the resource again in case it has changed.
 	refetched := &servingv1alpha1.KnativeServing{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, refetched); err != nil {
 		return fmt.Errorf("failed to refetch KnativeServing: %w", err)
 	}
-	refetched.SetFinalizers(refetched.GetFinalizers()[1:])
+
+	// Update the refetched finalizer list.
+	finalizers = sets.NewString(refetched.GetFinalizers()...)
+	finalizers.Delete(finalizer)
+	refetched.SetFinalizers(finalizers.List())
+
 	if err := r.client.Update(context.TODO(), refetched); err != nil {
 		return fmt.Errorf("failed to update KnativeServing with removed finalizer: %w", err)
 	}


### PR DESCRIPTION
Instead of handling the finalizer list as a stack and only act if our finalizer is the first one, this changes things so that we'll always act if our finalizer is part of the finalizer list.

This fixes the KnativeServing to hang indefinitely randomly.