### PR TITLE
Do not clone Knative Eventing and remove third-party operator test suites

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -12,18 +12,12 @@ fi
 source "$(dirname "${BASH_SOURCE[0]}")/../../test/vendor/knative.dev/test-infra/scripts/e2e-tests.sh"
 
 readonly KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v0.13.3}"
-readonly KNATIVE_SERVING_OPERATOR_VERSION="${KNATIVE_SERVING_OPERATOR_VERSION:-v0.13.3}"
 readonly KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v0.13.0}"
-readonly KNATIVE_EVENTING_OPERATOR_VERSION="${KNATIVE_EVENTING_OPERATOR_VERSION:-v0.13.3}"
 
 readonly KNATIVE_SERVING_BRANCH="${KNATIVE_SERVING_BRANCH:-release-${KNATIVE_SERVING_VERSION}}"
-readonly KNATIVE_SERVING_OPERATOR_BRANCH="${KNATIVE_SERVING_OPERATOR_BRANCH:-openshift-${KNATIVE_SERVING_OPERATOR_VERSION}}"
 readonly KNATIVE_SERVING_REPO="${KNATIVE_SERVING_REPO:-"https://github.com/openshift/knative-serving.git"}"
-readonly KNATIVE_SERVING_OPERATOR_REPO="${KNATIVE_SERVING_OPERATOR_REPO:-"https://github.com/openshift-knative/serving-operator.git"}"
 readonly KNATIVE_EVENTING_BRANCH="${KNATIVE_EVENTING_BRANCH:-release-${KNATIVE_EVENTING_VERSION}}"
-readonly KNATIVE_EVENTING_OPERATOR_BRANCH="${KNATIVE_EVENTING_OPERATOR_BRANCH:-openshift-${KNATIVE_EVENTING_OPERATOR_VERSION}}"
 readonly KNATIVE_EVENTING_REPO="${KNATIVE_EVENTING_REPO:-"https://github.com/openshift/knative-eventing.git"}"
-readonly KNATIVE_EVENTING_OPERATOR_REPO="${KNATIVE_EVENTING_OPERATOR_REPO:-"https://github.com/openshift-knative/eventing-operator.git"}"
 
 # Directories below are filled with source code by ci-operator
 readonly KNATIVE_SERVING_HOME="${GOPATH}/src/knative.dev/serving"

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -13,8 +13,6 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../test/vendor/knative.dev/test-infra/
 
 readonly KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v0.13.3}"
 readonly KNATIVE_SERVING_OPERATOR_VERSION="${KNATIVE_SERVING_OPERATOR_VERSION:-v0.13.3}"
-# KNATIVE_SEVING_HOME is filled with Knative Serving sources by ci-operator
-readonly KNATIVE_SERVING_HOME="${GOPATH}/src/knative.dev/serving"
 readonly KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v0.13.0}"
 readonly KNATIVE_EVENTING_OPERATOR_VERSION="${KNATIVE_EVENTING_OPERATOR_VERSION:-v0.13.3}"
 
@@ -26,6 +24,10 @@ readonly KNATIVE_EVENTING_BRANCH="${KNATIVE_EVENTING_BRANCH:-release-${KNATIVE_E
 readonly KNATIVE_EVENTING_OPERATOR_BRANCH="${KNATIVE_EVENTING_OPERATOR_BRANCH:-openshift-${KNATIVE_EVENTING_OPERATOR_VERSION}}"
 readonly KNATIVE_EVENTING_REPO="${KNATIVE_EVENTING_REPO:-"https://github.com/openshift/knative-eventing.git"}"
 readonly KNATIVE_EVENTING_OPERATOR_REPO="${KNATIVE_EVENTING_OPERATOR_REPO:-"https://github.com/openshift-knative/eventing-operator.git"}"
+
+# Directories below are filled with source code by ci-operator
+readonly KNATIVE_SERVING_HOME="${GOPATH}/src/knative.dev/serving"
+readonly KNATIVE_EVENTING_HOME="${GOPATH}/src/knative.dev/eventing"
 
 readonly CATALOG_SOURCE_FILENAME="${CATALOG_SOURCE_FILENAME:-catalogsource-ci.yaml}"
 readonly DOCKER_REPO_OVERRIDE="${DOCKER_REPO_OVERRIDE:-}"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -18,25 +18,20 @@ create_htpasswd_users && add_roles || exit $?
 
 failed=0
 
