### PR TITLE
Build all of our components with Golang 1.13.

### DIFF
--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.12 AS builder
+FROM openshift/origin-release:golang-1.13 AS builder
 
 ENV SRC=${GOPATH}/src/github.com/openshift-knative/serverless-operator/knative-operator
 

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.12 AS builder
+FROM openshift/origin-release:golang-1.13 AS builder
 
 ENV SRC=${GOPATH}/src/github.com/openshift-knative/serverless-operator/serving/ingress
 


### PR DESCRIPTION
As per title. We already do that in productization AFAIK so CI should so too.