### PR TITLE
Add a readiness probe that waits for the webhook to be up

### DIFF
--- a/olm-catalog/serverless-operator/csv.template.yaml
+++ b/olm-catalog/serverless-operator/csv.template.yaml
@@ -290,6 +290,11 @@ spec:
                   command:
                   - knative-openshift
                   imagePullPolicy: Always
+                  readinessProbe:
+                    httpGet:
+                      scheme: HTTPS
+                      port: 9876
+                      path: "/mutate-knativeservings"
                   env:
                     - name: WATCH_NAMESPACE
                       value: ""

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -348,6 +348,11 @@ spec:
                 command:
                 - knative-openshift
                 imagePullPolicy: Always
+                readinessProbe:
+                  httpGet:
+                    scheme: HTTPS
+                    port: 9876
+                    path: "/mutate-knativeservings"
                 env:
                 - name: WATCH_NAMESPACE
                   value: ""


### PR DESCRIPTION
The webhook in the current implementation sets itself up. It applies Mutating/ValidationWebhookConfig objects and creates a service to point at itself. It does all of that before it starts the webserver actually serving the webhook webserver so by the time it does that, we know that the system knows about the webhook.
This should improve scripted installs in that the operator being ready now actually means ready and KnativeServing/Eventing can be created.

For posterity: This is where the webhook resources get installed. Not how it happens before `run` is called

https://github.com/openshift-knative/serverless-operator/blob/f72d9d1a08efeefdc752821a2bb340c8bf3dab06/knative-operator/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go#L206-L214