### PR TITLE
Remove diff to avoid panic due to comparing unexported fields.

### DIFF
--- a/knative-operator/Gopkg.lock
+++ b/knative-operator/Gopkg.lock
@@ -1052,6 +1052,7 @@
     "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
+    "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/runtime",
@@ -1081,6 +1082,7 @@
     "sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder",
     "sigs.k8s.io/controller-runtime/pkg/webhook/admission/types",
     "sigs.k8s.io/controller-tools/pkg/crd/generator",
+    "sigs.k8s.io/yaml",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"github.com/operator-framework/operator-sdk/pkg/predicate"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -104,7 +103,7 @@ func (r *ReconcileKnativeEventing) configure(instance *eventingv1alpha1.KnativeE
 	}
 
 	// Only apply the update if something changed.
-	log.Info("Updating KnativeEventing with mutated state for Openshift", "diff", cmp.Diff(before.Spec, instance.Spec))
+	log.Info("Updating KnativeEventing with mutated state for Openshift")
 	if err := r.client.Update(context.TODO(), instance); err != nil {
 		return fmt.Errorf("failed to update KnativeEventing with mutated state: %w", err)
 	}

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/google/go-cmp/cmp"
-
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleclidownload"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/dashboard"
@@ -216,7 +214,7 @@ func (r *ReconcileKnativeServing) configure(instance *servingv1alpha1.KnativeSer
 	}
 
 	// Only apply the update if something changed.
-	log.Info("Updating KnativeServing with mutated state for Openshift", "diff", cmp.Diff(before.Spec, instance.Spec))
+	log.Info("Updating KnativeServing with mutated state for Openshift")
 	if err := r.client.Update(context.TODO(), instance); err != nil {
 		return fmt.Errorf("failed to update KnativeServing with mutated state: %w", err)
 	}


### PR DESCRIPTION
```
E0722 14:47:03.617271       1 runtime.go:67] Observed a panic: cannot handle unexported field at {v1alpha1.KnativeServingSpec}.CommonSpec.Resources[0].ResourceRequirements.Limits["memory"].i:
	"github.com/openshift-knative/serverless-operator/knative-operator/vendor/k8s.io/apimachinery/pkg/api/resource".Quantity
consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported
```

This can happen if a component races the webhook and we need to add resources from the reconciler. Not good!