### PR TITLE
Fix typo in serverless-operator.clusterserviceversion.yaml

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -382,7 +382,7 @@ spec:
                 - name: knative-openshift-ingress
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                   image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
-                  commangd:
+                  command:
                   - knative-openshift-ingress
                   imagePullPolicy: Always
                   env:


### PR DESCRIPTION
This patch fixes a typo `s/commangd/command/g`.

Although it seems we can drop the `command` as it is not used actually, this patch fixes it.

/cc @warrenvw @markusthoemmes 