### PR TITLE
Make it possible to choose different repos in tests

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -6,6 +6,10 @@ readonly BUILD_NUMBER=${BUILD_NUMBER:-$(uuidgen)}
 source "$(dirname "${BASH_SOURCE[0]}")/../../test/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh"
 
 readonly KNATIVE_VERSION="${KNATIVE_VERSION:-v0.13.2}"
+readonly KNATIVE_SERVING_REPO="${KNATIVE_SERVING_REPO:-"https://github.com/openshift/knative-serving.git"}"
+readonly KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-}"
+readonly KNATIVE_SERVING_OPERATOR_REPO="${KNATIVE_SERVING_OPERATOR_REPO:-"https://github.com/openshift-knative/serving-operator.git"}"
+readonly KNATIVE_SERVING_OPERATOR_VERSION="${KNATIVE_SERVING_OPERATOR_VERSION:-}"
 
 readonly CATALOG_SOURCE_FILENAME="${CATALOG_SOURCE_FILENAME:-catalogsource-ci.yaml}"
 readonly DOCKER_REPO_OVERRIDE="${DOCKER_REPO_OVERRIDE:-}"

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -87,14 +87,14 @@ function remove_temporary_gopath {
 }
 
 function checkout_knative_serving {
-  local knative_version=$1
+  local revision="${KNATIVE_SERVING_VERSION:-"release-${1}"}"
   # Setup a temporary GOPATH to safely check out the repository without breaking other things.
   make_temporary_gopath
 
   # Checkout the relevant code to run
   export KNATIVE_SERVING_HOME="$GOPATH/src/knative.dev/serving"
   mkdir -p "$KNATIVE_SERVING_HOME"
-  git clone -b "release-${knative_version}" --depth 1 https://github.com/openshift/knative-serving.git "$KNATIVE_SERVING_HOME"
+  git clone -b "$revision" --depth 1 "$KNATIVE_SERVING_REPO" "$KNATIVE_SERVING_HOME"
   git describe --always --tags
 }
 
@@ -263,18 +263,14 @@ function end_prober_test {
 
 function run_knative_serving_operator_tests {
   (
-  local version target serverless_rootdir exitstatus patchfile fork gitdesc
-  version=$1
-  fork="${2:-openshift-knative}"
-  serverless_rootdir="$(pwd)"
+  local revision target exitstatus gitdesc
+  revision="${KNATIVE_SERVING_OPERATOR_VERSION:-"openshift-${1}"}"
   make_temporary_gopath
 
-  logger.info "Checkout the code ${fork}/serving-operator @ ${version}"
+  logger.info "Checkout the code from $KNATIVE_SERVING_OPERATOR_REPO @ ${revision}"
   target="${GOPATH}/src/knative.dev/serving-operator"
   mkdir -p "$target"
-  git clone --branch "openshift-${version}" --depth 1 \
-    "https://github.com/${fork}/serving-operator.git" \
-    "${target}"
+  git clone --branch "$revision" --depth 1 "$KNATIVE_SERVING_OPERATOR_REPO" "${target}"
   pushd "${target}" || return $?
 
   gitdesc=$(git describe --always --tags --dirty)


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/SRVCOM-753 
It is important to have this parameterized. This way we can re-use the scripts in internal Jenkins for running tests from knative-serving and serving-operator repos (either from github or internal dist-git repos).