### PR TITLE
[BACKPORT][SRVKS-588] Avoid resourceVersion churn due to constant status resetting. (#377)

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -361,8 +361,8 @@ func (r *ReconcileKnativeServing) reconcileConfigMap(instance *servingv1alpha1.K
 // Install Kourier Ingress Gateway
 func (r *ReconcileKnativeServing) installKourier(instance *servingv1alpha1.KnativeServing) error {
 	// install Kourier
-	instance.Status.MarkDependencyInstalling("Kourier")
 	if err := kourier.Apply(instance, r.client, r.scheme); err != nil {
+		instance.Status.MarkDependencyInstalling("Kourier")
 		return err
 	}
 	instance.Status.MarkDependenciesInstalled()


### PR DESCRIPTION
This is a cherr-pick https://github.com/openshift-knative/serverless-operator/commit/c4db2c58960823cb9e0f64613b6dbd76890b7ec4 for 1.8 branch.

/cc @markusthoemmes @mgencur 