### PR TITLE
Enable multi-arch support in operator

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -223,8 +223,20 @@ func populateKnConsoleCLIDownload(baseURL string, instance *servingv1alpha1.Knat
 			Description: "The OpenShift Serverless client `kn` is a CLI tool that allows you to fully manage OpenShift Serverless Serving and Eventing resources without writing a single line of YAML.",
 			Links: []consolev1.CLIDownloadLink{
 				{
-					Text: "Download kn for Linux",
+					Text: "Download kn for Linux for x86_64",
 					Href: baseURL + "/amd64/linux/kn-linux-amd64.tar.gz",
+				},
+				{
+					Text: "Download kn for Linux for IBM Power little endian",
+					Href: baseURL + "/ppc64le/linux/kn-linux-ppc64le.tar.gz",
+				},
+				{
+					Text: "Download kn for Linux for IBM Z",
+					Href: baseURL + "/s390x/linux/kn-linux-s390x.tar.gz",
+				},
+				{
+					Text: "Download kn for Linux for ARM 64",
+					Href: baseURL + "/arm64/linux/kn-linux-arm64.tar.gz",
 				},
 				{
 					Text: "Download kn for macOS",


### PR DESCRIPTION
Filing here now based on feedback in https://github.com/openshift/knative-client/pull/411, but this depends on the multi-arch binaries landing in kn-cli-artifacts via https://github.com/openshift/knative-client/pull/414 and possibly other follow-up work.

If there is something else missing on the operator side, please let me know.

/hold

