### PR TITLE
Actually set the bootstrapServers in config-kafka configmap from spec

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -209,7 +209,7 @@ func (r *ReconcileKnativeKafka) ensureFinalizers(_ *mf.Manifest, instance *opera
 func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *operatorv1alpha1.KnativeKafka) error {
 	log.Info("Transforming manifest")
 	m, err := manifest.Transform(
-		InjectOwner(instance),
+		injectOwner(instance),
 		common.SetAnnotations(map[string]string{
 			common.KafkaOwnerName:      instance.Name,
 			common.KafkaOwnerNamespace: instance.Namespace,
@@ -376,7 +376,7 @@ func setBootstrapServers(bootstrapServers string) mf.Transformer {
 // resources that are in the same namespace as the owner.
 // For the resources that are in the same namespace, it fallbacks to
 // Manifestival's InjectOwner
-func InjectOwner(owner mf.Owner) mf.Transformer {
+func injectOwner(owner mf.Owner) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetNamespace() == owner.GetNamespace() {
 			return mf.InjectOwner(owner)(u)

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -260,6 +260,9 @@ func (r *ReconcileKnativeKafka) checkDeployments(manifest *mf.Manifest, instance
 
 // Delete Knative Kafka resources
 func (r *ReconcileKnativeKafka) deleteResources(manifest *mf.Manifest, instance *operatorv1alpha1.KnativeKafka) error {
+	if len(manifest.Resources()) <= 0 {
+		return nil
+	}
 	log.Info("Deleting resources in manifest")
 	if err := manifest.Delete(); err != nil {
 		// TODO: any conditions?

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -1,0 +1,300 @@
+package knativekafka
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	v1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	apis "knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	admissiontypes "sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+var (
+	defaultRequest = reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "knative-eventing", Name: "knative-kafka"},
+	}
+	deleteTime = metav1.NewTime(time.Now())
+)
+
+type fakeManager struct {
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func (*fakeManager) Add(manager.Runnable) error {
+	return nil
+}
+
+func (*fakeManager) SetFields(interface{}) error {
+	return nil
+}
+
+func (*fakeManager) Start(<-chan struct{}) error {
+	return nil
+}
+
+func (*fakeManager) GetConfig() *rest.Config {
+	return nil
+}
+
+func (f *fakeManager) GetScheme() *runtime.Scheme {
+	return f.scheme
+}
+
+func (*fakeManager) GetAdmissionDecoder() admissiontypes.Decoder {
+	return nil
+}
+
+func (f *fakeManager) GetClient() client.Client {
+	return f.client
+}
+
+func (*fakeManager) GetFieldIndexer() client.FieldIndexer {
+	return nil
+}
+
+func (*fakeManager) GetCache() cache.Cache {
+	return nil
+}
+
+func (*fakeManager) GetRecorder(name string) record.EventRecorder {
+	return nil
+}
+
+func (*fakeManager) GetRESTMapper() meta.RESTMapper {
+	return nil
+}
+
+var _ manager.Manager = &fakeManager{}
+
+func init() {
+	os.Setenv("OPERATOR_NAME", "TEST_OPERATOR")
+	os.Setenv("KAFKACHANNEL_MANIFEST_PATH", "testdata/kafkachannel-latest.yaml")
+	os.Setenv("KAFKASOURCE_MANIFEST_PATH", "testdata/kafkasource-latest.yaml")
+}
+
+func TestKnativeKafkaReconcile(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	tests := []struct {
+		name     string
+		instance v1alpha1.KnativeKafka
+	}{
+		{
+			name: "Create CR with channel and source enabled",
+			instance: v1alpha1.KnativeKafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "knative-kafka",
+					Namespace:         "knative-eventing",
+					DeletionTimestamp: nil,
+				},
+				Spec: v1alpha1.KnativeKafkaSpec{
+					Source: v1alpha1.Source{
+						Enabled: true,
+					},
+					Channel: v1alpha1.Channel{
+						Enabled:          true,
+						BootstrapServers: "foo.bar.com",
+					},
+				},
+				Status: v1alpha1.KnativeKafkaStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{
+							{
+								Status: "True",
+								Type:   "DeploymentsAvailable",
+							},
+							{
+								Status: "True",
+								Type:   "InstallSucceeded",
+							},
+						},
+					},
+				},
+			},
+		},
+		//{
+		//	name: "Create CR with channel enabled and source disabled",
+		//	instance: v1alpha1.KnativeKafka{
+		//		ObjectMeta: metav1.ObjectMeta{
+		//			Name:      "knative-kafka",
+		//			Namespace: "knative-eventing",
+		//			DeletionTimestamp: nil,
+		//		},
+		//		Spec: v1alpha1.KnativeKafkaSpec{
+		//			Source: v1alpha1.Source{
+		//				Enabled: true,
+		//			},
+		//			Channel: v1alpha1.Channel{
+		//				Enabled:          true,
+		//				BootstrapServers: "foo.bar.com",
+		//			},
+		//		},
+		//		Status: v1alpha1.KnativeKafkaStatus{
+		//			Status: duckv1.Status{
+		//				Conditions: []apis.Condition{
+		//					{
+		//						Status: "True",
+		//						Type:   "DeploymentsAvailable",
+		//					},
+		//					{
+		//						Status: "True",
+		//						Type:   "InstallSucceeded",
+		//					},
+		//				},
+		//			},
+		//		},
+		//	},
+		//},
+		//{
+		//	name: "Create CR with channel disabled and source enabled",
+		//	instance: v1alpha1.KnativeKafka{
+		//		ObjectMeta: metav1.ObjectMeta{
+		//			Name:      "knative-kafka",
+		//			Namespace: "knative-eventing",
+		//			DeletionTimestamp: nil,
+		//		},
+		//		Spec: v1alpha1.KnativeKafkaSpec{
+		//			Source: v1alpha1.Source{
+		//				Enabled: true,
+		//			},
+		//			Channel: v1alpha1.Channel{
+		//				Enabled:          true,
+		//				BootstrapServers: "foo.bar.com",
+		//			},
+		//		},
+		//		Status: v1alpha1.KnativeKafkaStatus{
+		//			Status: duckv1.Status{
+		//				Conditions: []apis.Condition{
+		//					{
+		//						Status: "True",
+		//						Type:   "DeploymentsAvailable",
+		//					},
+		//					{
+		//						Status: "True",
+		//						Type:   "InstallSucceeded",
+		//					},
+		//				},
+		//			},
+		//		},
+		//	},
+		//},
+		//{
+		//	name: "Delete CR",
+		//	instance: v1alpha1.KnativeKafka{
+		//		ObjectMeta: metav1.ObjectMeta{
+		//			Name:      "knative-kafka",
+		//			Namespace: "knative-eventing",
+		//			DeletionTimestamp: &deleteTime,
+		//		},
+		//		Spec: v1alpha1.KnativeKafkaSpec{
+		//			Source: v1alpha1.Source{
+		//				Enabled: true,
+		//			},
+		//			Channel: v1alpha1.Channel{
+		//				Enabled:          true,
+		//				BootstrapServers: "foo.bar.com",
+		//			},
+		//		},
+		//		Status: v1alpha1.KnativeKafkaStatus{
+		//			Status: duckv1.Status{
+		//				Conditions: []apis.Condition{
+		//					{
+		//						Status: "True",
+		//						Type:   "DeploymentsAvailable",
+		//					},
+		//					{
+		//						Status: "True",
+		//						Type:   "InstallSucceeded",
+		//					},
+		//				},
+		//			},
+		//		},
+		//	},
+		//},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Register operator types with the runtime scheme.
+			s := scheme.Scheme
+			s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &test.instance)
+
+			initObjs := []runtime.Object{&test.instance}
+
+			cl := fake.NewFakeClient(initObjs...)
+			mgr := &fakeManager{
+				client: cl,
+				scheme: s,
+			}
+			r, err := newReconciler(mgr)
+
+			// Reconcile to intialize
+			if _, err := r.Reconcile(defaultRequest); err != nil {
+				t.Fatalf("reconcile: (%v)", err)
+			}
+
+			// check if KafkaChannel controller deployment is created
+			chDeploy := &appsv1.Deployment{}
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "kafka-ch-controller", Namespace: "knative-eventing"}, chDeploy)
+			if err != nil {
+				t.Fatalf("get: (%v)", err)
+			}
+
+			// check if KafkaSource controller deployment is created
+			srcDeploy := &appsv1.Deployment{}
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "kafka-controller-manager", Namespace: "knative-sources"}, srcDeploy)
+			if err != nil {
+				t.Fatalf("get: (%v)", err)
+			}
+
+			// Delete KafkaChannel controller deployment.
+			err = cl.Delete(context.TODO(), chDeploy)
+			if err != nil {
+				t.Fatalf("delete: (%v)", err)
+			}
+
+			// Delete KafkaSource controller deployment.
+			err = cl.Delete(context.TODO(), srcDeploy)
+			if err != nil {
+				t.Fatalf("delete: (%v)", err)
+			}
+
+			// Reconcile again
+			if _, err := r.Reconcile(defaultRequest); err != nil {
+				t.Fatalf("reconcile: (%v)", err)
+			}
+
+			// Check again if KafkaChannel deployment is created after reconcile.
+			chDeploy = &appsv1.Deployment{}
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "kafka-ch-controller", Namespace: "knative-eventing"}, chDeploy)
+			if err != nil {
+				t.Fatalf("get: (%v)", err)
+			}
+
+			// Check again if KafkaSource controller deployment is created after reconcile.
+			srcDeploy = &appsv1.Deployment{}
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "kafka-controller-manager", Namespace: "knative-sources"}, srcDeploy)
+			if err != nil {
+				t.Fatalf("get: (%v)", err)
+			}
+		})
+	}
+}

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -99,55 +99,49 @@ func TestKnativeKafkaReconcile(t *testing.T) {
 		instance     *v1alpha1.KnativeKafka
 		exists       []types.NamespacedName
 		doesNotExist []types.NamespacedName
-	}{
-		{
-			name:     "Create CR with channel and source enabled",
-			instance: makeCr(true, true, false),
-			exists: []types.NamespacedName{
-				{Name: "kafka-ch-controller", Namespace: "knative-eventing"},
-				{Name: "kafka-controller-manager", Namespace: "knative-sources"},
-			},
-			doesNotExist: []types.NamespacedName{},
+	}{{
+		name:     "Create CR with channel and source enabled",
+		instance: makeCr(true, true, false),
+		exists: []types.NamespacedName{
+			{Name: "kafka-ch-controller", Namespace: "knative-eventing"},
+			{Name: "kafka-controller-manager", Namespace: "knative-sources"},
 		},
-		{
-			name:     "Create CR with channel enabled and source disabled",
-			instance: makeCr(true, false, false),
-			exists: []types.NamespacedName{
-				{Name: "kafka-ch-controller", Namespace: "knative-eventing"},
-			},
-			doesNotExist: []types.NamespacedName{
-				{Name: "kafka-controller-manager", Namespace: "knative-sources"},
-			},
+		doesNotExist: []types.NamespacedName{},
+	}, {
+		name:     "Create CR with channel enabled and source disabled",
+		instance: makeCr(true, false, false),
+		exists: []types.NamespacedName{
+			{Name: "kafka-ch-controller", Namespace: "knative-eventing"},
 		},
-		{
-			name:     "Create CR with channel disabled and source enabled",
-			instance: makeCr(false, true, false),
-			exists: []types.NamespacedName{
-				{Name: "kafka-controller-manager", Namespace: "knative-sources"},
-			},
-			doesNotExist: []types.NamespacedName{
-				{Name: "kafka-ch-controller", Namespace: "knative-eventing"},
-			},
+		doesNotExist: []types.NamespacedName{
+			{Name: "kafka-controller-manager", Namespace: "knative-sources"},
 		},
-		{
-			name:     "Create CR with channel and source disabled",
-			instance: makeCr(false, false, false),
-			exists:   []types.NamespacedName{},
-			doesNotExist: []types.NamespacedName{
-				{Name: "kafka-ch-controller", Namespace: "knative-eventing"},
-				{Name: "kafka-controller-manager", Namespace: "knative-sources"},
-			},
+	}, {
+		name:     "Create CR with channel disabled and source enabled",
+		instance: makeCr(false, true, false),
+		exists: []types.NamespacedName{
+			{Name: "kafka-controller-manager", Namespace: "knative-sources"},
 		},
-		{
-			name:     "Delete CR",
-			instance: makeCr(true, true, true),
-			exists:   []types.NamespacedName{},
-			doesNotExist: []types.NamespacedName{
-				{Name: "kafka-ch-controller", Namespace: "knative-eventing"},
-				{Name: "kafka-controller-manager", Namespace: "knative-sources"},
-			},
+		doesNotExist: []types.NamespacedName{
+			{Name: "kafka-ch-controller", Namespace: "knative-eventing"},
 		},
-	}
+	}, {
+		name:     "Create CR with channel and source disabled",
+		instance: makeCr(false, false, false),
+		exists:   []types.NamespacedName{},
+		doesNotExist: []types.NamespacedName{
+			{Name: "kafka-ch-controller", Namespace: "knative-eventing"},
+			{Name: "kafka-controller-manager", Namespace: "knative-sources"},
+		},
+	}, {
+		name:     "Delete CR",
+		instance: makeCr(true, true, true),
+		exists:   []types.NamespacedName{},
+		doesNotExist: []types.NamespacedName{
+			{Name: "kafka-ch-controller", Namespace: "knative-eventing"},
+			{Name: "kafka-controller-manager", Namespace: "knative-sources"},
+		},
+	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -252,116 +246,112 @@ func TestInjectOwner(t *testing.T) {
 		obj    *unstructured.Unstructured
 		owner  mf.Owner
 		expect *unstructured.Unstructured
-	}{
-		{
-			name: "namespaced resource in same namespace",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]interface{}{
-						"name":      "default",
-						"namespace": "knative-eventing",
-					},
-				},
-			},
-			owner: &v1alpha1.KnativeKafka{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "KnativeKafka",
-					APIVersion: "operator.serverless.openshift.io/v1alpha1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "knative-kafka",
-					Namespace: "knative-eventing",
-					UID:       types.UID("deadbeef"),
-				},
-			},
-			expect: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]interface{}{
-						"name":      "default",
-						"namespace": "knative-eventing",
-						"ownerReferences": []interface{}{map[string]interface{}{
-							"apiVersion":         "operator.serverless.openshift.io/v1alpha1",
-							"kind":               "KnativeKafka",
-							"name":               "knative-kafka",
-							"uid":                "deadbeef",
-							"blockOwnerDeletion": true,
-							"controller":         true,
-						}},
-					},
+	}{{
+		name: "namespaced resource in same namespace",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name":      "default",
+					"namespace": "knative-eventing",
 				},
 			},
 		},
-		{
-			name: "namespaced resource in different namespace",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]interface{}{
-						"name":      "default",
-						"namespace": "knative-sources",
-					},
-				},
+		owner: &v1alpha1.KnativeKafka{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KnativeKafka",
+				APIVersion: "operator.serverless.openshift.io/v1alpha1",
 			},
