### PR TITLE
Force cluster upgrade

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -219,7 +219,7 @@ function run_knative_serving_rolling_upgrade_tests {
     local latest_cluster_version=$(oc adm upgrade | sed -ne '/VERSION/,$ p' | grep -v VERSION | awk '{print $1}' | sort -r | head -n 1)
     [[ $latest_cluster_version != "" ]] || return 1
 
-    oc adm upgrade --to-latest=true
+    oc adm upgrade --to-latest=true --force=true
 
     timeout 7200 '[[ $(oc get clusterversion -o=jsonpath="{.items[0].status.history[?(@.version==\"${latest_cluster_version}\")].state}") != Completed ]]' || return 1
 


### PR DESCRIPTION
* this is mainly to overcome this error during upgrades:
message: 'Cluster operator kube-apiserver cannot be upgraded:
DefaultSecurityContextConstraintsUpgradeable:
Default SecurityContextConstraints object(s) have mutated
[anyuid privileged]'
      reason: DefaultSecurityContextConstraints_Mutated

We update the SCC for tests in this way and it doesn't help to remove these before the cluster upgrade. This is probably a new restriction in cluster upgrades (didn't happen last time but happens now with the upgrade from OCP 4.3.8 to 4.3.9)
oc adm policy add-scc-to-user privileged -z default -n serving-tests
oc adm policy add-scc-to-user privileged -z default -n serving-tests-alt
oc adm policy add-scc-to-user anyuid -z default -n serving-tests