### PR TITLE
Restructure tests to avoid installing knative more than once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test-unit:
 
 # Run only SERVING/EVENTING E2E tests from the current repo.
 test-e2e:
-	./test/e2e-tests.sh
+	./test/e2e-tests.sh $(ARGS)
 
 # Run E2E tests from the current repo for serving+eventing+knativeKafka
 test-e2e-with-kafka:

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -13,6 +13,7 @@ debugging.setup
 
 scale_up_workers || exit $?
 create_namespaces || exit $?
+add_systemnamespace_label || exit $?
 create_htpasswd_users && add_roles || exit $?
 
 failed=0

--- a/test/e2e/knative_eventing_test.go
+++ b/test/e2e/knative_eventing_test.go
@@ -25,8 +25,8 @@ var knativeControlPlaneDeploymentNames = []string{
 
 func TestKnativeEventing(t *testing.T) {
 	caCtx := test.SetupClusterAdmin(t)
-
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
+	defer test.CleanupAll(t, caCtx)
 
 	t.Run("create subscription and wait for CSV to succeed", func(t *testing.T) {
 		if _, err := test.WithOperatorReady(caCtx, "serverless-operator-subscription"); err != nil {
@@ -63,13 +63,6 @@ func TestKnativeEventing(t *testing.T) {
 			if err := test.WithDeploymentGone(caCtx, deploymentName, eventingNamespace); err != nil {
 				t.Fatalf("Deployment %s is not gone: %v", deploymentName, err)
 			}
-		}
-	})
-
-	t.Run("undeploy serverless operator and check dependent operators removed", func(t *testing.T) {
-		caCtx.Cleanup(t)
-		if err := test.WaitForOperatorDepsDeleted(caCtx); err != nil {
-			t.Fatalf("Operators still running: %v", err)
 		}
 	})
 }

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
+	"github.com/openshift-knative/serverless-operator/test/e2e/serving"
 	v1a1test "github.com/openshift-knative/serverless-operator/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -29,8 +30,8 @@ const (
 
 func TestKnativeServing(t *testing.T) {
 	caCtx := test.SetupClusterAdmin(t)
-
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
+	defer test.CleanupAll(t, caCtx)
 
 	t.Run("create subscription and wait for CSV to succeed", func(t *testing.T) {
 		if _, err := test.WithOperatorReady(caCtx, "serverless-operator-subscription"); err != nil {
@@ -78,6 +79,15 @@ func TestKnativeServing(t *testing.T) {
 	t.Run("update global proxy and verify calls goes through proxy server", func(t *testing.T) {
 		t.Skip("SRKVS-462: This test needs thorough hardening")
 		testKnativeServingForGlobalProxy(t, caCtx)
+	})
+
+	t.Run("downstream", func(t *testing.T) {
+		t.Run("user permissions", serving.UserPermissions)
+		t.Run("https", serving.KnativeServiceHTTPS)
+		t.Run("cli", serving.ConsoleCLIDownloadAndDeploymentResources)
+		t.Run("network policy", serving.NetworkPolicy)
+		t.Run("route conflicts", serving.RouteConflictBehavior)
+		t.Run("single namespace", serving.KnativeVersusKubeServicesInOneNamespace)
 	})
 
 	t.Run("remove knativeserving cr", func(t *testing.T) {

--- a/test/e2e/serving/deploy_kn_k8s_svc_in_same_namespace.go
+++ b/test/e2e/serving/deploy_kn_k8s_svc_in_same_namespace.go
@@ -1,4 +1,4 @@
-package servinge2e
+package serving
 
 import (
 	"context"
@@ -12,11 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
+func KnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 
 	caCtx := test.SetupClusterAdmin(t)
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
-	defer test.CleanupAll(t, caCtx)
 
 	//Create deployment
 	err := test.CreateDeployment(caCtx, kubeHelloworldService, testNamespace2, image)

--- a/test/e2e/serving/user_permissions.go
+++ b/test/e2e/serving/user_permissions.go
@@ -1,4 +1,4 @@
-package servinge2e
+package serving
 
 import (
 	"context"
@@ -20,14 +20,14 @@ const (
 	helloworldText        = "Hello World!"
 )
 
-func TestUserPermissions(t *testing.T) {
+func UserPermissions(t *testing.T) {
 
 	caCtx := test.SetupClusterAdmin(t)
 	paCtx := test.SetupProjectAdmin(t)
 	editCtx := test.SetupEdit(t)
 	viewCtx := test.SetupView(t)
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx, paCtx, editCtx, viewCtx) })
-	defer test.CleanupAll(t, caCtx, paCtx, editCtx, viewCtx)
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, paCtx, editCtx, viewCtx) })
+	defer test.CleanupAll(t, paCtx, editCtx, viewCtx)
 
 	if _, err := test.WithServiceReady(caCtx, helloworldService, testNamespace, image); err != nil {
 		t.Fatal("Knative Service not ready", err)

--- a/test/e2e/serving/verify_deploy_resources.go
+++ b/test/e2e/serving/verify_deploy_resources.go
@@ -1,4 +1,4 @@
-package servinge2e
+package serving
 
 import (
 	"context"
@@ -15,11 +15,9 @@ const (
 	knativeServing = "knative-serving"
 )
 
-func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
+func ConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
 
 	caCtx := test.SetupClusterAdmin(t)
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
-	defer test.CleanupAll(t, caCtx)
 
 	// Check the status of Service for kn ConsoleCLIDownload
 	service, err := test.WaitForServiceState(caCtx, "kn-cli", knativeServing, test.IsServiceReady)

--- a/test/e2e/serving/verify_http_and_https.go
+++ b/test/e2e/serving/verify_http_and_https.go
@@ -1,4 +1,4 @@
-package servinge2e
+package serving
 
 import (
 	"crypto/tls"
@@ -10,11 +10,8 @@ import (
 	"github.com/openshift-knative/serverless-operator/test"
 )
 
-func TestKnativeServiceHTTPS(t *testing.T) {
-
+func KnativeServiceHTTPS(t *testing.T) {
 	caCtx := test.SetupClusterAdmin(t)
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
-	defer test.CleanupAll(t, caCtx)
 
 	ksvc, err := test.WithServiceReady(caCtx, "https-service", testNamespace, image)
 	if err != nil {

--- a/test/e2e/serving/verify_networkpolicy.go
+++ b/test/e2e/serving/verify_networkpolicy.go
@@ -1,4 +1,4 @@
-package servinge2e
+package serving
 
 import (
 	"context"
@@ -24,8 +24,6 @@ func TestNetworkPolicy(t *testing.T) {
 	t.Skip("SRVKS-628: This needs investigation")
 
 	caCtx := test.SetupClusterAdmin(t)
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
-	defer test.CleanupAll(t, caCtx)
 
 	ksvc, err := test.WithServiceReady(caCtx, "networkpolicy-test", testNamespace3, image)
 	if err != nil {

--- a/test/e2e/serving/verify_route_conflict.go
+++ b/test/e2e/serving/verify_route_conflict.go
@@ -1,4 +1,4 @@
-package servinge2e
+package serving
 
 import (
 	"context"
@@ -17,11 +17,9 @@ import (
 
 // This test creates two services: conflict-test/a and test/a-conflict. Due to the domain template,
 // those two will clash in the generated URL. The test then verifies that the "older" service "wins".
-func TestRouteConflictBehavior(t *testing.T) {
+func RouteConflictBehavior(t *testing.T) {
 
 	caCtx := test.SetupClusterAdmin(t)
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
-	defer test.CleanupAll(t, caCtx)
 
 	svcA := types.NamespacedName{Namespace: "conflict-test", Name: "a"}
 	svcB := types.NamespacedName{Namespace: "test", Name: "a-conflict"}

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -78,7 +78,7 @@ function serverless_operator_e2e_tests {
 
   local failed=0
 
-  go_test_e2e -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2e \
+  go_test_e2e -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2e ${TEST_ARGS:-""} \
     --channel "$OLM_CHANNEL" \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@" || failed=$?

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -78,7 +78,7 @@ function serverless_operator_e2e_tests {
 
   local failed=0
 
-  go_test_e2e -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2e ${TEST_ARGS:-""} \
+  go_test_e2e -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2e \
     --channel "$OLM_CHANNEL" \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@" || failed=$?

--- a/test/service.go
+++ b/test/service.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	routev1 "github.com/openshift/api/route/v1"

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -1,16 +1,5 @@
 #!/usr/bin/env bash
 
-function wait_for_knative_serving_ingress_ns_deleted {
-  local NS="${SERVING_NAMESPACE}-ingress"
-  timeout 180 '[[ $(oc get ns $NS --no-headers | wc -l) == 1 ]]' || true
-  # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1798282 on Azure - if loadbalancer status is empty
-  # it's safe to remove the finalizer.
-  if oc -n $NS get svc kourier >/dev/null 2>&1 && [ "$(oc -n $NS get svc kourier -ojsonpath="{.status.loadBalancer.*}")" = "" ]; then
-    oc -n $NS patch services/kourier --type=json --patch='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
-  fi
-  timeout 180 '[[ $(oc get ns $NS --no-headers | wc -l) == 1 ]]' || return 1
-}
-
 function prepare_knative_serving_tests {
   logger.debug 'Preparing Serving tests'
 

--- a/test/v1alpha1/knativeserving.go
+++ b/test/v1alpha1/knativeserving.go
@@ -20,6 +20,20 @@ func KnativeServing(name, namespace string) *servingoperatorv1alpha1.KnativeServ
 	}
 }
 
+func EnsureKnativeServing(ctx *test.Context, name, namespace string) (*servingoperatorv1alpha1.KnativeServing, error) {
+	cr, err := ctx.Clients.Operator.KnativeServings(namespace).Get(name, metav1.GetOptions{})
+	if err != nil && !apierrs.IsNotFound(err) {
+		return cr, err
+	}
+	if cr.Status.IsReady() {
+		return cr, err
+	}
+	if _, err := test.WithOperatorReady(ctx, "serverless-operator-subscription"); err != nil {
+		return nil, err
+	}
+	return WithKnativeServingReady(ctx, name, namespace)
+}
+
 func WithKnativeServingReady(ctx *test.Context, name, namespace string) (*servingoperatorv1alpha1.KnativeServing, error) {
 	serving, err := CreateKnativeServing(ctx, name, namespace)
 	if err != nil {


### PR DESCRIPTION
It's silly to re-install both serving *and* eventing only to run a few more serving tests (but no eventing ones!!!). We should run all the e2e tests in a single installation of each component.

TODO: Refactor the subtests to allow running single tests by adding a "-run" arg to TEST_ARGS. You can do this, currently:
```
  $ TEST_ARGS="-run Serving" SCALE_UP=0 make test-e2e
```
But we'd like to be able to do this, too:
```
  $ TEST_ARGS="-run Serving/downstream/https" make test-e2e
```
That requires a guard to ensure the CR is installed.