### PR TITLE
Remove the spec.config block from KnativeServing example

### DIFF
--- a/olm-catalog/serverless-operator/1.7.0/serverless-operator.v1.7.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.7.0/serverless-operator.v1.7.0.clusterserviceversion.yaml
@@ -11,51 +11,6 @@ metadata:
             "name": "knative-serving"
           },
           "spec": {
-            "config": {
-              "autoscaler": {
-                "container-concurrency-target-default": "100",
-                "container-concurrency-target-percentage": "1.0",
-                "enable-scale-to-zero": "true",
-                "max-scale-up-rate": "10",
-                "panic-threshold-percentage": "200.0",
-                "panic-window": "6s",
-                "panic-window-percentage": "10.0",
-                "scale-to-zero-grace-period": "30s",
-                "stable-window": "60s",
-                "tick-interval": "2s"
-              },
-              "defaults": {
-                "revision-cpu-limit": "1000m",
-                "revision-cpu-request": "400m",
-                "revision-memory-limit": "200M",
-                "revision-memory-request": "100M",
-                "revision-timeout-seconds": "300"
-              },
-              "deployment": {
-                "registriesSkippingTagResolving": "ko.local,dev.local"
-              },
-              "gc": {
-                "stale-revision-create-delay": "24h",
-                "stale-revision-lastpinned-debounce": "5h",
-                "stale-revision-minimum-generations": "1",
-                "stale-revision-timeout": "15h"
-              },
-              "logging": {
-                "loglevel.activator": "info",
-                "loglevel.autoscaler": "info",
-                "loglevel.controller": "info",
-                "loglevel.queueproxy": "info",
-                "loglevel.webhook": "info"
-              },
-              "observability": {
-                "logging.enable-var-log-collection": "false",
-                "metrics.backend-destination": "prometheus"
-              },
-              "tracing": {
-                "backend": "none",
-                "sample-rate": "0.1"
-              }
-            }
           }
         },
         {


### PR DESCRIPTION
Don't give an example using `spec.config` since it's not something we plan to support users munging for the initial GA release.