### PR TITLE
Remove controller-runtime client where not necessary.

### DIFF
--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
@@ -146,7 +147,7 @@ func setupMonitoring(ctx context.Context, cfg *rest.Config) error {
 		return fmt.Errorf("failed to setup monitoring resources: %w", err)
 	}
 
-	if err := common.SetupServiceMonitor(ctx, cfg, cl, metricsPort, operatorMetricsPort); err != nil {
+	if err := common.SetupServiceMonitor(ctx, cfg, metricsPort, operatorMetricsPort); err != nil {
 		return fmt.Errorf("failed to setup the Service monitor: %w", err)
 	}
 

--- a/knative-operator/pkg/common/service_monitor.go
+++ b/knative-operator/pkg/common/service_monitor.go
@@ -10,10 +10,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func SetupServiceMonitor(ctx context.Context, cfg *rest.Config, api client.Client, metricsPort int32, operatorMetricsPort int32) error {
+func SetupServiceMonitor(ctx context.Context, cfg *rest.Config, metricsPort int32, operatorMetricsPort int32) error {
 	// Commented below to avoid a stream of these errors at startup:
 	// E1021 22:50:03.372487       1 reflector.go:134] github.com/operator-framework/operator-sdk/pkg/kube-metrics/collector.go:67: Failed to list *unstructured.Unstructured: the server could not find the requested resource
 	// if err = serveCRMetrics(cfg); err != nil {

--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -1,9 +1,10 @@
 package common
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"strings"
 
 	mf "github.com/manifestival/manifestival"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -78,18 +79,18 @@ func SetOwnerAnnotations(instance *operatorv1alpha1.KnativeServing) mf.Transform
 	}
 }
 
-func EnsureContainerMemoryLimit(s *operatorv1alpha1.CommonSpec, containerName string, memory resource.Quantity) error {
+func EnsureContainerMemoryLimit(s *operatorv1alpha1.CommonSpec, containerName string, memory resource.Quantity) {
 	for i, v := range s.Resources {
 		if v.Container == containerName {
 			if v.Limits == nil {
 				v.Limits = corev1.ResourceList{}
 			}
 			if _, ok := v.Limits[corev1.ResourceMemory]; ok {
-				return nil
+				return
 			}
 			v.Limits[corev1.ResourceMemory] = memory
 			s.Resources[i] = v
-			return nil
+			return
 		}
 	}
 	s.Resources = append(s.Resources, operatorv1alpha1.ResourceRequirementsOverride{
@@ -100,5 +101,5 @@ func EnsureContainerMemoryLimit(s *operatorv1alpha1.CommonSpec, containerName st
 			},
 		},
 	})
-	return nil
+	return
 }

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -101,9 +101,7 @@ func (r *ReconcileKnativeEventing) reconcileKnativeEventing(instance *eventingv1
 // configure default settings for OpenShift
 func (r *ReconcileKnativeEventing) configure(instance *eventingv1alpha1.KnativeEventing) error {
 	before := instance.DeepCopy()
-	if err := common.MutateEventing(instance, r.client); err != nil {
-		return err
-	}
+	common.MutateEventing(instance)
 	if equality.Semantic.DeepEqual(before.Spec, instance.Spec) {
 		return nil
 	}

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go
@@ -50,26 +50,13 @@ func (a *KnativeEventingConfigurator) Handle(ctx context.Context, req types.Requ
 		return admission.ErrorResponse(http.StatusBadRequest, err)
 	}
 
-	err = common.MutateEventing(ke, a.client)
-	if err != nil {
-		return admission.ErrorResponse(http.StatusInternalServerError, err)
-	}
+	common.MutateEventing(ke)
 
 	marshaled, err := json.Marshal(ke)
 	if err != nil {
 		return admission.ErrorResponse(http.StatusInternalServerError, err)
 	}
 	return util.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshaled)
-}
-
-// KnativeEventingConfigurator implements inject.Client.
-// A client will be automatically injected.
-var _ inject.Client = (*KnativeEventingConfigurator)(nil)
-
-// InjectClient injects the client.
-func (v *KnativeEventingConfigurator) InjectClient(c client.Client) error {
-	v.client = c
-	return nil
 }
 
 // KnativeEventingConfigurator implements inject.Decoder.


### PR DESCRIPTION
No behavioral change intended, this just reduces the surface area of the controller-runtime client a bit to see more clearly where it's actually needed.