### PR TITLE
Delete Kafka resources when spec.channel.enabled or spec.source.enabled is changed to false

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -165,7 +165,7 @@ func (r *ReconcileKnativeKafka) reconcileKnativeKafka(instance *operatorv1alpha1
 }
 
 func (r *ReconcileKnativeKafka) executeInstallStages(instance *operatorv1alpha1.KnativeKafka) error {
-	manifest, err := r.buildManifest(instance, ManifestBuildEnabledOnly)
+	manifest, err := r.buildManifest(instance, manifestBuildEnabledOnly)
 	if err != nil {
 		return fmt.Errorf("failed to load and build manifest: %w", err)
 	}
@@ -181,7 +181,7 @@ func (r *ReconcileKnativeKafka) executeInstallStages(instance *operatorv1alpha1.
 }
 
 func (r *ReconcileKnativeKafka) executeDeleteStages(instance *operatorv1alpha1.KnativeKafka) error {
-	manifest, err := r.buildManifest(instance, ManifestBuildDisabledOnly)
+	manifest, err := r.buildManifest(instance, manifestBuildDisabledOnly)
 	if err != nil {
 		return fmt.Errorf("failed to load and build manifest: %w", err)
 	}
@@ -310,7 +310,7 @@ func (r *ReconcileKnativeKafka) delete(instance *operatorv1alpha1.KnativeKafka) 
 }
 
 func (r *ReconcileKnativeKafka) deleteKnativeKafka(instance *operatorv1alpha1.KnativeKafka) error {
-	manifest, err := r.buildManifest(instance, ManifestBuildAll)
+	manifest, err := r.buildManifest(instance, manifestBuildAll)
 	if err != nil {
 		return fmt.Errorf("failed to build manifest: %w", err)
 	}
@@ -326,19 +326,19 @@ func (r *ReconcileKnativeKafka) deleteKnativeKafka(instance *operatorv1alpha1.Kn
 type manifestBuild int
 
 const (
-	ManifestBuildEnabledOnly manifestBuild = iota
-	ManifestBuildDisabledOnly
-	ManifestBuildAll
+	manifestBuildEnabledOnly manifestBuild = iota
+	manifestBuildDisabledOnly
+	manifestBuildAll
 )
 
 func (r *ReconcileKnativeKafka) buildManifest(instance *operatorv1alpha1.KnativeKafka, build manifestBuild) (*mf.Manifest, error) {
 	var resources []unstructured.Unstructured
 
-	if build == ManifestBuildAll || (build == ManifestBuildEnabledOnly && instance.Spec.Channel.Enabled) || (build == ManifestBuildDisabledOnly && !instance.Spec.Channel.Enabled) {
+	if build == manifestBuildAll || (build == manifestBuildEnabledOnly && instance.Spec.Channel.Enabled) || (build == manifestBuildDisabledOnly && !instance.Spec.Channel.Enabled) {
 		resources = append(resources, r.rawKafkaChannelManifest.Resources()...)
 	}
 
-	if build == ManifestBuildAll || (build == ManifestBuildEnabledOnly && instance.Spec.Source.Enabled) || (build == ManifestBuildDisabledOnly && !instance.Spec.Source.Enabled) {
+	if build == manifestBuildAll || (build == manifestBuildEnabledOnly && instance.Spec.Source.Enabled) || (build == manifestBuildDisabledOnly && !instance.Spec.Source.Enabled) {
 		resources = append(resources, r.rawKafkaSourceManifest.Resources()...)
 	}
 


### PR DESCRIPTION
## Changes
With this PR, when the components are disabled in spec their resources are deleted.

I also did some refactoring to reuse stage execution.

------------

As written in the umbrella ticket,  https://github.com/openshift-knative/serverless-operator/issues/486, there's still a lot to do.

Verification:

1. Install eventing

2. Enable the controller by uncommenting the stuff in `knative-operator/pkg/controller/add_knativekafka.go`

3. Need to manually create the CRD since it is not in the CSV yet
```
kubectl apply -f knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
```

4. Install:
```
cat <<EOS |kubectl apply -f -
---
apiVersion: operator.serverless.openshift.io/v1alpha1
kind: KnativeKafka
metadata:
  name: example
  namespace: knative-eventing
spec:
  source:
    enabled: true
  channel:
    enabled: true
    bootstrapServers: foo.example.com:1234
...
EOS
```

5. Watch the status of `KnativeKafka` CR, should be fine.
```
kubectl get knativekafka -n knative-eventing -o json | jq -r '.items[] | .metadata.name + ":" + (.status.conditions[] | .type + ":" + .status)'
```

6.Once status is ready, disable channel/source:
```
cat <<EOS |kubectl apply -f -
---
apiVersion: operator.serverless.openshift.io/v1alpha1
kind: KnativeKafka
metadata:
  name: example
  namespace: knative-eventing
spec:
  source:
    enabled: false
  channel:
    enabled: true
    bootstrapServers: foo.example.com:1234
...
EOS
```

7. See the resources gone and also check the status of the CR

8. Clean up:
```
kubectl delete knativekafkas example -n knative-eventing
```

