### PR TITLE
[SRVKS-535] Reduce churn on route objects by pre-defaulting it.

### DIFF
--- a/serving/ingress/pkg/controller/ingress/ingress_controller.go
+++ b/serving/ingress/pkg/controller/ingress/ingress_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/google/go-cmp/cmp"
 	routev1 "github.com/openshift/api/route/v1"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -142,8 +143,7 @@ func (r *ReconcileIngress) Reconcile(request reconcile.Request) (reconcile.Resul
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
 	} else if _, err := r.updateStatus(ctx, ing); err != nil {
-		logger.Errorf("Failed to update ingress status %v", err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("failed to update ingress status: %w", err)
 	}
 
 	return reconcile.Result{}, reconcileErr
@@ -156,14 +156,11 @@ func (r *ReconcileIngress) ReconcileIngress(ctx context.Context, ing *networking
 		return r.reconcileDeletion(ctx, ing)
 	}
 
-	logger.Infof("Reconciling ingress :%v", ing)
-
 	exposed := ing.Spec.Visibility == networkingv1alpha1.IngressVisibilityExternalIP
 	if exposed {
 		existing, err := r.routeList(ctx, ing)
 		if err != nil {
-			logger.Errorf("Failed to list openshift routes %v", err)
-			return err
+			return fmt.Errorf("failed to list routes: %w", err)
 		}
 		existingMap := make(map[string]routev1.Route, len(existing.Items))
 		for _, route := range existing.Items {
@@ -177,15 +174,13 @@ func (r *ReconcileIngress) ReconcileIngress(ctx context.Context, ing *networking
 			return nil
 		}
 		for _, route := range routes {
-			logger.Infof("Creating/Updating OpenShift Route for host %s", route.Spec.Host)
 			if err := r.reconcileRoute(ctx, ing, route); err != nil {
-				return fmt.Errorf("failed to create route for host %s: %v", route.Spec.Host, err)
+				return err
 			}
 			delete(existingMap, route.Name)
 		}
 		// If routes remains in existingMap, it must be obsoleted routes. Clean them up.
 		for _, rt := range existingMap {
-			logger.Infof("Deleting obsoleted route for host: %s", rt.Spec.Host)
 			if err := r.deleteRoute(ctx, &rt); err != nil {
 				return err
 			}
@@ -202,11 +197,10 @@ func (r *ReconcileIngress) ReconcileIngress(ctx context.Context, ing *networking
 
 func (r *ReconcileIngress) deleteRoute(ctx context.Context, route *routev1.Route) error {
 	logger := logging.FromContext(ctx)
-	logger.Infof("Deleting OpenShift Route for host %s", route.Spec.Host)
+	logger.Infof("Deleting route %s(%s)", route.Name, route.Spec.Host)
 	if err := r.client.Delete(ctx, route); err != nil {
-		return fmt.Errorf("failed to delete obsoleted route for host %s: %v", route.Spec.Host, err)
+		return fmt.Errorf("failed to delete route: %w", err)
 	}
-	logger.Infof("Deleted OpenShift Route %q in namespace %q", route.Name, route.Namespace)
 	return nil
 }
 
@@ -231,23 +225,22 @@ func (r *ReconcileIngress) reconcileRoute(ctx context.Context, ci *networkingv1a
 	route := &routev1.Route{}
 	err := r.client.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, route)
 	if err != nil && errors.IsNotFound(err) {
+		logger.Infof("Creating route %s(%s)", desired.Name, desired.Spec.Host)
 		err = r.client.Create(ctx, desired)
 		if err != nil {
-			logger.Errorf("Failed to create OpenShift Route %q in namespace %q: %v", desired.Name, desired.Namespace, err)
-			return err
+			return fmt.Errorf("failed to create route :%w", err)
 		}
-		logger.Infof("Created OpenShift Route %q in namespace %q", desired.Name, desired.Namespace)
 	} else if err != nil {
-		return err
+		return fmt.Errorf("failed to get route: %w", err)
 	} else if !equality.Semantic.DeepEqual(route.Spec, desired.Spec) {
+		logger.Infof("Updating route %s(%s) diff: %s", desired.Name, desired.Spec.Host, cmp.Diff(route.Spec, desired.Spec))
 		// Don't modify the informers copy
 		existing := route.DeepCopy()
 		existing.Spec = desired.Spec
 		existing.Annotations = desired.Annotations
 		err = r.client.Update(ctx, existing)
 		if err != nil {
-			logger.Errorf("Failed to update OpenShift Route %q in namespace %q: %v", desired.Name, desired.Namespace, err)
-			return err
+			return fmt.Errorf("failed to update route: %w", err)
 		}
 	}
 

--- a/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
+++ b/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -107,8 +108,9 @@ func TestRouteMigration(t *testing.T) {
 			Spec: routev1.RouteSpec{
 				Host: domainName,
 				To: routev1.RouteTargetReference{
-					Kind: "Service",
-					Name: "istio-ingressgateway",
+					Kind:   "Service",
+					Name:   "istio-ingressgateway",
+					Weight: ptr.Int32(100),
 				},
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.FromString(resources.KourierHttpPort),
@@ -117,6 +119,7 @@ func TestRouteMigration(t *testing.T) {
 					Termination:                   routev1.TLSTerminationEdge,
 					InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 				},
+				WildcardPolicy: routev1.WildcardPolicyNone,
 			},
 		}, noRemoveMissingLabel, noRemoveOtherLabel},
 	}

--- a/serving/ingress/pkg/controller/ingress/resources/route.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route.go
@@ -9,6 +9,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -132,13 +133,15 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 				TargetPort: intstr.FromString(KourierHttpPort),
 			},
 			To: routev1.RouteTargetReference{
-				Kind: "Service",
-				Name: serviceName,
+				Kind:   "Service",
+				Name:   serviceName,
+				Weight: ptr.Int32(100),
 			},
 			TLS: &routev1.TLSConfig{
 				Termination:                   routev1.TLSTerminationEdge,
 				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 			},
+			WildcardPolicy: routev1.WildcardPolicyNone,
 		},
 	}
 	return route, nil

