### PR TITLE
[SRVKS-561] Run e2e tests under strict NetworkPolicy

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -77,9 +77,8 @@ function downstream_serving_e2e_tests {
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
-  # Add system-namespace labels to serving.knative.openshift.io/system-namespace=true system namespaces for TestNetworkPolicy.
-  oc label namespace knative-serving serving.knative.openshift.io/system-namespace=true         || true
-  oc label namespace knative-serving-ingress serving.knative.openshift.io/system-namespace=true || true
+  # Add system-namespace labels for TestNetworkPolicy.
+  add_systemnamespace_label
 
   local failed=0
 
@@ -194,6 +193,11 @@ function delete_users {
     fi
   done < "users.htpasswd"
   rm -v users.htpasswd
+}
+
+function add_systemnamespace_label {
+  oc label namespace knative-serving serving.knative.openshift.io/system-namespace=true --overwrite         || true
+  oc label namespace knative-serving-ingress serving.knative.openshift.io/system-namespace=true --overwrite || true
 }
 
 function add_networkpolicy {

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -77,6 +77,10 @@ function downstream_serving_e2e_tests {
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
+  # Add system-namespace labels to serving.knative.openshift.io/system-namespace=true system namespaces for TestNetworkPolicy.
+  oc label namespace knative-serving serving.knative.openshift.io/system-namespace=true         || true
+  oc label namespace knative-serving-ingress serving.knative.openshift.io/system-namespace=true || true
+
   local failed=0
 
   go_test_e2e -failfast -timeout=30m -parallel=1 ./test/servinge2e \

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -9,6 +9,7 @@ readonly TEARDOWN="${TEARDOWN:-on_exit}"
 export TEST_NAMESPACE="${TEST_NAMESPACE:-serverless-tests}"
 NAMESPACES+=("${TEST_NAMESPACE}")
 NAMESPACES+=("serverless-tests2")
+NAMESPACES+=("serverless-tests3")
 
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/serving.bash"
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/eventing.bash"
@@ -189,4 +190,34 @@ function delete_users {
     fi
   done < "users.htpasswd"
   rm -v users.htpasswd
+}
+
+function add_networkpolicy {
+  local NAMESPACE=$1
+  cat <<EOF | oc apply -f -
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: deny-by-default
+  namespace: "$1"
+spec:
+  podSelector:
+EOF
+
+  cat <<EOF | oc apply -f -
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-serving-system-namespace
+  namespace: "$1"
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          serving.knative.openshift.io/system-namespace: "true"
+  podSelector: {}
+  policyTypes:
+  - Ingress
+EOF
 }

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -17,6 +17,8 @@ function prepare_knative_serving_tests {
   oc adm policy add-scc-to-user privileged -z default -n serving-tests-alt
   # Adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
   oc adm policy add-scc-to-user anyuid -z default -n serving-tests
+  add_networkpolicy "serving-tests"
+  add_networkpolicy "serving-tests-alt"
 
   export GATEWAY_OVERRIDE="kourier"
   export GATEWAY_NAMESPACE_OVERRIDE="knative-serving-ingress"

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -20,8 +20,7 @@ function prepare_knative_serving_tests {
   # Add networkpolicy to test namespace and label to serving namespaces for testing under the strict networkpolicy.
   add_networkpolicy "serving-tests"
   add_networkpolicy "serving-tests-alt"
-  oc label namespace knative-serving serving.knative.openshift.io/system-namespace=true         || true
-  oc label namespace knative-serving-ingress serving.knative.openshift.io/system-namespace=true || true
+  add_systemnamespace_label
 
   export GATEWAY_OVERRIDE="kourier"
   export GATEWAY_NAMESPACE_OVERRIDE="knative-serving-ingress"

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -17,8 +17,11 @@ function prepare_knative_serving_tests {
   oc adm policy add-scc-to-user privileged -z default -n serving-tests-alt
   # Adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
   oc adm policy add-scc-to-user anyuid -z default -n serving-tests
+  # Add networkpolicy to test namespace and label to serving namespaces for testing under the strict networkpolicy.
   add_networkpolicy "serving-tests"
   add_networkpolicy "serving-tests-alt"
+  oc label namespace knative-serving serving.knative.openshift.io/system-namespace=true         || true
+  oc label namespace knative-serving-ingress serving.knative.openshift.io/system-namespace=true || true
 
   export GATEWAY_OVERRIDE="kourier"
   export GATEWAY_NAMESPACE_OVERRIDE="knative-serving-ingress"

--- a/test/servinge2e/user_permissions_test.go
+++ b/test/servinge2e/user_permissions_test.go
@@ -11,6 +11,7 @@ import (
 const (
 	testNamespace         = "serverless-tests"
 	testNamespace2        = "serverless-tests2"
+	testNamespace3        = "serverless-tests3"
 	image                 = "gcr.io/knative-samples/helloworld-go"
 	helloworldService     = "helloworld-go"
 	helloworldService2    = "helloworld-go2"

--- a/test/servinge2e/verify_networkpolicy_test.go
+++ b/test/servinge2e/verify_networkpolicy_test.go
@@ -1,0 +1,79 @@
+package servinge2e
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/openshift-knative/serverless-operator/test"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	policyNameDeny  = "deny-all"
+	policyNameAllow = "allow-from-serving-system-ns"
+)
+
+// This test creates two networkpolicies.
+// 1. creates the deny-all policy and verify if access does not work.
+// 2. create the allow-from-serving-system-ns and verify if access works.
+func TestNetworkPolicy(t *testing.T) {
+	caCtx := test.SetupClusterAdmin(t)
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
+	defer test.CleanupAll(t, caCtx)
+
+	policy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyNameDeny,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+		},
+	}
+
+	_, err := caCtx.Clients.Kube.NetworkingV1().NetworkPolicies(testNamespace3).Create(policy)
+	if err != nil && !apierrs.IsAlreadyExists(err) {
+		t.Fatalf("Failed to create networkpolicy %v: %v", policy, err)
+	}
+	defer caCtx.Clients.Kube.NetworkingV1().NetworkPolicies(testNamespace3).Delete(policyNameDeny, &metav1.DeleteOptions{})
+
+	ksvc, err := test.WithServiceReady(caCtx, "networkpolicy-test", testNamespace3, image)
+	if err != nil {
+		t.Fatal("Knative Service not ready", err)
+	}
+
+	_, err = http.Get(ksvc.Status.URL.String())
+	if err == nil {
+		t.Fatalf("Netowrk policy did not block the request to %s", ksvc.Status.URL.String())
+	}
+
+	policyAllow := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyNameAllow,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"serving.knative.openshift.io/system-namespace": "true",
+						},
+					},
+				}},
+			}},
+		},
+	}
+
+	_, err = caCtx.Clients.Kube.NetworkingV1().NetworkPolicies(testNamespace3).Create(policyAllow)
+	if err != nil && !apierrs.IsAlreadyExists(err) {
+		t.Fatalf("Failed to create networkpolicy %v: %v", policyAllow, err)
+	}
+	defer caCtx.Clients.Kube.NetworkingV1().NetworkPolicies(testNamespace3).Delete(policyNameAllow, &metav1.DeleteOptions{})
+	_, err = http.Get(ksvc.Status.URL.String())
+	if err != nil {
+		t.Fatalf("Failed sending request to %s: %v", ksvc.Status.URL.String(), err)
+	}
+}


### PR DESCRIPTION
This patch changes to:

- ~~add system-namespace label (`serving.knative.openshift.io/system-namespace: true`) to knative-serving{-ingress} namespace.~~
- add test case to verify the "deny-all" networkpolicy does not work, but it works once added the networkpolicy "allow from system namespaces".
- add networkpolicy to `serving-tests` and `serving-tests-alt` before running e2e tests.