### PR TITLE
Revert "Rename knative-serving-openshift -> knative-openshift (#234)"

### DIFF
--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -9,9 +9,9 @@ RUN go build -o /usr/bin/manager ./cmd/manager
 
 FROM openshift/origin-base
 
-ENV OPERATOR=/usr/local/bin/knative-openshift \
+ENV OPERATOR=/usr/local/bin/knative-serving-openshift \
     USER_UID=1001 \
-    USER_NAME=knative-openshift
+    USER_NAME=knative-serving-openshift
 
 COPY --from=builder /usr/bin/manager ${OPERATOR}
 

--- a/knative-operator/README.md
+++ b/knative-operator/README.md
@@ -1,4 +1,4 @@
-# knative-openshift
+# knative-serving-openshift
 
 A platform-specific operator for OpenShift to be deployed with the
 primary knative-serving operator

--- a/knative-operator/build/Dockerfile
+++ b/knative-operator/build/Dockerfile
@@ -1,11 +1,11 @@
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
-ENV OPERATOR=/usr/local/bin/knative-openshift \
+ENV OPERATOR=/usr/local/bin/knative-serving-openshift \
     USER_UID=1001 \
-    USER_NAME=knative-openshift
+    USER_NAME=knative-serving-openshift
 
 # install operator binary
-COPY build/_output/bin/knative-openshift ${OPERATOR}
+COPY build/_output/bin/knative-serving-openshift ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/knative-operator/build/bin/entrypoint
+++ b/knative-operator/build/bin/entrypoint
@@ -5,7 +5,7 @@
 
 if ! whoami &>/dev/null; then
   if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-knative-openshift}:x:$(id -u):$(id -g):${USER_NAME:-knative-openshift} user:${HOME}:/sbin/nologin" >> /etc/passwd
+    echo "${USER_NAME:-knative-serving-openshift}:x:$(id -u):$(id -g):${USER_NAME:-knative-serving-openshift} user:${HOME}:/sbin/nologin" >> /etc/passwd
   fi
 fi
 

--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	ctx := context.TODO()
 	// Become the leader before proceeding
-	err = leader.Become(ctx, "knative-openshift-lock")
+	err = leader.Become(ctx, "knative-serving-openshift-lock")
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)

--- a/knative-operator/deploy/operator.yaml
+++ b/knative-operator/deploy/operator.yaml
@@ -1,24 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: knative-openshift
+  name: knative-serving-openshift
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: knative-openshift
+      name: knative-serving-openshift
   template:
     metadata:
       labels:
-        name: knative-openshift
+        name: knative-serving-openshift
         app: openshift-admission-server
     spec:
-      serviceAccountName: knative-openshift
+      serviceAccountName: knative-serving-openshift
       containers:
-        - name: knative-openshift
+        - name: knative-serving-openshift
           image: docker.io/jcrossley3/knative-operator
           command:
-          - knative-openshift
+          - knative-serving-openshift
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -28,7 +28,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "knative-openshift"
+              value: "knative-serving-openshift"
             - name: MIN_OPENSHIFT_VERSION
               value: "4.3.0-0"
             - name: REQUIRED_SERVING_NAMESPACE

--- a/knative-operator/deploy/role.yaml
+++ b/knative-operator/deploy/role.yaml
@@ -1,7 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: knative-openshift
+  name: knative-serving-openshift
 rules:
 - apiGroups:
   - ""
@@ -37,7 +37,7 @@ rules:
   resources:
   - deployments/finalizers
   resourceNames:
-  - knative-openshift
+  - knative-serving-openshift
   verbs:
   - "update"
 - apiGroups:
@@ -56,7 +56,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: knative-openshift
+  name: knative-serving-openshift
 rules:
   - apiGroups: ["*"]
     resources: ["*"]

