### PR TITLE
Refactor image override logic

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -121,7 +121,7 @@ function deploy_knativeserving_cr {
 
   timeout 900 '[[ $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
 
-  logger.success 'Serverless has been installed sucessfully.'
+  logger.success 'Knative Serving has been installed sucessfully.'
 }
 
 function teardown_serverless {

--- a/knative-operator/pkg/common/openshift_test.go
+++ b/knative-operator/pkg/common/openshift_test.go
@@ -72,7 +72,8 @@ func TestMutate(t *testing.T) {
 		}
 
 		verifyIngress(t, ks, domain)
-		verifyImageOverride(t, ks, image)
+		verifyImageOverride(t, &ks.Spec.Registry, "queue-proxy", image)
+		verifyQueueProxySidecarImageOverride(t, ks, image)
 		verifyCerts(t, ks)
 		tc.ha(t, ks)
 
@@ -82,7 +83,8 @@ func TestMutate(t *testing.T) {
 			t.Error(err)
 		}
 		verifyIngress(t, ks, domain)
-		verifyImageOverride(t, ks, image)
+		verifyImageOverride(t, &ks.Spec.Registry, "queue-proxy", image)
+		verifyQueueProxySidecarImageOverride(t, ks, image)
 		verifyCerts(t, ks)
 		tc.ha(t, ks)
 
@@ -93,7 +95,8 @@ func TestMutate(t *testing.T) {
 			t.Error(err)
 		}
 		verifyIngress(t, ks, domain)
-		verifyImageOverride(t, ks, image)
+		verifyImageOverride(t, &ks.Spec.Registry, "queue-proxy", image)
+		verifyQueueProxySidecarImageOverride(t, ks, image)
 		verifyCerts(t, ks)
 		tc.ha(t, ks)
 	}
@@ -128,13 +131,10 @@ func verifyIngress(t *testing.T, ks *servingv1alpha1.KnativeServing, expected st
 	}
 }
 
-func verifyImageOverride(t *testing.T, ks *servingv1alpha1.KnativeServing, expected string) {
+func verifyQueueProxySidecarImageOverride(t *testing.T, ks *servingv1alpha1.KnativeServing, expected string) {
 	// Because we overrode the queue image...
 	if ks.Spec.Config["deployment"]["queueSidecarImage"] != expected {
 		t.Errorf("Missing queue image, config=%v", ks.Spec.Config["deployment"])
-	}
-	if ks.Spec.Registry.Override["queue-proxy"] != expected {
-		t.Errorf("Missing queue image, override=%v", ks.Spec.Registry.Override)
 	}
 }
 

--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -2,7 +2,9 @@ package common
 
 import (
 	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
+	"os"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"strings"
 )
 
 var Log = logf.Log.WithName("knative").WithName("openshift")
@@ -30,4 +32,20 @@ func Configure(ks *servingv1alpha1.KnativeServing, cm, key, value string) bool {
 // IngressNamespace returns namespace where ingress is deployed.
 func IngressNamespace(servingNamespace string) string {
 	return servingNamespace + "-ingress"
+}
+
+// buildImageOverrideMapFromEnviron creates a map to overrides registry images
+func buildImageOverrideMapFromEnviron() map[string]string {
+	overrideMap := map[string]string{}
+
+	for _, e := range os.Environ() {
+		pair := strings.SplitN(e, "=", 2)
+		if strings.HasPrefix(pair[0], "IMAGE_") {
+			name := strings.SplitN(pair[0], "_", 2)[1]
+			if pair[1] != "" {
+				overrideMap[name] = pair[1]
+			}
+		}
+	}
+	return overrideMap
 }

--- a/knative-operator/pkg/common/util_test.go
+++ b/knative-operator/pkg/common/util_test.go
@@ -1,0 +1,12 @@
+package common_test
+
+import (
+	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
+	"testing"
+)
+
+func verifyImageOverride(t *testing.T, registry *servingv1alpha1.Registry, imageName string, expected string) {
+	if registry.Override[imageName] != expected {
+		t.Errorf("Missing queue image. Expected a map with following override in it : %v=%v, actual: %v", imageName, expected, registry.Override)
+	}
+}

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -114,7 +114,7 @@ function prepare_knative_serving_tests {
 }
 
 function run_knative_serving_e2e_and_conformance_tests {
-  logger.info "Running E2E and conformance tests"
+  logger.info "Running Serving E2E and conformance tests"
   (
   local knative_version=$1
 
@@ -147,7 +147,7 @@ function run_knative_serving_e2e_and_conformance_tests {
 }
 
 function run_knative_serving_rolling_upgrade_tests {
-  logger.info "Running rolling upgrade tests"
+  logger.info "Running Serving rolling upgrade tests"
   (
   local knative_version=$1
 


### PR DESCRIPTION
* Extract image override decision logic from `imagesFromEnviron` to `buildImageOverrideMapFromEnviron`
* Make `imagesFromEnviron` to use that extracted method

`buildImageOverrideMapFromEnviron` will be used in eventing too