### PR TITLE
Hardcode 1.7.0 image references in the CSV.

### DIFF
--- a/hack/catalog.sh
+++ b/hack/catalog.sh
@@ -30,8 +30,8 @@ elif [ -n "$DOCKER_REPO_OVERRIDE" ]; then
   export IMAGE_KNATIVE_OPERATOR="${DOCKER_REPO_OVERRIDE}/knative-operator"
   export IMAGE_KNATIVE_OPENSHIFT_INGRESS="${DOCKER_REPO_OVERRIDE}/knative-openshift-ingress"
 else
-  export IMAGE_KNATIVE_OPERATOR="registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator"
-  export IMAGE_KNATIVE_OPENSHIFT_INGRESS="registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress"
+  export IMAGE_KNATIVE_OPERATOR="registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.7.0:knative-operator"
+  export IMAGE_KNATIVE_OPENSHIFT_INGRESS="registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.7.0:knative-openshift-ingress"
 fi
 
 CRD=$(cat $(ls $CRD_DIR/*) | grep -v -- "---" | indent apiVersion)


### PR DESCRIPTION
As per title, to make this branch use the newly promoted images by default.