### PR TITLE
fix installplan lookup with custom OLM_SOURCE

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -104,7 +104,7 @@ function find_install_plan {
   local csv=$1
   for plan in `oc get installplan -n ${OPERATORS_NAMESPACE} --no-headers -o name`; do 
     [[ $(oc get $plan -n ${OPERATORS_NAMESPACE} -o=jsonpath='{.spec.clusterServiceVersionNames}' | grep -c $csv) -eq 1 && \
-       $(oc get $plan -n ${OPERATORS_NAMESPACE} -o=jsonpath="{.status.bundleLookups[0].catalogSourceRef.name}" | grep -c $OPERATOR) -eq 1 ]] && echo $plan && return 0
+       $(oc get $plan -n ${OPERATORS_NAMESPACE} -o=jsonpath="{.status.bundleLookups[0].catalogSourceRef.name}" | grep -c $OLM_SOURCE) -eq 1 ]] && echo $plan && return 0
   done
   echo ""
 }


### PR DESCRIPTION
The OLM_SOURCE env is used to define custom CatalogSource.  e.g. when OLM_SOURCE is set to `stage-applications` , the Subscription will be

```
spec:
  channel: "4.5"
  installPlanApproval: Manual
  name: serverless-operator
  source: stage-applications
  sourceNamespace: openshift-marketplace
  startingCSV: serverless-operator.v1.9.0
```

and the installplan catalogSourceRef:

```
  - catalogSourceRef:
      name: stage-applications
      namespace: openshift-marketplace
```

so the catalogSourceRef.name refers not to a name of the subscription (which is $OPERATOR), but to a name of the CatalogSource (which is $OLM_SOURCE )