### PR TITLE
Validation for the KnativeKafka CRs

### DIFF
--- a/knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
+++ b/knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
@@ -43,7 +43,6 @@ spec:
                   type: boolean
               required:
               - enabled
-              - bootstrapServers
               type: object
             source:
               description: Allows configuration for KafkaSource installation
@@ -55,6 +54,9 @@ spec:
               required:
               - enabled
               type: object
+          required:
+          - channel
+          - source
           type: object
         status:
           properties:

--- a/knative-operator/deploy/operator.yaml
+++ b/knative-operator/deploy/operator.yaml
@@ -35,5 +35,11 @@ spec:
               value: "knative-serving"
             - name: REQUIRED_EVENTING_NAMESPACE
               value: "knative-eventing"
+            - name: REQUIRED_KAFKA_NAMESPACE
+              value: "knative-eventing"
             - name: KOURIER_MANIFEST_PATH
               value: deploy/resources/kourier/kourier-latest.yaml
+            - name: KAFKACHANNEL_MANIFEST_PATH
+              value: deploy/resources/knativekafka/kafkachannel-latest.yaml
+            - name: KAFKASOURCE_MANIFEST_PATH
+              value: deploy/resources/knativekafka/kafkasource-latest.yaml

--- a/knative-operator/pkg/webhook/add_knativekafka.go
+++ b/knative-operator/pkg/webhook/add_knativekafka.go
@@ -1,9 +1,10 @@
 package webhook
 
-import (
-	kk "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativekafka"
-)
-
-func init() {
-	AddToManagerFuncs = append(AddToManagerFuncs, kk.ValidatingWebhook)
-}
+//
+//import (
+//	kk "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativekafka"
+//)
+//
+//func init() {
+//	AddToManagerFuncs = append(AddToManagerFuncs, kk.ValidatingWebhook)
+//}

