### PR TITLE
[SRVKS-588] Avoid resourceVersion churn due to constant status resetting.

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -363,8 +363,8 @@ func (r *ReconcileKnativeServing) reconcileConfigMap(instance *servingv1alpha1.K
 // Install Kourier Ingress Gateway
 func (r *ReconcileKnativeServing) installKourier(instance *servingv1alpha1.KnativeServing) error {
 	// install Kourier
-	instance.Status.MarkDependencyInstalling("Kourier")
 	if err := kourier.Apply(instance, r.client, r.scheme); err != nil {
+		instance.Status.MarkDependencyInstalling("Kourier")
 		return err
 	}
 	instance.Status.MarkDependenciesInstalled()


### PR DESCRIPTION
The status conditions have a guard that avoid updating the condition's lastTransitionTime timestamp if you're trying to set it to the same state multiple times. As such, running `MarkDependenciesInstalled` on each reconcile is benign.

However, internally flipping the state on each reconcile is not. It'll cause us to constantly update the timestamps and thus churn through resourceVersions. This prevents that. The status will be "Unknown" before `Apply` returns for the first time, which is I think just as good as what we have today. If we want to be smarter with the status setting, we'd need to check if we *actually* need to run apply etc etc. Not sure it's worth it.