### PR TITLE
Quote channel to prevent an error from parsing a number

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -89,7 +89,7 @@ function approve_csv {
 
   # Switch channel and source if required
   oc get subscription "$OPERATOR" -n "${OPERATORS_NAMESPACE}" -oyaml | \
-    sed -e "s/\(.*channel:\).*/\1 ${channel}/" \
+    sed -e "s/\(.*channel:\).*/\1 \"${channel}\"/" \
         -e "s/\(.*source:\).*/\1 ${OLM_SOURCE}/" | oc replace -f -
 
   # Wait for the installplan to be available


### PR DESCRIPTION
* the olm doesn't accept numbers so e.g. 4.3 needs to be quoted to make
it a string