### PR TITLE
[SRVLS-264] Create knative components in openshift-serverless

### DIFF
--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -81,10 +81,10 @@ EOF
 function teardown_tracing {
   logger.warn 'Teardown tracing'
 
-  oc delete service    -n "${ZIPKIN_NAMESPACE}" zipkin
-  oc delete deployment -n "${ZIPKIN_NAMESPACE}" zipkin
+  oc delete service    -n "${ZIPKIN_NAMESPACE}" zipkin 2>/dev/null || true
+  oc delete deployment -n "${ZIPKIN_NAMESPACE}" zipkin 2>/dev/null || true
 
-  timeout 600 "[[ \$(oc get pods -n ${ZIPKIN_NAMESPACE} --field-selector=status.phase!=Succeeded -o jsonpath='{.items}') != '[]' ]]" || return 2
+  timeout 600 "[[ \$(oc get pods -n ${ZIPKIN_NAMESPACE} --field-selector=status.phase!=Succeeded -o jsonpath='{.items}') != '[]' ]]"
 
   logger.success 'Tracing is uninstalled.'
 }

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -34,8 +34,11 @@ export SCALE_UP="${SCALE_UP:-6}"
 export OLM_NAMESPACE="${OLM_NAMESPACE:-openshift-marketplace}"
 export OPERATORS_NAMESPACE="${OPERATORS_NAMESPACE:-openshift-serverless}"
 export SERVERLESS_NAMESPACE="${SERVERLESS_NAMESPACE:-serverless}"
