### PR TITLE
Sort environment variables to make unit test stable.

### DIFF
--- a/knative-operator/pkg/common/deployment_test.go
+++ b/knative-operator/pkg/common/deployment_test.go
@@ -2,6 +2,7 @@ package common_test
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -87,10 +88,23 @@ func TestApplyEnvironmentToDeployment(t *testing.T) {
 				if err := c.Get(context.TODO(), client.ObjectKey{Name: test.expect.Name, Namespace: test.expect.Namespace}, got); err != nil {
 					t.Fatalf("Deployment.Get = %v, want no error", err)
 				}
+
+				sortEnv(got)
+				sortEnv(test.expect)
+
 				if !equality.Semantic.DeepEqual(test.expect, got) {
 					t.Fatalf("Deployment wasn't what we expected: %#v, want %#v", got, test.expect)
 				}
 			}
+		})
+	}
+}
+
+func sortEnv(deploy *appsv1.Deployment) {
+	for i := range deploy.Spec.Template.Spec.Containers {
+		container := &deploy.Spec.Template.Spec.Containers[i]
+		sort.Slice(container.Env, func(i, j int) bool {
+			return container.Env[i].Name < container.Env[j].Name
 		})
 	}
 }


### PR DESCRIPTION
I recently introduced a flaky unit test. Because of map semantics in the test, the order in which the env vars are added is non-deterministic.

Sorting them makes them deterministic without affecting what we want to test.

See error here https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/241/pull-ci-openshift-knative-serverless-operator-master-unit-test/570