### PR TITLE
Confirm upgrade of knativeserving version from hard-coded value

### DIFF
--- a/test/serving.bash
+++ b/test/serving.bash
@@ -122,7 +122,8 @@ function run_knative_serving_rolling_upgrade_tests {
       [[ $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") == "$serving_version" ]] || return 1
     else
       approve_csv "$upgrade_to" "$OLM_UPGRADE_CHANNEL" || return 1
-      timeout 900 '[[ ! ( $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") != $serving_version && $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
+      # Check KnativeServing has the latest version with Ready status
+      timeout 900 '[[ ! ( $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}") == ${KNATIVE_SERVING_VERSION} && $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") == True ) ]]' || return 1
 
       # Assert that the old image references eventually fade away
       # Ignore kn-cli-artifacts as it's not part of the Knative Serving deployment.

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -107,7 +107,7 @@ function run_knative_serving_rolling_upgrade_tests {
   if [[ $UPGRADE_SERVERLESS == true ]]; then
     prev_serving_version=$(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}")
     # This is ugly hack. Use KNATIVE_SERVING_VERSION if issues/361 was solved.
-    latest_serving_version=v$(cat knative-operator/vendor/knative.dev/operator/version/version.go | grep "ServingVersion =" |  awk '{print $NF}' | tr -d '"')
+    latest_serving_version=$(cat knative-operator/vendor/knative.dev/operator/version/version.go | grep "ServingVersion =" |  awk '{print $NF}' | tr -d '"')
 
     # Get latest CSV from the given channel
     upgrade_to=$("${rootdir}/hack/catalog.sh" | sed -n '/channels/,$p;' | sed -n "/- name: \"${OLM_UPGRADE_CHANNEL}\"$/{n;p;}" | awk '{ print $2 }')

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -74,7 +74,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
 function run_knative_serving_rolling_upgrade_tests {
   logger.info "Running Serving rolling upgrade tests"
   (
-  local failed upgrade_to latest_cluster_version cluster_version prev_serving_version latest_serving_verssion
+  local failed upgrade_to latest_cluster_version cluster_version prev_serving_version latest_serving_version
 
   # Save the rootdir before changing dir
   rootdir="$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -107,7 +107,7 @@ function run_knative_serving_rolling_upgrade_tests {
   if [[ $UPGRADE_SERVERLESS == true ]]; then
     prev_serving_version=$(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.version}")
     # This is ugly hack. Use KNATIVE_SERVING_VERSION if issues/361 was solved.
-    latest_serving_version=$(cat ${rootdir}/knative-operator/vendor/knative.dev/operator/version/version.go | grep "ServingVersion =" |  awk '{print $NF}' | tr -d '"')
+    latest_serving_version=$(sed -n 's/^.*ServingVersion.*"\(.*\)".*$/\1/p' ${rootdir}/knative-operator/vendor/knative.dev/operator/version/version.go)
 
     logger.info "updating serving version from ${prev_serving_version} to ${latest_serving_version}"
 


### PR DESCRIPTION
When CSV is updated but KnativeServing was not updated, upgrade test fails as current script expects to update of the version.

Hence this patch the "updated version" from hard-coded value and verifies the version during upgrade test.

Fixes https://github.com/openshift-knative/serverless-operator/issues/362
