### PR TITLE
SRVKE-411 Override webhook resource request/limit with S-O

### DIFF
--- a/knative-operator/pkg/common/eventing.go
+++ b/knative-operator/pkg/common/eventing.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
 
 	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
@@ -10,6 +11,7 @@ import (
 func MutateEventing(ke *eventingv1alpha1.KnativeEventing, c client.Client) error {
 	stages := []func(*eventingv1alpha1.KnativeEventing, client.Client) error{
 		eventingImagesFromEnviron,
+		ensureEventingWebhookMemoryLimit,
 	}
 	for _, stage := range stages {
 		if err := stage(ke, c); err != nil {
@@ -29,4 +31,8 @@ func eventingImagesFromEnviron(ke *eventingv1alpha1.KnativeEventing, _ client.Cl
 
 	log.Info("Setting", "registry", ke.Spec.Registry)
 	return nil
+}
+
+func ensureEventingWebhookMemoryLimit(ks *eventingv1alpha1.KnativeEventing, c client.Client) error {
+	return EnsureContainerMemoryLimit(&ks.Spec.CommonSpec, "eventing-webhook", resource.MustParse("1024Mi"))
 }

--- a/knative-operator/pkg/common/serving.go
+++ b/knative-operator/pkg/common/serving.go
@@ -7,7 +7,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
@@ -34,7 +33,7 @@ func Mutate(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 		ensureCustomCerts,
 		imagesFromEnviron,
 		defaultToHa,
-		ensureWebhookMemoryLimit,
+		ensureServingWebhookMemoryLimit,
 	}
 	for _, stage := range stages {
 		if err := stage(ks, c); err != nil {
@@ -54,30 +53,8 @@ func defaultToHa(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 	return nil
 }
 
-func ensureWebhookMemoryLimit(ks *servingv1alpha1.KnativeServing, c client.Client) error {
-	const mem = "1024Mi"
-	for i, v := range ks.Spec.Resources {
-		if v.Container == "webhook" {
-			if v.Limits == nil {
-				v.Limits = corev1.ResourceList{}
-			}
-			if _, ok := v.Limits[corev1.ResourceMemory]; ok {
-				return nil
-			}
-			v.Limits[corev1.ResourceMemory] = resource.MustParse(mem)
-			ks.Spec.Resources[i] = v
-			return nil
-		}
-	}
-	ks.Spec.Resources = append(ks.Spec.Resources, servingv1alpha1.ResourceRequirementsOverride{
-		Container: "webhook",
-		ResourceRequirements: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse(mem),
-			},
-		},
-	})
-	return nil
+func ensureServingWebhookMemoryLimit(ks *servingv1alpha1.KnativeServing, c client.Client) error {
+	return EnsureContainerMemoryLimit(&ks.Spec.CommonSpec, "webhook", resource.MustParse("1024Mi"))
 }
 
 func domainTemplate(ks *servingv1alpha1.KnativeServing, c client.Client) error {


### PR DESCRIPTION
- Extracted the `EnsureWebhookMemoryLimit` into util.go, made it reusable in eventing
- Use that func in eventing to ensure eventing webhook memory too

Basically implement https://github.com/openshift-knative/eventing-operator/pull/14/files properly