### PR TITLE
Allow upgrades to OCP that is not yet available via channel (#303)

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -44,6 +44,8 @@ NAMESPACES=("${SERVING_NAMESPACE}" "${SERVERLESS_NAMESPACE}" "${EVENTING_NAMESPA
 export NAMESPACES
 readonly UPGRADE_SERVERLESS="${UPGRADE_SERVERLESS:-"true"}"
 readonly UPGRADE_CLUSTER="${UPGRADE_CLUSTER:-"false"}"
+# Change this when forcing the upgrade to an image that is not yet available via upgrade channel
+readonly UPGRADE_OCP_IMAGE="${UPGRADE_OCP_IMAGE:-}"
 
 readonly INSTALL_PREVIOUS_VERSION="${INSTALL_PREVIOUS_VERSION:-"false"}"
 export OLM_CHANNEL="${OLM_CHANNEL:-"preview-4.6"}"


### PR DESCRIPTION
* for example, to a nightly build of OCP

This is a port for master branch. It was previously merged in release-1.7 branch.