### PR TITLE
Hardcode 1.7.0 image references for proper upgrade testing.

### DIFF
--- a/olm-catalog/serverless-operator/1.7.0/serverless-operator.v1.7.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.7.0/serverless-operator.v1.7.0.clusterserviceversion.yaml
@@ -316,7 +316,7 @@ spec:
               serviceAccountName: knative-serving-operator
               containers:
                 - name: knative-openshift
-                  image: $IMAGE_KNATIVE_OPERATOR
+                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.7.0:knative-operator
                   command:
                   - knative-openshift
                   imagePullPolicy: Always
@@ -393,7 +393,7 @@ spec:
               serviceAccountName: knative-openshift-ingress
               containers:
                 - name: knative-openshift-ingress
-                  image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
+                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.7.0:knative-openshift-ingress
                   command:
                   - knative-openshift-ingress
                   imagePullPolicy: Always
@@ -507,9 +507,9 @@ spec:
     - name: knative-serving-operator
       image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
     - name: knative-operator
-      image: $IMAGE_KNATIVE_OPERATOR
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.7.0:knative-operator
     - name: knative-openshift-ingress
-      image: $IMAGE_KNATIVE_OPENSHIFT_INGRESS
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.7.0:knative-openshift-ingress
     - name: knative-eventing-operator
       image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-eventing-operator
     - name: IMAGE_eventing-controller


### PR DESCRIPTION
Without this change, the 1.8.0 images are deployed for both versions, nullifying certain aspects of upgrade testing.