-			owner: &v1alpha1.KnativeKafka{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "KnativeKafka",
-					APIVersion: "operator.serverless.openshift.io/v1alpha1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "knative-kafka",
-					Namespace: "knative-eventing",
-					UID:       types.UID("deadbeef"),
-				},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "knative-kafka",
+				Namespace: "knative-eventing",
+				UID:       types.UID("deadbeef"),
 			},
-			expect: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]interface{}{
-						"name":      "default",
-						"namespace": "knative-sources",
-					},
+		},
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name":      "default",
+					"namespace": "knative-eventing",
+					"ownerReferences": []interface{}{map[string]interface{}{
+						"apiVersion":         "operator.serverless.openshift.io/v1alpha1",
+						"kind":               "KnativeKafka",
+						"name":               "knative-kafka",
+						"uid":                "deadbeef",
+						"blockOwnerDeletion": true,
+						"controller":         true,
+					}},
 				},
 			},
 		},
-		{
-			name: "cluster-scoped resource",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "rbac.authorization.k8s.io/v1",
-					"kind":       "ClusterRole",
-					"metadata": map[string]interface{}{
-						"name": "default",
-					},
-				},
-			},
-			owner: &v1alpha1.KnativeKafka{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "KnativeKafka",
-					APIVersion: "operator.serverless.openshift.io/v1alpha1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "knative-kafka",
-					Namespace: "knative-eventing",
-					UID:       types.UID("deadbeef"),
-				},
-			},
-			expect: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "rbac.authorization.k8s.io/v1",
-					"kind":       "ClusterRole",
-					"metadata": map[string]interface{}{
-						"name": "default",
-					},
+	}, {
+		name: "namespaced resource in different namespace",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name":      "default",
+					"namespace": "knative-sources",
 				},
 			},
 		},
