### PR TITLE
Declare SCALE_UP=6 before scale_up_workers

### DIFF
--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -11,6 +11,11 @@ if [ -n "$OPENSHIFT_CI" ]; then
 fi
 debugging.setup
 
+if [[ $TEST_KNATIVE_E2E == true ]]; then
+  # Need 6 worker nodes when running upstream.
+  SCALE_UP=6
+fi
+
 scale_up_workers || exit $?
 create_namespaces || exit $?
 
@@ -33,8 +38,6 @@ fi
 
 # Run upstream knative serving & eventing tests
 if [[ $TEST_KNATIVE_E2E == true ]]; then
-  # Need 6 worker nodes when running upstream.
-  SCALE_UP=6
   (( !failed )) && ensure_serverless_installed || failed=7
   (( !failed )) && upstream_knative_serving_e2e_and_conformance_tests || failed=8
   (( !failed )) && upstream_knative_eventing_e2e || failed=9


### PR DESCRIPTION
This patch changes declare `SCALE_UP=6` before calling `scale_up_workers`.

/cc @maschmid @rhuss @matzew 