### PR TITLE
Create new 4.5 channel with 1.7.1

### DIFF
--- a/olm-catalog/serverless-operator/serverless-operator.package.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.package.yaml
@@ -9,3 +9,5 @@ channels:
   currentCSV: serverless-operator.v1.7.1
 - name: "4.4"
   currentCSV: serverless-operator.v1.7.1
+- name: "4.5"
+  currentCSV: serverless-operator.v1.7.1


### PR DESCRIPTION
Create a new 4.5 channel with `serverless-operator.v1.7.1`, even though 4.5 will not be available at the time we plan to release Serverless 1.7.1.