--- a/knative-operator/pkg/webhook/add_knativekafka.go
+++ b/knative-operator/pkg/webhook/add_knativekafka.go
@@ -1,0 +1,9 @@
+package webhook
+
+import (
+	kk "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativekafka"
+)
+
+func init() {
+	AddToManagerFuncs = append(AddToManagerFuncs, kk.ValidatingWebhook)
+}

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating.go
@@ -1,0 +1,139 @@
+package knativekafka
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
+	webhookutil "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/util"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+// Creates a new validating KnativeKafka Webhook
+func ValidatingWebhook(mgr manager.Manager) (webhook.Webhook, error) {
+	common.Log.Info("Setting up validating webhook for KnativeKafka")
+	return builder.NewWebhookBuilder().
+		Name("validating.knativekafka.openshift.io").
+		Validating().
+		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
+		WithManager(mgr).
+		ForType(&operatorv1alpha1.KnativeKafka{}).
+		Handlers(&KnativeKafkaValidator{}).
+		Build()
+}
+
+// KnativeKafkaValidator validates KnativeKafka CR's
+type KnativeKafkaValidator struct {
+	client  client.Client
+	decoder types.Decoder
+}
+
+// Implement admission.Handler so the controller can handle admission request.
+var _ admission.Handler = (*KnativeKafkaValidator)(nil)
+
+// What makes us a webhook
+func (v *KnativeKafkaValidator) Handle(ctx context.Context, req types.Request) types.Response {
+	ke := &operatorv1alpha1.KnativeKafka{}
+
+	err := v.decoder.Decode(req, ke)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	allowed, reason, err := v.validate(ctx, ke)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.ValidationResponse(allowed, reason)
+}
+
+// KnativeKafkaValidator checks for a minimum OpenShift version
+func (v *KnativeKafkaValidator) validate(ctx context.Context, ke *operatorv1alpha1.KnativeKafka) (allowed bool, reason string, err error) {
+	log := common.Log.WithName("validate")
+	stages := []func(context.Context, *operatorv1alpha1.KnativeKafka) (bool, string, error){
+		v.validateNamespace,
+		v.validateVersion,
+		v.validateLoneliness,
+		v.validateShape,
+	}
+	for _, stage := range stages {
+		allowed, reason, err = stage(ctx, ke)
+		if len(reason) > 0 {
+			if err != nil {
+				log.Error(err, reason)
+			} else {
+				log.Info(reason)
+			}
+		}
+		if !allowed {
+			return
+		}
+	}
+	return
+}
+
+// KnativeKafkaValidator implements inject.Client.
+// A client will be automatically injected.
+var _ inject.Client = (*KnativeKafkaValidator)(nil)
+
+// InjectClient injects the client.
+func (v *KnativeKafkaValidator) InjectClient(c client.Client) error {
+	v.client = c
+	return nil
+}
+
+// KnativeKafkaValidator implements inject.Decoder.
+// A decoder will be automatically injected.
+var _ inject.Decoder = (*KnativeKafkaValidator)(nil)
+
+// InjectDecoder injects the decoder.
+func (v *KnativeKafkaValidator) InjectDecoder(d types.Decoder) error {
+	v.decoder = d
+	return nil
+}
+
+// validate minimum openshift version
+func (v *KnativeKafkaValidator) validateVersion(ctx context.Context, _ *operatorv1alpha1.KnativeKafka) (bool, string, error) {
+	return webhookutil.ValidateOpenShiftVersion(ctx, v.client)
+}
+
+// validate required namespace, if any
+func (v *KnativeKafkaValidator) validateNamespace(ctx context.Context, ke *operatorv1alpha1.KnativeKafka) (bool, string, error) {
+	ns, required := os.LookupEnv("REQUIRED_KAFKA_NAMESPACE")
+	if required && ns != ke.Namespace {
+		return false, fmt.Sprintf("KnativeKafka may only be created in %s namespace", ns), nil
+	}
+	return true, "", nil
+}
+
+// validate this is the only KE in this namespace
+func (v *KnativeKafkaValidator) validateLoneliness(ctx context.Context, ke *operatorv1alpha1.KnativeKafka) (bool, string, error) {
+	list := &operatorv1alpha1.KnativeKafkaList{}
+	if err := v.client.List(ctx, &client.ListOptions{Namespace: ke.Namespace}, list); err != nil {
+		return false, "Unable to list KnativeKafkas", err
+	}
+	for _, v := range list.Items {
+		if ke.Name != v.Name {
+			return false, "Only one KnativeKafka allowed per namespace", nil
+		}
+	}
+	return true, "", nil
+}
+
+// validate the shape of the CR
+func (v *KnativeKafkaValidator) validateShape(_ context.Context, ke *operatorv1alpha1.KnativeKafka) (bool, string, error) {
+	if ke.Spec.Channel.Enabled && ke.Spec.Channel.BootstrapServers == "" {
+		return false, "spec.channel.bootStrapServers is a required detail when spec.channel.enabled is true", nil
+	}
+	return true, "", nil
+}

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating.go
@@ -8,7 +8,6 @@ import (
 
 	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	webhookutil "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/util"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -62,7 +61,6 @@ func (v *KnativeKafkaValidator) validate(ctx context.Context, ke *operatorv1alph
 	log := common.Log.WithName("validate")
 	stages := []func(context.Context, *operatorv1alpha1.KnativeKafka) (bool, string, error){
 		v.validateNamespace,
-		v.validateVersion,
 		v.validateLoneliness,
 		v.validateShape,
 	}
@@ -100,11 +98,6 @@ var _ inject.Decoder = (*KnativeKafkaValidator)(nil)
 func (v *KnativeKafkaValidator) InjectDecoder(d types.Decoder) error {
 	v.decoder = d
 	return nil
-}
-
-// validate minimum openshift version
-func (v *KnativeKafkaValidator) validateVersion(ctx context.Context, _ *operatorv1alpha1.KnativeKafka) (bool, string, error) {
-	return webhookutil.ValidateOpenShiftVersion(ctx, v.client)
 }
 
 // validate required namespace, if any

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
@@ -7,7 +7,6 @@ import (
 
 	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
 	. "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativekafka"
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/testutil"
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -69,18 +68,6 @@ func TestInvalidNamespace(t *testing.T) {
 	result := validator.Handle(context.TODO(), types.Request{})
 	if result.Response.Allowed {
 		t.Error("The required namespace is wrong, but the request is allowed")
-	}
-}
-
-func TestInvalidVersion(t *testing.T) {
-	os.Clearenv()
-	os.Setenv("MIN_OPENSHIFT_VERSION", "4.1.13")
-	validator := KnativeKafkaValidator{}
-	validator.InjectDecoder(&mockDecoder{ke1})
-	validator.InjectClient(fake.NewFakeClient(testutil.MockClusterVersion("3.2.0")))
-	result := validator.Handle(context.TODO(), types.Request{})
-	if result.Response.Allowed {
-		t.Error("The version is too low, but the request is allowed")
 	}
 }
 

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
@@ -1,0 +1,120 @@
+package knativekafka_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
+	. "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativekafka"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/testutil"
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+func init() {
+	configv1.AddToScheme(scheme.Scheme)
+	operatorv1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme)
+}
+
+var ke1 = &operatorv1alpha1.KnativeKafka{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ke1",
+	},
+	Spec: operatorv1alpha1.KnativeKafkaSpec{
+		Source: operatorv1alpha1.Source{
+			Enabled: false,
+		},
+		Channel: operatorv1alpha1.Channel{
+			Enabled: false,
+		},
+	},
+}
+var ke2 = &operatorv1alpha1.KnativeKafka{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ke2",
+	},
+	Spec: operatorv1alpha1.KnativeKafkaSpec{
+		Source: operatorv1alpha1.Source{
+			Enabled: false,
+		},
+		Channel: operatorv1alpha1.Channel{
+			Enabled: false,
+		},
+	},
+}
+var ke3 = &operatorv1alpha1.KnativeKafka{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ke3",
+	},
+	Spec: operatorv1alpha1.KnativeKafkaSpec{
+		Source: operatorv1alpha1.Source{
+			Enabled: false,
+		},
+		Channel: operatorv1alpha1.Channel{
+			Enabled: true,
+		},
+	},
+}
+
+func TestInvalidNamespace(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("REQUIRED_KAFKA_NAMESPACE", "knative-eventing")
+	validator := KnativeKafkaValidator{}
+	validator.InjectDecoder(&mockDecoder{ke1})
+	result := validator.Handle(context.TODO(), types.Request{})
+	if result.Response.Allowed {
+		t.Error("The required namespace is wrong, but the request is allowed")
+	}
+}
+
+func TestInvalidVersion(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("MIN_OPENSHIFT_VERSION", "4.1.13")
+	validator := KnativeKafkaValidator{}
+	validator.InjectDecoder(&mockDecoder{ke1})
+	validator.InjectClient(fake.NewFakeClient(testutil.MockClusterVersion("3.2.0")))
+	result := validator.Handle(context.TODO(), types.Request{})
+	if result.Response.Allowed {
+		t.Error("The version is too low, but the request is allowed")
+	}
+}
+
+func TestLoneliness(t *testing.T) {
+	os.Clearenv()
+	validator := KnativeKafkaValidator{}
+	validator.InjectDecoder(&mockDecoder{ke1})
+	validator.InjectClient(fake.NewFakeClient(ke2))
+	result := validator.Handle(context.TODO(), types.Request{})
+	if result.Response.Allowed {
+		t.Errorf("Too many KnativeKafkas: %v", result.Response)
+	}
+}
+
+func TestShape(t *testing.T) {
+	os.Clearenv()
+	validator := KnativeKafkaValidator{}
+	validator.InjectDecoder(&mockDecoder{ke3})
+	validator.InjectClient(fake.NewFakeClient())
+	result := validator.Handle(context.TODO(), types.Request{})
+	if result.Response.Allowed {
+		t.Error("The shape is invalid, but the request is allowed")
+	}
+}
+
+type mockDecoder struct {
+	ke *operatorv1alpha1.KnativeKafka
+}
+
+var _ types.Decoder = (*mockDecoder)(nil)
+
+func (mock *mockDecoder) Decode(_ types.Request, obj runtime.Object) error {
+	if p, ok := obj.(*operatorv1alpha1.KnativeKafka); ok {
+		*p = *mock.ke
+	}
+	return nil
+}

