### PR TITLE
Add activator HA check.

### DIFF
--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -60,7 +60,7 @@ func TestKnativeServing(t *testing.T) {
 		}
 
 		// Check the status of deployments in the knative serving namespace
-		for _, deployment := range []string{"controller", "autoscaler-hpa"} {
+		for _, deployment := range []string{"activator", "controller", "autoscaler-hpa"} {
 			if err := test.CheckDeploymentScale(caCtx, knativeServing, deployment, haReplicas); err != nil {
 				t.Fatalf("Failed to verify default HA settings: %v", err)
 			}


### PR DESCRIPTION
I backported the respective change into the serving operator here: https://github.com/openshift-knative/serving-operator/commit/ae00341445d1cd1fb8e372200287ebe6499e1431. The activator should now also start with 2 replicas by default.