### PR TITLE
Collecting build artifacts

### DIFF
--- a/hack/lib/ui.bash
+++ b/hack/lib/ui.bash
@@ -20,6 +20,28 @@ readonly COLOR_CYAN='\e[0;36m'
 readonly COLOR_LIGHT_RED='\e[1;31m'
 readonly COLOR_LIGHT_YELLOW='\e[1;33m'
 
+function debugging.setup {
+  local debuglog debugdir
+  debugdir="${ARTIFACTS:-/tmp}"
+  debuglog="${debugdir}/debuglog-$(basename "$0").log"
+  logger.debug "Debug log (set -x) is written to: ${debuglog}"
+  # ref: https://serverfault.com/a/579078
+  # Use FD 19 to capture the debug stream caused by "set -x":
+  exec 19> "$debuglog"
+  # Tell bash about it  (there's nothing special about 19, its arbitrary)
+  export BASH_XTRACEFD=19
+
+  # Register finish of debugging at exit
+  trap debugging.finish EXIT
+  set -x
+}
+
+function debugging.finish {
+  # Close the output:
+  set +x
+  exec 19>&-
+}
+
 function logger.debug {
   logger.__log 'DEBUG' "${COLOR_BLUE}" "$*"
 }

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-readonly BUILD_NUMBER=${BUILD_NUMBER:-$(uuidgen)}
+readonly BUILD_NUMBER=${BUILD_NUMBER:-$(head -c 128 < /dev/urandom | base64 | fold -w 8 | head -n 1)}
+
+if [[ -n "${ARTIFACT_DIR}" ]]; then
+  ARTIFACTS="${ARTIFACT_DIR}/build-${BUILD_NUMBER}"
+  readonly ARTIFACTS
+  mkdir -p "${ARTIFACTS}"
+fi
 
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/../../test/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -7,9 +7,9 @@ set -Eeuo pipefail
 
 # Enable extra verbosity if running in CI.
 if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
-  set -x
   env
 fi
+debugging.setup
 
 register_teardown || exit $?
 scale_up_workers || exit $?

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -7,9 +7,9 @@ set -Eeuo pipefail
 
 # Enable extra verbosity if running in CI.
 if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
-  set -x
   env
 fi
+debugging.setup
 
 scale_up_workers || exit $?
 create_namespaces || exit $?


### PR DESCRIPTION
This PR collects build artifacts in a PROW artifacts directory.
Those were previously dropped, but now are archived:

 * Go test XML reports
 * Go test logs

Also, adding a neat trick to collect debug log (set -x) in a file
without cluttering the primary output. This file is also collected as a
build artifact for further inspection.