### PR TITLE
WIP - debug: Remove NetworkPolicy from upstream test

### DIFF
--- a/test/serving.bash
+++ b/test/serving.bash
@@ -19,8 +19,8 @@ function prepare_knative_serving_tests {
   # Adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
   oc adm policy add-scc-to-user anyuid -z default -n serving-tests
   # Add networkpolicy to test namespace and label to serving namespaces for testing under the strict networkpolicy.
-  add_networkpolicy "serving-tests"
-  add_networkpolicy "serving-tests-alt"
+#  add_networkpolicy "serving-tests"
+#  add_networkpolicy "serving-tests-alt"
   add_systemnamespace_label
 
   export GATEWAY_OVERRIDE="kourier"


### PR DESCRIPTION
To narrow down the recent connection timeout error, this patch tries to remove NetworkPolicy

/cc @nak3 