### PR TITLE
Remove tech-preview and preview-4.3 channels

### DIFF
--- a/olm-catalog/serverless-operator/serverless-operator.package.yaml
+++ b/olm-catalog/serverless-operator/serverless-operator.package.yaml
@@ -1,10 +1,6 @@
 packageName: serverless-operator
 defaultChannel: "4.3"
 channels:
-- name: "techpreview"
-  currentCSV: serverless-operator.v1.5.0
-- name: "preview-4.3"
-  currentCSV: serverless-operator.v1.6.0
 - name: "4.3"
   currentCSV: serverless-operator.v1.7.2
 - name: "4.4"


### PR DESCRIPTION
As agreed, removing the `tech-preview` and `preview-4.3` channels as they're no longer required.