### PR TITLE
Describe CRC based testing better.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ If you want to quickly run the most relevant tests locally (those that are requi
 the CI environment), use these commands:
 
 ```
-crc start --cpus=6 --memory 16384
+$ crc start --cpus=6 --memory 16384
+$ SCALE_UP=-1 make images test-operator
 ```
 
 ### Requirements
@@ -29,8 +30,7 @@ If you want to use CRC to run tests locally, the following configuration has
 been tested to work with the operator E2E tests.
 
 ```
-$ crc start --cpus=6 --memory 16384
-$ SCALE_UP=-1 make images test-operator
+crc start --cpus=6 --memory 16384
 ```
 
 ### Creating the images

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ applications and functions.
 
 ## Development and private cluster testing
 
+### tl;dr
+
+If you want to quickly run the most relevant tests locally (those that are required by
+the CI environment), use these commands:
+
+```
+crc start --cpus=6 --memory 16384
+```
+
 ### Requirements
 
 - `podman` aliased to `docker` or `docker` (17.05 or newer)
@@ -13,6 +22,16 @@ applications and functions.
 - `envsubst`
 - `bash` (4.0.0 or newer)
 - `make`
+
+### CRC-based cluster
+
+If you want to use CRC to run tests locally, the following configuration has
+been tested to work with the operator E2E tests.
+
+```
+$ crc start --cpus=6 --memory 16384
+$ SCALE_UP=-1 make images test-operator
+```
 
 ### Creating the images
 
@@ -28,14 +47,17 @@ pushed to your docker repository.
 
 Use the appropriate make targets or scripts in `hack`:
 
-- `make dev`: Deploys the serverless-operator without deploying Knative Serving.
-- `make install`: Scales the cluster appropriately, deploys serverless-operator
-  and Knative Serving.
-- `make install-previous`: same with `make install` but deploy previous serverless-operator
+- `make dev`: Deploys the serverless-operator without deploying Knative Serving and Eventing.
+- `make install`: Scales the cluster appropriately, deploys serverless-operator, Knative Serving and Eventing.
+- `make install-previous`: same as `make install` but deploy previous serverless-operator
   version.
 
 **Note:** Don't forget you can chain `make` targets. `make images dev` is handy
 for example.
+
+**Note:** If you're using a system that cannot scale up dynamically (like CRC), remember
+to disable the scaleup logic using the `SCALE_UP=-1` environment variable, like
+`SCALE_UP=-1 make install`.
 
 ### Running tests
 
@@ -44,6 +66,10 @@ for example.
 - `make test-unit`: Runs unit tests.
 - `make test-e2e`: Scales, installs and runs E2E tests.
 - `make test-operator`: Runs unit and E2E tests.
+
+**Note:** If you're using a system that cannot scale up dynamically (like CRC), remember
+to disable the scaleup logic using the `SCALE_UP=-1` environment variable, like
+`SCALE_UP=-1 make test-operator`.
 
 #### knative-serving and knative-eventing E2E tests
 

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -166,7 +166,7 @@ function create_htpasswd_users {
   kubectl create secret generic htpass-secret \
     --from-file=htpasswd="$(pwd)/users.htpasswd" \
     -n openshift-config \
-    --dry-run=client -o yaml | kubectl apply -f -
+    --dry-run -o yaml | kubectl apply -f -
   oc apply -f openshift/identity/htpasswd.yaml
 
   logger.info 'Generate kubeconfig for each user'

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -172,7 +172,7 @@ function create_htpasswd_users {
   logger.info 'Generate kubeconfig for each user'
   for i in $(seq 1 $num_users); do
     cp "${KUBECONFIG}" "user${i}.kubeconfig"
-    occmd="bash -c '! oc login --kubeconfig=user${i}.kubeconfig --username=user${i} --password=password${i} > /dev/null'"
+    occmd="bash -c '! oc login --config=user${i}.kubeconfig --username=user${i} --password=password${i} > /dev/null'"
     timeout 900 "${occmd}" || return 1
   done
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -151,7 +151,9 @@ function create_htpasswd_users {
   logger.info "Creating htpasswd for ${num_users} users"
 
   if kubectl get secret htpass-secret -n openshift-config -o jsonpath='{.data.htpasswd}' 2>/dev/null | base64 -d > users.htpasswd; then
-    logger.info 'Secret htpass-secret already existsed, updating it.'
+    logger.info 'Secret htpass-secret already existed, updating it.'
+    # Add a newline to the end of the file if not already present (htpasswd will butcher it otherwise).
+    sed -i -e '$a\' users.htpasswd
   else
     touch users.htpasswd
   fi
@@ -164,13 +166,13 @@ function create_htpasswd_users {
   kubectl create secret generic htpass-secret \
     --from-file=htpasswd="$(pwd)/users.htpasswd" \
     -n openshift-config \
-    --dry-run -o yaml | kubectl apply -f -
+    --dry-run=client -o yaml | kubectl apply -f -
   oc apply -f openshift/identity/htpasswd.yaml
 
   logger.info 'Generate kubeconfig for each user'
   for i in $(seq 1 $num_users); do
     cp "${KUBECONFIG}" "user${i}.kubeconfig"
-    occmd="bash -c '! oc login --config=user${i}.kubeconfig --username=user${i} --password=password${i} > /dev/null'"
+    occmd="bash -c '! oc login --kubeconfig=user${i}.kubeconfig --username=user${i} --password=password${i} > /dev/null'"
     timeout 900 "${occmd}" || return 1
   done
 }


### PR DESCRIPTION
I had to adjust the CRC base configuration to be able to fully install and run our system. Also had to fix the user account addition logic since on CRC clusters, there's already a `developer` user that butchered our htpasswd strategy.

The downstream tests (`make test-operator`) passed succesfully.