### PR TITLE
Enable access log on OpenShift Ingress Router

### DIFF
--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -63,3 +63,17 @@ function cluster_scalable {
     return 1
   fi
 }
+
+# Enable
+function enable_access_log {
+  logger.debug "Enable access log on OpenShift Ingress Router"
+  oc patch \
+     --namespace=openshift-ingress-operator \
+     --patch='{"spec": {"logging": {"access": {"destination": {"type": "Container"}}}}}' \
+     --type=merge \
+     ingresscontroller/default
+  [[ $? -eq 0 ]] || logger.error "Failed to enable access log"
+
+  # TODO: Access log is only available after OCP 4.5. Add error handling once 4.4 was not supported.
+  return 0
+}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -11,6 +11,7 @@ if [ -n "$OPENSHIFT_CI" ]; then
 fi
 debugging.setup
 
+enable_access_log || exit $?
 scale_up_workers || exit $?
 create_namespaces || exit $?
 create_htpasswd_users && add_roles || exit $?

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -11,6 +11,7 @@ if [ -n "$OPENSHIFT_CI" ]; then
 fi
 debugging.setup
 
+enable_access_log || exit $?
 create_namespaces || exit $?
 
 failed=0


### PR DESCRIPTION
Once we enabled access log, OpenShift Ingress Router deploys sidecar
container `log`:

```
$ oc get pod -n openshift-ingress
NAME                             READY   STATUS    RESTARTS   AGE
router-default-b69b559d7-t8vcg   2/2     Running   0          26m
```

and we could see the access log like this:

```
$ oc  -n openshift-ingress logs -c log router-default-b69b559d7-t8vcg
2020-10-02T10:39:16.777555+00:00 router-default-b69b559d7-t8vcg router-default-b69b559d7-t8vcg haproxy[55]: 3.34.158.228:15893 [02/Oct/2020:10:38:17.692] public_ssl be_tcp:openshift-authentication:oauth-openshift/pod:oauth-openshift-68c8dfb86b-m6q57:oauth-openshift:10.130.0.32:6443 1/0/59084 3093 -- 14/14/13/13/0 0/0
```

/cc @markusthoemmes @mgencur 
