### PR TITLE
Use spec.rule.Visibility instead of spec.Visibility in KIngress

### DIFF
--- a/serving/ingress/pkg/controller/ingress/resources/route.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route.go
@@ -29,12 +29,11 @@ var ErrNoValidLoadbalancerDomain = errors.New("unable to find Ingress LoadBalanc
 func MakeRoutes(ci *networkingv1alpha1.Ingress) ([]*routev1.Route, error) {
 	routes := []*routev1.Route{}
 
-	// Skip all route creation for cluster-local ingresses.
-	if ci.Spec.Visibility == networkingv1alpha1.IngressVisibilityClusterLocal {
-		return routes, nil
-	}
-
 	for _, rule := range ci.Spec.Rules {
+		// Skip route creation for cluster-local visibility.
+		if rule.Visibility == networkingv1alpha1.IngressVisibilityClusterLocal {
+			continue
+		}
 		for _, host := range rule.Hosts {
 			// Ignore domains like myksvc.myproject.svc.cluster.local
 			// TODO: This also ignores any top-level vanity domains

--- a/serving/ingress/pkg/controller/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route_test.go
@@ -91,11 +91,9 @@ func TestMakeRoute(t *testing.T) {
 			want: []*routev1.Route{},
 		},
 		{
-			name: "valid but cluster-local",
-			ingress: ingress(withLocalVisibility, withRules(
-				rule(withHosts([]string{localDomain, externalDomain}))),
-			),
-			want: []*routev1.Route{},
+			name:    "valid but cluster-local",
+			ingress: ingress(withRules(rule(withHosts([]string{localDomain, externalDomain}), withLocalVisibilityRule))),
+			want:    []*routev1.Route{},
 		},
 		{
 			name: "valid, with timeout",
@@ -271,9 +269,6 @@ func ingress(options ...ingressOption) *networkingv1alpha1.Ingress {
 			Name:      "ingress",
 			UID:       uid,
 		},
-		Spec: networkingv1alpha1.IngressSpec{
-			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
-		},
 		Status: networkingv1alpha1.IngressStatus{
 			LoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
 				Ingress: []networkingv1alpha1.LoadBalancerIngressStatus{{
@@ -319,10 +314,6 @@ func withDisabledAnnotation(ing *networkingv1alpha1.Ingress) {
 	}
 	annos[DisableRouteAnnotation] = ""
 	ing.SetAnnotations(annos)
-}
-
-func withLocalVisibility(ing *networkingv1alpha1.Ingress) {
-	ing.Spec.Visibility = networkingv1alpha1.IngressVisibilityClusterLocal
 }
 
 func withLBInternalDomain(domain string) ingressOption {


### PR DESCRIPTION
Since upstream deprecates spec.Visibility by https://github.com/knative/networking/commit/f8dacf70c1e8a7daa7dd8847f42f3eb70fc5496a
This patch changes to use spec.rule.Visibility instead of spec.Visibility to create OpenShift Route.

For the context of `spec.visibility`:
- Since Knative v0.13, the `spec.visibility` always sets to `External` (default value) by [this commit](https://github.com/knative/serving/commit/b0c2013b48e86d9ebefb5f5a9c773d0c1cee1c0f#diff-7aca98cf2c25eb7a257bbe27cdfc7682L136.)
- The route controller always set `spec.rules.visibility` instead.
- Hence downstream (based on serving v0.16) is safe to use `spec.rules.visibility`.