### PR TITLE
Provide options to specify CHANNEL and SOURCE for upgrades

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -28,4 +28,7 @@ readonly UPGRADE_SERVERLESS="${UPGRADE_SERVERLESS:-"true"}"
 readonly UPGRADE_CLUSTER="${UPGRADE_CLUSTER:-"false"}"
 
 readonly INSTALL_PREVIOUS_VERSION="${INSTALL_PREVIOUS_VERSION:-"false"}"
-readonly CHANNEL="${CHANNEL:-"4.3"}"
+export OLM_CHANNEL="${OLM_CHANNEL:-"4.3"}"
+# Change this when upgrades need switching to a different channel
+export OLM_UPGRADE_CHANNEL="${OLM_UPGRADE_CHANNEL:-"$OLM_CHANNEL"}"
+export OLM_SOURCE="${OLM_SOURCE:-"$OPERATOR"}"

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -191,19 +191,19 @@ function run_knative_serving_rolling_upgrade_tests {
   if [[ $UPGRADE_SERVERLESS == true ]]; then
     # Get latest CSV from the given channel
     local upgrade_to
-    upgrade_to=$("${rootdir}/hack/catalog.sh" | sed -n '/channels/,$p;' | sed -n "/- name: \"${CHANNEL}\"$/{n;p;}" | awk '{ print $2 }')
+    upgrade_to=$("${rootdir}/hack/catalog.sh" | sed -n '/channels/,$p;' | sed -n "/- name: \"${OLM_UPGRADE_CHANNEL}\"$/{n;p;}" | awk '{ print $2 }')
 
     local cluster_version
     cluster_version=$(oc get clusterversion -o=jsonpath="{.items[0].status.history[?(@.state==\"Completed\")].version}")
     if [[ "$cluster_version" = 4.1.* || "${HOSTNAME}" = *ocp-41* || \
           "$cluster_version" = 4.2.* || "${HOSTNAME}" = *ocp-42* ]]; then
-      if approve_csv "$upgrade_to" ; then # Upgrade should fail on OCP 4.1, 4.2
+      if approve_csv "$upgrade_to" "$OLM_UPGRADE_CHANNEL" ; then # Upgrade should fail on OCP 4.1, 4.2
         return 1
       fi
       # Check we got RequirementsNotMet error
       [[ $(oc get ClusterServiceVersion $upgrade_to -n $OPERATORS_NAMESPACE -o=jsonpath="{.status.requirementStatus[?(@.name==\"$upgrade_to\")].message}") =~ "requirement not met: minKubeVersion" ]] || return 1
     else
-      approve_csv "$upgrade_to" || return 1
+      approve_csv "$upgrade_to" "$OLM_UPGRADE_CHANNEL" || return 1
       timeout 900 '[[ ! ( $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
     fi
     end_prober_test ${PROBER_PID}

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -40,7 +40,7 @@ function run_e2e_tests {
   local failed=0
 
   go_test_e2e -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2e \
-    --channel "$CHANNEL" \
+    --channel "$OLM_CHANNEL" \
     --kubeconfig "${kubeconfigs[0]}" \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@" || failed=1


### PR DESCRIPTION
Upgrades might need switching channel (and for downstream testing also source from redhat-operators to serverless-operator).