--- a/serving/ingress/pkg/controller/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route_test.go
@@ -9,6 +9,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -67,8 +68,9 @@ func TestMakeRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
 					To: routev1.RouteTargetReference{
-						Kind: "Service",
-						Name: lbService,
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString(KourierHttpPort),
@@ -77,6 +79,7 @@ func TestMakeRoute(t *testing.T) {
 						Termination:                   routev1.TLSTerminationEdge,
 						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 			}},
 		},
@@ -115,8 +118,9 @@ func TestMakeRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
 					To: routev1.RouteTargetReference{
-						Kind: "Service",
-						Name: lbService,
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString(KourierHttpPort),
@@ -125,6 +129,7 @@ func TestMakeRoute(t *testing.T) {
 						Termination:                   routev1.TLSTerminationEdge,
 						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 			}},
 		},
@@ -150,8 +155,9 @@ func TestMakeRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
 					To: routev1.RouteTargetReference{
-						Kind: "Service",
-						Name: lbService,
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString(KourierHttpPort),
@@ -160,6 +166,7 @@ func TestMakeRoute(t *testing.T) {
 						Termination:                   routev1.TLSTerminationEdge,
 						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
@@ -177,8 +184,9 @@ func TestMakeRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					Host: externalDomain2,
 					To: routev1.RouteTargetReference{
-						Kind: "Service",
-						Name: lbService,
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString(KourierHttpPort),
@@ -188,6 +196,7 @@ func TestMakeRoute(t *testing.T) {
 						Termination:                   routev1.TLSTerminationEdge,
 						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 			}},
 		},
@@ -213,8 +222,9 @@ func TestMakeRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					Host: externalDomain2,
 					To: routev1.RouteTargetReference{
-						Kind: "Service",
-						Name: lbService,
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString(KourierHttpPort),
@@ -224,6 +234,7 @@ func TestMakeRoute(t *testing.T) {
 						Termination:                   routev1.TLSTerminationEdge,
 						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 			}},
 		},


### PR DESCRIPTION
When we update routes we compare the generated Spec against the Spec that's present in the API. As the latter is subject to defaulting, we currently always generate a diff and thus always update the resource, even though that doesn't really have an effect at all.
By adding the weight and wildcardPolicy values to the generated route explicitly, we can avoid those unnecessary API calls.

Also:
- Added a log that logs the respective diff to ease debugging in the future.
- Removed duplicated error logging. Returning an error will always log an error anyway.