-export SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
-export EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-knative-eventing}"
+export SERVING_NAMESPACE="${SERVING_NAMESPACE:-${OPERATORS_NAMESPACE}}"
+export EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-${OPERATORS_NAMESPACE}}"
+# required by knative test-infra to override knative-* namespaces
+export SYSTEM_NAMESPACE="${OPERATORS_NAMESPACE}"
+export TEST_EVENTING_NAMESPACE="${OPERATORS_NAMESPACE}"
 # eventing e2e and conformance tests use a container for tracing tests that has hardcoded `istio-system` in it
 export ZIPKIN_NAMESPACE="${ZIPKIN_NAMESPACE:-istio-system}"
 

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
@@ -25,7 +25,7 @@ func ValidatingWebhook(mgr manager.Manager) (webhook.Webhook, error) {
 	return builder.NewWebhookBuilder().
 		Name("validating.knativeeventing.openshift.io").
 		Validating().
-		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
+		Operations(admissionregistrationv1beta1.Create).
 		WithManager(mgr).
 		ForType(&eventingv1alpha1.KnativeEventing{}).
 		Handlers(&KnativeEventingValidator{}).

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
@@ -115,15 +115,15 @@ func (v *KnativeEventingValidator) validateNamespace(ctx context.Context, ke *ev
 	return true, "", nil
 }
 
-// validate this is the only KE in this namespace
+// validate this is the only KE in the cluster
 func (v *KnativeEventingValidator) validateLoneliness(ctx context.Context, ke *eventingv1alpha1.KnativeEventing) (bool, string, error) {
 	list := &eventingv1alpha1.KnativeEventingList{}
-	if err := v.client.List(ctx, &client.ListOptions{Namespace: ke.Namespace}, list); err != nil {
+	if err := v.client.List(ctx, &client.ListOptions{Namespace: ""}, list); err != nil {
 		return false, "Unable to list KnativeEventings", err
 	}
-	for _, v := range list.Items {
-		if ke.Name != v.Name {
-			return false, "Only one KnativeEventing allowed per namespace", nil
+	for _, item := range list.Items {
+		if ke.Name != item.Name || ke.Namespace != item.Namespace {
+			return false, fmt.Sprintf("Existing instance found: %s/%s", item.Namespace, item.Name), nil
 		}
 	}
 	return true, "", nil

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating.go
@@ -25,7 +25,7 @@ func ValidatingWebhook(mgr manager.Manager) (webhook.Webhook, error) {
 	return builder.NewWebhookBuilder().
 		Name("validating.knativeserving.openshift.io").
 		Validating().
-		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
+		Operations(admissionregistrationv1beta1.Create).
 		WithManager(mgr).
 		ForType(&servingv1alpha1.KnativeServing{}).
 		Handlers(&KnativeServingValidator{}).

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating.go
@@ -115,15 +115,15 @@ func (v *KnativeServingValidator) validateNamespace(ctx context.Context, ks *ser
 	return true, "", nil
 }
 
-// validate this is the only KS in this namespace
+// validate this is the only KS in the cluster
 func (v *KnativeServingValidator) validateLoneliness(ctx context.Context, ks *servingv1alpha1.KnativeServing) (bool, string, error) {
 	list := &servingv1alpha1.KnativeServingList{}
-	if err := v.client.List(ctx, &client.ListOptions{Namespace: ks.Namespace}, list); err != nil {
-		return false, "Unable to list KnativeServings", err
+	if err := v.client.List(ctx, &client.ListOptions{Namespace: ""}, list); err != nil {
+		return false, "Unable to list instances", err
 	}
-	for _, v := range list.Items {
-		if ks.Name != v.Name {
-			return false, "Only one KnativeServing allowed per namespace", nil
+	for _, item := range list.Items {
+		if ks.Name != item.Name || ks.Namespace != item.Namespace {
+			return false, fmt.Sprintf("Existing instance found: %s/%s", item.Namespace, item.Name), nil
 		}
 	}
 	return true, "", nil

--- a/olm-catalog/serverless-operator/1.9.0/serverless-operator.v1.9.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.9.0/serverless-operator.v1.9.0.clusterserviceversion.yaml
@@ -300,9 +300,9 @@ spec:
                     - name: MIN_OPENSHIFT_VERSION
                       value: "4.3.0-0"
                     - name: REQUIRED_SERVING_NAMESPACE
-                      value: "knative-serving"
+                      value: "openshift-serverless"
                     - name: REQUIRED_EVENTING_NAMESPACE
-                      value: "knative-eventing"
+                      value: "openshift-serverless"
                     - name: KOURIER_MANIFEST_PATH
                       value: deploy/resources/kourier/kourier-latest.yaml
                     - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH

--- a/test/e2e/knative_eventing_test.go
+++ b/test/e2e/knative_eventing_test.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	eventingName      = "knative-eventing"
-	eventingNamespace = "knative-eventing"
+	eventingNamespace = "openshift-serverless"
 )
 
 var knativeControlPlaneDeploymentNames = []string{

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	servingName                   = "knative-serving"
-	servingNamespace              = "knative-serving"
+	servingNamespace              = "openshift-serverless"
 	testNamespace                 = "serverless-tests"
 	image                         = "gcr.io/knative-samples/helloworld-go"
 	proxyImage                    = "gcr.io/knative-samples/autoscale-go:0.1"

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -198,8 +198,8 @@ function delete_users {
 }
 
 function add_systemnamespace_label {
-  oc label namespace knative-serving serving.knative.openshift.io/system-namespace=true --overwrite         || true
-  oc label namespace knative-serving-ingress serving.knative.openshift.io/system-namespace=true --overwrite || true
+  oc label namespace ${SERVING_NAMESPACE} serving.knative.openshift.io/system-namespace=true --overwrite         || true
+  oc label namespace ${SERVING_NAMESPACE}-ingress serving.knative.openshift.io/system-namespace=true --overwrite || true
 }
 
 function add_networkpolicy {

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -2,13 +2,12 @@
 
 function wait_for_knative_serving_ingress_ns_deleted {
   local NS="${SERVING_NAMESPACE}-ingress"
-  timeout 180 '[[ $(oc get ns $NS --no-headers | wc -l) == 1 ]]' || true
   # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1798282 on Azure - if loadbalancer status is empty
   # it's safe to remove the finalizer.
   if oc -n $NS get svc kourier >/dev/null 2>&1 && [ "$(oc -n $NS get svc kourier -ojsonpath="{.status.loadBalancer.*}")" = "" ]; then
     oc -n $NS patch services/kourier --type=json --patch='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
   fi
-  timeout 180 '[[ $(oc get ns $NS --no-headers | wc -l) == 1 ]]' || return 1
+  timeout 180 '[[ $(oc get ns $NS --no-headers 2>/dev/null | wc -l) == 1 ]]' || return 1
 }
 
 function prepare_knative_serving_tests {
@@ -88,6 +87,9 @@ function run_knative_serving_rolling_upgrade_tests {
   cd "$KNATIVE_SERVING_HOME" || return $?
 
   prepare_knative_serving_tests || return $?
+
+  # We may be in a previous version's namespace
+  export SYSTEM_NAMESPACE=${SERVING_NAMESPACE}
 
   failed=0
   image_template="registry.svc.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-{{.Name}}"

--- a/test/servinge2e/verify_deploy_resources_test.go
+++ b/test/servinge2e/verify_deploy_resources_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	knativeServing = "knative-serving"
+	knativeServingNamespace = "openshift-serverless"
 )
 
 func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
@@ -22,11 +22,11 @@ func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
 	defer test.CleanupAll(t, caCtx)
 
 	// Check the status of Deployment for kn ConsoleCLIDownload
-	if err := test.CheckDeploymentScale(caCtx, knativeServing, "kn-cli-downloads", 1); err != nil {
+	if err := test.CheckDeploymentScale(caCtx, knativeServingNamespace, "kn-cli-downloads", 1); err != nil {
 		t.Fatalf("failed to verify kn ConcoleCLIDownload Deployment: %v", err)
 	}
 	// Verify that Route for kn ConsoleCLIDownload is ready and has a host
-	host, err := checkRouteIsReady(caCtx, knativeServing, "kn-cli-downloads")
+	host, err := checkRouteIsReady(caCtx, knativeServingNamespace, "kn-cli-downloads")
 	if err != nil {
 		t.Fatalf("failed to verify kn ConsoleCLIDownload Route is ready: %v", err)
 	}


### PR DESCRIPTION
Most of the complexity is to account for existing installations in the old namespaces being upgraded with minimal service disruption. See commits for details.