### PR TITLE
Fix an error with undefined ARTIFACTS_DIR

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -2,7 +2,7 @@
 
 readonly BUILD_NUMBER=${BUILD_NUMBER:-$(head -c 128 < /dev/urandom | base64 | fold -w 8 | head -n 1)}
 
-if [[ -n "${ARTIFACT_DIR}" ]]; then
+if [[ -n "${ARTIFACT_DIR:-}" ]]; then
   ARTIFACTS="${ARTIFACT_DIR}/build-${BUILD_NUMBER}"
   readonly ARTIFACTS
   mkdir -p "${ARTIFACTS}"


### PR DESCRIPTION
* Fixes an error for environments where ARTIFACTS_DIR is undefined (e.g. downstream testing, jenkins)