### PR TITLE
Update Serving src image to 0.14.1 and define the version in Dockerfile

### DIFF
--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -1,5 +1,5 @@
 FROM src
 
 COPY oc /usr/bin/oc
-COPY serving ${GOPATH}/src/knative.dev/serving
+COPY --from=registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-src /go/src/knative.dev/serving/ /go/src/knative.dev/serving/
 COPY --from=registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-src /go/src/knative.dev/eventing/ /go/src/knative.dev/eventing/


### PR DESCRIPTION
Moving the version definition from https://github.com/openshift/release/blob/master/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-master__4.3.yaml#L10 to the current repo. It will remove the issue with upgrades when changes to these two repos are dependent on each other.

PR for openshift/release: https://github.com/openshift/release/pull/9685 (this PR can be merged later)
