### PR TITLE
Image override with deployment name

### DIFF
--- a/knative-operator/pkg/common/eventing.go
+++ b/knative-operator/pkg/common/eventing.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	eventingv1alpha1 "knative.dev/eventing-operator/pkg/apis/eventing/v1alpha1"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,7 +20,7 @@ func MutateEventing(ke *eventingv1alpha1.KnativeEventing, c client.Client) error
 
 // eventingImagesFromEnviron overrides registry images
 func eventingImagesFromEnviron(ke *eventingv1alpha1.KnativeEventing, _ client.Client) error {
-	ke.Spec.Registry.Override = buildImageOverrideMapFromEnviron()
+	ke.Spec.Registry.Override = BuildImageOverrideMapFromEnviron(os.Environ())
 
 	if defaultVal, ok := ke.Spec.Registry.Override["default"]; ok {
 		ke.Spec.Registry.Default = defaultVal

--- a/knative-operator/pkg/common/eventing_test.go
+++ b/knative-operator/pkg/common/eventing_test.go
@@ -19,7 +19,8 @@ func init() {
 
 func TestMutateEventing(t *testing.T) {
 	const (
-		image = "docker.io/foo:tag"
+		image1 = "docker.io/foo:tag"
+		image2 = "docker.io/baz:tag"
 	)
 	client := fake.NewFakeClient()
 	ke := &eventingv1alpha1.KnativeEventing{
@@ -29,10 +30,14 @@ func TestMutateEventing(t *testing.T) {
 		},
 	}
 	// Setup image override
-	os.Setenv("IMAGE_foo", image)
+	os.Setenv("IMAGE_foo", image1)
+	// Setup image override with deployment name
+	os.Setenv("IMAGE_bar_baz", image2)
+
 	// Mutate for OpenShift
 	if err := common.MutateEventing(ke, client); err != nil {
 		t.Error(err)
 	}
-	verifyImageOverride(t, (*v1alpha1.Registry)(&ke.Spec.Registry), "foo", image)
+	verifyImageOverride(t, (*v1alpha1.Registry)(&ke.Spec.Registry), "foo", image1)
+	verifyImageOverride(t, (*v1alpha1.Registry)(&ke.Spec.Registry), "bar/baz", image2)
 }

--- a/knative-operator/pkg/common/serving.go
+++ b/knative-operator/pkg/common/serving.go
@@ -7,6 +7,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -116,7 +117,7 @@ func ensureCustomCerts(ks *servingv1alpha1.KnativeServing, _ client.Client) erro
 
 // imagesFromEnviron overrides registry images
 func imagesFromEnviron(ks *servingv1alpha1.KnativeServing, _ client.Client) error {
-	ks.Spec.Registry.Override = buildImageOverrideMapFromEnviron()
+	ks.Spec.Registry.Override = BuildImageOverrideMapFromEnviron(os.Environ())
 
 	if defaultVal, ok := ks.Spec.Registry.Override["default"]; ok {
 		ks.Spec.Registry.Default = defaultVal

--- a/knative-operator/pkg/common/util_test.go
+++ b/knative-operator/pkg/common/util_test.go
@@ -1,12 +1,91 @@
 package common_test
 
 import (
-	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
+	"fmt"
 	"testing"
+
+	"reflect"
+
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
+
+	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 )
+
+func TestBuildImageOverrideMapFromEnviron(t *testing.T) {
+	cases := []struct {
+		name     string
+		envMap   map[string]string
+		expected map[string]string
+	}{
+		{
+			name: "Simple container name",
+			envMap: map[string]string{
+				"IMAGE_foo": "quay.io/myimage",
+			},
+			expected: map[string]string{
+				"foo": "quay.io/myimage",
+			},
+		},
+		{
+			name: "Deployment+container name",
+			envMap: map[string]string{
+				"IMAGE_foo_bar": "quay.io/myimage",
+			},
+			expected: map[string]string{
+				"foo/bar": "quay.io/myimage",
+			},
+		},
+		{
+			name: "Deployment+container and container name",
+			envMap: map[string]string{
+				"IMAGE_foo_bar": "quay.io/myimage1",
+				"IMAGE_bar":     "quay.io/myimage2",
+			},
+			expected: map[string]string{
+				"foo/bar": "quay.io/myimage1",
+				"bar":     "quay.io/myimage2",
+			},
+		},
+		{
+			name: "Different prefix",
+			envMap: map[string]string{
+				"X_foo": "quay.io/myimage",
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "No env var value",
+			envMap: map[string]string{
+				"IMAGE_foo": "",
+			},
+			expected: map[string]string{},
+		},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		environ := environFromMap(tc.envMap)
+		overrideMap := common.BuildImageOverrideMapFromEnviron(environ)
+
+		if !reflect.DeepEqual(overrideMap, tc.expected) {
+			t.Errorf("Image override map is not equal. Case name: %q. Expected: %v, actual: %v", tc.name, tc.expected, overrideMap)
+		}
+
+	}
+}
 
 func verifyImageOverride(t *testing.T, registry *servingv1alpha1.Registry, imageName string, expected string) {
 	if registry.Override[imageName] != expected {
 		t.Errorf("Missing queue image. Expected a map with following override in it : %v=%v, actual: %v", imageName, expected, registry.Override)
 	}
+}
+
+func environFromMap(envMap map[string]string) []string {
+	e := []string{}
+
+	for k, v := range envMap {
+		e = append(e, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return e
 }


### PR DESCRIPTION
Support the image override with deployment names : https://github.com/knative/eventing-operator/pull/159

Following env var
```
- name: IMAGE_imc-controller_controller
  value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-controller
```

will result in 
```
spec:
  registry:
    override:
      imc-controller/controller: >-
        registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-controller
```

Old image override behavior is not changed.