### PR TITLE
Remove diff to avoid panic due to comparing unexported fields. (#385) - release-1.9

### DIFF
--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -109,7 +108,7 @@ func (r *ReconcileKnativeEventing) configure(instance *eventingv1alpha1.KnativeE
 	}
 
 	// Only apply the update if something changed.
-	log.Info("Updating KnativeEventing with mutated state for Openshift", "diff", cmp.Diff(before.Spec, instance.Spec))
+	log.Info("Updating KnativeEventing with mutated state for Openshift")
 	if err := r.client.Update(context.TODO(), instance); err != nil {
 		return fmt.Errorf("failed to update KnativeEventing with mutated state: %w", err)
 	}

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleclidownload"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/dashboard"
@@ -221,7 +220,7 @@ func (r *ReconcileKnativeServing) configure(instance *servingv1alpha1.KnativeSer
 	}
 
 	// Only apply the update if something changed.
-	log.Info("Updating KnativeServing with mutated state for Openshift", "diff", cmp.Diff(before.Spec, instance.Spec))
+	log.Info("Updating KnativeServing with mutated state for Openshift")
 	if err := r.client.Update(context.TODO(), instance); err != nil {
 		return fmt.Errorf("failed to update KnativeServing with mutated state: %w", err)
 	}


### PR DESCRIPTION
* Remove diff to avoid panic due to comparing unexported fields.

* Rerun dep ensure.