### PR TITLE
Run HA tests against the correct namespace and fix short-circuit.

### DIFF
--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -60,7 +60,7 @@ func TestKnativeServing(t *testing.T) {
 		}
 
 		// The list of deployments that are HA-ed
-		for _, deployment := range []string{"controller, autoscaler-hpa"} {
+		for _, deployment := range []string{"controller", "autoscaler-hpa"} {
 			if err := test.CheckDeploymentScale(caCtx, knativeServing, deployment, haReplicas); err != nil {
 				t.Fatalf("Failed to verify default HA settings: %v", err)
 			}


### PR DESCRIPTION
We've been incorrectly short-circuiting this function in our CI, effectively never running the HA tests at all.

This removes the wrong short-circuit and makes the tests run. Turns out, they ran against a wrong namespace so this fixes that as well.