### PR TITLE
Scale up workers only for upstream E2E tests

### DIFF
--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -8,6 +8,11 @@ function scale_up_workers {
     return 0
   fi
 
+  if ! cluster_scalable; then
+    logger.info 'Skipping scaling up, the cluster is not scalable.'
+    return 0
+  fi
+
   logger.debug 'Get the machineset with most replicas'
   current_total="$(oc get machineconfigpool worker -o jsonpath='{.status.readyMachineCount}')"
   az_total="$(oc get machineset -n openshift-machine-api --no-headers|wc -l)"
@@ -51,4 +56,10 @@ function wait_until_machineset_scales_up {
   echo -e "\n\n"
   logger.error "Timeout waiting for scale up to $1 replicas"
   return 1
+}
+
+function cluster_scalable {
+  if [[ $(oc get infrastructure cluster -ojsonpath='{.status.platform}') = VSphere ]]; then
+    return 1
+  fi
 }

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -11,7 +11,6 @@ if [ -n "$OPENSHIFT_CI" ]; then
 fi
 debugging.setup
 
-scale_up_workers || exit $?
 create_namespaces || exit $?
 
 failed=0
@@ -34,7 +33,7 @@ fi
 # Run upstream knative serving & eventing tests
 if [[ $TEST_KNATIVE_E2E == true ]]; then
   # Need 6 worker nodes when running upstream.
-  SCALE_UP=6
+  SCALE_UP=6 scale_up_workers || failed=10
   (( !failed )) && ensure_serverless_installed || failed=7
   (( !failed )) && upstream_knative_serving_e2e_and_conformance_tests || failed=8
   (( !failed )) && upstream_knative_eventing_e2e || failed=9


### PR DESCRIPTION
This properly sets the SCALE_UP variable to 6 and scales up only for upstream E2E tests

/cc @maschmid @rhuss @matzew