### PR TITLE
Drop liveness probe of serverless-index

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -64,11 +64,6 @@ spec:
         - containerPort: 50051
           name: grpc
           protocol: TCP
-        livenessProbe:
-          exec:
-            command:
-            - grpc_health_probe
-            - -addr=localhost:50051
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
The more bundle images we add, the slower the start of this becomes. The liveness probes potentially prematurely forces a restart for no reason and we don't really need it either.