### PR TITLE
[WIP] Remove miminum validation to fix 4.5 CRD conversion.

### DIFF
--- a/olm-catalog/serverless-operator/1.7.0/operator_v1alpha1_knativeserving_crd.yaml
+++ b/olm-catalog/serverless-operator/1.7.0/operator_v1alpha1_knativeserving_crd.yaml
@@ -119,7 +119,6 @@ spec:
                 replicas:
                   description: The number of replicas that HA parts of the control plane will be scaled to
                   type: integer
-                  minimum: 1
           type: object
         status:
           description: Status defines the observed state of KnativeServing


### PR DESCRIPTION
CRD conversion on 4.5 breaks likely due to this setting. This is just trying out if that's true.