### PR TITLE
Fix approve_csv to actually use the oc replace command

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -90,8 +90,7 @@ function approve_csv {
   # Switch channel and source if required
   oc get subscription "$OPERATOR" -n "${OPERATORS_NAMESPACE}" -oyaml | \
     sed -e "s/\(.*channel:\).*/\1 ${channel}/" \
-        -e "s/\(.*source:\).*/\1 ${OLM_SOURCE}/" \
-    oc replace -f -
+        -e "s/\(.*source:\).*/\1 ${OLM_SOURCE}/" | oc replace -f -
 
   # Wait for the installplan to be available
   timeout 900 "[[ -z \$(find_install_plan $csv_version) ]]" || return 1


### PR DESCRIPTION
The `oc replace` command is supposed to be at the end of the pipe right after the sed command but the `|` was missing there. As a result, the following error was thrown in all upgrade tests and the changes were not applied:
```
+ approve_csv serverless-operator.v1.6.0 4.3
+ local csv_version install_plan channel
+ csv_version=serverless-operator.v1.6.0
+ channel=4.3
+ oc get subscription serverless-operator -n openshift-operators -oyaml
+ sed -e 's/\(.*channel:\).*/\1 4.3/' -e 's/\(.*source:\).*/\1 serverless-operator/' oc replace -f -
sed: file - line 2: unknown command: `k'
```