### PR TITLE
Add default behavior for HA

### DIFF
--- a/knative-operator/pkg/common/openshift.go
+++ b/knative-operator/pkg/common/openshift.go
@@ -22,12 +22,23 @@ func Mutate(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 		configureLogURLTemplate,
 		ensureCustomCerts,
 		imagesFromEnviron,
+		defaultToHa,
 	}
 	for _, stage := range stages {
 		if err := stage(ks, c); err != nil {
 			return fmt.Errorf("failed to mutate KnativeServing: %w", err)
 		}
 	}
+	return nil
+}
+
+func defaultToHa(ks *servingv1alpha1.KnativeServing, c client.Client) error {
+	if ks.Spec.HighAvailability == nil {
+		ks.Spec.HighAvailability = &servingv1alpha1.HighAvailability{
+			Replicas: 2,
+		}
+	}
+
 	return nil
 }
 

--- a/knative-operator/pkg/common/openshift_test.go
+++ b/knative-operator/pkg/common/openshift_test.go
@@ -41,6 +41,7 @@ func TestMutate(t *testing.T) {
 	verifyIngress(t, ks, domain)
 	verifyImageOverride(t, ks, image)
 	verifyCerts(t, ks)
+	verifyHA(t, ks)
 
 	// Rerun, should be a noop
 	err = common.Mutate(ks, client)
@@ -104,5 +105,16 @@ func verifyImageOverride(t *testing.T, ks *servingv1alpha1.KnativeServing, expec
 func verifyCerts(t *testing.T, ks *servingv1alpha1.KnativeServing) {
 	if ks.Spec.ControllerCustomCerts == (servingv1alpha1.CustomCerts{}) {
 		t.Error("Missing custom certs config")
+	}
+}
+
+func verifyHA(t *testing.T, ks *servingv1alpha1.KnativeServing) {
+	if ks.Spec.HighAvailability == nil {
+		t.Error("Missing HA")
+		return
+	}
+
+	if ks.Spec.HighAvailability.Replicas != 2 {
+		t.Errorf("Wrong ha replica size: %v", ks.Spec.HighAvailability.Replicas)
 	}
 }

--- a/olm-catalog/serverless-operator/1.6.0/operator_v1alpha1_knativeserving_crd.yaml
+++ b/olm-catalog/serverless-operator/1.6.0/operator_v1alpha1_knativeserving_crd.yaml
@@ -112,6 +112,14 @@ spec:
                     image location of the individual knative image.
                   type: object
               type: object
+            high-availability:
+              description: Allows specification of HA control plane
+              type: object
+              properties:
+                replicas:
+                  description: The number of replicas that HA parts of the control plane will be scaled to
+                  type: integer
+                  minimum: 1
           type: object
         status:
           description: Status defines the observed state of KnativeServing


### PR DESCRIPTION
Adds following behaviors:

- New `KnativeServing` resources are defaulted to HA, replicas=2 setup
- Existing `KnativeServing` resources are migrated to the same HA setup on update, if one is not specified
- If you don't want scaled up control plane, just use `KnativeServing.Spec.HighAvailability.Replicas=1`