### PR TITLE
Use the correct channel in operator e2e tests.

### DIFF
--- a/test/flags.go
+++ b/test/flags.go
@@ -13,9 +13,9 @@ var Flags = initializeFlags()
 
 // FlagsStruct is struct that defines testing options
 type FlagsStruct struct {
-	Kubeconfigs string // Path to .kube/config
+	Kubeconfigs   string // Path to .kube/config
 	CatalogSource string // CatalogSource in the openshift-marketplace namespace for the serverless-operator Subscription
-	Channel string // serverless-operator Subscription channel
+	Channel       string // serverless-operator Subscription channel
 }
 
 func initializeFlags() *FlagsStruct {
@@ -29,8 +29,8 @@ func initializeFlags() *FlagsStruct {
 		"Provide the path to the `kubeconfig` file you'd like to use for these tests. The `current-context` will be used.")
 	flag.StringVar(&f.CatalogSource, "catalogsource", "serverless-operator",
 		"CatalogSource in the openshift-marketplace namespace for the serverless-operator Subscription, \"serverless-operator\" by default")
-	flag.StringVar(&f.Channel, "channel", "techpreview",
-		"serverless-operator Subscription channel, \"techpreview\" by default.")
+	flag.StringVar(&f.Channel, "channel", "preview-4.3",
+		"serverless-operator Subscription channel, \"preview-4.3\" by default.")
 
 	return &f
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -40,6 +40,7 @@ function run_e2e_tests {
   local failed=0
 
   go_test_e2e -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2e \
+    --channel "$CHANNEL" \
     --kubeconfig "${kubeconfigs[0]}" \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@" || failed=1


### PR DESCRIPTION
Without this being correctly hooked up, the operator e2e tests deploy the wrong version.