### PR TITLE
Update .gitignore to exclude certificates created by hack/lib/mesh.bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ catalogsource-ci.yaml
 user*.kubeconfig
 users.htpasswd
 puller.kubeconfig
+# certs created by hack/lib/mesh.bash
+example.com.*
+custom.example.com.*


### PR DESCRIPTION
This makes a tiny change to update .gitignore to exclude certificates created by hack/lib/mesh.bash.

When I run `make install-mesh`, following certificates are generated. We would not like to include our commits.

```
$ ls -1 *example*
custom.example.com.crt
custom.example.com.csr
custom.example.com.key
example.com.crt
example.com.key
```

/cc @maschmid  @mgencur 