### PR TITLE
Use golang-1.13 image for build

### DIFF
--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.12 AS builder
+FROM openshift/origin-release:golang-1.13 AS builder
 
 ENV SRC=${GOPATH}/src/github.com/openshift-knative/serverless-operator/knative-operator
 

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.12 AS builder
+FROM openshift/origin-release:golang-1.13 AS builder
 
 ENV SRC=${GOPATH}/src/github.com/openshift-knative/serverless-operator/serving/ingress
 


### PR DESCRIPTION
This patch updates builder image to golang-1.13.

For example, it still uses golang-1.12, so the error message `fmt.Errorf` is not
working well with `%w`.