### PR TITLE
separate servicemesh and serverless installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 install-previous:
 	INSTALL_PREVIOUS_VERSION="true" ./hack/install.sh
 
-install-mesh: install
+install-mesh:
 	UNINSTALL_MESH="false" ./hack/mesh.sh
 
 uninstall-mesh:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ for example.
 
 - `make test-unit`: Runs unit tests.
 - `make test-e2e`: Scales, installs and runs E2E tests.
+- `make install-mesh test-e2e`: Scales, installs and runs E2E tests, including ServiceMesh integration tests
 - `make test-operator`: Runs unit and E2E tests.
 
 #### knative-serving and knative-eventing E2E tests
@@ -247,5 +248,5 @@ spec:
 To uninstall service mesh operator, run `make uninstall-mesh`.
 
 ```
-make install-mesh 
+make uninstall-mesh
 ```

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -77,7 +77,7 @@ function downstream_serving_e2e_tests {
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
-  # Add system-namespace labels for TestNetworkPolicy.
+  # Add system-namespace labels for TestNetworkPolicy and ServiceMesh tests.
   add_systemnamespace_label
 
   local failed=0


### PR DESCRIPTION
To enable `make install-mesh test-e2e`  (test-e2e installs serverless on its own, so we cannot have "make install" before test-e2e)