-(( !failed )) && install_catalogsource || failed=3
+(( !failed )) && install_catalogsource || failed=1
 (( !failed )) && logger.success '🚀 Cluster prepared for testing.'
 
 # Run serverless-operator specific tests.
-(( !failed )) && serverless_operator_e2e_tests || failed=4
-
-# Run upstream knative serving & eventing operator tests
-(( !failed )) && deploy_serverless_operator_latest || failed=11
-(( !failed )) && knative_serving_operator_tests || failed=12
-(( !failed )) && knative_eventing_operator_tests || failed=14
+(( !failed )) && serverless_operator_e2e_tests || failed=2
 
 # Run upstream knative serving & eventing tests
-(( !failed )) && ensure_serverless_installed || failed=15
+(( !failed )) && ensure_serverless_installed || failed=3
 
 # Run knative serving additional e2e tests
-(( !failed )) && downstream_serving_e2e_tests || failed=5
+(( !failed )) && downstream_serving_e2e_tests || failed=4
 
-(( !failed )) && upstream_knative_serving_e2e_and_conformance_tests || failed=16
-(( !failed )) && knative_eventing_tests || failed=17
+(( !failed )) && upstream_knative_serving_e2e_and_conformance_tests || failed=5
+(( !failed )) && knative_eventing_tests || failed=6
 
 (( failed )) && dump_state
 (( failed )) && exit $failed

--- a/test/eventing.bash
+++ b/test/eventing.bash
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-function checkout_knative_eventing {
-  checkout_repo 'knative.dev/eventing' \
-    "${KNATIVE_EVENTING_REPO}" \
-    "${KNATIVE_EVENTING_VERSION}" \
-    "${KNATIVE_EVENTING_BRANCH}"
-}
-
 function checkout_knative_eventing_operator {
   checkout_repo 'knative.dev/eventing-operator' \
     "${KNATIVE_EVENTING_OPERATOR_REPO}" \
@@ -19,7 +12,7 @@ function knative_eventing_tests {
   local exitstatus=0
   logger.info 'Running eventing tests'
 
-  checkout_knative_eventing
+  cd "$KNATIVE_EVENTING_HOME" || return $?
 
   image_template="registry.svc.ci.openshift.org/openshift/knative-${KNATIVE_EVENTING_VERSION}:knative-eventing-test-{{.Name}}"
 
@@ -29,8 +22,6 @@ function knative_eventing_tests {
     || exitstatus=$? && true
 
   print_test_result ${exitstatus}
-
-  remove_temporary_gopath
 
   return $exitstatus
   )

--- a/test/eventing.bash
+++ b/test/eventing.bash
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-function checkout_knative_eventing_operator {
-  checkout_repo 'knative.dev/eventing-operator' \
-    "${KNATIVE_EVENTING_OPERATOR_REPO}" \
-    "${KNATIVE_EVENTING_OPERATOR_VERSION}" \
-    "${KNATIVE_EVENTING_OPERATOR_BRANCH}"
-}
-
 function knative_eventing_tests {
   (
   local exitstatus=0
@@ -22,27 +15,6 @@ function knative_eventing_tests {
     || exitstatus=$? && true
 
   print_test_result ${exitstatus}
-
-  return $exitstatus
-  )
-}
-
-function knative_eventing_operator_tests {
-  logger.info 'Running eventing operator tests'
-  (
-  local exitstatus=0
-
-  checkout_knative_eventing_operator
-
-  export TEST_NAMESPACE="${EVENTING_NAMESPACE}"
-
-  go_test_e2e -timeout=20m -parallel=1 ./test/e2e \
-    --kubeconfig "$KUBECONFIG" \
-    || exitstatus=$? && true
-
-  print_test_result ${exitstatus}
-
-  remove_temporary_gopath
 
   return $exitstatus
   )


### PR DESCRIPTION
* the sources will be provided by ci-operator

Regarding operator test suites, the related discussion around removing those is here: https://coreos.slack.com/archives/CD87JDUB0/p1591185499029200
Summary: the tests do not provide much value as they're short, partially replicated by the serverless operator test suite, and they haven't revealed any bugs. It should be sufficient to run then as part of QE cycle rather than slowing down every single PR.