### PR TITLE
Delete KnativeKafka resources when CR is deleted

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/README.md
+++ b/knative-operator/deploy/resources/knativekafka/README.md
@@ -1,0 +1,15 @@
+- Download the files from Github releases (no auto download at the moment)
+- Remove comments and blank lines with
+```
+sed -i \
+        -e '/^[ \t]*#/d' \
+        -e '/^[ \t]*$/d' \
+        kafkachannel-vX.XX.X.yaml
+
+sed -i \
+        -e '/^[ \t]*#/d' \
+        -e '/^[ \t]*$/d' \
+        kafkasource-vX.XX.X.yaml
+```
+- Create `kafkachannel-latest.yaml` and `kafkasource-latest.yaml` symlinks for the new files
+- Dump the old files

--- a/knative-operator/deploy/resources/knativekafka/kafkachannel-v0.17.4.yaml
+++ b/knative-operator/deploy/resources/knativekafka/kafkachannel-v0.17.4.yaml
@@ -1,17 +1,3 @@
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -19,7 +5,6 @@ metadata:
   labels:
     contrib.eventing.knative.dev/release: "v0.17.4"
     duck.knative.dev/addressable: "true"
-# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
 - apiGroups:
   - messaging.knative.dev
@@ -30,22 +15,7 @@ rules:
   - get
   - list
   - watch
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -53,7 +23,6 @@ metadata:
   labels:
     contrib.eventing.knative.dev/release: "v0.17.4"
     duck.knative.dev/channelable: "true"
-# Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
 - apiGroups:
   - messaging.knative.dev
@@ -67,22 +36,7 @@ rules:
   - watch
   - update
   - patch
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -181,22 +135,7 @@ rules:
   resources:
   - leases
   verbs: *everything
-
 ---
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -204,22 +143,7 @@ metadata:
   namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: "v0.17.4"
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -287,22 +211,7 @@ rules:
   - create
   - patch
   - update
-
 ---
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -310,22 +219,7 @@ metadata:
   namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: "v0.17.4"
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -397,7 +291,6 @@ rules:
   - "leases"
   verbs: *everything
 - # Necessary for conversion webhook. These are copied from the serving
-  # TODO: Do we really need all these permissions?
   apiGroups:
   - "apiextensions.k8s.io"
   resources:
@@ -410,21 +303,7 @@ rules:
   - "delete"
   - "patch"
   - "watch"
-
 ---
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -432,22 +311,7 @@ metadata:
   namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: "v0.17.4"
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -492,22 +356,7 @@ roleRef:
   kind: ClusterRole
   name: kafka-webhook
   apiGroup: rbac.authorization.k8s.io
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -523,10 +372,6 @@ spec:
   validation:
     openAPIV3Schema:
       type: object
-      # this is a work around so we don't need to flush out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
       x-kubernetes-preserve-unknown-fields: true
   names:
     kind: KafkaChannel
@@ -569,113 +414,32 @@ spec:
       service:
         name: kafka-webhook
         namespace: knative-eventing
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-kafka
   namespace: knative-eventing
 data:
-  # Broker URL. Replace this with the URLs for your kafka cluster,
-  # which is in the format of my-cluster-kafka-bootstrap.my-kafka-namespace:9092.
   bootstrapServers: REPLACE_WITH_CLUSTER_URL
-
 ---
-# Copyright 20 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-leader-election-kafka
   namespace: knative-eventing
 data:
-  # An inactive but valid configuration follows; see example.
   resourceLock: "leases"
   leaseDuration: "15s"
   renewDeadline: "10s"
   retryPeriod: "2s"
   _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # resourceLock controls which API resource is used as the basis for the
-    # leader election lock. Valid values are:
-    #
-    # - leases -> use the coordination API
-    # - configmaps -> use configmaps
-    # - endpoints -> use endpoints
     resourceLock: "leases"
-
-    # leaseDuration is how long non-leaders will wait to try to acquire the
-    # lock; 15 seconds is the value used by core kubernetes controllers.
     leaseDuration: "15s"
-    # renewDeadline is how long a leader will try to renew the lease before
-    # giving up; 10 seconds is the value used by core kubernetes controllers.
     renewDeadline: "10s"
-    # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
     retryPeriod: "2s"
-    # enabledComponents is a comma-delimited list of component names for which
-    # leader election is enabled. Valid values are:
-    #
-    # - kafkachannel-dispatcher
-    # - kafkachannel-controller
     enabledComponents: "kafkachannel-dispatcher,kafkachannel-controller"
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -691,22 +455,7 @@ spec:
     targetPort: 8443
   selector:
     role: kafka-webhook
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -751,22 +500,7 @@ spec:
       - name: config-logging
         configMap:
           name: config-logging
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -806,23 +540,7 @@ metadata:
   namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: "v0.17.4"
