### PR TITLE
Bump operator version in preview-4.3 channel

### DIFF
--- a/olm-catalog/serverless-operator/serverless-operator.package.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.package.yaml
@@ -4,7 +4,7 @@ channels:
 - name: "techpreview"
   currentCSV: serverless-operator.v1.5.0
 - name: "preview-4.3"
-  currentCSV: serverless-operator.v1.6.0
+  currentCSV: serverless-operator.v1.7.1
 - name: "4.3"
   currentCSV: serverless-operator.v1.7.1
 - name: "4.4"


### PR DESCRIPTION
QE agrees that we should bump serverless-operator from `1.6.0` to `1.7.1` in the `preview-4.3` channel.