-	}
+		owner: &v1alpha1.KnativeKafka{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KnativeKafka",
+				APIVersion: "operator.serverless.openshift.io/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "knative-kafka",
+				Namespace: "knative-eventing",
+				UID:       types.UID("deadbeef"),
+			},
+		},
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name":      "default",
+					"namespace": "knative-sources",
+				},
+			},
+		},
+	}, {
+		name: "cluster-scoped resource",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind":       "ClusterRole",
+				"metadata": map[string]interface{}{
+					"name": "default",
+				},
+			},
+		},
+		owner: &v1alpha1.KnativeKafka{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KnativeKafka",
+				APIVersion: "operator.serverless.openshift.io/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "knative-kafka",
+				Namespace: "knative-eventing",
+				UID:       types.UID("deadbeef"),
+			},
+		},
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind":       "ClusterRole",
+				"metadata": map[string]interface{}{
+					"name": "default",
+				},
+			},
+		},
+	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -385,105 +375,100 @@ func TestSetBootstrapServers(t *testing.T) {
 		obj              *unstructured.Unstructured
 		bootstrapServers string
 		expect           *unstructured.Unstructured
-	}{
-		{
-			name: "Update config-kafka",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "config-kafka",
-					},
-				},
-			},
-			bootstrapServers: "example.com:1234",
-			expect: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "config-kafka",
-					},
-					"data": map[string]interface{}{
-						"bootstrapServers": "example.com:1234",
-					},
+	}{{
+		name: "Update config-kafka",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
 				},
 			},
 		},