-# The data is populated at install time.
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -867,8 +585,6 @@ spec:
           containerPort: 9090
         - name: profiling
           containerPort: 8008
-        # TODO set proper resource limits.
-
         readinessProbe: &probe
           periodSeconds: 1
           httpGet:
@@ -878,8 +594,5 @@ spec:
             - name: k-kubelet-probe
               value: "webhook"
         livenessProbe: *probe
-      # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
-      # high value that we respect whatever value it has configured for the lame duck grace period.
       terminationGracePeriodSeconds: 300
-
 ---

--- a/knative-operator/deploy/resources/knativekafka/kafkasource-v0.17.4.yaml
+++ b/knative-operator/deploy/resources/knativekafka/kafkasource-v0.17.4.yaml
@@ -1,39 +1,10 @@
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-sources
   labels:
     contrib.eventing.knative.dev/release: "v0.17.4"
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -41,22 +12,7 @@ metadata:
   namespace: knative-sources
   labels:
     contrib.eventing.knative.dev/release: "v0.17.4"
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -154,7 +110,6 @@ rules:
   - "patch"
   - "watch"
 - # Necessary for conversion webhook. These are copied from the serving
-  # TODO: Do we really need all these permissions?
   apiGroups:
   - "apiextensions.k8s.io"
   resources:
@@ -168,8 +123,6 @@ rules:
   - "patch"
   - "watch"
 ---
-# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
-# Ref: https://github.com/knative/eventing/tree/master/config/core/rolessource-observer-clusterrole.yaml.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -186,22 +139,7 @@ rules:
   - get
   - list
   - watch
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -227,8 +165,6 @@ subjects:
 - kind: ServiceAccount
   name: kafka-controller-manager
   namespace: knative-sources
-# An aggregated ClusterRole for all Addressable CRDs.
-# Ref: https://github.com/knative/eventing/tree/master/config/core/rolesaddressable-resolvers-clusterrole.yaml
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -244,28 +180,11 @@ subjects:
 - kind: ServiceAccount
   name: kafka-controller-manager
   namespace: knative-sources
-# An aggregated ClusterRole for all PodSpecable CRDs.
-# Ref: https://github.com/knative/eventing/blob/master/config/core/roles/podspecable-binding-clusterrole.yaml
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: podspecable-binding
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -307,22 +226,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -343,10 +247,6 @@ spec:
   validation:
     openAPIV3Schema:
       type: object
-      # this is a work around so we don't need to flush out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
       x-kubernetes-preserve-unknown-fields: true
   names:
     categories:
@@ -388,22 +288,7 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -418,22 +303,7 @@ spec:
   ports:
   - name: https-kafka
     port: 443
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -500,22 +370,7 @@ spec:
     targetPort: 8443
   selector:
     control-plane: kafka-controller-manager
-
 ---
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -591,94 +446,30 @@ metadata:
   namespace: knative-sources
   labels:
     contrib.eventing.knative.dev/release: "v0.17.4"
-# The data is populated at install time.
-
 ---
-# Copyright 20 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-leader-election-kafka
   namespace: knative-sources
 data:
-  # An inactive but valid configuration follows; see example.
   resourceLock: "leases"
   leaseDuration: "15s"
   renewDeadline: "10s"
   retryPeriod: "2s"
   _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # resourceLock controls which API resource is used as the basis for the
-    # leader election lock. Valid values are:
-    #
-    # - leases -> use the coordination API
-    # - configmaps -> use configmaps
-    # - endpoints -> use endpoints
     resourceLock: "leases"
-
-    # leaseDuration is how long non-leaders will wait to try to acquire the
-    # lock; 15 seconds is the value used by core kubernetes controllers.
     leaseDuration: "15s"
-    # renewDeadline is how long a leader will try to renew the lease before
-    # giving up; 10 seconds is the value used by core kubernetes controllers.
     renewDeadline: "10s"
-    # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
     retryPeriod: "2s"
-    # enabledComponents is a comma-delimited list of component names for which
-    # leader election is enabled. Valid values are:
-    #
-    # - kafka-controller
     enabledComponents: "kafka-controller"
-
 ---
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-logging
   namespace: knative-sources
 data:
-  # Common configuration for all Knative codebase
   zap-logger-config: |
     {
       "level": "debug",
@@ -700,8 +491,6 @@ data:
         "callerEncoder": ""
       }
     }
