### PR TITLE
[POC] Prototype to automatically connect Knative Serving with skupper.

### DIFF
--- a/serving/ingress/pkg/controller/ingress/resources/skupper.go
+++ b/serving/ingress/pkg/controller/ingress/resources/skupper.go
@@ -1,0 +1,64 @@
+package resources
+
+import (
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/ptr"
+	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+)
+
+func MakeSkupperResources(i *networkingv1alpha1.Ingress) (*corev1.Service, []*routev1.Route) {
+	svcName := i.Name + "-skupper"
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: i.Namespace,
+			Name:      svcName,
+			Annotations: map[string]string{
+				"skupper.io/proxy":  "http",
+				"skupper.io/target": i.Name + "." + i.Namespace,
+			},
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(i, networkingv1alpha1.SchemeGroupVersion.WithKind("Ingress"))},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				Name: "http",
+				Port: 80,
+			}},
+		},
+	}
+
+	routes := make([]*routev1.Route, 0, len(i.Spec.Rules))
+	for _, rule := range i.Spec.Rules {
+		// Skip making route when visibility of the rule is local only.
+		if rule.Visibility == networkingv1alpha1.IngressVisibilityClusterLocal {
+			continue
+		}
+
+		for _, host := range rule.Hosts {
+			route := &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       i.Namespace,
+					Name:            routeName(string(i.UID), host),
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(i, networkingv1alpha1.SchemeGroupVersion.WithKind("Ingress"))},
+				},
+				Spec: routev1.RouteSpec{
+					Host: host,
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("http"),
+					},
+					To: routev1.RouteTargetReference{
+						Kind:   "Service",
+						Name:   svcName,
+						Weight: ptr.Int32(100),
+					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
+				},
+			}
+			routes = append(routes, route)
+		}
+	}
+
+	return svc, routes
+}

--- a/skupper/controller/controller.yaml
+++ b/skupper/controller/controller.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skupper-site-controller
+  labels:
+    app.kubernetes.io/part-of: skupper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: skupper-site-controller
+  template:
+    metadata:
+      labels:
+        application: skupper-site-controller
+    spec:
+      serviceAccountName: skupper-site-controller
+      containers:
+        - name: site-controller
+          image: quay.io/skupper/site-controller:0.3
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SKUPPER_SERVICE_CONTROLLER_IMAGE
+              value: quay.io/skupper/service-controller:0.3

--- a/skupper/controller/kustomization.yaml
+++ b/skupper/controller/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Adds namespace to all resources.
+namespace: hybrid-cloud-demo
+
+# Adds hybrid-cloud-demo label to all resources.
+commonLabels:
+  app.kubernetes.io/part-of: hybrid-cloud-demo
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: skupper-site
+    behavior: create
+    literals:
+      - cluster-local="false"
+      - console="true"
+      - console-authentication="openshift"
+      - console-password="bugs"
+      - console-user="bunny"
+      - edge="false"
+      - name=hybrid-cloud-skupper
+      - router-console="true"
+      - service-controller="true"
+      - service-sync="true"
+
+resources:
+  - controller.yaml

--- a/skupper/rbac/controller.yaml
+++ b/skupper/rbac/controller.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: skupper-site-controller
+  namespace: default
+  labels:
+    application: skupper-site-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    application: skupper-site-controller
+  name: skupper-site-controller-cr
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    application: skupper-site-controller
+  name: skupper-site-controller
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - pods/exec
+      - services
+      - secrets
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    application: skupper-site-controller
+  name: skupper-site-controller
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: skupper-site-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: skupper-site-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    application: skupper-site-controller
+  name: skupper-site-controller-crb
+subjects:
+  - kind: ServiceAccount
+    name: skupper-site-controller
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: skupper-site-controller-cr

--- a/skupper/rbac/kustomization.yaml
+++ b/skupper/rbac/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Adds namespace to all resources.
+namespace: hybrid-cloud-demo
+
+# Adds hybrid-cloud-demo label to all resources.
+commonLabels:
+  app.kubernetes.io/part-of: hybrid-cloud-demo
+
+resources:
+  - controller.yaml

--- a/skupper/service.yaml
+++ b/skupper/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: test
+  namespace: hybrid-cloud-demo
+  annotations:
+    serving.knative.openshift.io/multi-cloud-routing: "enabled"
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go
+          env:
+            - name: TARGET
+              value: world


### PR DESCRIPTION
This is a prototype on how Knative Serving integration with Skupper can look like.

I added a new annotation `serving.knative.openshift.io/multi-cloud-routing` which can be added to a Knative Service. If it's added, our Ingress will not create routes the "usual way", but instead create a K8s Service/Route combination that routes all requests via skupper so they automatically get spread across the entire skupper network and thus across multiple cloud providers in theory.

To set it up:

```console
$ make images install
$ kubectl apply -k skupper/rbac
$ kubectl apply -k skupper/controller
# Wait for everything to be up just to be sure.

$ kubectl apply -f skupper/service.yaml
$ curl $URL_OF_THE_SERVICE
```

**Caveats:** When first deploying things, it might take a while for the service to actually work but once it does it works great. Haven't looked deeper into what's the root cause of that just yet.