### PR TITLE
[SRVKS-565] Create OpenShift Route in the same namespace with Knative Service instead of knative-serving-ingress

### DIFF
--- a/olm-catalog/serverless-operator/1.8.0/serverless-operator.v1.8.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.8.0/serverless-operator.v1.8.0.clusterserviceversion.yaml
@@ -170,8 +170,15 @@ spec:
           - services
           - events
           - configmaps
+          - endpoints
           verbs:
           - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - endpoints/restricted
+          verbs:
+          - "create"
         - apiGroups:
           - ""
           resources:

--- a/serving/ingress/deploy/release.yaml
+++ b/serving/ingress/deploy/release.yaml
@@ -17,8 +17,15 @@ rules:
   - services
   - events
   - configmaps
+  - endpoints
   verbs:
   - "*"
+- apiGroups:
+  - ""
+  resources:
+  - endpoints/restricted
+  verbs:
+  - "create"
 - apiGroups:
   - ""
   resources:

--- a/serving/ingress/pkg/controller/ingress/ingress_controller.go
+++ b/serving/ingress/pkg/controller/ingress/ingress_controller.go
@@ -155,7 +155,7 @@ func (r *ReconcileIngress) Reconcile(request reconcile.Request) (reconcile.Resul
 	return reconcile.Result{}, r.reconcileEndpoints(ctx, ing)
 }
 
