### PR TITLE
Bootstrap the 1.7.0 release.

### DIFF
--- a/olm-catalog/serverless-operator/1.7.0/operator_v1alpha1_knativeserving_crd.yaml
+++ b/olm-catalog/serverless-operator/1.7.0/operator_v1alpha1_knativeserving_crd.yaml
@@ -1,0 +1,168 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: knativeservings.operator.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.version
+    name: Version
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+    name: Reason
+    type: string
+  group: operator.knative.dev
+  names:
+    kind: KnativeServing
+    listKind: KnativeServingList
+    plural: knativeservings
+    shortNames:
+    - ks
+    singular: knativeserving
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Schema for the knativeservings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec defines the desired state of KnativeServing
+          properties:
+            cluster-local-gateway:
+              description: A means to override the cluster-local-gateway
+              properties:
+                selector:
+                  additionalProperties:
+                    type: string
+                  description: The selector for the ingress-gateway.
+                  type: object
+              type: object
+            config:
+              additionalProperties:
+                additionalProperties:
+                  type: string
+                type: object
+              description: A means to override the corresponding entries in the upstream
+                configmaps
+              type: object
+            controller-custom-certs:
+              description: Enabling the controller to trust registries with self-signed
+                certificates
+              properties:
+                name:
+                  description: The name of the ConfigMap or Secret
+                  type: string
+                type:
+                  description: One of ConfigMap or Secret
+                  enum:
+                  - ConfigMap
+                  - Secret
+                  - ""
+                  type: string
+              type: object
+            knative-ingress-gateway:
+              description: A means to override the knative-ingress-gateway
+              properties:
+                selector:
+                  additionalProperties:
+                    type: string
+                  description: The selector for the ingress-gateway.
+                  type: object
+              type: object
+            registry:
+              description: A means to override the corresponding deployment images
+                in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+              properties:
+                default:
+                  description: The default image reference template to use for all
+                    knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                  type: string
+                imagePullSecrets:
+                  description: A list of secrets to be used when pulling the knative
+                    images. The secret must be created in the same namespace as the
+                    knative-serving deployments, and not the namespace of this resource.
+                  items:
+                    properties:
+                      name:
+                        description: The name of the secret.
+                        type: string
+                    type: object
+                  type: array
+                override:
+                  additionalProperties:
+                    type: string
+                  description: A map of a container name or image name to the full
+                    image location of the individual knative image.
+                  type: object
+              type: object
+            high-availability:
+              description: Allows specification of HA control plane
+              type: object
+              properties:
+                replicas:
+                  description: The number of replicas that HA parts of the control plane will be scaled to
+                  type: integer
+                  minimum: 1
+          type: object
+        status:
+          description: Status defines the observed state of KnativeServing
+          properties:
+            conditions:
+              description: The latest available observations of a resource's current
+                state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the last time the condition
+                      transitioned from one status to another. We use VolatileTime
+                      in place of metav1.Time to exclude this from creating equality.Semantic
+                      differences (all other things held constant).
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  severity:
+                    description: Severity with which to treat failures of this type
+                      of condition. When this is not specified, it defaults to Error.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition.
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            version:
+              description: The version of the installed release
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/olm-catalog/serverless-operator/1.7.0/serverless-operator.v1.7.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.7.0/serverless-operator.v1.7.0.clusterserviceversion.yaml
@@ -1,0 +1,463 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.knative.dev/v1alpha1",
+          "kind": "KnativeServing",
+          "metadata": {
+            "name": "knative-serving"
+          },
+          "spec": {
+            "config": {
+              "autoscaler": {
+                "container-concurrency-target-default": "100",
+                "container-concurrency-target-percentage": "1.0",
+                "enable-scale-to-zero": "true",
+                "max-scale-up-rate": "10",
+                "panic-threshold-percentage": "200.0",
+                "panic-window": "6s",
+                "panic-window-percentage": "10.0",
+                "scale-to-zero-grace-period": "30s",
+                "stable-window": "60s",
+                "tick-interval": "2s"
+              },
+              "defaults": {
+                "revision-cpu-limit": "1000m",
+                "revision-cpu-request": "400m",
+                "revision-memory-limit": "200M",
+                "revision-memory-request": "100M",
+                "revision-timeout-seconds": "300"
+              },
+              "deployment": {
+                "registriesSkippingTagResolving": "ko.local,dev.local"
+              },
+              "gc": {
+                "stale-revision-create-delay": "24h",
+                "stale-revision-lastpinned-debounce": "5h",
+                "stale-revision-minimum-generations": "1",
+                "stale-revision-timeout": "15h"
+              },
+              "logging": {
+                "loglevel.activator": "info",
+                "loglevel.autoscaler": "info",
+                "loglevel.controller": "info",
+                "loglevel.queueproxy": "info",
+                "loglevel.webhook": "info"
+              },
+              "observability": {
+                "logging.enable-var-log-collection": "false",
+                "metrics.backend-destination": "prometheus"
+              },
+              "tracing": {
+                "backend": "none",
+                "sample-rate": "0.1"
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+    certified: "false"
+    containerImage: quay.io/openshift-knative/serverless-operator:v1.7.0
+    createdAt: "2019-07-27T17:00:00Z"
+    description: |-
+      Provides a collection of API's based on Knative to support deploying and serving
+      of serverless applications and functions.
+    repository: https://github.com/openshift-knative/serverless-operator
+    operators.operatorframework.io/internal-objects: '["knativeservings.operator.knative.dev"]'
+    support: Red Hat, Inc.
+  name: serverless-operator.v1.7.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents an installation of a particular version of Knative Serving
+      displayName: Knative Serving
+      kind: KnativeServing
+      name: knativeservings.operator.knative.dev
+      statusDescriptors:
+      - description: The version of Knative Serving installed
+        displayName: Version
+        path: version
+      - description: Conditions of Knative Serving installed
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes.conditions'
+      version: v1alpha1
+  minKubeVersion: 1.15.0
+  description: |-
+    The Red Hat OpenShift Serverless operator provides a collection of APIs that
+    enables containers, microservices and functions to run "serverless".
+    Serverless applications can scale up and down (to zero) on demand and be triggered by a
+    number of event sources. OpenShift Serverless integrates with a number of
+    platform services, such as Metering and Monitoring and it is based on the open
+    source project Knative.  
+    
+    This is a **[Technology Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+    
+    # Prerequisites
+    The components provided with the OpenShift Serverless operator require minimum cluster sizes on 
+    OpenShift Container Platform. For more information, see the documentation on [Getting started 
+    with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/serverless_applications/index#serverless-getting-started).
+    
+    # Supported Features
+    - **Easy to get started:** Provides a simplified developer experience to deploy
+      and run cloud native applications on Kubernetes, providing powerful
+      abstractions.
+    - **Immutable Revisions:** Deploy new features performing canary, A/B or
+      blue-green testing with gradual traffic rollout following best practices.      
+    - **Use any programming language or runtime of choice:** From Java, Python, Go
+      and JavaScript to Quarkus, SpringBoot or Node.js.
+    - **Automatic scaling:** Removes the requirement to configure numbers of replicas 
+      or idling behavior. Applications automatically scale to zero when not in use, 
+      or scale up to meet demand, with built in reliability and fault tolerance. 
+    - **Event Driven Applications:** You can build loosely coupled, distributed applications 
+      that can be connected to a variety of either built in or third party event sources, 
+      powered by operators.
+    - **Ready for the hybrid cloud:** Provides true, portable serverless functionality, 
+      that can run anywhere OpenShift Container Platform runs. You can leverage data 
+      locality and SaaS as you need it.
+    
+    # Components & APIs
+    This operator provides the following components:
+    
+    ## Knative Serving
+    Knative Serving builds on Kubernetes to support deploying and serving of
+    applications and functions as serverless containers. Serving is easy to get
+    started with and scales to support advanced scenarios. Other features
+    includes: 
+    - Rapid deployment of serverless containers
+    - Automatic scaling up and down to zero
+    - Routing and network programming
+    - Point-in-time snapshots of deployed code and configurations
+    ![](https://i.imgur.com/vqL48B8.png)
+    
+    ## Knative Client - `kn`
+    The Knative client `kn` is your door to the Knative world. It allows you to
+    create Knative resources interactively from the command line or from within
+    Shell scripts.
+    
+    `kn` offers you:
+    - Full support for managing all features of Knative Serving (services,
+      revisions, traffic splits) 
+    - Growing support Knative eventing, closely following its development
+      (managing of sources & triggers) 
+    - A plugin architecture similar to that of kubectl plugins 
+    - A thin client-specific API in golang which helps in tasks like synchronously
+      waiting on Knative service write operations.  
+    - An easy integration of Knative into Tekton Pipelines by using kn in a Tekton
+      Task.
+    
+    # Further Information
+    For documentation on OpenShift Serverless, see:
+    - [Installation
+    Guide](https://docs.openshift.com/container-platform/4.3/serverless/installing-openshift-serverless.html)
+    - [Getting
+    started](https://docs.openshift.com/container-platform/4.3/serverless/serverless-getting-started.html)
+  displayName: OpenShift Serverless Operator
+  icon:
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: knative-serving-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - events
+          - configmaps
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - "*"
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - "*"
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - "*"
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - networking.internal.knative.dev
+          resources:
+          - clusteringresses
+          - clusteringresses/status
+          - clusteringresses/finalizers
+          - ingresses
+          - ingresses/status
+          - ingresses/finalizers
+          verbs:
+          - "*"
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          - routes/status
+          - routes/finalizers
+          verbs:
+          - "*"
+        - apiGroups:
+          - operator.knative.dev
+          resources:
+          - knativeservings
+          - knativeservings/finalizers
+          verbs:
+          - '*'
+        serviceAccountName: knative-openshift-ingress
+      deployments:
+      - name: knative-serving-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: knative-serving-operator
+          template:
+            metadata:
+              annotations:
+                sidecar.istio.io/inject: "false"
+              labels:
+                name: knative-serving-operator
+            spec:
+              containers:
+              - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: knative-serving-operator
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: METRICS_DOMAIN
+                  value: knative.dev/serving-operator
+                image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
+                imagePullPolicy: IfNotPresent
+                name: knative-serving-operator
+                ports:
+                - containerPort: 9090
+                  name: metrics
+              serviceAccountName: knative-serving-operator
+      - name: knative-serving-openshift
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: knative-serving-openshift
+          template:
+            metadata:
+              labels:
+                name: knative-serving-openshift
+                app: openshift-admission-server
+            spec:
+              serviceAccountName: knative-serving-operator
+              containers:
+                - name: knative-serving-openshift
+                  image: $IMAGE_KNATIVE_OPERATOR
+                  command:
+                  - knative-serving-openshift
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      value: ""
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: "knative-serving-openshift"
+                    - name: MIN_OPENSHIFT_VERSION
+                      value: "4.3.0-0"
+                    - name: REQUIRED_NAMESPACE
+                      value: "knative-serving"
+                    - name: KOURIER_MANIFEST_PATH
+                      value: deploy/resources/kourier/kourier-latest.yaml
+                    - name: IMAGE_queue-proxy
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+                    - name: IMAGE_activator
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+                    - name: IMAGE_autoscaler
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+                    - name: IMAGE_autoscaler-hpa
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+                    - name: IMAGE_controller
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+                    - name: IMAGE_webhook
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+                    - name: IMAGE_3scale-kourier-gateway
+                      value: docker.io/maistra/proxyv2-ubi8:1.0.8
+                    - name: IMAGE_3scale-kourier-control
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
+      - name: knative-openshift-ingress
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: knative-openshift-ingress
+          template:
+            metadata:
+              labels:
+                name: knative-openshift-ingress
+            spec:
+              serviceAccountName: knative-openshift-ingress
+              containers:
+                - name: knative-openshift-ingress
+                  image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
+                  command:
+                  - knative-openshift-ingress
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      value: "" # watch all namespaces for ClusterIngress
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: "knative-openshift-ingress"
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - knative-serving-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - operator.knative.dev
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: knative-serving-operator
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - serverless
+  - FaaS
+  - microservices
+  - scale to zero
+  - knative
+  - serving
+  links:
+  - name: Documentation
+    url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+  - name: Source Repository
+    url: https://github.com/openshift-knative/serverless-operator
+  maintainers:
+  - email: serverless-support@redhat.com
+    name: Serverless Team
+  maturity: alpha
+  provider:
+    name: Red Hat, Inc.
+  relatedImages:
+    - name: IMAGE_QUEUE
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+    - name: IMAGE_activator
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+    - name: IMAGE_autoscaler
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+    - name: IMAGE_autoscaler-hpa
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+    - name: IMAGE_controller
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+    - name: IMAGE_webhook
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+    - name: IMAGE_3scale-kourier-control
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
+    - name: IMAGE_3scale-kourier-gateway
+      image: docker.io/maistra/proxyv2-ubi8:1.0.8
+    - name: knative-serving-operator
+      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
+    - name: knative-operator
+      image: $IMAGE_KNATIVE_OPERATOR
+    - name: knative-openshift-ingress
+      image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
+  replaces: serverless-operator.v1.6.0
+  version: 1.7.0

--- a/olm-catalog/serverless-operator/serverless-operator.package.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.package.yaml
@@ -4,4 +4,4 @@ channels:
 - name: techpreview
   currentCSV: serverless-operator.v1.5.0
 - name: preview-4.3
-  currentCSV: serverless-operator.v1.6.0
+  currentCSV: serverless-operator.v1.7.0

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -182,9 +182,6 @@ function run_knative_serving_rolling_upgrade_tests {
   PROBER_PID=$!
 
   if [[ $UPGRADE_SERVERLESS == true ]]; then
-    local serving_version
-    serving_version=$(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}")
-
     # Get latest CSV from the given channel
     local upgrade_to
     upgrade_to=$("${rootdir}/hack/catalog.sh" | sed -n '/channels/,$p;' | sed -n "/- name: ${CHANNEL}$/{n;p;}" | awk '{ print $2 }')
@@ -198,14 +195,9 @@ function run_knative_serving_rolling_upgrade_tests {
       fi
       # Check we got RequirementsNotMet error
       [[ $(oc get ClusterServiceVersion $upgrade_to -n $OPERATORS_NAMESPACE -o=jsonpath="{.status.requirementStatus[?(@.name==\"$upgrade_to\")].message}") =~ "requirement not met: minKubeVersion" ]] || return 1
-      # Check KnativeServing still has the old version
-      [[ $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") == "$serving_version" ]] || return 1
     else
       approve_csv "$upgrade_to" || return 1
-      timeout 900 '[[ ! ( $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") != $serving_version && $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
-
-      # Assert that the old image references eventually fade away
-      timeout 900 "oc get pod -n $SERVING_NAMESPACE -o yaml | grep image: | uniq | grep $serving_version" || return 1
+      timeout 900 '[[ ! ( $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
     fi
     end_prober_test ${PROBER_PID}
   fi


### PR DESCRIPTION
- Added a CSV for 1.7.0.
- Adjusted the upgrade test because we're not inherently shipping a Knative version upgrade.