### PR TITLE
Mark nested vendor files as vendor to ignore the diffs in PRs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+knative-operator/vendor linguist-vendored
+serving/ingress/vendor linguist-vendored
+test/vendor linguist-vendored


### PR DESCRIPTION
As per title. Reviewing is a pain otherwise.