-  # Log level overrides
-  # For all components changes are be picked up immediately.
   loglevel.controller: "info"
   loglevel.webhook: "info"
 ---
@@ -712,36 +501,9 @@ metadata:
   namespace: knative-sources
 data:
   _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # logging.enable-var-log-collection defaults to false.
-    # A fluentd sidecar will be set up to collect var log if
-    # this flag is true.
     logging.enable-var-log-collection: false
-
-    # logging.fluentd-sidecar-image provides the fluentd sidecar image
-    # to inject as a sidecar to collect logs from /var/log.
-    # Must be presented if logging.enable-var-log-collection is true.
     logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
-
-    # logging.fluentd-sidecar-output-config provides the configuration
-    # for the fluentd sidecar, which will be placed into a configmap and
-    # mounted into the fluentd sidecar image.
     logging.fluentd-sidecar-output-config: |
-      # Parse json log before sending to Elastic Search
       <filter **>
         @type parser
         key_name log
@@ -758,13 +520,11 @@ data:
           </pattern>
         </parse>
       </filter>
-      # Send to Elastic Search
       <match **>
         @id elasticsearch
         @type elasticsearch
         @log_level info
         include_tag_key true
-        # Elasticsearch service is in monitoring namespace.
         host elasticsearch-logging.knative-monitoring
         port 9200
         logstash_format true
@@ -782,63 +542,12 @@ data:
           overflow_action block
         </buffer>
       </match>
-
-    # logging.revision-url-template provides a template to use for producing the
-    # logging URL that is injected into the status of each Revision.
-    # This value is what you might use the the Knative monitoring bundle, and provides
-    # access to Kibana after setting up kubectl proxy.
     logging.revision-url-template: |
       http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
-
-    # If non-empty, this enables queue proxy writing request logs to stdout.
-    # The value determines the shape of the request logs and it must be a valid go text/template.
-    # It is important to keep this as a single line. Multiple lines are parsed as separate entities
-    # by most collection agents and will split the request logs into multiple records.
-    #
-    # The following fields and functions are available to the template:
-    #
-    # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
-    # representing an HTTP request received by the server.
-    #
-    # Response:
-    # struct {
-    #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
-    #   Size    int       // An int representing the size of the response.
-    #   Latency float64   // A float64 representing the latency of the response in seconds.
-    # }
-    #
-    # Revision:
-    # struct {
-    #   Name          string  // Knative revision name
-    #   Namespace     string  // Knative revision namespace
-    #   Service       string  // Knative service name
-    #   Configuration string  // Knative configuration name
-    #   PodName       string  // Name of the pod hosting the revision
-    #   PodIP         string  // IP of the pod hosting the revision
-    # }
-    #
     logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
-
-    # metrics.backend-destination field specifies the system metrics destination.
-    # It supports either prometheus (the default) or stackdriver.
-    # Note: Using stackdriver will incur additional charges
     metrics.backend-destination: prometheus
-
-    # metrics.request-metrics-backend-destination specifies the request metrics
-    # destination. If non-empty, it enables queue proxy to send request metrics.
-    # Currently supported values: prometheus, stackdriver.
     metrics.request-metrics-backend-destination: prometheus
-
-    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
-    # field is optional. When running on GCE, application default credentials will be
-    # used if this field is not provided.
     metrics.stackdriver-project-id: "<your stackdriver project id>"
-
-    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
-    # Stackdriver using "global" resource type and custom metric type if the
-    # metrics are not supported by "knative_revision" resource type. Setting this
-    # flag to "true" could cause extra Stackdriver charge.
-    # If metrics.backend-destination is not Stackdriver, this is ignored.
     metrics.allow-stackdriver-custom-metrics: "false"
 ---
 apiVersion: v1
@@ -852,37 +561,9 @@ metadata:
     knative.dev/config-category: eventing
 data:
   _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-    #
-    # This may be "zipkin" or "stackdriver", the default is "none"
     backend: "none"
-
-    # URL to zipkin collector where traces are sent.
-    # This must be specified when backend is "zipkin"
     zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
-
-    # The GCP project into which stackdriver metrics will be written
-    # when backend is "stackdriver".  If unspecified, the project-id
-    # is read from GCP metadata when running on GCP.
     stackdriver-project-id: "my-project"
-
-    # Enable zipkin debug mode. This allows all spans to be sent to the server
-    # bypassing sampling.
     debug: "false"
-
-    # Percentage (0-1) of requests to trace
     sample-rate: "0.1"
-
 ---

