### PR TITLE
Poll until networkpolicy becomes active in TestNetworkPolicy

### DIFF
--- a/test/servinge2e/verify_networkpolicy_test.go
+++ b/test/servinge2e/verify_networkpolicy_test.go
@@ -50,13 +50,13 @@ func TestNetworkPolicy(t *testing.T) {
 	err = wait.PollImmediate(test.Interval, 1*time.Minute, func() (bool, error) {
 		_, inErr := http.Get(ksvc.Status.URL.String())
 		if inErr == nil {
-			t.Logf("Netowrk policy did not block the request to %s", ksvc.Status.URL.String())
+			t.Logf("Network policy did not block the request to %s", ksvc.Status.URL.String())
 			return false, nil
 		}
 		return true, nil
 	})
 	if err != nil {
-		t.Fatalf("Netowrk policy did not block the request: %v", err)
+		t.Fatalf("Network policy did not block the request: %v", err)
 	}
 
 	policyAllow := &networkingv1.NetworkPolicy{
@@ -87,12 +87,12 @@ func TestNetworkPolicy(t *testing.T) {
 	err = wait.PollImmediate(test.Interval, 1*time.Minute, func() (bool, error) {
 		_, inErr := http.Get(ksvc.Status.URL.String())
 		if inErr != nil {
-			t.Logf("Netowrk policy did not allow the request to %s: %v", ksvc.Status.URL.String(), inErr)
+			t.Logf("Network policy did not allow the request to %s: %v", ksvc.Status.URL.String(), inErr)
 			return false, nil
 		}
 		return true, nil
 	})
 	if err != nil {
-		t.Fatalf("Netowrk policy did not allow the request: %v", err)
+		t.Fatalf("Network policy did not allow the request: %v", err)
 	}
 }


### PR DESCRIPTION
Network policy take a few seconds until it becomes active. Due to
this, TestNetworkPolicy fails sometimes like this:

https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/353/pull-ci-openshift-knative-serverless-operator-master-4.5-e2e-aws-ocp-45/1276044676339601408