-		{
-			name: "Update config-kafka - overwrite",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "config-kafka",
-					},
-					"data": map[string]interface{}{
-						"bootstrapServers": "TO_BE_OVERWRITTEN",
-					},
+		bootstrapServers: "example.com:1234",
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
 				},
-			},
-			bootstrapServers: "example.com:1234",
-			expect: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "config-kafka",
-					},
-					"data": map[string]interface{}{
-						"bootstrapServers": "example.com:1234",
-					},
+				"data": map[string]interface{}{
+					"bootstrapServers": "example.com:1234",
 				},
 			},
 		},
-		{
-			name: "Do not update other configmaps",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "config-foo",
-					},
+	}, {
+		name: "Update config-kafka - overwrite",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
 				},
-			},
-			bootstrapServers: "example.com:1234",
-			expect: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "config-foo",
-					},
+				"data": map[string]interface{}{
+					"bootstrapServers": "TO_BE_OVERWRITTEN",
 				},
 			},
 		},
-		{
-			name: "Do not update other resources",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Secret",
-					"metadata": map[string]interface{}{
-						"name": "config-kafka",
-					},
+		bootstrapServers: "example.com:1234",
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
 				},
-			},
-			bootstrapServers: "example.com:1234",
-			expect: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Secret",
-					"metadata": map[string]interface{}{
-						"name": "config-kafka",
-					},
+				"data": map[string]interface{}{
+					"bootstrapServers": "example.com:1234",
 				},
 			},
 		},
