### PR TITLE
[SRVKS-513] Manually combine configmaps for service-ca and trusted-ca.

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -234,11 +234,9 @@ func (r *ReconcileKnativeServing) ensureFinalizers(instance *servingv1alpha1.Kna
 func (r *ReconcileKnativeServing) ensureCustomCertsConfigMap(instance *servingv1alpha1.KnativeServing) error {
 	const (
 		// Docs: https://github.com/openshift/service-ca-operator
-		serviceCAKey     = "service.alpha.openshift.io/inject-cabundle"
-		serviceCAContent = "service-ca.crt"
+		serviceCAKey = "service.alpha.openshift.io/inject-cabundle"
 		// Docs: https://docs.openshift.com/container-platform/4.3/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki
-		trustedCAKey     = "config.openshift.io/inject-trusted-cabundle"
-		trustedCAContent = "tls-ca-bundle.pem"
+		trustedCAKey = "config.openshift.io/inject-trusted-cabundle"
 	)
 
 	certs := instance.Spec.ControllerCustomCerts

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -242,6 +242,10 @@ func (r *ReconcileKnativeServing) ensureCustomCertsConfigMap(instance *servingv1
 	)
 
 	certs := instance.Spec.ControllerCustomCerts
+
+	// If the user doesn't specify anything else, this is set by the webhook/controller defaulter to
+	// cause us to automatically pull in the relevant ConfigMaps from the cluster. The user needs
+	// to specifically opt-out of this today by specifying an empty Name and ConfigMap explicitly.
 	if certs.Type != "ConfigMap" || certs.Name == "" {
 		return nil
 	}


### PR DESCRIPTION
My assumption about being able to use both the serviceCA annotation and the trustedCA label on the same configMap have been proven wrong. This pulls their management apart into separate configMaps that are watched by the reconciler. The contents of both configMaps are unified into a single configMap, which is then mounted into the controller via the operator's mechanism.

**Note:** This retains "stomping" behavior from master. We should maybe think about if that's the right thing or if the user should be able to add even more certs to the configmap if needed. I'd like to tackle that separately though.