### PR TITLE
Stop using LoadBalancer in status field

### DIFF
--- a/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
+++ b/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
@@ -54,7 +54,7 @@ var (
 			}},
 		},
 		Status: networkingv1alpha1.IngressStatus{
-			LoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
+			PrivateLoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
 				Ingress: []networkingv1alpha1.LoadBalancerIngressStatus{{
 					DomainInternal: "istio-ingressgateway." + serviceMeshNamespace + ".svc.cluster.local",
 				}},

--- a/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
+++ b/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
@@ -54,7 +54,7 @@ var (
 			}},
 		},
 		Status: networkingv1alpha1.IngressStatus{
-			PrivateLoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
+			PublicLoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
 				Ingress: []networkingv1alpha1.LoadBalancerIngressStatus{{
 					DomainInternal: "istio-ingressgateway." + serviceMeshNamespace + ".svc.cluster.local",
 				}},

--- a/serving/ingress/pkg/controller/ingress/resources/route.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route.go
@@ -101,8 +101,8 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 	name := routeName(string(ci.GetUID()), host)
 	serviceName := ""
 	namespace := ""
-	if ci.Status.LoadBalancer != nil {
-		for _, lbIngress := range ci.Status.LoadBalancer.Ingress {
+	if ci.Status.PrivateLoadBalancer != nil {
+		for _, lbIngress := range ci.Status.PrivateLoadBalancer.Ingress {
 			if lbIngress.DomainInternal != "" {
 				// DomainInternal should look something like:
 				// kourier.knative-serving-ingress.svc.cluster.local

--- a/serving/ingress/pkg/controller/ingress/resources/route.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route.go
@@ -101,8 +101,8 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 	name := routeName(string(ci.GetUID()), host)
 	serviceName := ""
 	namespace := ""
-	if ci.Status.PrivateLoadBalancer != nil {
-		for _, lbIngress := range ci.Status.PrivateLoadBalancer.Ingress {
+	if ci.Status.PublicLoadBalancer != nil {
+		for _, lbIngress := range ci.Status.PublicLoadBalancer.Ingress {
 			if lbIngress.DomainInternal != "" {
 				// DomainInternal should look something like:
 				// kourier.knative-serving-ingress.svc.cluster.local

--- a/serving/ingress/pkg/controller/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route_test.go
@@ -270,7 +270,7 @@ func ingress(options ...ingressOption) *networkingv1alpha1.Ingress {
 			UID:       uid,
 		},
 		Status: networkingv1alpha1.IngressStatus{
-			PrivateLoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
+			PublicLoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
 				Ingress: []networkingv1alpha1.LoadBalancerIngressStatus{{
 					DomainInternal: fmt.Sprintf("%s.%s.svc.cluster.local", lbService, lbNamespace),
 				}},
@@ -318,7 +318,7 @@ func withDisabledAnnotation(ing *networkingv1alpha1.Ingress) {
 
 func withLBInternalDomain(domain string) ingressOption {
 	return func(ing *networkingv1alpha1.Ingress) {
-		ing.Status.PrivateLoadBalancer.Ingress[0].DomainInternal = domain
+		ing.Status.PublicLoadBalancer.Ingress[0].DomainInternal = domain
 	}
 }
 

--- a/serving/ingress/pkg/controller/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route_test.go
@@ -270,7 +270,7 @@ func ingress(options ...ingressOption) *networkingv1alpha1.Ingress {
 			UID:       uid,
 		},
 		Status: networkingv1alpha1.IngressStatus{
-			LoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
+			PrivateLoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
 				Ingress: []networkingv1alpha1.LoadBalancerIngressStatus{{
 					DomainInternal: fmt.Sprintf("%s.%s.svc.cluster.local", lbService, lbNamespace),
 				}},
@@ -318,7 +318,7 @@ func withDisabledAnnotation(ing *networkingv1alpha1.Ingress) {
 
 func withLBInternalDomain(domain string) ingressOption {
 	return func(ing *networkingv1alpha1.Ingress) {
-		ing.Status.LoadBalancer.Ingress[0].DomainInternal = domain
+		ing.Status.PrivateLoadBalancer.Ingress[0].DomainInternal = domain
 	}
 }
 


### PR DESCRIPTION
As upstream removed the LoadBalancer status by  https://github.com/knative/networking/commit/730b2ab8639b39f4559f34916ba67307f8458a04, this patch replaces LoadBalancer with PublicLoadBalancer.

For the background, Ingress had three LB status, `LoadBalancer`, `PublicLoadBalancer` and `PrivateLoadBalancer`. But `LoadBalancer` was always same value with `PublicLoadBalancer` and so it was deprecated.

/cc @markusthoemmes 