### PR TITLE
[SRVKS-535] Reduce churn on route objects by pre-defaulting it.

### DIFF
--- a/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
+++ b/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -107,8 +108,9 @@ func TestRouteMigration(t *testing.T) {
 			Spec: routev1.RouteSpec{
 				Host: domainName,
 				To: routev1.RouteTargetReference{
-					Kind: "Service",
-					Name: "istio-ingressgateway",
+					Kind:   "Service",
+					Name:   "istio-ingressgateway",
+					Weight: ptr.Int32(100),
 				},
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.FromString(resources.KourierHttpPort),
@@ -117,6 +119,7 @@ func TestRouteMigration(t *testing.T) {
 					Termination:                   routev1.TLSTerminationEdge,
 					InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 				},
+				WildcardPolicy: routev1.WildcardPolicyNone,
 			},
 		}, noRemoveMissingLabel, noRemoveOtherLabel},
 	}

--- a/serving/ingress/pkg/controller/ingress/resources/route.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route.go
@@ -9,6 +9,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -132,13 +133,15 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 				TargetPort: intstr.FromString(KourierHttpPort),
 			},
 			To: routev1.RouteTargetReference{
-				Kind: "Service",
-				Name: serviceName,
+				Kind:   "Service",
+				Name:   serviceName,
+				Weight: ptr.Int32(100),
 			},
 			TLS: &routev1.TLSConfig{
 				Termination:                   routev1.TLSTerminationEdge,
 				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 			},
+			WildcardPolicy: routev1.WildcardPolicyNone,
 		},
 	}
 	return route, nil

--- a/serving/ingress/pkg/controller/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route_test.go
@@ -9,6 +9,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -67,8 +68,9 @@ func TestMakeRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
 					To: routev1.RouteTargetReference{
-						Kind: "Service",
-						Name: lbService,
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString(KourierHttpPort),
@@ -77,6 +79,7 @@ func TestMakeRoute(t *testing.T) {
 						Termination:                   routev1.TLSTerminationEdge,
 						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 			}},
 		},
@@ -115,8 +118,9 @@ func TestMakeRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
 					To: routev1.RouteTargetReference{
-						Kind: "Service",
-						Name: lbService,
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString(KourierHttpPort),
@@ -125,6 +129,7 @@ func TestMakeRoute(t *testing.T) {
 						Termination:                   routev1.TLSTerminationEdge,
 						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 			}},
 		},
@@ -150,8 +155,9 @@ func TestMakeRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
 					To: routev1.RouteTargetReference{
-						Kind: "Service",
-						Name: lbService,
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString(KourierHttpPort),
@@ -160,6 +166,7 @@ func TestMakeRoute(t *testing.T) {
 						Termination:                   routev1.TLSTerminationEdge,
 						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
@@ -177,8 +184,9 @@ func TestMakeRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					Host: externalDomain2,
 					To: routev1.RouteTargetReference{
-						Kind: "Service",
-						Name: lbService,
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString(KourierHttpPort),
@@ -188,6 +196,7 @@ func TestMakeRoute(t *testing.T) {
 						Termination:                   routev1.TLSTerminationEdge,
 						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 			}},
 		},
@@ -213,8 +222,9 @@ func TestMakeRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					Host: externalDomain2,
 					To: routev1.RouteTargetReference{
-						Kind: "Service",
-						Name: lbService,
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString(KourierHttpPort),
@@ -224,6 +234,7 @@ func TestMakeRoute(t *testing.T) {
 						Termination:                   routev1.TLSTerminationEdge,
 						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 			}},
 		},


### PR DESCRIPTION
Backport of https://github.com/openshift-knative/serverless-operator/pull/294.