--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_lifecycle_test.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_lifecycle_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2019 The Knative Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package v1alpha1
 
 import (

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -197,11 +197,7 @@ func kafkaChannelManifest(instance *operatorv1alpha1.KnativeKafka, apiClient cli
 		return nil, fmt.Errorf("failed to load KafkaChannel manifest: %w", err)
 	}
 
-	transformers := []mf.Transformer{
-		mf.InjectOwner(instance),
-	}
-
-	manifest, err = manifest.Transform(transformers...)
+	manifest, err = manifest.Transform(mf.InjectOwner(instance))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load KafkaChannel manifest: %w", err)
 	}
@@ -272,9 +268,9 @@ func (r *ReconcileKnativeKafka) delete(instance *operatorv1alpha1.KnativeKafka) 
 	}
 
 	log.Info("Running cleanup logic")
-	log.Info("Deleting kourier")
+	log.Info("Deleting KnativeKafka")
 	if err := deleteKnativeKafka(instance, r.client); err != nil {
-		return fmt.Errorf("failed to delete kourier: %w", err)
+		return fmt.Errorf("failed to delete KnativeKafka: %w", err)
 	}
 
 	// The above might take a while, so we refetch the resource again in case it has changed.

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -25,7 +25,8 @@ import (
 )
 
 const (
-	// This needs to remain "knative-kafka-openshift" to be compatible with earlier versions.
+	// DO NOT change to something else in the future!
+	// This needs to remain "knative-kafka-openshift" to be compatible with earlier versions in the future versions.
 	finalizerName = "knative-kafka-openshift"
 )
 

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -7,13 +7,14 @@ import (
 
 	mfc "github.com/manifestival/controller-runtime-client"
 	mf "github.com/manifestival/manifestival"
+	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-
-	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -21,6 +22,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	// This needs to remain "knative-kafka-openshift" to be compatible with earlier versions.
+	finalizerName = "knative-kafka-openshift"
 )
 
 var log = logf.Log.WithName("controller_knativekafka")
@@ -86,10 +92,10 @@ func (r *ReconcileKnativeKafka) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 
-	// TODO: check for deletion
-	// if original.GetDeletionTimestamp() != nil {
-	//		return reconcile.Result{}, r.delete(original)
-	//	}
+	// check for deletion
+	if original.GetDeletionTimestamp() != nil {
+		return reconcile.Result{}, r.delete(original)
+	}
 
 	instance := original.DeepCopy()
 	reconcileErr := r.reconcileKnativeKafka(instance)
@@ -114,7 +120,7 @@ func (r *ReconcileKnativeKafka) reconcileKnativeKafka(instance *operatorv1alpha1
 
 	stages := []func(*operatorv1alpha1.KnativeKafka) error{
 		// TODO r.configure,
-		// TODO r.ensureFinalizers,
+		r.ensureFinalizers,
 		r.installKnativeKafka,
 	}
 	for _, stage := range stages {
@@ -123,6 +129,18 @@ func (r *ReconcileKnativeKafka) reconcileKnativeKafka(instance *operatorv1alpha1
 		}
 	}
 	return nil
+}
+
+// set a finalizer to clean up cluster-scoped resources and resources from other namespaces
+func (r *ReconcileKnativeKafka) ensureFinalizers(instance *operatorv1alpha1.KnativeKafka) error {
+	for _, finalizer := range instance.GetFinalizers() {
+		if finalizer == finalizerName {
+			return nil
+		}
+	}
+	log.Info("Adding finalizer")
+	instance.SetFinalizers(append(instance.GetFinalizers(), finalizerName))
+	return r.client.Update(context.TODO(), instance)
 }
 
 // Install Knative Kafka components
@@ -231,6 +249,91 @@ func checkDeployments(manifest *mf.Manifest, api client.Client) error {
 				return fmt.Errorf("Deployment %q/%q not ready", u.GetName(), u.GetNamespace())
 			}
 		}
