### PR TITLE
Revert "Add a readiness probe that waits for the webhook to be up"

### DIFF
--- a/olm-catalog/serverless-operator/csv.template.yaml
+++ b/olm-catalog/serverless-operator/csv.template.yaml
@@ -290,11 +290,6 @@ spec:
                   command:
                   - knative-openshift
                   imagePullPolicy: Always
-                  readinessProbe:
-                    httpGet:
-                      scheme: HTTPS
-                      port: 9876
-                      path: "/mutate-knativeservings"
                   env:
                     - name: WATCH_NAMESPACE
                       value: ""

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -348,11 +348,6 @@ spec:
                 command:
                 - knative-openshift
                 imagePullPolicy: Always
-                readinessProbe:
-                  httpGet:
-                    scheme: HTTPS
-                    port: 9876
-                    path: "/mutate-knativeservings"
                 env:
                 - name: WATCH_NAMESPACE
                   value: ""


### PR DESCRIPTION
This reverts commit 6e5e35332d996270c80e5bc1d78720f71ef1fcf4.

This causes a lot of noise in the logs and isn't as important anymore given our bandaid solution in the upstream operator.