-	}
+	}, {
+		name: "Do not update other configmaps",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-foo",
+				},
+			},
+		},
+		bootstrapServers: "example.com:1234",
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-foo",
+				},
+			},
+		},
+	}, {
+		name: "Do not update other resources",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+			},
+		},
+		bootstrapServers: "example.com:1234",
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+			},
+		},
+	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -2,7 +2,6 @@ package knativekafka
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -26,12 +25,6 @@ var (
 		NamespacedName: types.NamespacedName{Namespace: "knative-eventing", Name: "knative-kafka"},
 	}
 )
-
-func init() {
-	os.Setenv("OPERATOR_NAME", "TEST_OPERATOR")
-	os.Setenv("KAFKACHANNEL_MANIFEST_PATH", "testdata/kafkachannel-latest.yaml")
-	os.Setenv("KAFKASOURCE_MANIFEST_PATH", "testdata/kafkasource-latest.yaml")
-}
 
 func TestKnativeKafkaReconcile(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
@@ -95,12 +88,12 @@ func TestKnativeKafkaReconcile(t *testing.T) {
 
 			cl := fake.NewFakeClient(initObjs...)
 
-			kafkaChannelManifest, err := mf.ManifestFrom(mf.Path(os.Getenv("KAFKACHANNEL_MANIFEST_PATH")))
+			kafkaChannelManifest, err := mf.ManifestFrom(mf.Path("testdata/kafkachannel-latest.yaml"))
 			if err != nil {
 				t.Fatalf("failed to load KafkaChannel manifest: %v", err)
 			}
 
-			kafkaSourceManifest, err := mf.ManifestFrom(mf.Path(os.Getenv("KAFKASOURCE_MANIFEST_PATH")))
+			kafkaSourceManifest, err := mf.ManifestFrom(mf.Path("testdata/kafkasource-latest.yaml"))
 			if err != nil {
 				t.Fatalf("failed to load KafkaSource manifest: %v", err)
 			}

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -211,33 +211,6 @@ func TestKnativeKafkaReconcile(t *testing.T) {
 	}
 }
 
-func makeCr(channel bool, source bool, deleted bool) *v1alpha1.KnativeKafka {
-	var deleteTime *metav1.Time
-	if deleted {
-		t := metav1.NewTime(time.Now())
-		deleteTime = &t
-	}
-
-	instance := v1alpha1.KnativeKafka{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "knative-kafka",
-			Namespace:         "knative-eventing",
-			DeletionTimestamp: deleteTime,
-		},
-		Spec: v1alpha1.KnativeKafkaSpec{
-			Source: v1alpha1.Source{
-				Enabled: source,
-			},
-			Channel: v1alpha1.Channel{
-				Enabled:          channel,
-				BootstrapServers: "foo.bar.com",
-			},
-		},
-	}
-
-	return &instance
-}
-
 func TestInjectOwner(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 
@@ -482,4 +455,31 @@ func TestSetBootstrapServers(t *testing.T) {
 			}
 		})
 	}
