### PR TITLE
[WIP][SRVKS-571] Move k-s-i resources to knative-serving namespace

### DIFF
--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -33,11 +33,6 @@ func Configure(ks *servingv1alpha1.KnativeServing, cm, key, value string) bool {
 	return true
 }
 
-// IngressNamespace returns namespace where ingress is deployed.
-func IngressNamespace(servingNamespace string) string {
-	return servingNamespace + "-ingress"
-}
-
 // BuildImageOverrideMapFromEnviron creates a map to overrides registry images
 func BuildImageOverrideMapFromEnviron(environ []string) map[string]string {
 	overrideMap := map[string]string{}

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -140,7 +140,7 @@ func TestKourierReconcile(t *testing.T) {
 
 			// Check if Kourier is deployed.
 			deploy := &appsv1.Deployment{}
-			err := cl.Get(context.TODO(), types.NamespacedName{Name: "3scale-kourier-gateway", Namespace: "knative-serving-ingress"}, deploy)
+			err := cl.Get(context.TODO(), types.NamespacedName{Name: "3scale-kourier-gateway", Namespace: "knative-serving"}, deploy)
 			if err != nil {
 				t.Fatalf("get: (%v)", err)
 			}
@@ -172,7 +172,7 @@ func TestKourierReconcile(t *testing.T) {
 			}
 
 			// Check again if Kourier deployment is created after reconcile.
-			err = cl.Get(context.TODO(), types.NamespacedName{Name: "3scale-kourier-gateway", Namespace: "knative-serving-ingress"}, deploy)
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "3scale-kourier-gateway", Namespace: "knative-serving"}, deploy)
 			if test.deleted {
 				if err != nil {
 					t.Fatalf("get: (%v)", err)

--- a/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
+++ b/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
@@ -126,6 +126,12 @@ func manifest(namespace string, apiclient client.Client, instance *servingv1alph
 	if err != nil {
 		return mf.Manifest{}, err
 	}
+
+	manifest = manifest.Filter(mf.None(
+		mf.ByKind("namespace"),
+		mf.ByName("config-leader-election"), mf.ByName("config-logging"), mf.ByName("config-config-observability"),
+	))
+
 	transforms := []mf.Transformer{
 		mf.InjectNamespace(namespace),
 		replaceImageFromEnvironment("IMAGE_", scheme),

--- a/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
+++ b/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
@@ -25,12 +25,12 @@ import (
 )
 
 const (
-	name                 = "ingress-operator"
-	serviceMeshNamespace = "knative-serving-ingress"
-	namespace            = "ingress-namespace"
-	uid                  = "8a7e9a9d-fbc6-11e9-a88e-0261aff8d6d8"
-	domainName           = name + "." + namespace + ".default.domainName"
-	routeName0           = "route-" + uid + "-336636653035"
+	name             = "ingress-operator"
+	servingNamespace = "knative-serving"
+	namespace        = "ingress-namespace"
+	uid              = "8a7e9a9d-fbc6-11e9-a88e-0261aff8d6d8"
+	domainName       = name + "." + namespace + ".default.domainName"
+	routeName0       = "route-" + uid + "-336636653035"
 )
 
 var (
@@ -56,7 +56,7 @@ var (
 		Status: networkingv1alpha1.IngressStatus{
 			LoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
 				Ingress: []networkingv1alpha1.LoadBalancerIngressStatus{{
-					DomainInternal: "istio-ingressgateway." + serviceMeshNamespace + ".svc.cluster.local",
+					DomainInternal: "kourier." + servingNamespace + ".svc.cluster.local",
 				}},
 			},
 		},
@@ -100,7 +100,7 @@ func TestRouteMigration(t *testing.T) {
 		want: []routev1.Route{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            routeName0,
-				Namespace:       serviceMeshNamespace,
+				Namespace:       servingNamespace,
 				Labels:          map[string]string{networking.IngressLabelKey: name, serving.RouteLabelKey: name, serving.RouteNamespaceLabelKey: namespace},
 				Annotations:     map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
 				ResourceVersion: "1",
@@ -109,7 +109,7 @@ func TestRouteMigration(t *testing.T) {
 				Host: domainName,
 				To: routev1.RouteTargetReference{
 					Kind:   "Service",
-					Name:   "istio-ingressgateway",
+					Name:   "kourier",
 					Weight: ptr.Int32(100),
 				},
 				Port: &routev1.RoutePort{
@@ -276,7 +276,7 @@ func TestIngressController(t *testing.T) {
 
 			// Check if route has been created.
 			routes := &routev1.Route{}
-			err := cl.Get(context.TODO(), types.NamespacedName{Name: routeName0, Namespace: serviceMeshNamespace}, routes)
+			err := cl.Get(context.TODO(), types.NamespacedName{Name: routeName0, Namespace: servingNamespace}, routes)
 
 			assert.True(t, test.wantRouteErr(err))
 			assert.Equal(t, test.want, routes.ObjectMeta.Annotations)

--- a/serving/ingress/pkg/controller/ingress/resources/route.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route.go
@@ -106,7 +106,7 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 		for _, lbIngress := range ci.Status.LoadBalancer.Ingress {
 			if lbIngress.DomainInternal != "" {
 				// DomainInternal should look something like:
-				// kourier.knative-serving-ingress.svc.cluster.local
+				// kourier.knative-serving.svc.cluster.local
 				parts := strings.Split(lbIngress.DomainInternal, ".")
 				if len(parts) > 2 && parts[2] == "svc" {
 					serviceName = parts[0]


### PR DESCRIPTION
This patch moves  k-s-i resources to knative-serving namespace.

/hold

https://github.com/knative/operator/issues/112 is a critical blocker for this change.