### PR TITLE
Update Knative Serving references to 0.13.2.

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -5,7 +5,7 @@ readonly BUILD_NUMBER=${BUILD_NUMBER:-$(uuidgen)}
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/../../test/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh"
 
-readonly KNATIVE_VERSION="${KNATIVE_VERSION:-v0.13.1}"
+readonly KNATIVE_VERSION="${KNATIVE_VERSION:-v0.13.2}"
 
 readonly CATALOG_SOURCE_FILENAME="${CATALOG_SOURCE_FILENAME:-catalogsource-ci.yaml}"
 readonly DOCKER_REPO_OVERRIDE="${DOCKER_REPO_OVERRIDE:-}"

--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -84,7 +84,8 @@ func main() {
 
 	ctx := context.TODO()
 	// Become the leader before proceeding
-	err = leader.Become(ctx, "knative-openshift-lock")
+	// This needs to remain "knative-serving-openshift-lock" to allow for safe upgrades.
+	err = leader.Become(ctx, "knative-serving-openshift-lock")
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -7,7 +7,6 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleclidownload"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/kourier"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/predicate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -34,6 +33,7 @@ const (
 	routeLabelKey     = "serving.knative.dev/route"
 	ingressClassKey   = "networking.knative.dev/ingress.class"
 	istioIngressClass = "istio.ingress.networking.knative.dev"
+	finalizerName     = "knative-serving-openshift"
 )
 
 var log = common.Log.WithName("controller")
@@ -210,12 +210,12 @@ func (r *ReconcileKnativeServing) updateDeployment(instance *servingv1alpha1.Kna
 // set a finalizer to clean up service mesh when instance is deleted
 func (r *ReconcileKnativeServing) ensureFinalizers(instance *servingv1alpha1.KnativeServing) error {
 	for _, finalizer := range instance.GetFinalizers() {
-		if finalizer == finalizerName() {
+		if finalizer == finalizerName {
 			return nil
 		}
 	}
 	log.Info("Adding finalizer")
-	instance.SetFinalizers(append(instance.GetFinalizers(), finalizerName()))
+	instance.SetFinalizers(append(instance.GetFinalizers(), finalizerName))
 	return r.client.Update(context.TODO(), instance)
 }
 
@@ -260,10 +260,9 @@ func (r *ReconcileKnativeServing) createConsoleCLIDownload(instance *servingv1al
 
 // general clean-up, mostly resources in different namespaces from servingv1alpha1.KnativeServing.
 func (r *ReconcileKnativeServing) delete(instance *servingv1alpha1.KnativeServing) error {
-	finalizer := finalizerName()
 	finalizers := sets.NewString(instance.GetFinalizers()...)
 
-	if !finalizers.Has(finalizer) {
+	if !finalizers.Has(finalizerName) {
 		log.Info("Finalizer has already been removed, nothing to do")
 		return nil
 	}
@@ -287,19 +286,11 @@ func (r *ReconcileKnativeServing) delete(instance *servingv1alpha1.KnativeServin
 
 	// Update the refetched finalizer list.
 	finalizers = sets.NewString(refetched.GetFinalizers()...)
-	finalizers.Delete(finalizer)
+	finalizers.Delete(finalizerName)
 	refetched.SetFinalizers(finalizers.List())
 
 	if err := r.client.Update(context.TODO(), refetched); err != nil {
 		return fmt.Errorf("failed to update KnativeServing with removed finalizer: %w", err)
 	}
 	return nil
-}
-
-func finalizerName() string {
-	name, err := k8sutil.GetOperatorName()
-	if err != nil {
-		panic(err)
-	}
-	return name
 }

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -33,7 +33,9 @@ const (
 	routeLabelKey     = "serving.knative.dev/route"
 	ingressClassKey   = "networking.knative.dev/ingress.class"
 	istioIngressClass = "istio.ingress.networking.knative.dev"
-	finalizerName     = "knative-serving-openshift"
+
+	// This needs to remain "knative-serving-openshift" to be compatible with earlier versions.
+	finalizerName = "knative-serving-openshift"
 )
 
 var log = common.Log.WithName("controller")

--- a/olm-catalog/serverless-operator/1.7.0/serverless-operator.v1.7.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.7.0/serverless-operator.v1.7.0.clusterserviceversion.yaml
@@ -306,7 +306,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: METRICS_DOMAIN
                   value: knative.dev/serving-operator
-                image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
+                image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
                 imagePullPolicy: IfNotPresent
                 name: knative-serving-operator
                 ports:
@@ -384,17 +384,17 @@ spec:
                     - name: KOURIER_MANIFEST_PATH
                       value: deploy/resources/kourier/kourier-latest.yaml
                     - name: IMAGE_queue-proxy
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-queue
                     - name: IMAGE_activator
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-activator
                     - name: IMAGE_autoscaler
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler
                     - name: IMAGE_autoscaler-hpa
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler-hpa
                     - name: IMAGE_controller
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-controller
                     - name: IMAGE_webhook
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-webhook
                     - name: IMAGE_3scale-kourier-gateway
                       value: docker.io/maistra/proxyv2-ubi8:1.0.8
                     - name: IMAGE_3scale-kourier-control
@@ -531,23 +531,23 @@ spec:
     name: Red Hat, Inc.
   relatedImages:
     - name: IMAGE_QUEUE
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-queue
     - name: IMAGE_activator
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-activator
     - name: IMAGE_autoscaler
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler
     - name: IMAGE_autoscaler-hpa
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler-hpa
     - name: IMAGE_controller
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-controller
     - name: IMAGE_webhook
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-webhook
     - name: IMAGE_3scale-kourier-control
       image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
     - name: IMAGE_3scale-kourier-gateway
       image: docker.io/maistra/proxyv2-ubi8:1.0.8
     - name: knative-serving-operator
-      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
+      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
     - name: knative-operator
       image: $IMAGE_KNATIVE_OPERATOR
     - name: knative-openshift-ingress

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -189,6 +189,9 @@ function run_knative_serving_rolling_upgrade_tests {
   PROBER_PID=$!
 
   if [[ $UPGRADE_SERVERLESS == true ]]; then
+    local serving_version
+    serving_version=$(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}")
+
     # Get latest CSV from the given channel
     local upgrade_to
     upgrade_to=$("${rootdir}/hack/catalog.sh" | sed -n '/channels/,$p;' | sed -n "/- name: \"${OLM_UPGRADE_CHANNEL}\"$/{n;p;}" | awk '{ print $2 }')
@@ -202,9 +205,14 @@ function run_knative_serving_rolling_upgrade_tests {
       fi
       # Check we got RequirementsNotMet error
       [[ $(oc get ClusterServiceVersion $upgrade_to -n $OPERATORS_NAMESPACE -o=jsonpath="{.status.requirementStatus[?(@.name==\"$upgrade_to\")].message}") =~ "requirement not met: minKubeVersion" ]] || return 1
+      # Check KnativeServing still has the old version
+      [[ $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") == "$serving_version" ]] || return 1
     else
       approve_csv "$upgrade_to" "$OLM_UPGRADE_CHANNEL" || return 1
-      timeout 900 '[[ ! ( $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
+      timeout 900 '[[ ! ( $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") != $serving_version && $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
+
+      # Assert that the old image references eventually fade away
+      timeout 900 "oc get pod -n $SERVING_NAMESPACE -o yaml | grep image: | uniq | grep $serving_version" || return 1
     fi
     end_prober_test ${PROBER_PID}
   fi


### PR DESCRIPTION
The title has it all. 0.13.2 has the latest and greatest.