### PR TITLE
Reduce hacks needed for bundle format CI.

### DIFF
--- a/olm-catalog/serverless-operator/index.Dockerfile
+++ b/olm-catalog/serverless-operator/index.Dockerfile
@@ -1,0 +1,20 @@
+FROM quay.io/operator-framework/upstream-opm-builder
+
+RUN echo "http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    echo "http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk update && apk add podman
+
+# Add internal registry to insecure registries.
+RUN printf "[registries.insecure]\nregistries = ['image-registry.openshift-image-registry.svc:5000']" > /etc/containers/registries.conf
+
+# Make /etc accessable by the entire root group.
+# Required to avoid "Error: open /etc/nsswitch.conf: permission denied".
+RUN chgrp -R 0 /etc && chmod -R g=u /etc
+
+# Run as nobody and create a properly owned HOME directory for podman to be able to write
+# its config files. Also set that directory as a workdir to be able to create more files.
+ENV USER=nobody
+ENV HOME /home/$USER
+RUN mkdir -p $HOME && chgrp -R 0 $HOME && chmod -R g=u $HOME
+USER $USER
+WORKDIR $HOME

--- a/olm-catalog/serverless-operator/index.Dockerfile
+++ b/olm-catalog/serverless-operator/index.Dockerfile
@@ -7,9 +7,9 @@ RUN echo "http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositorie
 # Add internal registry to insecure registries.
 RUN printf "[registries.insecure]\nregistries = ['image-registry.openshift-image-registry.svc:5000']" > /etc/containers/registries.conf
 
-# Make /etc accessable by the entire root group.
+# Create a barebones /etc/nsswitch.conf file.
 # Required to avoid "Error: open /etc/nsswitch.conf: permission denied".
-RUN chgrp -R 0 /etc && chmod -R g=u /etc
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
 # Run as nobody and create a properly owned HOME directory for podman to be able to write
 # its config files. Also set that directory as a workdir to be able to create more files.

--- a/olm-catalog/serverless-operator/index.Dockerfile
+++ b/olm-catalog/serverless-operator/index.Dockerfile
@@ -15,6 +15,6 @@ RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 # its config files. Also set that directory as a workdir to be able to create more files.
 ENV USER=nobody
 ENV HOME /home/$USER
-RUN mkdir -p $HOME && chgrp -R 0 $HOME && chmod -R g=u $HOME
+RUN addgroup $USER root && mkdir -p $HOME && chown -R $USER:root $HOME && chmod -R g=u $HOME
 USER $USER
 WORKDIR $HOME


### PR DESCRIPTION
- Dropped the need to run with a hacked version of OPM by specifying the internal registry as an insecure registry to make podman do "the right thing" automatically.
- Dropped the need to run the index image as a root by specifying the needed access in the image.
- Checked in the Dockerfile to produce the image here to make rebuilding easier if ever needed.