### PR TITLE
Fixing the names of the actual deployments of 0.16

### DIFF
--- a/test/e2e/knative_eventing_test.go
+++ b/test/e2e/knative_eventing_test.go
@@ -13,14 +13,14 @@ const (
 )
 
 var knativeControlPlaneDeploymentNames = []string{
-	"broker-controller",
-	"broker-filter",
-	"broker-ingress",
 	"eventing-controller",
 	"eventing-webhook",
 	"imc-controller",
 	"imc-dispatcher",
 	"mt-broker-controller",
+	"mt-broker-filter",
+	"mt-broker-ingress",
+	"sugar-controller",
 }
 
 func TestKnativeEventing(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Context: failure in: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/477/pull-ci-openshift-knative-serverless-operator-master-4.5-operator-e2e-aws-ocp-45/1310830781823717376

reports:

```
=== RUN   TestKnativeEventing/create_subscription_and_wait_for_CSV_to_succeed
=== RUN   TestKnativeEventing/deploy_knativeeventing_cr_and_wait_for_it_to_be_ready
=== RUN   TestKnativeEventing/verify_correct_deployment_shape
    knative_eventing_test.go:47: Deployment broker-controller is not ready: Deployment broker-controller in namespace knative-eventing not ready in time.: deployments.apps "broker-controller" not found
--- FAIL: TestKnativeEventing (161.64s)
    --- PASS: TestKnativeEventing/create_subscription_and_wait_for_CSV_to_succeed (80.93s)
    --- PASS: TestKnativeEventing/deploy_knativeeventing_cr_and_wait_for_it_to_be_ready (80.42s)
    --- FAIL: TestKnativeEventing/verify_correct_deployment_shape (0.08s)
FAIL
FAIL	github.com/openshift-knative/serverless-operator/test/e2e	161.873s
FAIL
```

Starting w/ 0.16 the `broker-controller` (and `-filter` and `-ingress`) are scaled to `replicas: 0`.  They are replaced w/ the `mt-broker-xyz` deployments.  In addition, we also have a `sugar-controller` now.

This PR corrects the actual names of the desired deployements


