### PR TITLE
Scale up worker nodes to 6 when running upstream e2e tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test-operator: test-unit test-e2e
 
 # Run upstream E2E tests including upgrades (Serving, Eventing, ...).
 test-upstream-e2e:
-	./test/upstream-e2e-tests.sh
+	SCALE_UP=$${SCALE_UP:-6} ./test/upstream-e2e-tests.sh
 
 # Run upstream E2E tests without upgrades.
 test-upstream-e2e-no-upgrade:

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ test-operator: test-unit test-e2e
 
 # Run upstream E2E tests including upgrades (Serving, Eventing, ...).
 test-upstream-e2e:
-	SCALE_UP=$${SCALE_UP:-6} ./test/upstream-e2e-tests.sh
+	./test/upstream-e2e-tests.sh
 
 # Run upstream E2E tests without upgrades.
 test-upstream-e2e-no-upgrade:
-	SCALE_UP=$${SCALE_UP:-6} TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
 # Run only upstream upgrade tests.
 test-upstream-upgrade:

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -33,6 +33,8 @@ fi
 
 # Run upstream knative serving & eventing tests
 if [[ $TEST_KNATIVE_E2E == true ]]; then
+  # Need 6 worker nodes when running upstream.
+  SCALE_UP=6
   (( !failed )) && ensure_serverless_installed || failed=7
   (( !failed )) && upstream_knative_serving_e2e_and_conformance_tests || failed=8
   (( !failed )) && upstream_knative_eventing_e2e || failed=9


### PR DESCRIPTION
When running upstream e2e tests, we always scale up worker nodes to 6.

For example, today `test-upstream-e2e` missed it and failed periodic job as:

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-master-4.5-vsphere-e2e-vsphere-ocp-45-continuous/1292249380140617728

```
0/6 nodes are available: 3 Insufficient cpu, 3 node(s) had taint
```

Hence, this patch adds `SCALE_UP=6` before `upstream_knative_serving_e2e_and_conformance_tests`
so we will not miss it.

/cc @mgencur @markusthoemmes @jcrossley3 