-func (r *ReconcileIngress) routeExist(ctx context.Context, ing *networkingv1alpha1.Ingress) (bool, error) {
+func (r *ReconcileIngress) ingressExist(ctx context.Context, ing *networkingv1alpha1.Ingress) (bool, error) {
 	// List Route
 	listOpts := &client.ListOptions{
 		Namespace: ing.Namespace, // List only one namespace
@@ -163,12 +163,12 @@ func (r *ReconcileIngress) routeExist(ctx context.Context, ing *networkingv1alph
 			serving.RouteNamespaceLabelKey: ing.Namespace,
 		}),
 	}
-	var routeList routev1.RouteList
-	err := r.client.List(ctx, &routeList, listOpts)
+	var ingList networkingv1alpha1.IngressList
+	err := r.client.List(ctx, &ingList, listOpts)
 	if err != nil {
 		return true, err
 	}
-	if len(routeList.Items) == 0 {
+	if len(ingList.Items) == 0 {
 		return false, nil
 	}
 	return true, nil
@@ -183,7 +183,7 @@ func (r *ReconcileIngress) reconcileService(ctx context.Context, ing *networking
 	}
 
 	// If there are no route in the namespace, cleanup.
-	if exist, err := r.routeExist(ctx, ing); err != nil {
+	if exist, err := r.ingressExist(ctx, ing); err != nil {
 		return err
 	} else if !exist {
 		return r.deleteService(ctx, ing, serviceName)
@@ -222,8 +222,8 @@ func (r *ReconcileIngress) reconcileEndpoints(ctx context.Context, ing *networki
 	if err != nil {
 		return err
 	}
-	// If there are no route in the namespace, cleanup.
-	if exist, err := r.routeExist(ctx, ing); err != nil {
+	// If there are no ingress in the namespace, cleanup.
+	if exist, err := r.ingressExist(ctx, ing); err != nil {
 		return err
 	} else if !exist {
 		return r.deleteEndpoints(ctx, ing, serviceName)

--- a/serving/ingress/pkg/controller/ingress/resources/endpoint.go
+++ b/serving/ingress/pkg/controller/ingress/resources/endpoint.go
@@ -1,20 +1,17 @@
 package resources
 
 import (
-	//	"context"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/resources"
 )
 
-// MakePublicEndpoints constructs a K8s Endpoints that is not backed a selector
-// and will be manually reconciled by the SKS controller.
+// MakeEndpoints constructs a K8s Endpoints that has same Subsets with Kourier gateway.
 func MakeEndpoints(src *corev1.Endpoints, ing *networkingv1alpha1.Ingress, name string) *corev1.Endpoints {
 	return &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name, // Name of Endpoints must match that of Service.
+			Name:        name, // Name of Endpoints must be same with Service.
 			Namespace:   ing.Namespace,
 			Labels:      resources.UnionMaps(ing.GetLabels(), map[string]string{}),
 			Annotations: resources.CopyMap(ing.GetAnnotations()),

--- a/serving/ingress/pkg/controller/ingress/resources/endpoint.go
+++ b/serving/ingress/pkg/controller/ingress/resources/endpoint.go
@@ -1,0 +1,24 @@
+package resources
+
+import (
+	//	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/resources"
+)
+
+// MakePublicEndpoints constructs a K8s Endpoints that is not backed a selector
+// and will be manually reconciled by the SKS controller.
+func MakeEndpoints(src *corev1.Endpoints, ing *networkingv1alpha1.Ingress, name string) *corev1.Endpoints {
+	return &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name, // Name of Endpoints must match that of Service.
+			Namespace:   ing.Namespace,
+			Labels:      resources.UnionMaps(ing.GetLabels(), map[string]string{}),
+			Annotations: resources.CopyMap(ing.GetAnnotations()),
+		},
+		Subsets: src.Subsets,
+	}
+}

--- a/serving/ingress/pkg/controller/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route_test.go
@@ -23,6 +23,8 @@ const (
 	lbService   = "lb-service"
 	lbNamespace = "lb-namespace"
 
+	ingressNamespace = "ingress-namespace"
+
 	uid        = "8a7e9a9d-fbc6-11e9-a88e-0261aff8d6d8"
 	routeName0 = "route-" + uid + "-323531366235"
 	routeName1 = "route-" + uid + "-663738313063"
@@ -62,7 +64,7 @@ func TestMakeRoute(t *testing.T) {
 					Annotations: map[string]string{
 						TimeoutAnnotation: "600s",
 					},
-					Namespace: lbNamespace,
+					Namespace: ingressNamespace,
 					Name:      routeName0,
 				},
 				Spec: routev1.RouteSpec{
@@ -112,7 +114,7 @@ func TestMakeRoute(t *testing.T) {
 					Annotations: map[string]string{
 						TimeoutAnnotation: "3600s",
 					},
-					Namespace: lbNamespace,
+					Namespace: ingressNamespace,
 					Name:      routeName0,
 				},
 				Spec: routev1.RouteSpec{
@@ -149,7 +151,7 @@ func TestMakeRoute(t *testing.T) {
 					Annotations: map[string]string{
 						TimeoutAnnotation: "600s",
 					},
-					Namespace: lbNamespace,
+					Namespace: ingressNamespace,
 					Name:      routeName0,
 				},
 				Spec: routev1.RouteSpec{
@@ -178,7 +180,7 @@ func TestMakeRoute(t *testing.T) {
 					Annotations: map[string]string{
 						TimeoutAnnotation: "600s",
 					},
-					Namespace: lbNamespace,
+					Namespace: ingressNamespace,
 					Name:      routeName1,
 				},
 				Spec: routev1.RouteSpec{
@@ -216,7 +218,7 @@ func TestMakeRoute(t *testing.T) {
 					Annotations: map[string]string{
 						TimeoutAnnotation: "600s",
 					},
-					Namespace: lbNamespace,
+					Namespace: ingressNamespace,
 					Name:      routeName1,
 				},
 				Spec: routev1.RouteSpec{
@@ -267,7 +269,7 @@ func ingress(options ...ingressOption) *networkingv1alpha1.Ingress {
 				serving.RouteLabelKey:          "route1",
 				serving.RouteNamespaceLabelKey: "default",
 			},
-			Namespace: "default",
+			Namespace: ingressNamespace,
 			Name:      "ingress",
 			UID:       uid,
 		},

--- a/serving/ingress/pkg/controller/ingress/resources/service.go
+++ b/serving/ingress/pkg/controller/ingress/resources/service.go
@@ -9,6 +9,7 @@ import (
 	"knative.dev/serving/pkg/resources"
 )
 
+// MakeK8sService constructs a K8s Service to expose Kourier gateway endpoints.
 func MakeK8sService(ctx context.Context, ing *networkingv1alpha1.Ingress, name string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/serving/ingress/pkg/controller/ingress/resources/service.go
+++ b/serving/ingress/pkg/controller/ingress/resources/service.go
@@ -1,0 +1,29 @@
+package resources
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/resources"
+)
+
+func MakeK8sService(ctx context.Context, ing *networkingv1alpha1.Ingress, name string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ing.Namespace,
+			Labels:      resources.UnionMaps(ing.GetLabels(), map[string]string{}),
+			Annotations: resources.CopyMap(ing.GetAnnotations()),
+		},
+
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{
+				Name: KourierHttpPort,
+				Port: 80,
+			}},
+		},
+	}
+}

--- a/serving/ingress/pkg/controller/ingress/resources/util.go
+++ b/serving/ingress/pkg/controller/ingress/resources/util.go
@@ -1,0 +1,35 @@
+package resources
+
+import (
+	"errors"
+	"strings"
+
+	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+)
+
+// ErrNoValidLoadbalancerDomain indicates that the current ingress does not have a DomainInternal field, or
+// said field does not contain a value we can work with.
+var ErrNoValidLoadbalancerDomain = errors.New("unable to find Ingress LoadBalancer with DomainInternal set")
+
+func IngressName(ing *networkingv1alpha1.Ingress) (string, string, error) {
+	serviceName := ""
+	namespace := ""
+	if ing.Status.LoadBalancer != nil {
+		for _, lbIngress := range ing.Status.LoadBalancer.Ingress {
+			if lbIngress.DomainInternal != "" {
+				// DomainInternal should look something like:
+				// kourier.knative-serving-ingress.svc.cluster.local
+				parts := strings.Split(lbIngress.DomainInternal, ".")
+				if len(parts) > 2 && parts[2] == "svc" {
+					serviceName = parts[0]
+					namespace = parts[1]
+				}
+			}
+		}
+	}
+
+	if serviceName == "" || namespace == "" {
+		return "", "", ErrNoValidLoadbalancerDomain
+	}
+	return serviceName, namespace, nil
+}


### PR DESCRIPTION
This patch changes to create OpenShift Route in the same namespace
with Knative Service intead of knative-serving-ingress.

In order to create Route in each namespace, O-K-I makes service and
endpoints for Kourier Gateway in each namespace. Then, OpenShift
Route points to the service as the target.
