### PR TITLE
Add eventing upgrade-broker-0-15 image

### DIFF
--- a/olm-catalog/serverless-operator/1.9.0/serverless-operator.v1.9.0.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/1.9.0/serverless-operator.v1.9.0.clusterserviceversion.yaml
@@ -355,6 +355,8 @@ spec:
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-filter
                     - name: IMAGE_DISPATCHER_IMAGE
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-dispatcher
+                    - name: IMAGE_v0.15.0-upgrade__upgrade-brokers
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-upgrade-v0-15-0
                     - name: IMAGE_KN_CLI_ARTIFACTS
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:kn-cli-artifacts
       - name: knative-openshift-ingress


### PR DESCRIPTION
https://github.com/openshift-knative/operator/blob/release-0.15/cmd/operator/kodata/knative-eventing/0.15.2/2-upgrade-to-v0.15.2.yaml
seems to have an upgrade batch job but our own csv does not have the
image name/value add it.


----

#