### PR TITLE
[BACKPORT][SRVKS-567] Set KnativeServing CR status to "Dependency installing" whenever Kourier installation failed

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -395,8 +395,8 @@ func (r *ReconcileKnativeServing) reconcileConfigMap(instance *servingv1alpha1.K
 // Install Kourier Ingress Gateway
 func (r *ReconcileKnativeServing) installKourier(instance *servingv1alpha1.KnativeServing) error {
 	// install Kourier
+	instance.Status.MarkDependencyInstalling("Kourier")
 	if err := kourier.Apply(instance, r.client, r.scheme); err != nil {
-		instance.Status.MarkDependencyInstalling("Kourier")
 		return err
 	}
 	instance.Status.MarkDependenciesInstalled()

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -395,7 +395,12 @@ func (r *ReconcileKnativeServing) reconcileConfigMap(instance *servingv1alpha1.K
 // Install Kourier Ingress Gateway
 func (r *ReconcileKnativeServing) installKourier(instance *servingv1alpha1.KnativeServing) error {
 	// install Kourier
-	return kourier.Apply(instance, r.client, r.scheme)
+	if err := kourier.Apply(instance, r.client, r.scheme); err != nil {
+		instance.Status.MarkDependencyInstalling("Kourier")
+		return err
+	}
+	instance.Status.MarkDependenciesInstalled()
+	return nil
 }
 
 // installKnConsoleCLIDownload creates CR for kn CLI download link

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -399,7 +399,6 @@ func TestKnativeServingStatus(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, ks)
 	s.AddKnownTypes(configv1.SchemeGroupVersion, ingress)
-	s.AddKnownTypes(v1alpha3.SchemeGroupVersion, &v1alpha3.VirtualServiceList{})
 	s.AddKnownTypes(routev1.GroupVersion, knRoute)
 
 	cl := fake.NewFakeClient(initObjs...)

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -385,6 +385,56 @@ func TestCustomCertsConfigMap(t *testing.T) {
 	}
 }
 
+// TestKnativeServingStatus tests KnativeServing CR status with Kourier's installation failure.
+func TestKnativeServingStatus(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	ks := &defaultKnativeServing
+	ingress := &defaultIngress
+	knRoute := &defaultKnRoute
+
+	initObjs := []runtime.Object{ks, ingress, knRoute}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, ks)
+	s.AddKnownTypes(configv1.SchemeGroupVersion, ingress)
+	s.AddKnownTypes(v1alpha3.SchemeGroupVersion, &v1alpha3.VirtualServiceList{})
+	s.AddKnownTypes(routev1.GroupVersion, knRoute)
+
+	cl := fake.NewFakeClient(initObjs...)
+	r := &ReconcileKnativeServing{client: cl, scheme: s}
+
+	// Test with invalid Kourier manifest file.
+	os.Setenv("KOURIER_MANIFEST_PATH", "kourier/testdata/non-exist-file")
+	if _, err := r.Reconcile(defaultRequest); err == nil {
+		t.Fatalf("reconcile does not fail with invalid manifest path")
+	}
+
+	failedKs := &v1alpha1.KnativeServing{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "knative-serving", Namespace: "knative-serving"}, failedKs)
+	if err != nil {
+		t.Fatalf("get: (%v)", err)
+	}
+	if failedKs.Status.GetCondition(v1alpha1.DependenciesInstalled).Status != corev1.ConditionFalse {
+		t.Fatalf("status: (%v)", failedKs.Status.GetCondition(v1alpha1.DependenciesInstalled))
+	}
+
+	// Reconcile with correct Kourier manifest file.
+	os.Setenv("KOURIER_MANIFEST_PATH", "kourier/testdata/kourier-latest.yaml")
+	if _, err := r.Reconcile(defaultRequest); err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+	successKs := &v1alpha1.KnativeServing{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "knative-serving", Namespace: "knative-serving"}, successKs)
+	if err != nil {
+		t.Fatalf("get: (%v)", err)
+	}
+	if successKs.Status.GetCondition(v1alpha1.DependenciesInstalled).Status != corev1.ConditionTrue {
+		t.Fatalf("status: (%v)", failedKs.Status.GetCondition(v1alpha1.DependenciesInstalled))
+	}
+}
+
 func ctrl(certVersion string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
+++ b/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
@@ -30,11 +30,9 @@ func Apply(instance *servingv1alpha1.KnativeServing, api client.Client, scheme *
 		return fmt.Errorf("failed to apply kourier manifest: %w", err)
 	}
 	if err := checkDeployments(&manifest, instance, api); err != nil {
-		instance.Status.MarkDependencyInstalling("Kourier")
 		return fmt.Errorf("failed to check deployments: %w", err)
 	}
 	log.Info("Kourier is ready")
-	instance.Status.MarkDependenciesInstalled()
 	return nil
 }
 


### PR DESCRIPTION
This is a backport patch for https://github.com/openshift-knative/serverless-operator/pull/316

Currently `MarkDependencyInstalling("Kourier")` is called only when
`checkDeployments()` returned error.
Due to this, when kourier installation failed by `manifest.Apply()` or
other place, the correct status is not set.

Hence this patch fixes it by adding `MarkDependencyInstalling("Kourier")`
whenever `kourier.Apply()` returns error.