### PR TITLE
Bumping the Knative operator and the Knative Eventing bits

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -13,7 +13,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../test/vendor/knative.dev/test-infra/
 
 # Adjust these when upgrading the knative versions.
 export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v0.15.2}"
-export KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v0.15.2}"
+export KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v0.16.0}"
 
 # Adjust these when cutting a new CSV.
 # TODO: Read these from metadata.

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -340,9 +340,9 @@ spec:
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-webhook
                     - name: IMAGE_broker-controller__broker-controller
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-broker
-                    - name: IMAGE_broker-filter__filter
+                    - name: IMAGE_mt-broker-filter__filter
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter
-                    - name: IMAGE_broker-ingress__ingress
+                    - name: IMAGE_mt-broker-ingress__ingress
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress
                     - name: IMAGE_mt-broker-controller__mt-broker-controller
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtchannel-broker
@@ -505,9 +505,9 @@ spec:
       image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-webhook
     - name: IMAGE_broker-controller__broker-controller
       image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-broker
-    - name: IMAGE_broker-filter__filter
+    - name: IMAGE_mt-broker-filter__filter
       image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter
-    - name: IMAGE_broker-ingress__ingress
+    - name: IMAGE_mt-broker-ingress__ingress
       image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress
     - name: IMAGE_mt-broker-controller__mt-broker-controller
       image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtchannel-broker

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -262,7 +262,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: METRICS_DOMAIN
                   value: knative.dev/serving-operator
-                image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-operator
+                image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-operator
                 imagePullPolicy: IfNotPresent
                 name: knative-operator
                 ports:
@@ -333,37 +333,37 @@ spec:
                     - name: IMAGE_storage-version-migration__migrate
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-serving-storage-version-migration
                     - name: IMAGE_storage-version-migration-eventing__migrate
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-storage-version-migration
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-storage-version-migration
                     - name: IMAGE_eventing-controller__eventing-controller
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-controller
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-controller
                     - name: IMAGE_eventing-webhook__eventing-webhook
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-webhook
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-webhook
                     - name: IMAGE_broker-controller__broker-controller
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-broker
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-broker
                     - name: IMAGE_broker-filter__filter
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-mtbroker-filter
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter
                     - name: IMAGE_broker-ingress__ingress
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-mtbroker-ingress
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress
                     - name: IMAGE_mt-broker-controller__mt-broker-controller
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-mtchannel-broker
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtchannel-broker
                     - name: IMAGE_imc-controller__controller
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-controller
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-controller
                     - name: IMAGE_imc-dispatcher__dispatcher
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-dispatcher
-                    - name: IMAGE_v0.15.0-upgrade__upgrade-brokers
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-upgrade-v0-15-0
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher
+                    - name: IMAGE_v0.16.0-broker-cleanup__brokers
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-cleanup
                     - name: IMAGE_PING_IMAGE
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-ping
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-ping
                     - name: IMAGE_MT_PING_IMAGE
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-mtping
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtping
                     - name: IMAGE_APISERVER_RA_IMAGE
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-apiserver-receive-adapter
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-apiserver-receive-adapter
                     - name: IMAGE_BROKER_INGRESS_IMAGE
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-ingress
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-ingress
                     - name: IMAGE_BROKER_FILTER_IMAGE
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-filter
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-filter
                     - name: IMAGE_DISPATCHER_IMAGE
-                      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-dispatcher
+                      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher
                     - name: IMAGE_KN_CLI_ARTIFACTS
                       value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:kn-cli-artifacts
       - name: knative-openshift-ingress
@@ -492,7 +492,7 @@ spec:
     - name: IMAGE_3scale-kourier-gateway
       image: docker.io/maistra/proxyv2-ubi8:1.1.0
     - name: knative-operator
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-operator
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
@@ -500,40 +500,40 @@ spec:
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
     - name: IMAGE_eventing-controller__eventing-controller
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-controller
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-controller
     - name: IMAGE_eventing-webhook__eventing-webhook
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-webhook
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-webhook
     - name: IMAGE_broker-controller__broker-controller
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-broker
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-broker
     - name: IMAGE_broker-filter__filter
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-mtbroker-filter
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter
     - name: IMAGE_broker-ingress__ingress
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-mtbroker-ingress
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress
     - name: IMAGE_mt-broker-controller__mt-broker-controller
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-mtchannel-broker
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtchannel-broker
     - name: IMAGE_imc-controller__controller
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-controller
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-controller
     - name: IMAGE_imc-dispatcher__dispatcher
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-dispatcher
-    - name: IMAGE_v0.15.0-upgrade__upgrade-brokers
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-upgrade-v0-15-0
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher
+    - name: IMAGE_v0.16.0-broker-cleanup__brokers
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-cleanup
     - name: IMAGE_PING_IMAGE
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-ping
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-ping
     - name: IMAGE_MT_PING_IMAGE
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-mtping
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtping
     - name: IMAGE_APISERVER_RA_IMAGE
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-apiserver-receive-adapter
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-apiserver-receive-adapter
     - name: IMAGE_BROKER_INGRESS_IMAGE
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-ingress
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-ingress
     - name: IMAGE_BROKER_FILTER_IMAGE
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-filter
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-filter
     - name: IMAGE_DISPATCHER_IMAGE
-      image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-dispatcher
+      image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher
     - name: IMAGE_KN_CLI_ARTIFACTS
       image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:kn-cli-artifacts
     - name: IMAGE_storage-version-migration__migrate
       value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-serving-storage-version-migration
     - name: IMAGE_storage-version-migration-eventing__migrate
-      value: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-storage-version-migration
+      value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-storage-version-migration
   replaces: serverless-operator.v1.9.0
   version: 1.10.0

--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -2,4 +2,4 @@ FROM src
 
 COPY oc /usr/bin/oc
 COPY --from=registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-serving-src /go/src/knative.dev/serving/ /go/src/knative.dev/serving/
-COPY --from=registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-src /go/src/knative.dev/eventing/ /go/src/knative.dev/eventing/
+COPY --from=registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-src /go/src/knative.dev/eventing/ /go/src/knative.dev/eventing/


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Bumping both:
* knative operator
* knative eventing

The 0.16.0 eventing ships a _new_ image (`v0.16.0-broker-cleanup__brokers`), and the old ` v0.15.0-upgrade` is gone... 
To align that all in a _reasonable_ fashion, this PR does bump two things (operator and eventing), instead of just one

