### PR TITLE
Watch secondary resources of Kafka components

### DIFF
--- a/knative-operator/pkg/common/constants.go
+++ b/knative-operator/pkg/common/constants.go
@@ -6,6 +6,6 @@ const (
 	ServingOwnerNamespace            = "serving.knative.openshift.io/ownerNamespace"
 	ServerlessOperatorOwnerName      = "operator.knative.openshift.io/ownerName"
 	ServerlessOperatorOwnerNamespace = "operator.knative.openshift.io/ownerNamespace"
-	KafkaOwnerName                   = "kafka.knative.openshift.io/ownerName"
-	KafkaOwnerNamespace              = "kafka.knative.openshift.io/ownerNamespace"
+	KafkaOwnerName                   = "knativekafkas.operator.serverless.openshift.io/ownerName"
+	KafkaOwnerNamespace              = "knativekafkas.operator.serverless.openshift.io/ownerNamespace"
 )

--- a/knative-operator/pkg/common/constants.go
+++ b/knative-operator/pkg/common/constants.go
@@ -6,4 +6,6 @@ const (
 	ServingOwnerNamespace            = "serving.knative.openshift.io/ownerNamespace"
 	ServerlessOperatorOwnerName      = "operator.knative.openshift.io/ownerName"
 	ServerlessOperatorOwnerNamespace = "operator.knative.openshift.io/ownerNamespace"
+	KafkaOwnerName                   = "kafka.knative.openshift.io/ownerName"
+	KafkaOwnerNamespace              = "kafka.knative.openshift.io/ownerNamespace"
 )

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -232,7 +232,7 @@ func (r *ReconcileKnativeKafka) applyKnativeKafka(instance *operatorv1alpha1.Kna
 }
 
 func (r *ReconcileKnativeKafka) installKnativeKafkaChannel(instance *operatorv1alpha1.KnativeKafka, apiclient client.Client) error {
-	manifest, err := r.kafkaChannelManifest(instance, apiclient)
+	manifest, err := r.kafkaChannelManifest(instance)
 	if err != nil {
 		return err
 	}
@@ -253,7 +253,7 @@ func rawKafkaChannelManifest(apiclient client.Client) (mf.Manifest, error) {
 	return mfc.NewManifest(kafkaChannelManifestPath(), apiclient, mf.UseLogger(log.WithName("mf")))
 }
 
-func (r *ReconcileKnativeKafka) kafkaChannelManifest(instance *operatorv1alpha1.KnativeKafka, apiClient client.Client) (*mf.Manifest, error) {
+func (r *ReconcileKnativeKafka) kafkaChannelManifest(instance *operatorv1alpha1.KnativeKafka) (*mf.Manifest, error) {
 	manifest, err := r.rawKafkaChannelManifest.Transform(
 		mf.InjectOwner(instance),
 		setOwnerAnnotations(instance),
@@ -266,7 +266,7 @@ func (r *ReconcileKnativeKafka) kafkaChannelManifest(instance *operatorv1alpha1.
 }
 
 func (r *ReconcileKnativeKafka) installKnativeKafkaSource(instance *operatorv1alpha1.KnativeKafka, apiclient client.Client) error {
-	manifest, err := r.kafkaSourceManifest(instance, apiclient)
+	manifest, err := r.kafkaSourceManifest(instance)
 	if err != nil {
 		return err
 	}
@@ -287,7 +287,7 @@ func rawKafkaSourceManifest(apiclient client.Client) (mf.Manifest, error) {
 	return mfc.NewManifest(kafkaSourceManifestPath(), apiclient, mf.UseLogger(log.WithName("mf")))
 }
 
-func (r *ReconcileKnativeKafka) kafkaSourceManifest(instance *operatorv1alpha1.KnativeKafka, apiclient client.Client) (*mf.Manifest, error) {
+func (r *ReconcileKnativeKafka) kafkaSourceManifest(instance *operatorv1alpha1.KnativeKafka) (*mf.Manifest, error) {
 	manifest, err := r.rawKafkaSourceManifest.Transform(setOwnerAnnotations(instance))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load KafkaSource manifest: %w", err)
@@ -335,7 +335,7 @@ func (r *ReconcileKnativeKafka) delete(instance *operatorv1alpha1.KnativeKafka) 
 
 	log.Info("Running cleanup logic")
 	log.Info("Deleting KnativeKafka")
-	if err := r.deleteKnativeKafka(instance, r.client); err != nil {
+	if err := r.deleteKnativeKafka(instance); err != nil {
 		return fmt.Errorf("failed to delete KnativeKafka: %w", err)
 	}
 
@@ -356,15 +356,15 @@ func (r *ReconcileKnativeKafka) delete(instance *operatorv1alpha1.KnativeKafka) 
 	return nil
 }
 
-func (r *ReconcileKnativeKafka) deleteKnativeKafka(instance *operatorv1alpha1.KnativeKafka, api client.Client) error {
+func (r *ReconcileKnativeKafka) deleteKnativeKafka(instance *operatorv1alpha1.KnativeKafka) error {
 	if instance.Spec.Channel.Enabled {
-		if err := r.deleteKnativeKafkaChannel(instance, api); err != nil {
+		if err := r.deleteKnativeKafkaChannel(instance); err != nil {
 			return fmt.Errorf("unable to delete Knative KafkaChannel: %w", err)
 		}
 	}
 
 	if instance.Spec.Source.Enabled {
-		if err := r.deleteKnativeKafkaSource(instance, api); err != nil {
+		if err := r.deleteKnativeKafkaSource(instance); err != nil {
 			return fmt.Errorf("unable to delete Knative KafkaSource: %w", err)
 		}
 	}
@@ -372,8 +372,8 @@ func (r *ReconcileKnativeKafka) deleteKnativeKafka(instance *operatorv1alpha1.Kn
 	return nil
 }
 
-func (r *ReconcileKnativeKafka) deleteKnativeKafkaChannel(instance *operatorv1alpha1.KnativeKafka, apiclient client.Client) error {
-	manifest, err := r.kafkaChannelManifest(instance, apiclient)
+func (r *ReconcileKnativeKafka) deleteKnativeKafkaChannel(instance *operatorv1alpha1.KnativeKafka) error {
+	manifest, err := r.kafkaChannelManifest(instance)
 	if err != nil {
 		return err
 	}
@@ -387,8 +387,8 @@ func (r *ReconcileKnativeKafka) deleteKnativeKafkaChannel(instance *operatorv1al
 	return nil
 }
 
-func (r *ReconcileKnativeKafka) deleteKnativeKafkaSource(instance *operatorv1alpha1.KnativeKafka, apiclient client.Client) error {
-	manifest, err := r.kafkaSourceManifest(instance, apiclient)
+func (r *ReconcileKnativeKafka) deleteKnativeKafkaSource(instance *operatorv1alpha1.KnativeKafka) error {
+	manifest, err := r.kafkaSourceManifest(instance)
 	if err != nil {
 		return err
 	}

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -8,11 +8,14 @@ import (
 	mfc "github.com/manifestival/controller-runtime-client"
 	mf "github.com/manifestival/manifestival"
 	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,7 +60,59 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// NOT IMPLEMENTED YET
+	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForOwner{
+		OwnerType:    &operatorv1alpha1.KnativeKafka{},
+		IsController: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	// common function to enqueue reconcile requests for resources
+	enqueueRequests := handler.ToRequestsFunc(func(obj handler.MapObject) []reconcile.Request {
+		annotations := obj.Meta.GetAnnotations()
+		ownerNamespace := annotations[common.KafkaOwnerNamespace]
+		ownerName := annotations[common.KafkaOwnerName]
+		if ownerNamespace != "" && ownerName != "" {
+			return []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Namespace: ownerNamespace, Name: ownerName},
+			}}
+		}
+		return nil
+	})
+
+	gvkToResource := make(map[schema.GroupVersionKind]runtime.Object)
+
+	// Watch for Knative KafkaChannel resources.
+	kafkaChannelManifest, err := rawKafkaChannelManifest(mgr.GetClient())
+	if err != nil {
+		return err
+	}
+	kafkaChannelResources := kafkaChannelManifest.Resources()
+
+	for i := range kafkaChannelResources {
+		resource := &kafkaChannelResources[i]
+		gvkToResource[resource.GroupVersionKind()] = resource
+	}
+
+	// Watch for Knative KafkaSource resources.
+	kafkaSourceManifest, err := rawKafkaSourceManifest(mgr.GetClient())
+	if err != nil {
+		return err
+	}
+	kafkaSourceResources := kafkaSourceManifest.Resources()
+
+	for i := range kafkaSourceResources {
+		resource := &kafkaSourceResources[i]
+		gvkToResource[resource.GroupVersionKind()] = resource
+	}
+
+	for _, t := range gvkToResource {
+		err = c.Watch(&source.Kind{Type: t}, &handler.EnqueueRequestsFromMapFunc{ToRequests: enqueueRequests})
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -164,7 +219,7 @@ func applyKnativeKafka(instance *operatorv1alpha1.KnativeKafka, api client.Clien
 	}
 
 	if instance.Spec.Source.Enabled {
-		if err := installKnativeKafkaSource(api); err != nil {
+		if err := installKnativeKafkaSource(instance, api); err != nil {
 			return fmt.Errorf("unable to install Knative KafkaSource: %w", err)
 		}
 	} else {
@@ -191,13 +246,23 @@ func installKnativeKafkaChannel(instance *operatorv1alpha1.KnativeKafka, apiclie
 	return nil
 }
 
+// rawKafkaChannelManifest returns KafkaChannel manifest without transformations
+func rawKafkaChannelManifest(apiclient client.Client) (mf.Manifest, error) {
+	return mfc.NewManifest(kafkaChannelManifestPath(), apiclient, mf.UseLogger(log.WithName("mf")))
+}
+
 func kafkaChannelManifest(instance *operatorv1alpha1.KnativeKafka, apiClient client.Client) (*mf.Manifest, error) {
-	manifest, err := mfc.NewManifest(kafkaChannelManifestPath(), apiClient, mf.UseLogger(log.WithName("mf")))
+	manifest, err := rawKafkaChannelManifest(apiClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load KafkaChannel manifest: %w", err)
 	}
 
-	manifest, err = manifest.Transform(mf.InjectOwner(instance))
+	transformers := []mf.Transformer{
+		mf.InjectOwner(instance),
+		setOwnerAnnotations(instance),
+	}
+
+	manifest, err = manifest.Transform(transformers...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load KafkaChannel manifest: %w", err)
 	}
@@ -205,8 +270,8 @@ func kafkaChannelManifest(instance *operatorv1alpha1.KnativeKafka, apiClient cli
 	return &manifest, nil
 }
 
-func installKnativeKafkaSource(apiclient client.Client) error {
-	manifest, err := kafkaSourceManifest(apiclient)
+func installKnativeKafkaSource(instance *operatorv1alpha1.KnativeKafka, apiclient client.Client) error {
+	manifest, err := kafkaSourceManifest(instance, apiclient)
 	if err != nil {
 		return fmt.Errorf("failed to load or transform KafkaSource manifest: %w", err)
 	}
@@ -215,19 +280,34 @@ func installKnativeKafkaSource(apiclient client.Client) error {
 	if err := manifest.Apply(); err != nil {
 		return fmt.Errorf("failed to apply KafkaSource manifest: %w", err)
 	}
-	if err := checkDeployments(&manifest, apiclient); err != nil {
+	if err := checkDeployments(manifest, apiclient); err != nil {
 		return fmt.Errorf("failed to check deployments: %w", err)
 	}
 	log.Info("Knative KafkaSource installation is ready")
 	return nil
 }
 
-func kafkaSourceManifest(apiclient client.Client) (mf.Manifest, error) {
-	manifest, err := mfc.NewManifest(kafkaSourceManifestPath(), apiclient, mf.UseLogger(log.WithName("mf")))
+// rawKafkaSourceManifest returns KafkaSource manifest without transformations
+func rawKafkaSourceManifest(apiclient client.Client) (mf.Manifest, error) {
+	return mfc.NewManifest(kafkaSourceManifestPath(), apiclient, mf.UseLogger(log.WithName("mf")))
+}
+
+func kafkaSourceManifest(instance *operatorv1alpha1.KnativeKafka, apiclient client.Client) (*mf.Manifest, error) {
+	manifest, err := rawKafkaSourceManifest(apiclient)
 	if err != nil {
-		return mf.Manifest{}, fmt.Errorf("failed to load KafkaSource manifest: %w", err)
+		return nil, fmt.Errorf("failed to load KafkaSource manifest: %w", err)
 	}
-	return manifest, nil
+
+	transformers := []mf.Transformer{
+		setOwnerAnnotations(instance),
+	}
+
+	manifest, err = manifest.Transform(transformers...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load KafkaSource manifest: %w", err)
+	}
+
+	return &manifest, nil
 }
 
 func kafkaChannelManifestPath() string {
@@ -298,7 +378,7 @@ func deleteKnativeKafka(instance *operatorv1alpha1.KnativeKafka, api client.Clie
 	}
 
 	if instance.Spec.Source.Enabled {
-		if err := deleteKnativeKafkaSource(api); err != nil {
+		if err := deleteKnativeKafkaSource(instance, api); err != nil {
 			return fmt.Errorf("unable to delete Knative KafkaSource: %w", err)
 		}
 	}
@@ -321,8 +401,8 @@ func deleteKnativeKafkaChannel(instance *operatorv1alpha1.KnativeKafka, apiclien
 	return nil
 }
 
-func deleteKnativeKafkaSource(apiclient client.Client) error {
-	manifest, err := kafkaSourceManifest(apiclient)
+func deleteKnativeKafkaSource(instance *operatorv1alpha1.KnativeKafka, apiclient client.Client) error {
+	manifest, err := kafkaSourceManifest(instance, apiclient)
 	if err != nil {
 		return fmt.Errorf("failed to load or transform KafkaSource manifest: %w", err)
 	}
@@ -332,4 +412,15 @@ func deleteKnativeKafkaSource(apiclient client.Client) error {
 		return fmt.Errorf("failed to delete KafkaSource manifest: %w", err)
 	}
 	return nil
+}
+
+// setOwnerAnnotations is a transformer to set owner annotations on given object
+func setOwnerAnnotations(instance *operatorv1alpha1.KnativeKafka) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		u.SetAnnotations(map[string]string{
+			common.KafkaOwnerName:      instance.Name,
+			common.KafkaOwnerNamespace: instance.Namespace,
+		})
+		return nil
+	}
 }


### PR DESCRIPTION
Bases https://github.com/openshift-knative/serverless-operator/pull/493

Similar to other PRs in the umbrella ticket, https://github.com/openshift-knative/serverless-operator/issues/486, I didn't want to wait until the CI is green and that's merged. This is a WIP PR to see in advance if things fail and if possibly get some reviews.

-------------------------
## Changes
This PR creates watches for the secondary resources that are created.

Also, I noticed there were a lot of duplicate code, so I created reusable functions following in a separate PR (https://github.com/openshift-knative/serverless-operator/pull/513):
- injecting owner annotations
- creating reconciliation enqueue request for watched resources
- finding the resource types to watch
-------------------------

As written in the umbrella ticket,  https://github.com/openshift-knative/serverless-operator/issues/486, there's still a lot to do.

Verification:

1. Install eventing

2. Enable the controller by uncommenting the stuff in `knative-operator/pkg/controller/add_knativekafka.go`

3. Need to manually create the CRD since it is not in the CSV yet
```
kubectl apply -f knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
```

4. Install:
```
cat <<EOS |kubectl apply -f -
---
apiVersion: operator.serverless.openshift.io/v1alpha1
kind: KnativeKafka
metadata:
  name: example
  namespace: knative-eventing
spec:
  source:
    enabled: true
  channel:
    enabled: true
    bootstrapServers: foo.example.com:1234
...
EOS
```

5. Delete any resource created by the operator for Kafka and see if it is recreated.

6. Clean up:
```
kubectl delete knativekafkas example -n knative-eventing
```