### PR TITLE
Fix links to documentation

### DIFF
--- a/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
@@ -427,7 +427,7 @@ spec:
   - serving
   links:
   - name: Documentation
-    url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/serverless_applications/index
+    url: https://docs.openshift.com/container-platform/4.3/serverless/serverless-getting-started.html
   - name: Source Repository
     url: https://github.com/openshift-knative/serverless-operator
   maintainers:

--- a/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.6.0/serverless-operator.v1.6.0.clusterserviceversion.yaml
@@ -157,7 +157,7 @@ spec:
     # Further Information
     For documentation on OpenShift Serverless, see:
     - [Installation
-    Guide](https://docs.openshift.com/container-platform/4.3/serverless/installing-openshift-serverless.html)
+    Guide](https://docs.openshift.com/container-platform/4.3/serverless/installing_serverless/installing-openshift-serverless.html)
     - [Getting
     started](https://docs.openshift.com/container-platform/4.3/serverless/serverless-getting-started.html)
   displayName: OpenShift Serverless Operator
@@ -427,7 +427,7 @@ spec:
   - serving
   links:
   - name: Documentation
-    url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+    url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/serverless_applications/index
   - name: Source Repository
     url: https://github.com/openshift-knative/serverless-operator
   maintainers:


### PR DESCRIPTION
Fix links: a 404, and an update from OCP 4.2 to 4.3. Fixes https://issues.redhat.com/browse/SRVKS-499.