### PR TITLE
DeploymentsAvailable condition

### DIFF
--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_lifecycle.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_lifecycle.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	kafkaCondSet = apis.NewLivingConditionSet(
+		knativeoperatorv1alpha1.DeploymentsAvailable,
 		knativeoperatorv1alpha1.InstallSucceeded,
 	)
 )
@@ -33,4 +34,18 @@ func (is *KnativeKafkaStatus) MarkInstallFailed(msg string) {
 		knativeoperatorv1alpha1.InstallSucceeded,
 		"Error",
 		"Install failed with message: %s", msg)
+}
+
+// MarkDeploymentsAvailable marks the DeploymentsAvailable status as true.
+func (is *KnativeKafkaStatus) MarkDeploymentsAvailable() {
+	kafkaCondSet.Manage(is).MarkTrue(knativeoperatorv1alpha1.DeploymentsAvailable)
+}
+
+// MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
+// it's waiting for deployments.
+func (is *KnativeKafkaStatus) MarkDeploymentsNotReady() {
+	kafkaCondSet.Manage(is).MarkFalse(
+		knativeoperatorv1alpha1.DeploymentsAvailable,
+		"NotReady",
+		"Waiting on deployments")
 }

--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_lifecycle_test.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_lifecycle_test.go
@@ -11,12 +11,27 @@ func TestKnativeKafkaHappyPath(t *testing.T) {
 	ks := &KnativeKafkaStatus{}
 	ks.InitializeConditions()
 
+	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
 	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
 
 	// Install succeeds.
 	ks.MarkInstallSucceeded()
+	// Dependencies are assumed successful too.
+	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
 	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
 
+	// Deployments are not available at first.
+	ks.MarkDeploymentsNotReady()
+	apistest.CheckConditionFailed(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
+	if ready := ks.IsReady(); ready {
+		t.Errorf("ks.IsReady() = %v, want false", ready)
+	}
+
+	// Deployments become ready and we're good.
+	ks.MarkDeploymentsAvailable()
+	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
 	if ready := ks.IsReady(); !ready {
 		t.Errorf("ks.IsReady() = %v, want true", ready)
 	}
@@ -26,17 +41,25 @@ func TestKnativeKafkaErrorPath(t *testing.T) {
 	ks := &KnativeKafkaStatus{}
 	ks.InitializeConditions()
 
+	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
 	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
 
 	// Install fails.
 	ks.MarkInstallFailed("test")
+	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
 	apistest.CheckConditionFailed(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
+
+	// Install now succeeds.
+	ks.MarkInstallSucceeded()
+	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
 	if ready := ks.IsReady(); ready {
 		t.Errorf("ks.IsReady() = %v, want false", ready)
 	}
 
-	// Install now succeeds.
-	ks.MarkInstallSucceeded()
+	// Deployments become ready
+	ks.MarkDeploymentsAvailable()
+	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
 	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
 	if ready := ks.IsReady(); !ready {
 		t.Errorf("ks.IsReady() = %v, want true", ready)

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -327,45 +327,17 @@ func (r *ReconcileKnativeKafka) delete(instance *operatorv1alpha1.KnativeKafka) 
 }
 
 func (r *ReconcileKnativeKafka) deleteKnativeKafka(instance *operatorv1alpha1.KnativeKafka) error {
-	if instance.Spec.Channel.Enabled {
-		if err := r.deleteKnativeKafkaChannel(instance); err != nil {
-			return fmt.Errorf("unable to delete Knative KafkaChannel: %w", err)
-		}
-	}
-
-	if instance.Spec.Source.Enabled {
-		if err := r.deleteKnativeKafkaSource(instance); err != nil {
-			return fmt.Errorf("unable to delete Knative KafkaSource: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (r *ReconcileKnativeKafka) deleteKnativeKafkaChannel(instance *operatorv1alpha1.KnativeKafka) error {
-	manifest, err := r.kafkaChannelManifest(instance)
+	manifest, err := r.buildManifest(instance)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to build manifest: %w", err)
 	}
 
-	log.Info("Deleting Knative KafkaChannel")
+	if err := r.transform(manifest, instance); err != nil {
+		return fmt.Errorf("failed to transform manifest: %w", err)
+	}
 
 	if err := manifest.Delete(); err != nil {
 		return fmt.Errorf("failed to delete Knative KafkaChannel manifest: %w", err)
-	}
-
-	return nil
-}
-
-func (r *ReconcileKnativeKafka) deleteKnativeKafkaSource(instance *operatorv1alpha1.KnativeKafka) error {
-	manifest, err := r.kafkaSourceManifest(instance)
-	if err != nil {
-		return err
-	}
-
-	log.Info("Deleting Knative KafkaSource")
-	if err := manifest.Delete(); err != nil {
-		return fmt.Errorf("failed to delete KafkaSource manifest: %w", err)
 	}
 	return nil
 }

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -308,7 +308,7 @@ func (r *ReconcileKnativeKafka) deleteKnativeKafka(instance *operatorv1alpha1.Kn
 	}
 
 	if err := manifest.Delete(); err != nil {
-		return fmt.Errorf("failed to delete Knative KafkaChannel manifest: %w", err)
+		return fmt.Errorf("failed to delete KnativeKafka manifest: %w", err)
 	}
 	return nil
 }

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -219,38 +219,9 @@ func rawKafkaChannelManifest(apiclient client.Client) (mf.Manifest, error) {
 	return mfc.NewManifest(kafkaChannelManifestPath(), apiclient, mf.UseLogger(log.WithName("mf")))
 }
 
-func (r *ReconcileKnativeKafka) kafkaChannelManifest(instance *operatorv1alpha1.KnativeKafka) (*mf.Manifest, error) {
-	manifest, err := r.rawKafkaChannelManifest.Transform(
-		mf.InjectOwner(instance),
-		common.SetAnnotations(map[string]string{
-			common.KafkaOwnerName:      instance.Name,
-			common.KafkaOwnerNamespace: instance.Namespace,
-		}),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to transform KafkaChannel manifest: %w", err)
-	}
-
-	return &manifest, nil
-}
-
 // rawKafkaSourceManifest returns KafkaSource manifest without transformations
 func rawKafkaSourceManifest(apiclient client.Client) (mf.Manifest, error) {
 	return mfc.NewManifest(kafkaSourceManifestPath(), apiclient, mf.UseLogger(log.WithName("mf")))
-}
-
-func (r *ReconcileKnativeKafka) kafkaSourceManifest(instance *operatorv1alpha1.KnativeKafka) (*mf.Manifest, error) {
-	manifest, err := r.rawKafkaSourceManifest.Transform(
-		common.SetAnnotations(map[string]string{
-			common.KafkaOwnerName:      instance.Name,
-			common.KafkaOwnerNamespace: instance.Namespace,
-		}),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load KafkaSource manifest: %w", err)
-	}
-
-	return &manifest, nil
 }
 
 func kafkaChannelManifestPath() string {

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -211,43 +211,6 @@ func (r *ReconcileKnativeKafka) apply(manifest *mf.Manifest, instance *operatorv
 	return nil
 }
 
-func (r *ReconcileKnativeKafka) applyKnativeKafka(instance *operatorv1alpha1.KnativeKafka) error {
-	if instance.Spec.Channel.Enabled {
-		if err := r.installKnativeKafkaChannel(instance); err != nil {
-			return fmt.Errorf("unable to install Knative KafkaChannel: %w", err)
-		}
-	} else {
-		// TODO: ensure they don't exist
-	}
-
-	if instance.Spec.Source.Enabled {
-		if err := r.installKnativeKafkaSource(instance); err != nil {
-			return fmt.Errorf("unable to install Knative KafkaSource: %w", err)
-		}
-	} else {
-		// TODO: ensure they don't exist
-	}
-
-	return nil
-}
-
-func (r *ReconcileKnativeKafka) installKnativeKafkaChannel(instance *operatorv1alpha1.KnativeKafka) error {
-	manifest, err := r.kafkaChannelManifest(instance)
-	if err != nil {
-		return err
-	}
-
-	log.Info("Installing Knative KafkaChannel")
-	if err := manifest.Apply(); err != nil {
-		return fmt.Errorf("failed to apply KafkaChannel manifest: %w", err)
-	}
-	if err := r.checkDeployments(manifest); err != nil {
-		return fmt.Errorf("failed to check deployments: %w", err)
-	}
-	log.Info("Knative KafkaChannel installation is ready")
-	return nil
-}
-
 // rawKafkaChannelManifest returns KafkaChannel manifest without transformations
 func rawKafkaChannelManifest(apiclient client.Client) (mf.Manifest, error) {
 	return mfc.NewManifest(kafkaChannelManifestPath(), apiclient, mf.UseLogger(log.WithName("mf")))
@@ -266,23 +229,6 @@ func (r *ReconcileKnativeKafka) kafkaChannelManifest(instance *operatorv1alpha1.
 	}
 
 	return &manifest, nil
-}
-
-func (r *ReconcileKnativeKafka) installKnativeKafkaSource(instance *operatorv1alpha1.KnativeKafka) error {
-	manifest, err := r.kafkaSourceManifest(instance)
-	if err != nil {
-		return err
-	}
-
-	log.Info("Installing Knative KafkaSource")
-	if err := manifest.Apply(); err != nil {
-		return fmt.Errorf("failed to apply KafkaSource manifest: %w", err)
-	}
-	if err := r.checkDeployments(manifest); err != nil {
-		return fmt.Errorf("failed to check deployments: %w", err)
-	}
-	log.Info("Knative KafkaSource installation is ready")
-	return nil
 }
 
 // rawKafkaSourceManifest returns KafkaSource manifest without transformations

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -187,7 +188,7 @@ func (r *ReconcileKnativeKafka) ensureFinalizers(_ *mf.Manifest, instance *opera
 func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *operatorv1alpha1.KnativeKafka) error {
 	log.Info("Transforming manifest")
 	m, err := manifest.Transform(
-		mf.InjectOwner(instance),
+		InjectOwner(instance),
 		common.SetAnnotations(map[string]string{
 			common.KafkaOwnerName:      instance.Name,
 			common.KafkaOwnerNamespace: instance.Namespace,
@@ -382,4 +383,21 @@ func mergeManifests(client mf.Client, m1, m2 *mf.Manifest) (*mf.Manifest, error)
 	}
 	result.Client = client
 	return &result, nil
+}
+
+// InjectOwner creates a Tranformer which adds an OwnerReference pointing to
+// `owner` to namespace-scoped objects.
+//
+// The difference from Manifestival's Inject owner is, it only does it for
+// resources that are in the same namespace as the owner.
+// For the resources that are in the same namespace, it fallbacks to
+// Manifestival's InjectOwner
+func InjectOwner(owner mf.Owner) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetNamespace() == owner.GetNamespace() {
+			return mf.InjectOwner(owner)(u)
+		} else {
+			return nil
+		}
+	}
 }


### PR DESCRIPTION
### Changes
This PR introduce DeploymentsAvailable condition.

I also did some refactoring since implementing DeploymentsAvailable condition forced me to:
- Reuse deployment checking code
- Unify operations done on channel and source manifests by introducing stages
- Merge channel and source manifests and only operate on a single manifest, instead of calling the stages twice per each

I had to do the refactoring since we can only mark `DeploymentsAvailable` once. ...when both source and channel deployments in different namespaces are available. This forced me to merge the manifests and install at once and check the deployments at once.

-----------------------------

As written in the umbrella ticket,  https://github.com/openshift-knative/serverless-operator/issues/486, there's still a lot to do.

Verification:

1. Install eventing

2. Enable the controller by uncommenting the stuff in `knative-operator/pkg/controller/add_knativekafka.go`

3. Need to manually create the CRD since it is not in the CSV yet
```
kubectl apply -f knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
```

4. Install:
```
cat <<EOS |kubectl apply -f -
---
apiVersion: operator.serverless.openshift.io/v1alpha1
kind: KnativeKafka
metadata:
  name: example
  namespace: knative-eventing
spec:
  source:
    enabled: true
  channel:
    enabled: true
    bootstrapServers: foo.example.com:1234
...
EOS
```

5. Watch the status of `KnativeKafka` CR
```
kubectl get knativekafka -n knative-eventing -o json | jq -r '.items[] | .metadata.name + ":" + (.status.conditions[] | .type + ":" + .status)'
```

6. Clean up:
```
kubectl delete knativekafkas example -n knative-eventing
```

