### PR TITLE
Run upgrade tests from multiple previous version in a single CI run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ images:
 install:
 	./hack/install.sh
 
+# Installs CSV version latest-1.
+# To override this, specify a concrete version by passing
+# INITIAL_CSV=serverless-operator.v1.X.X.
 install-previous:
 	INSTALL_PREVIOUS_VERSION="true" ./hack/install.sh
 

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -42,11 +42,14 @@ readonly EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-knative-eventing}"
 declare -a NAMESPACES
 NAMESPACES=("${SERVING_NAMESPACE}" "${SERVERLESS_NAMESPACE}" "${EVENTING_NAMESPACE}")
 export NAMESPACES
-readonly UPGRADE_SERVERLESS="${UPGRADE_SERVERLESS:-"true"}"
 readonly UPGRADE_CLUSTER="${UPGRADE_CLUSTER:-"false"}"
-
 readonly INSTALL_PREVIOUS_VERSION="${INSTALL_PREVIOUS_VERSION:-"false"}"
+# Specify concrete INITIAL_CSV when trying to install older Serverless than one version back.
+export INITIAL_CSV="${INITIAL_CSV:-}"
 export OLM_CHANNEL="${OLM_CHANNEL:-"preview-4.6"}"
 # Change this when upgrades need switching to a different channel
 export OLM_UPGRADE_CHANNEL="${OLM_UPGRADE_CHANNEL:-"$OLM_CHANNEL"}"
 export OLM_SOURCE="${OLM_SOURCE:-"$OPERATOR"}"
+# Specify whether upgrade tests should use Manual or Automatic approval strategy
+export AUTO_UPGRADES="${AUTO_UPGRADES:-"false"}"
+readonly CSVS_BREAKING_PROBER_TEST="serverless-operator.v1.7.0" # Separate by space

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -20,8 +20,21 @@ failed=0
 (( !failed )) && install_catalogsource || failed=3
 (( !failed )) && logger.success 'Cluster prepared for testing.'
 
-(( !failed )) && install_serverless_previous || failed=5
-(( !failed )) && run_knative_serving_rolling_upgrade_tests || failed=6
+# Test upgrades from CSV one version back, with manual approval.
+(( !failed )) && install_serverless_previous || failed=4
+(( !failed )) && run_knative_serving_rolling_upgrade_tests || failed=5
+(( !failed )) && teardown_serverless || failed=6
+
+# Test upgrades from CSV two versions back to the latest, with automatic approval.
+upgrade_from="$(latest_minus_two_csv)" || return $?
+(( !failed )) && INITIAL_CSV="$upgrade_from" install_serverless_previous || failed=7
+(( !failed )) && INITIAL_CSV="$upgrade_from" AUTO_UPGRADES=true run_knative_serving_rolling_upgrade_tests || failed=8
+(( !failed )) && teardown_serverless || failed=9
+
+# Test upgrades from oldest compatible CSV to the latest, with automatic approval.
+upgrade_from="$(oldest_compatible_csv "$OLM_UPGRADE_CHANNEL")" || return $?
+(( !failed )) && INITIAL_CSV="$upgrade_from" install_serverless_previous || failed=10
+(( !failed )) && INITIAL_CSV="$upgrade_from" AUTO_UPGRADES=true run_knative_serving_rolling_upgrade_tests || failed=11
 
 echo ">>> Knative Servings"
 oc get knativeserving.operator.knative.dev --all-namespaces -o yaml


### PR DESCRIPTION
This PR adds a few scenarios to upgrade tests:
* upgrade from oldest CSV with the same minKubeVersion as the latest on the given channel
* upgrade from latest-2 CSV
Both of these scenarios use automatic upgrades/approval. However, at the beginning the Subscription has a manual approval strategy so that we can install the given old version and start upgrade from there. Then the approval strategy is changed to automatic and the first InstallPlan approved manually (because it stays manual), the next install plans are then automatically approved by OLM. These tests run pre-upgrade tests from Knative Serving after the first old version is installed, and then run post-upgrade tests after OLM upgrades to the latest version. We don't run Prober test in these scenarios because some upgrades break it and we can't control that with automatic upgrades.

The test container execution times are as follows:
* 16min - without these scenarios (meaning we test only upgrades from latest-1) (on OCP 4.3)
* 25min - when testing upgrades from latest-1 and from oldest compatible CSV (via minKubeVersion) (on OCP 4.3)
* 48min - when testing ugprade from latest-1, from latest-2, and from oldest compatible CSV (on OCP 4.4) - this execution time is strange but I couldn't verify it on other OCP version because the Prober test is currently very unstable (unrelated to this PR). Update: In the latest run https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/322/pull-ci-openshift-knative-serverless-operator-master-4.3-upgrade-tests-aws-ocp-43/917 it took 31 minutes for the test container to run everything

