### PR TITLE
Take 2: [WIP] CSV 1.8 and eventing 0.14

### DIFF
--- a/olm-catalog/serverless-operator/1.8.0/operator_v1alpha1_knativeeventing_crd.yaml
+++ b/olm-catalog/serverless-operator/1.8.0/operator_v1alpha1_knativeeventing_crd.yaml
@@ -1,0 +1,90 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: knativeeventings.operator.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.version
+    name: Version
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+    name: Reason
+    type: string
+  group: operator.knative.dev
+  names:
+    kind: KnativeEventing
+    listKind: KnativeEventingList
+    plural: knativeeventings
+    singular: knativeeventing
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec defines the desired state of KnativeEventing
+          properties:
+            config:
+              additionalProperties:
+                additionalProperties:
+                  type: string
+                type: object
+              description: A means to override the corresponding entries in the upstream
+                configmaps
+              type: object
+            registry:
+              description: A means to override the corresponding deployment images in the upstream.
+                This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+              type: object
+              properties:
+                default:
+                  description: The default image reference template to use for all knative images.
+                    Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                  type: string
+                override:
+                  description: A map of a container name or image name to the full image location of the individual knative image.
+                  type: object
+                  additionalProperties:
+                    type: string
+                imagePullSecrets:
+                  description: A list of secrets to be used when pulling the knative images. The secret must be created in the
+                    same namespace as the knative-eventing deployments, and not the namespace of this resource.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the secret.
+                        type: string
+            default-broker-class:
+              description: The default broker type to use for the brokers Knative creates.
+                If no value is provided, ChannelBasedBroker will be used.
+              type: string
+          type: object
+        status:
+          properties:
+            version:
+              description: The version of the installed release
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/olm-catalog/serverless-operator/1.8.0/operator_v1alpha1_knativeserving_crd.yaml
+++ b/olm-catalog/serverless-operator/1.8.0/operator_v1alpha1_knativeserving_crd.yaml
@@ -1,0 +1,202 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: knativeservings.operator.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.version
+    name: Version
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    name: Reason
+    type: string
+  group: operator.knative.dev
+  names:
+    kind: KnativeServing
+    listKind: KnativeServingList
+    plural: knativeservings
+    singular: knativeserving
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Schema for the knativeservings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec defines the desired state of KnativeServing
+          properties:
+            config:
+              additionalProperties:
+                additionalProperties:
+                  type: string
+                type: object
+              description: A means to override the corresponding entries in the upstream
+                configmaps
+              type: object
+            knative-ingress-gateway:
+              description: A means to override the knative-ingress-gateway
+              type: object
+              properties:
+                selector:
+                  description: The selector for the ingress-gateway.
+                  type: object
+                  additionalProperties:
+                    type: string
+            cluster-local-gateway:
+              description: A means to override the cluster-local-gateway
+              type: object
+              properties:
+                selector:
+                  description: The selector for the ingress-gateway.
+                  type: object
+                  additionalProperties:
+                    type: string
+            registry:
+              description: A means to override the corresponding deployment images in the upstream.
+                This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+              type: object
+              properties:
+                default:
+                  description: The default image reference template to use for all knative images.
+                    Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                  type: string
+                override:
+                  description: A map of a container name or image name to the full image location of the individual knative image.
+                  type: object
+                  additionalProperties:
+                    type: string
+                imagePullSecrets:
+                  description: A list of secrets to be used when pulling the knative images. The secret must be created in the
+                    same namespace as the knative-serving deployments, and not the namespace of this resource.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the secret.
+                        type: string
+            controller-custom-certs:
+              description: Enabling the controller to trust registries with self-signed certificates
+              type: object
+              properties:
+                type:
+                  description: One of ConfigMap or Secret
+                  type: string
+                  enum:
+                  - ConfigMap
+                  - Secret
+                  - ""
+                name:
+                  description: The name of the ConfigMap or Secret
+                  type: string
+            high-availability:
+              description: Allows specification of HA control plane
+              type: object
+              properties:
+                replicas:
+                  description: The number of replicas that HA parts of the control plane will be scaled to
+                  type: integer
+                  minimum: 1
+            resources:
+              description: A mapping of deployment name to resource requirements
+              type: array
+              items:
+                type: object
+                properties:
+                  container:
+                    description: The name of the container
+                    type: string
+                  requests:
+                    type: object
+                    properties:
+                      memory:
+                        type: string
+                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      cpu:
+                        type: string
+                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      storage:
+                        type: string
+                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      ephemeral-storage:
+                        type: string
+                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                  limits:
+                    type: object
+                    properties:
+                      memory:
+                        type: string
+                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      cpu:
+                        type: string
+                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      storage:
+                        type: string
+                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      ephemeral-storage:
+                        type: string
+                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+          type: object
+        status:
+          description: Status defines the observed state of KnativeServing
+          properties:
+            conditions:
+              description: The latest available observations of a resource's current
+                state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the last time the condition
+                      transitioned from one status to another. We use VolatileTime
+                      in place of metav1.Time to exclude this from creating equality.Semantic
+                      differences (all other things held constant).
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  severity:
+                    description: Severity with which to treat failures of this type
+                      of condition. When this is not specified, it defaults to Error.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition.
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            version:
+              description: The version of the installed release
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/olm-catalog/serverless-operator/1.8.0/serverless-operator.v1.8.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.8.0/serverless-operator.v1.8.0.clusterserviceversion.yaml
@@ -1,0 +1,556 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.knative.dev/v1alpha1",
+          "kind": "KnativeServing",
+          "metadata": {
+            "name": "knative-serving"
+          },
+          "spec": {
+          }
+        },
+        {
+          "apiVersion": "operator.knative.dev/v1alpha1",
+          "kind": "KnativeEventing",
+          "metadata": {
+            "name": "knative-eventing"
+          },
+          "spec": {
+          }
+        }
+      ]
+    capabilities: Full Lifecycle
+    categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+    certified: "false"
+    createdAt: "2020-04-20T17:00:00Z"
+    description: |-
+      Provides a collection of API's based on Knative to support deploying and serving
+      of serverless applications and functions.
+    repository: https://github.com/openshift-knative/serverless-operator
+    support: Red Hat, Inc.
+  name: serverless-operator.v1.8.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents an installation of a particular version of Knative Serving
+      displayName: Knative Serving
+      kind: KnativeServing
+      name: knativeservings.operator.knative.dev
+      statusDescriptors:
+      - description: The version of Knative Serving installed
+        displayName: Version
+        path: version
+      - description: Conditions of Knative Serving installed
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes.conditions'
+      version: v1alpha1
+    - description: Represents an installation of a particular version of Knative Eventing
+      displayName: Knative Eventing
+      kind: KnativeEventing
+      name: knativeeventings.operator.knative.dev
+      statusDescriptors:
+      - description: The version of Knative Eventing installed
+        displayName: Version
+        path: version
+      version: v1alpha1
+  minKubeVersion: 1.15.0
+  description: |-
+    The Red Hat OpenShift Serverless operator provides a collection of APIs that
+    enables containers, microservices and functions to run "serverless".
+    Serverless applications can scale up and down (to zero) on demand and be triggered by a
+    number of event sources. OpenShift Serverless integrates with a number of
+    platform services, such as Metering and Monitoring and it is based on the open
+    source project Knative.
+
+    # Prerequisites
+    The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+    OpenShift Container Platform. For more information, see the documentation on [Getting started
+    with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/serverless_applications/index#serverless-getting-started).
+
+    # Supported Features
+    - **Easy to get started:** Provides a simplified developer experience to deploy
+      and run cloud native applications on Kubernetes, providing powerful
+      abstractions.
+    - **Immutable Revisions:** Deploy new features performing canary, A/B or
+      blue-green testing with gradual traffic rollout following best practices.
+    - **Use any programming language or runtime of choice:** From Java, Python, Go
+      and JavaScript to Quarkus, SpringBoot or Node.js.
+    - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+      or idling behavior. Applications automatically scale to zero when not in use,
+      or scale up to meet demand, with built in reliability and fault tolerance.
+    - **Event Driven Applications:** You can build loosely coupled, distributed applications
+      that can be connected to a variety of either built in or third party event sources,
+      powered by operators.
+    - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+      that can run anywhere OpenShift Container Platform runs. You can leverage data
+      locality and SaaS as you need it.
+
+    # Components & APIs
+    This operator provides the following components:
+
+    ## Knative Serving
+    Knative Serving builds on Kubernetes to support deploying and serving of
+    applications and functions as serverless containers. Serving is easy to get
+    started with and scales to support advanced scenarios. Other features
+    includes:
+    - Rapid deployment of serverless containers
+    - Automatic scaling up and down to zero
+    - Routing and network programming
+    - Point-in-time snapshots of deployed code and configurations
+    ![](https://i.imgur.com/vqL48B8.png)
+
+    ## Knative Eventing
+
+    Knative Eventing is a **[Technology Preview feature](https://access.redhat.com/support/offerings/techpreview)!**
+
+    Knative Eventing is a system that is designed to address a common need for cloud native
+    development and provides composable primitives to enable late-binding event sources and
+    event consumers.
+    Knative Eventing is designed to address a common need for cloud
+    native development:
+    - Services are loosely coupled during development and deployed independently
+    - A producer can generate events before a consumer is listening, and a consumer
+       can express an interest in an event or class of events that is not yet being
+       produced.
+    - Services can be connected to create new applications
+       * without modifying producer or consumer, and
+       * with the ability to select a specific subset of events from a particular
+         producer.
+
+    ## Knative Client - `kn`
+    The Knative client `kn` is your door to the Knative world. It allows you to
+    create Knative resources interactively from the command line or from within
+    Shell scripts.
+
+    `kn` offers you:
+    - Full support for managing all features of Knative Serving (services,
+      revisions, traffic splits)
+    - Growing support Knative eventing, closely following its development
+      (managing of sources & triggers)
+    - A plugin architecture similar to that of kubectl plugins
+    - A thin client-specific API in golang which helps in tasks like synchronously
+      waiting on Knative service write operations.
+    - An easy integration of Knative into Tekton Pipelines by using kn in a Tekton
+      Task.
+
+    # Further Information
+    For documentation on OpenShift Serverless, see:
+    - [Installation
+    Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/serverless_applications/installing-openshift-serverless-1)
+    - [Getting
+    started](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/serverless_applications/serverless-getting-started)
+  displayName: OpenShift Serverless Operator
+  icon:
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: knative-serving-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - events
+          - configmaps
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - "*"
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - "*"
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - "*"
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - networking.internal.knative.dev
+          resources:
+          - clusteringresses
+          - clusteringresses/status
+          - clusteringresses/finalizers
+          - ingresses
+          - ingresses/status
+          - ingresses/finalizers
+          verbs:
+          - "*"
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          - routes/status
+          - routes/finalizers
+          verbs:
+          - "*"
+        - apiGroups:
+          - operator.knative.dev
+          resources:
+          - knativeservings
+          - knativeservings/finalizers
+          verbs:
+          - '*'
+        serviceAccountName: knative-openshift-ingress
+      deployments:
+      - name: knative-serving-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: knative-serving-operator
+          template:
+            metadata:
+              annotations:
+                sidecar.istio.io/inject: "false"
+              labels:
+                name: knative-serving-operator
+            spec:
+              containers:
+              - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: knative-serving-operator
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: METRICS_DOMAIN
+                  value: knative.dev/serving-operator
+                image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
+                imagePullPolicy: IfNotPresent
+                name: knative-serving-operator
+                ports:
+                - containerPort: 9090
+                  name: metrics
+              serviceAccountName: knative-serving-operator
+      - name: knative-eventing-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: knative-eventing-operator
+          template:
+            metadata:
+              annotations:
+                sidecar.istio.io/inject: "false"
+              labels:
+                name: knative-eventing-operator
+            spec:
+              containers:
+              - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: knative-eventing-operator
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: METRICS_DOMAIN
+                  value: knative.dev/eventing-operator
+                image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-operator
+                imagePullPolicy: IfNotPresent
+                name: knative-eventing-operator
+                ports:
+                - containerPort: 9090
+                  name: metrics
+              serviceAccountName: knative-serving-operator
+      - name: knative-openshift
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: knative-openshift
+          template:
+            metadata:
+              labels:
+                name: knative-openshift
+                app: openshift-admission-server
+            spec:
+              serviceAccountName: knative-serving-operator
+              containers:
+                - name: knative-openshift
+                  image: $IMAGE_KNATIVE_OPERATOR
+                  command:
+                  - knative-openshift
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      value: ""
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: "knative-openshift"
+                    - name: MIN_OPENSHIFT_VERSION
+                      value: "4.3.0-0"
+                    - name: REQUIRED_SERVING_NAMESPACE
+                      value: "knative-serving"
+                    - name: REQUIRED_EVENTING_NAMESPACE
+                      value: "knative-eventing"
+                    - name: KOURIER_MANIFEST_PATH
+                      value: deploy/resources/kourier/kourier-latest.yaml
+                    - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH
+                      value: deploy/resources/console_cli_download_kn_resources.yaml
+                    - name: IMAGE_queue-proxy
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-queue
+                    - name: IMAGE_activator
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-activator
+                    - name: IMAGE_autoscaler
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler
+                    - name: IMAGE_autoscaler-hpa
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler-hpa
+                    - name: IMAGE_controller
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-controller
+                    - name: IMAGE_webhook
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-webhook
+                    - name: IMAGE_3scale-kourier-gateway
+                      value: docker.io/maistra/proxyv2-ubi8:1.0.8
+                    - name: IMAGE_3scale-kourier-control
+                      value: quay.io/3scale/kourier:fix_duplication
+                    - name: IMAGE_eventing-controller_eventing-controller
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-controller
+                    - name: IMAGE_eventing-webhook_eventing-webhook
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-webhook
+                    - name: IMAGE_broker-controller_eventing_controller
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-broker
+                    - name: IMAGE_broker-filter_filter
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-mtbroker-filter
+                    - name: IMAGE_broker-ingress_ingress
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-mtbroker-ingress
+                    - name: IMAGE_mt-broker-controller_eventing-controller
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-mtchannel-broker
+                    - name: IMAGE_imc-controller_controller
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-controller
+                    - name: IMAGE_imc-dispatcher_dispatcher
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-dispatcher
+                    - name: IMAGE_v0.14.0-upgrade_upgrade-brokers
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-upgrade-v0-14-0
+                    - name: IMAGE_PING_IMAGE
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-ping
+                    - name: IMAGE_JOB_RUNNER_IMAGE
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-jobrunner
+                    - name: IMAGE_APISERVER_RA_IMAGE
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-apiserver-receive-adapter
+                    - name: IMAGE_BROKER_INGRESS_IMAGE
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-ingress
+                    - name: IMAGE_BROKER_FILTER_IMAGE
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-filter
+                    - name: IMAGE_DISPATCHER_IMAGE
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-dispatcher
+                    - name: IMAGE_KN_CLI_ARTIFACTS
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kn-cli-artifacts
+      - name: knative-openshift-ingress
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: knative-openshift-ingress
+          template:
+            metadata:
+              labels:
+                name: knative-openshift-ingress
+            spec:
+              serviceAccountName: knative-openshift-ingress
+              containers:
+                - name: knative-openshift-ingress
+                  image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
+                  command:
+                  - knative-openshift-ingress
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      value: "" # watch all namespaces for ClusterIngress
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: "knative-openshift-ingress"
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - knative-serving-operator
+          - knative-eventing-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - operator.knative.dev
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: knative-serving-operator
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - serverless
+  - FaaS
+  - microservices
+  - scale to zero
+  - knative
+  - serving
+  - eventing
+  links:
+  - name: Documentation
+    url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/serverless_applications/index
+  - name: Source Repository
+    url: https://github.com/openshift-knative/serverless-operator
+  maintainers:
+  - email: serverless-support@redhat.com
+    name: Serverless Team
+  maturity: stable
+  provider:
+    name: Red Hat, Inc.
+  relatedImages:
+    - name: IMAGE_QUEUE
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-queue
+    - name: IMAGE_activator
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-activator
+    - name: IMAGE_autoscaler
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler
+    - name: IMAGE_autoscaler-hpa
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler-hpa
+    - name: IMAGE_controller
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-controller
+    - name: IMAGE_webhook
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-webhook
+    - name: IMAGE_3scale-kourier-control
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kourier
+    - name: IMAGE_3scale-kourier-gateway
+      image: docker.io/maistra/proxyv2-ubi8:1.0.8
+    - name: knative-serving-operator
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
+    - name: knative-operator
+      image: $IMAGE_KNATIVE_OPERATOR
+    - name: knative-openshift-ingress
+      image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
+    - name: knative-eventing-operator
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-operator
+    - name: IMAGE_eventing-controller_eventing-controller
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-controller
+    - name: IMAGE_eventing-webhook_eventing-webhook
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-webhook
+    - name: IMAGE_broker-controller_eventing_controller
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-broker
+    - name: IMAGE_broker-filter_filter
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-mtbroker-filter
+    - name: IMAGE_broker-ingress_ingress
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-mtbroker-ingress
+    - name: IMAGE_mt-broker-controller_eventing-controller
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-mtchannel-broker
+    - name: IMAGE_imc-controller_controller
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-controller
+    - name: IMAGE_imc-dispatcher_dispatcher
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-dispatcher
+    - name: IMAGE_PING_IMAGE
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-ping
+    - name: IMAGE_JOB_RUNNER_IMAGE
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-jobrunner
+    - name: IMAGE_APISERVER_RA_IMAGE
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-apiserver-receive-adapter
+    - name: IMAGE_BROKER_INGRESS_IMAGE
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-ingress
+    - name: IMAGE_BROKER_FILTER_IMAGE
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-filter
+    - name: IMAGE_DISPATCHER_IMAGE
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-dispatcher
+    - name: IMAGE_KN_CLI_ARTIFACTS
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kn-cli-artifacts
+    - name: IMAGE_KN_CLI_ARTIFACTS
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kn-cli-artifacts
+  replaces: serverless-operator.v1.7.0
+  version: 1.8.0

--- a/olm-catalog/serverless-operator/1.8.0/serverless-operator.v1.8.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.8.0/serverless-operator.v1.8.0.clusterserviceversion.yaml
@@ -374,7 +374,7 @@ spec:
                     - name: IMAGE_v0.14.0-upgrade_upgrade-brokers
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-upgrade-v0-14-0
                     - name: IMAGE_PING_IMAGE
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-ping
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-adapter
                     - name: IMAGE_JOB_RUNNER_IMAGE
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-jobrunner
                     - name: IMAGE_APISERVER_RA_IMAGE
@@ -524,7 +524,7 @@ spec:
       image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-controller
     - name: IMAGE_eventing-webhook_eventing-webhook
       image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-webhook
-    - name: IMAGE_broker-controller_eventing_controller
+    - name: IMAGE_broker-controller_eventing-controller
       image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-broker
     - name: IMAGE_broker-filter_filter
       image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-mtbroker-filter
@@ -536,8 +536,10 @@ spec:
       image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-controller
     - name: IMAGE_imc-dispatcher_dispatcher
       image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-dispatcher
+    - name: IMAGE_v0.14.0-upgrade_upgrade-brokers
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-upgrade-v0-14-0
     - name: IMAGE_PING_IMAGE
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-ping
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-adapter
     - name: IMAGE_JOB_RUNNER_IMAGE
       image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-jobrunner
     - name: IMAGE_APISERVER_RA_IMAGE

--- a/olm-catalog/serverless-operator/1.8.0/serverless-operator.v1.8.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.8.0/serverless-operator.v1.8.0.clusterserviceversion.yaml
@@ -359,7 +359,7 @@ spec:
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-controller
                     - name: IMAGE_eventing-webhook_eventing-webhook
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-webhook
-                    - name: IMAGE_broker-controller_eventing_controller
+                    - name: IMAGE_broker-controller_eventing-controller
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-broker
                     - name: IMAGE_broker-filter_filter
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-mtbroker-filter

--- a/olm-catalog/serverless-operator/serverless-operator.package.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.package.yaml
@@ -6,6 +6,6 @@ channels:
 - name: "preview-4.3"
   currentCSV: serverless-operator.v1.6.0
 - name: "4.3"
-  currentCSV: serverless-operator.v1.7.0
+  currentCSV: serverless-operator.v1.8.0
 - name: "4.4"
-  currentCSV: serverless-operator.v1.7.0
+  currentCSV: serverless-operator.v1.8.0

--- a/test/e2e/knative_eventing_test.go
+++ b/test/e2e/knative_eventing_test.go
@@ -13,10 +13,13 @@ const (
 
 var knativeControlPlaneDeploymentNames = []string{
 	"broker-controller",
+	"broker-filter",
+	"broker-ingress",
 	"eventing-controller",
 	"eventing-webhook",
 	"imc-controller",
 	"imc-dispatcher",
+	"mt-broker-controller",
 }
 
 func TestKnativeEventing(t *testing.T) {


### PR DESCRIPTION
1.8 CSV with eventing 0.14

* Do `make images dev`
* Go to OpenShift console, install serverless operator
* Install eventing (in knative-eventing namespace)

Image override for eventing 0.14 upgrade job work work. See
- Sandbox operator PR: https://github.com/knative-sandbox/operator/issues/76
- knative/eventing-operator PR: https://github.com/openshift-knative/eventing-operator/pull/27