+	}
+	return nil
+}
+
+// general clean-up. required for the resources that cannot be garbage collected with the owner reference mechanism
+func (r *ReconcileKnativeKafka) delete(instance *operatorv1alpha1.KnativeKafka) error {
+	finalizers := sets.NewString(instance.GetFinalizers()...)
+
+	if !finalizers.Has(finalizerName) {
+		log.Info("Finalizer has already been removed, nothing to do")
+		return nil
+	}
+
+	log.Info("Running cleanup logic")
+	log.Info("Deleting kourier")
+	if err := deleteKnativeKafka(instance, r.client); err != nil {
+		return fmt.Errorf("failed to delete kourier: %w", err)
+	}
+
+	// The above might take a while, so we refetch the resource again in case it has changed.
+	refetched := &operatorv1alpha1.KnativeKafka{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, refetched); err != nil {
+		return fmt.Errorf("failed to refetch KnativeKafka: %w", err)
+	}
+
+	// Update the refetched finalizer list.
+	finalizers = sets.NewString(refetched.GetFinalizers()...)
+	finalizers.Delete(finalizerName)
+	refetched.SetFinalizers(finalizers.List())
+
+	if err := r.client.Update(context.TODO(), refetched); err != nil {
+		return fmt.Errorf("failed to update KnativeKafka with removed finalizer: %w", err)
+	}
+	return nil
+}
+
+func deleteKnativeKafka(instance *operatorv1alpha1.KnativeKafka, api client.Client) error {
+	if instance.Spec.Channel.Enabled {
+		if err := deleteKnativeKafkaChannel(instance, api); err != nil {
+			return fmt.Errorf("unable to delete Knative KafkaChannel: %w", err)
+		}
+	}
+
+	if instance.Spec.Source.Enabled {
+		if err := deleteKnativeKafkaSource(api); err != nil {
+			return fmt.Errorf("unable to delete Knative KafkaSource: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func deleteKnativeKafkaChannel(instance *operatorv1alpha1.KnativeKafka, apiclient client.Client) error {
+	manifest, err := mfc.NewManifest(kafkaChannelManifestPath(), apiclient, mf.UseLogger(log.WithName("mf")))
+	if err != nil {
+		return fmt.Errorf("failed to load KafkaChannel manifest: %w", err)
+	}
+
+	log.Info("Deleting Knative KafkaChannel")
+
+	transformers := []mf.Transformer{
+		mf.InjectOwner(instance),
+	}
+
+	manifest, err = manifest.Transform(transformers...)
+	if err != nil {
+		return fmt.Errorf("failed to load KafkaChannel manifest: %w", err)
+	}
+
+	if err := manifest.Delete(); err != nil {
+		return fmt.Errorf("failed to delete Knative KafkaChannel manifest: %w", err)
+	}
+
+	return nil
+}
+
+func deleteKnativeKafkaSource(apiclient client.Client) error {
+	manifest, err := mfc.NewManifest(kafkaSourceManifestPath(), apiclient, mf.UseLogger(log.WithName("mf")))
+	if err != nil {
+		return fmt.Errorf("failed to load KafkaSource manifest: %w", err)
+	}
+
+	log.Info("Deleting Knative KafkaSource")
+	if err := manifest.Delete(); err != nil {
+		return fmt.Errorf("failed to delete KafkaSource manifest: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Bases https://github.com/openshift-knative/serverless-operator/pull/487

Similar to other PRs in the umbrella ticket, https://github.com/openshift-knative/serverless-operator/issues/486, I didn't want to wait until the CI is green and that's merged. This is a WIP PR to see in advance if things fail and if possibly get some reviews.

This PR deletes the resources when the KnativeKafka CR is deleted.
Specifically,
- KafkaChannel resources --> garbage collection also works for these since they're in the same namespace and we set ownerRefs for them
- KafkaSource resources that are put in another namespace, `knative-sources` -->  no GC, manual deletion for these
- Deletion of cluster-scoped resources

Deletion of the resources when a component gets disabled is to be handled in another PR (e.g. `spec.channel.enabled=true` is changed to `spec.channel.enabled=false`)

As written in the umbrella ticket,  https://github.com/openshift-knative/serverless-operator/issues/486, there's still a lot to do.

Verification:

1. Enable the controller by uncommenting the stuff in `knative-operator/pkg/controller/add_knativekafka.go`

2. Install operator and eventing by `make install`

3. Need to manually create the CRD since it is not in the CSV yet
```
kubectl apply -f knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
```

4. Install:
```
cat <<EOS |kubectl apply -f -
---
apiVersion: operator.serverless.openshift.io/v1alpha1
kind: KnativeKafka
metadata:
  name: example
  namespace: knative-eventing
spec:
  source:
    enabled: true
  channel:
    enabled: true
    bootstrapServers: foo.example.com:1234
...
EOS
```

5. Delete the CR and check if created resources are deleted:
```
kubectl delete knativekafkas example -n knative-eventing
```

6. Following commands should say `Error from server (NotFound): error when deleting "knative-operator/deploy/resources/knativekafka/kafka....yaml": foo "bar" not found` for each of the resource defined in them
```
k delete -f knative-operator/deploy/resources/knativekafka/kafkasource-latest.yaml
k delete -f knative-operator/deploy/resources/knativekafka/kafkachannel-latest.yaml
```