### PR TITLE
[SRVKS-569] Add KnativeServing tracing config to CRD schema

### DIFF
--- a/olm-catalog/serverless-operator/1.8.0/operator_v1alpha1_knativeserving_crd.yaml
+++ b/olm-catalog/serverless-operator/1.8.0/operator_v1alpha1_knativeserving_crd.yaml
@@ -55,12 +55,59 @@ spec:
                   type: object
               type: object
             config:
-              additionalProperties:
-                additionalProperties:
-                  type: string
-                type: object
               description: A means to override the corresponding entries in the upstream
                 configmaps
+              properties:
+                autoscaler:
+                  additionalProperties:
+                    type: string
+                  type: object
+                defaults:
+                  additionalProperties:
+                    type: string
+                  type: object
+                deployment:
+                  additionalProperties:
+                    type: string
+                  type: object
+                domain:
+                  additionalProperties:
+                    type: string
+                  type: object
+                gc:
+                  additionalProperties:
+                    type: string
+                  type: object
+                logging:
+                  additionalProperties:
+                    type: string
+                  type: object
+                network:
+                  additionalProperties:
+                    type: string
+                  type: object
+                observability:
+                  additionalProperties:
+                    type: string
+                  type: object
+                tracing:
+                  description: configuration for tracing
+                  properties:
+                    backend:
+                      description: The backend for tracing. It may be "zipkin" or
+                        "none". The default is "none"
+                      type: string
+                    debug:
+                      description: URL to jaeger collector where traces are sent.
+                        This must be specified when backend is "zipkin".
+                      type: string
+                    sample-rate:
+                      description: Percentage (0-1) of requests to trace
+                      type: string
+                    zipkin-endpoint:
+                      description: URL to zipkin collector where traces are sent.
+                      type: string
+                  type: object
               type: object
             controller-custom-certs:
               description: Enabling the controller to trust registries with self-signed


### PR DESCRIPTION
This patch adds KnativeServing tracing config to CRD schema. 

After this patch, `oc explain` prints following config:

```
$ oc explain ks.spec.config.tracing
KIND:     KnativeServing
VERSION:  operator.knative.dev/v1alpha1

RESOURCE: tracing <Object>

DESCRIPTION:
     configuration for tracing

FIELDS:
   backend	<string>
     The backend for tracing. It may be "zipkin" or "none". The default is
     "none"

   debug	<string>
     URL to jaeger collector where traces are sent. This must be specified when
     backend is "zipkin".

   sample-rate	<string>
     Percentage (0-1) of requests to trace

   zipkin-endpoint	<string>
     URL to zipkin collector where traces are sent.
```