### PR TITLE
[SRVKS-484] Make knative-operator and ingress log with readable timestamps.

### DIFF
--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -53,6 +53,7 @@ func main() {
 	// Add flags registered by imported packages (e.g. glog and
 	// controller-runtime)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Set("zap-time-encoding", "iso8601")
 
 	pflag.Parse()
 

--- a/serving/ingress/cmd/manager/main.go
+++ b/serving/ingress/cmd/manager/main.go
@@ -47,6 +47,7 @@ func main() {
 	// Add flags registered by imported packages (e.g. glog and
 	// controller-runtime)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Set("zap-time-encoding", "iso8601")
 
 	pflag.Parse()
 


### PR DESCRIPTION
- **knative-operator**:
  - Force set the zap-time-encoding flag.
- **serving/ingress**:
  - Force set the zap-time-encoding flag.
  - Adjust the "inner" logger to read Knative's default config, which has the correct time encoding set.
  - Add a "key" to each log in the reconciler to allow for easier debuggability.