### PR TITLE
Dockerfile for serverless-operator-src image

### DIFF
--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -1,0 +1,4 @@
+FROM src
+
+COPY oc /usr/bin/oc
+COPY serving ${GOPATH}/src/knative.dev/serving


### PR DESCRIPTION
* this image is used to run tests

This Dockerfile will be used in https://github.com/openshift/release/pull/9143, that PR should pass tests and then we can test https://github.com/openshift-knative/serverless-operator/pull/304  again and merge.