+}
+
+func makeCr(channel bool, source bool, deleted bool) *v1alpha1.KnativeKafka {
+	var deleteTime *metav1.Time
+	if deleted {
+		t := metav1.NewTime(time.Now())
+		deleteTime = &t
+	}
+
+	instance := v1alpha1.KnativeKafka{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "knative-kafka",
+			Namespace:         "knative-eventing",
+			DeletionTimestamp: deleteTime,
+		},
+		Spec: v1alpha1.KnativeKafkaSpec{
+			Source: v1alpha1.Source{
+				Enabled: source,
+			},
+			Channel: v1alpha1.Channel{
+				Enabled:          channel,
+				BootstrapServers: "foo.bar.com",
+			},
+		},
+	}
+
+	return &instance
 }

--- a/knative-operator/pkg/controller/knativekafka/testdata/kafkachannel-latest.yaml
+++ b/knative-operator/pkg/controller/knativekafka/testdata/kafkachannel-latest.yaml
@@ -1,0 +1,1 @@
+../../../../deploy/resources/knativekafka/kafkachannel-latest.yaml

--- a/knative-operator/pkg/controller/knativekafka/testdata/kafkasource-latest.yaml
+++ b/knative-operator/pkg/controller/knativekafka/testdata/kafkasource-latest.yaml
@@ -1,0 +1,1 @@
+../../../../deploy/resources/knativekafka/kafkasource-latest.yaml


### PR DESCRIPTION
## Changes

With this PR, `bootstrapServers` field in `config-kafka` configmap is set with the value from spec.
------------------

As written in the umbrella ticket,  https://github.com/openshift-knative/serverless-operator/issues/486, there's still a lot to do.

Verification:

1. Install eventing

2. Enable the controller by uncommenting the stuff in `knative-operator/pkg/controller/add_knativekafka.go`

3. Need to manually create the CRD since it is not in the CSV yet
```
kubectl apply -f knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
```

4. Install:
```
cat <<EOS |kubectl apply -f -
---
apiVersion: operator.serverless.openshift.io/v1alpha1
kind: KnativeKafka
metadata:
  name: example
  namespace: knative-eventing
spec:
  source:
    enabled: true
  channel:
    enabled: true
    bootstrapServers: foo.example.com:1234
...
EOS
```

5. Watch the status of `KnativeKafka` CR, should be fine.
```
kubectl get knativekafka -n knative-eventing -o json | jq -r '.items[] | .metadata.name + ":" + (.status.conditions[] | .type + ":" + .status)'
```

6.Once status is ready, check configmap `config-kafka` in `knative-eventing` namespace. The `bootstrapServers` field should be set accordingly.

7. Clean up:
```
kubectl delete knativekafkas example -n knative-eventing
```