--- a/olm-catalog/serverless-operator/csv.template.yaml
+++ b/olm-catalog/serverless-operator/csv.template.yaml
@@ -321,6 +321,8 @@ spec:
                       value: "knative-serving"
                     - name: REQUIRED_EVENTING_NAMESPACE
                       value: "knative-eventing"
+                    - name: REQUIRED_KAFKA_NAMESPACE
+                      value: "knative-eventing"
                     - name: KOURIER_MANIFEST_PATH
                       value: deploy/resources/kourier/kourier-latest.yaml
                     - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -379,6 +379,8 @@ spec:
                         value: "knative-serving"
                       - name: REQUIRED_EVENTING_NAMESPACE
                         value: "knative-eventing"
+                      - name: REQUIRED_KAFKA_NAMESPACE
+                        value: "knative-eventing"
                       - name: KOURIER_MANIFEST_PATH
                         value: deploy/resources/kourier/kourier-latest.yaml
                       - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH


### PR DESCRIPTION
With this PR, KnativeKafka spec is validated.

Validations:
- Check if `spec.channel.bootstrapServers` is not empty, when `spec.channel.enabled` is `true`. The requiredness check for `spec.channel`, `spec.source`, `spec.channel.enabled` and `spec.source.enabled` is done by Kubernetes via the OpenAPI validaton rules defined in the CRD.
- CR namespace must be in the predefined one
- There must be only 1 CRs

Verification instructions:

1. Enable the controller by uncommenting the stuff in `knative-operator/pkg/controller/add_knativekafka.go`

2. `make images` && `make install` --> deploys S-O and installs KnativeServing and KnativeEventing

3. Need to manually create the CRD since it is not in the CSV yet
```
kubectl apply -f knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
```

4. Install KnativeKafka:
```
cat <<EOS |kubectl apply -f -
---
apiVersion: operator.serverless.openshift.io/v1alpha1
kind: KnativeKafka
metadata:
  name: example
  namespace: knative-eventing
spec:
  source:
    enabled: true
  channel:
    enabled: true
    bootstrapServers: foo.example.com:1234
...
EOS
```

5. Watch the status of `KnativeKafka` CR, should be fine.
```
kubectl get knativekafka -n knative-eventing -o json | jq -r '.items[] | .metadata.name + ":" + (.status.conditions[] | .type + ":" + .status)'
```

7. Clean up:
```
kubectl delete knativekafkas example -n knative-eventing
```

Try with different combinations of the spec:
- Empty spec
- No `source` field in spec, no `source.enabled` in spec, etc.
- No `channel` field in spec, ..., 
- No `channel.bootstrapServers` with `channel.enabled=true`
...

Try loneliness (create 2 instances of the CR)

Try creating in another namespace than `knative-eventing`