### PR TITLE
Revert "Quote channel to prevent an error from parsing a number (#263)"

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -89,7 +89,7 @@ function approve_csv {
 
   # Switch channel and source if required
   oc get subscription "$OPERATOR" -n "${OPERATORS_NAMESPACE}" -oyaml | \
-    sed -e "s/\(.*channel:\).*/\1 \"${channel}\"/" \
+    sed -e "s/\(.*channel:\).*/\1 ${channel}/" \
         -e "s/\(.*source:\).*/\1 ${OLM_SOURCE}/" | oc replace -f -
 
   # Wait for the installplan to be available


### PR DESCRIPTION
This broke our master branch. 

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/263/pull-ci-openshift-knative-serverless-operator-master-4.4-e2e-aws-ocp-44/482

I take the blame for this as I merged prematurely.

This reverts commit 358259e32c143d713bc78b97f2ee6d75f4fb2440.