--- a/knative-operator/deploy/role_binding.yaml
+++ b/knative-operator/deploy/role_binding.yaml
@@ -1,24 +1,24 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: knative-openshift
+  name: knative-serving-openshift
 subjects:
 - kind: ServiceAccount
-  name: knative-openshift
+  name: knative-serving-openshift
 roleRef:
   kind: Role
-  name: knative-openshift
+  name: knative-serving-openshift
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: knative-openshift
+  name: knative-serving-openshift
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: knative-openshift
+  name: knative-serving-openshift
 subjects:
 - kind: ServiceAccount
-  name: knative-openshift
+  name: knative-serving-openshift
   namespace: default

--- a/knative-operator/deploy/service_account.yaml
+++ b/knative-operator/deploy/service_account.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: knative-openshift
+  name: knative-serving-openshift

--- a/knative-operator/pkg/webhook/webhook.go
+++ b/knative-operator/pkg/webhook/webhook.go
@@ -50,8 +50,8 @@ func AddToManager(m manager.Manager) error {
 		Port:    9876,
 		CertDir: "/tmp/cert",
 		BootstrapOptions: &webhook.BootstrapOptions{
-			MutatingWebhookConfigName:   "mutating-knative-openshift",
-			ValidatingWebhookConfigName: "validating-knative-openshift",
+			MutatingWebhookConfigName:   "mutating-knative-serving-openshift",
+			ValidatingWebhookConfigName: "validating-knative-serving-openshift",
 			Service: &webhook.Service{
 				Namespace: operatorNs,
 				Name:      "admission-server-service",

--- a/olm-catalog/serverless-operator/1.7.0/serverless-operator.v1.7.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.7.0/serverless-operator.v1.7.0.clusterserviceversion.yaml
@@ -347,24 +347,24 @@ spec:
                 - containerPort: 9090
                   name: metrics
               serviceAccountName: knative-serving-operator
-      - name: knative-openshift
+      - name: knative-serving-openshift
         spec:
           replicas: 1
           selector:
             matchLabels:
-              name: knative-openshift
+              name: knative-serving-openshift
           template:
             metadata:
               labels:
-                name: knative-openshift
+                name: knative-serving-openshift
                 app: openshift-admission-server
             spec:
               serviceAccountName: knative-serving-operator
               containers:
-                - name: knative-openshift
+                - name: knative-serving-openshift
                   image: $IMAGE_KNATIVE_OPERATOR
                   command:
-                  - knative-openshift
+                  - knative-serving-openshift
                   imagePullPolicy: Always
                   env:
                     - name: WATCH_NAMESPACE
@@ -374,7 +374,7 @@ spec:
                         fieldRef:
                           fieldPath: metadata.name
                     - name: OPERATOR_NAME
-                      value: "knative-openshift"
+                      value: "knative-serving-openshift"
                     - name: MIN_OPENSHIFT_VERSION
                       value: "4.3.0-0"
                     - name: REQUIRED_SERVING_NAMESPACE

--- a/test/service.go
+++ b/test/service.go
@@ -138,7 +138,7 @@ func WaitForServiceState(ctx *Context, name, namespace string, inState func(s *s
 
 func WaitForOperatorDepsDeleted(ctx *Context) error {
 	serverlessDependencies := []string{"knative-openshift-ingress",
-		"knative-serving-operator", "knative-eventing-operator", "knative-openshift"}
+		"knative-serving-operator", "knative-eventing-operator", "knative-serving-openshift"}
 
 	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
 		existingDeployments, err := ctx.Clients.Kube.AppsV1().Deployments(OperatorsNamespace).List(metav1.ListOptions{})


### PR DESCRIPTION
This reverts commit d2d5e97ba9fd6c18d220b95fab22e0ab9d0f9194.

The rename breaks our upgradeability if images change. I suspect that is because the deployment is no longer updated atomically or something along these lines. See #236 for reference on what the upgrade should look like.

Sending this in to get CI clearance. @jcrossley3 let's discuss this before merging though.

/hold