### PR TITLE
Fix image overrides for env vars that contain underscores

### DIFF
--- a/knative-operator/pkg/common/eventing_test.go
+++ b/knative-operator/pkg/common/eventing_test.go
@@ -32,7 +32,7 @@ func TestMutateEventing(t *testing.T) {
 	// Setup image override
 	os.Setenv("IMAGE_foo", image1)
 	// Setup image override with deployment name
-	os.Setenv("IMAGE_bar_baz", image2)
+	os.Setenv("IMAGE_bar__baz", image2)
 
 	// Mutate for OpenShift
 	if err := common.MutateEventing(ke, client); err != nil {

--- a/knative-operator/pkg/common/util_test.go
+++ b/knative-operator/pkg/common/util_test.go
@@ -27,9 +27,27 @@ func TestBuildImageOverrideMapFromEnviron(t *testing.T) {
 			},
 		},
 		{
+			name: "Simple env var",
+			envMap: map[string]string{
+				"IMAGE_CRONJOB_RA_IMAGE": "quay.io/myimage",
+			},
+			expected: map[string]string{
+				"CRONJOB_RA_IMAGE": "quay.io/myimage",
+			},
+		},
+		{
+			name: "Simple env var with deployment name",
+			envMap: map[string]string{
+				"IMAGE_eventing-controller__CRONJOB_RA_IMAGE": "quay.io/myimage",
+			},
+			expected: map[string]string{
+				"eventing-controller/CRONJOB_RA_IMAGE": "quay.io/myimage",
+			},
+		},
+		{
 			name: "Deployment+container name",
 			envMap: map[string]string{
-				"IMAGE_foo_bar": "quay.io/myimage",
+				"IMAGE_foo__bar": "quay.io/myimage",
 			},
 			expected: map[string]string{
 				"foo/bar": "quay.io/myimage",
@@ -38,8 +56,8 @@ func TestBuildImageOverrideMapFromEnviron(t *testing.T) {
 		{
 			name: "Deployment+container and container name",
 			envMap: map[string]string{
-				"IMAGE_foo_bar": "quay.io/myimage1",
-				"IMAGE_bar":     "quay.io/myimage2",
+				"IMAGE_foo__bar": "quay.io/myimage1",
+				"IMAGE_bar":      "quay.io/myimage2",
 			},
 			expected: map[string]string{
 				"foo/bar": "quay.io/myimage1",

--- a/test/e2e/disallowed_img_registry.go
+++ b/test/e2e/disallowed_img_registry.go
@@ -1,0 +1,65 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openshift-knative/serverless-operator/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+const gcr = "gcr.io"
+
+func verifyNoDisallowedImageReference(t *testing.T, caCtx *test.Context, namespace string) {
+	podSpecableTypes := []schema.GroupVersionResource{{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "daemonsets",
+	}, {
+		Group:    "batch",
+		Version:  "v1",
+		Resource: "jobs",
+	}, {
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
+	}, {
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "replicasets",
+	}}
+
+	for _, podSpecableType := range podSpecableTypes {
+
+		result, err := caCtx.Clients.Dynamic.Resource(podSpecableType).Namespace(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			t.Fatalf("Error listing %v: %v", podSpecableType, err)
+		}
+
+		for _, u := range result.Items {
+			ps := &duckv1.WithPod{}
+
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), ps)
+			if err != nil {
+				t.Fatalf("Error converting unstructured to podSpecable %v: %v", u, err)
+			}
+
+			for _, container := range ps.Spec.Template.Spec.Containers {
+				if strings.Contains(container.Image, gcr) {
+					t.Fatalf("Container %q in resource %q of type %v contains disallowed image registry ref %q in image %q", container.Name, ps.Name, podSpecableType, gcr, container.Image)
+				}
+
+				for _, env := range container.Env {
+					if strings.Contains(env.Value, gcr) {
+						t.Fatalf("Container %q in resource %q of type %v contains disallowed image registry ref %q in env var %q", container.Name, ps.Name, podSpecableType, gcr, env.Name)
+					}
+				}
+			}
+		}
+
+	}
+
+}

--- a/test/e2e/knative_eventing_test.go
+++ b/test/e2e/knative_eventing_test.go
@@ -49,6 +49,10 @@ func TestKnativeEventing(t *testing.T) {
 		}
 	})
 
+	t.Run("make sure no gcr.io references are there", func(t *testing.T) {
+		verifyNoDisallowedImageReference(t, caCtx, knativeEventing)
+	})
+
 	t.Run("remove knativeeventing cr", func(t *testing.T) {
 		if err := v1a1test.DeleteKnativeEventing(caCtx, knativeEventing, knativeEventing); err != nil {
 			t.Fatal("Failed to remove Knative Eventing", err)

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -68,6 +68,10 @@ func TestKnativeServing(t *testing.T) {
 
 	})
 
+	t.Run("make sure no gcr.io references are there", func(t *testing.T) {
+		verifyNoDisallowedImageReference(t, caCtx, knativeServing)
+	})
+
 	t.Run("update global proxy and verify calls goes through proxy server", func(t *testing.T) {
 		t.Skip("SRKVS-462: This test needs thorough hardening")
 		testKnativeServingForGlobalProxy(t, caCtx)


### PR DESCRIPTION
Changes:
- Use double underscore to separate the deployment name from the container names. Otherwise the env vars we need to override with an underscore in its name is not really overridden.
- Added a test that aims to fail if there's any image override mistakes. After the deployments and other things are created, the test checks if there's any refs to `gcr.io` in container images, container env vars.

To see the test fails, use these overrides in CSV:
```
- name: IMAGE_eventing-controller
                      value: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:c408dc0f092d31ef1169daa5541be2763f6d41d775c565329fd53b6babac8ba8
- name: IMAGE_CRONJOB_RA_IMAGE
                      value: gcr.io/knative-releases/knative.dev/eventing/cmd/cronjob_receive_adapter@sha256:206733e8b5fdfc8d775d8231cfd23835095967125d080881c6fea4e5aebe2955
```

cc @matzew --> I am gonna have to update my WIP PR [0](https://github.com/openshift-knative/serverless-operator/pull/289) for CSV 0.18 and eventing 0.14 once this is merged.