### PR TITLE
[WIP] Adjust rollout settings to minimize Kourier rollout impact.

### DIFF
--- a/knative-operator/deploy/resources/kourier/kourier-release-0.14.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier-release-0.14.yaml
@@ -92,6 +92,12 @@ spec:
   selector:
     matchLabels:
       app: 3scale-kourier-gateway
+  minReadySeconds: 5
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0%
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Playing with this to see if it helps our TestProbe flakes (and thus the users during rollout).