### PR TITLE
Refactor secondary resource watching related code

### DIFF
--- a/knative-operator/pkg/common/health_dashboard.go
+++ b/knative-operator/pkg/common/health_dashboard.go
@@ -9,7 +9,6 @@ import (
 	mf "github.com/manifestival/manifestival"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -52,7 +51,10 @@ func manifest(apiclient client.Client, deploymentName string, namespace string) 
 		return mf.Manifest{}, fmt.Errorf("failed to read dashboard manifest: %w", err)
 	}
 	transforms := []mf.Transformer{
-		SetOwnerAnnotations(metav1.ObjectMeta{Namespace: namespace, Name: deploymentName}, ServerlessOperatorOwnerName, ServerlessOperatorOwnerNamespace),
+		SetAnnotations(map[string]string{
+			ServerlessOperatorOwnerName:      deploymentName,
+			ServerlessOperatorOwnerNamespace: namespace,
+		}),
 		mf.InjectNamespace(ConfigManagedNamespace),
 	}
 	if manifest, err = manifest.Transform(transforms...); err != nil {

--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -6,6 +6,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -121,4 +123,20 @@ func EnqueueRequestByOwnerAnnotations(ownerNameAnnotationKey, ownerNamespaceAnno
 		}
 		return nil
 	}
+}
+
+func BuildGVKToResourceMap(manifests ...mf.Manifest) map[schema.GroupVersionKind]runtime.Object {
+	gvkToResource := make(map[schema.GroupVersionKind]runtime.Object)
+
+	for _, manifest := range manifests {
+		resources := manifest.Resources()
+
+		for i := range resources {
+			// it is ok to overwrite existing since we are only interested
+			// in the types of the resources, not the instances
+			gvkToResource[resources[i].GroupVersionKind()] = &resources[i]
+		}
+	}
+
+	return gvkToResource
 }

--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mf "github.com/manifestival/manifestival"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -69,11 +70,11 @@ func BuildImageOverrideMapFromEnviron(environ []string) map[string]string {
 }
 
 // SetOwnerAnnotations is a transformer to set owner annotations on given object
-func SetOwnerAnnotations(instance *operatorv1alpha1.KnativeServing) mf.Transformer {
+func SetOwnerAnnotations(meta metav1.ObjectMeta, ownerNameAnnotationKey, ownerNamespaceAnnotationKey string) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		u.SetAnnotations(map[string]string{
-			ServingOwnerName:      instance.Name,
-			ServingOwnerNamespace: instance.Namespace,
+			ownerNameAnnotationKey:      meta.Name,
+			ownerNamespaceAnnotationKey: meta.Namespace,
 		})
 		return nil
 	}

--- a/knative-operator/pkg/controller/healthdashboard/healthdashboard_controller.go
+++ b/knative-operator/pkg/controller/healthdashboard/healthdashboard_controller.go
@@ -4,7 +4,6 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -36,18 +35,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// common function to enqueue reconcile requests for resources
-	enqueueRequests := handler.ToRequestsFunc(func(obj handler.MapObject) []reconcile.Request {
-		annotations := obj.Meta.GetAnnotations()
-		ownerNamespace := annotations[common.ServerlessOperatorOwnerNamespace]
-		ownerName := annotations[common.ServerlessOperatorOwnerName]
-		if ownerNamespace != "" && ownerName != "" {
-			return []reconcile.Request{{
-				NamespacedName: types.NamespacedName{Namespace: obj.Meta.GetNamespace(), Name: obj.Meta.GetName()},
-			}}
-		}
-		return nil
-	})
+	enqueueRequests := common.EnqueueRequestByOwnerAnnotations(common.ServerlessOperatorOwnerName, common.ServerlessOperatorOwnerNamespace)
 	err = c.Watch(&source.Kind{Type: &v1.ConfigMap{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: enqueueRequests}, skipCreatePredicate{})
 	if err != nil {
 		return err

--- a/knative-operator/pkg/controller/healthdashboard/healthdashboard_controller.go
+++ b/knative-operator/pkg/controller/healthdashboard/healthdashboard_controller.go
@@ -7,7 +7,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -35,8 +34,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	enqueueRequests := common.EnqueueRequestByOwnerAnnotations(common.ServerlessOperatorOwnerName, common.ServerlessOperatorOwnerNamespace)
-	err = c.Watch(&source.Kind{Type: &v1.ConfigMap{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: enqueueRequests}, skipCreatePredicate{})
+	err = c.Watch(&source.Kind{Type: &v1.ConfigMap{}}, common.EnqueueRequestByOwnerAnnotations(common.ServerlessOperatorOwnerName, common.ServerlessOperatorOwnerNamespace), skipCreatePredicate{})
 	if err != nil {
 		return err
 	}

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -80,17 +80,7 @@ func add(mgr manager.Manager, r *ReconcileKnativeKafka) error {
 	}
 
 	// common function to enqueue reconcile requests for resources
-	enqueueRequests := handler.ToRequestsFunc(func(obj handler.MapObject) []reconcile.Request {
-		annotations := obj.Meta.GetAnnotations()
-		ownerNamespace := annotations[common.KafkaOwnerNamespace]
-		ownerName := annotations[common.KafkaOwnerName]
-		if ownerNamespace != "" && ownerName != "" {
-			return []reconcile.Request{{
-				NamespacedName: types.NamespacedName{Namespace: ownerNamespace, Name: ownerName},
-			}}
-		}
-		return nil
-	})
+	enqueueRequests := common.EnqueueRequestByOwnerAnnotations(common.KafkaOwnerName, common.KafkaOwnerNamespace)
 
 	gvkToResource := make(map[schema.GroupVersionKind]runtime.Object)
 

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -78,13 +78,10 @@ func add(mgr manager.Manager, r *ReconcileKnativeKafka) error {
 		return err
 	}
 
-	// common function to enqueue reconcile requests for resources
-	enqueueRequests := common.EnqueueRequestByOwnerAnnotations(common.KafkaOwnerName, common.KafkaOwnerNamespace)
-
 	gvkToResource := common.BuildGVKToResourceMap(r.rawKafkaChannelManifest, r.rawKafkaSourceManifest)
 
 	for _, t := range gvkToResource {
-		err = c.Watch(&source.Kind{Type: t}, &handler.EnqueueRequestsFromMapFunc{ToRequests: enqueueRequests})
+		err = c.Watch(&source.Kind{Type: t}, common.EnqueueRequestByOwnerAnnotations(common.KafkaOwnerName, common.KafkaOwnerNamespace))
 		if err != nil {
 			return err
 		}

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -232,7 +232,10 @@ func rawKafkaChannelManifest(apiclient client.Client) (mf.Manifest, error) {
 func (r *ReconcileKnativeKafka) kafkaChannelManifest(instance *operatorv1alpha1.KnativeKafka) (*mf.Manifest, error) {
 	manifest, err := r.rawKafkaChannelManifest.Transform(
 		mf.InjectOwner(instance),
-		common.SetOwnerAnnotations(instance.ObjectMeta, common.KafkaOwnerName, common.KafkaOwnerNamespace),
+		common.SetAnnotations(map[string]string{
+			common.KafkaOwnerName:      instance.Name,
+			common.KafkaOwnerNamespace: instance.Namespace,
+		}),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform KafkaChannel manifest: %w", err)
@@ -264,7 +267,12 @@ func rawKafkaSourceManifest(apiclient client.Client) (mf.Manifest, error) {
 }
 
 func (r *ReconcileKnativeKafka) kafkaSourceManifest(instance *operatorv1alpha1.KnativeKafka) (*mf.Manifest, error) {
-	manifest, err := r.rawKafkaSourceManifest.Transform(common.SetOwnerAnnotations(instance.ObjectMeta, common.KafkaOwnerName, common.KafkaOwnerNamespace))
+	manifest, err := r.rawKafkaSourceManifest.Transform(
+		common.SetAnnotations(map[string]string{
+			common.KafkaOwnerName:      instance.Name,
+			common.KafkaOwnerNamespace: instance.Namespace,
+		}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load KafkaSource manifest: %w", err)
 	}

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,19 +81,7 @@ func add(mgr manager.Manager, r *ReconcileKnativeKafka) error {
 	// common function to enqueue reconcile requests for resources
 	enqueueRequests := common.EnqueueRequestByOwnerAnnotations(common.KafkaOwnerName, common.KafkaOwnerNamespace)
 
-	gvkToResource := make(map[schema.GroupVersionKind]runtime.Object)
-
-	// Watch for Knative KafkaChannel resources.
-	kafkaChannelResources := r.rawKafkaChannelManifest.Resources()
-	for i := range kafkaChannelResources {
-		gvkToResource[kafkaChannelResources[i].GroupVersionKind()] = &kafkaChannelResources[i]
-	}
-
-	// Watch for Knative KafkaSource resources.
-	kafkaSourceResources := r.rawKafkaSourceManifest.Resources()
-	for i := range kafkaSourceResources {
-		gvkToResource[kafkaSourceResources[i].GroupVersionKind()] = &kafkaSourceResources[i]
-	}
+	gvkToResource := common.BuildGVKToResourceMap(r.rawKafkaChannelManifest, r.rawKafkaSourceManifest)
 
 	for _, t := range gvkToResource {
 		err = c.Watch(&source.Kind{Type: t}, &handler.EnqueueRequestsFromMapFunc{ToRequests: enqueueRequests})

--- a/knative-operator/pkg/controller/knativeserving/dashboard/dashboard.go
+++ b/knative-operator/pkg/controller/knativeserving/dashboard/dashboard.go
@@ -64,7 +64,10 @@ func manifest(instance *servingv1alpha1.KnativeServing, apiclient client.Client)
 	// set owner to watch events.
 	transforms := []mf.Transformer{
 		mf.InjectNamespace(ConfigManagedNamespace),
-		common.SetOwnerAnnotations(instance.ObjectMeta, common.ServingOwnerName, common.ServingOwnerNamespace),
+		common.SetAnnotations(map[string]string{
+			common.ServingOwnerName:      instance.Name,
+			common.ServingOwnerNamespace: instance.Namespace,
+		}),
 	}
 
 	manifest, err = manifest.Transform(transforms...)

--- a/knative-operator/pkg/controller/knativeserving/dashboard/dashboard.go
+++ b/knative-operator/pkg/controller/knativeserving/dashboard/dashboard.go
@@ -62,7 +62,10 @@ func manifest(instance *servingv1alpha1.KnativeServing, apiclient client.Client)
 	}
 
 	// set owner to watch events.
-	transforms := []mf.Transformer{mf.InjectNamespace(ConfigManagedNamespace), common.SetOwnerAnnotations(instance)}
+	transforms := []mf.Transformer{
+		mf.InjectNamespace(ConfigManagedNamespace),
+		common.SetOwnerAnnotations(instance.ObjectMeta, common.ServingOwnerName, common.ServingOwnerNamespace),
+	}
 
 	manifest, err = manifest.Transform(transforms...)
 	if err != nil {

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -95,11 +95,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// append ConsoleCLIDownload type as well to Watch for kn CCD CO
 	gvkToResource[consolev1.GroupVersion.WithKind("ConsoleCLIDownload")] = &consolev1.ConsoleCLIDownload{}
 
-	// common function to enqueue reconcile requests for resources
-	enqueueRequests := common.EnqueueRequestByOwnerAnnotations(common.ServingOwnerName, common.ServingOwnerNamespace)
-
 	for _, t := range gvkToResource {
-		err = c.Watch(&source.Kind{Type: t}, &handler.EnqueueRequestsFromMapFunc{ToRequests: enqueueRequests})
+		err = c.Watch(&source.Kind{Type: t}, common.EnqueueRequestByOwnerAnnotations(common.ServingOwnerName, common.ServingOwnerNamespace))
 		if err != nil {
 			return err
 		}

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
@@ -85,18 +84,13 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for Kourier resources.
+	// Load Kourier resources to watch them
 	kourierManifest, err := kourier.RawManifest(mgr.GetClient())
 	if err != nil {
 		return err
 	}
-	kourierResources := kourierManifest.Resources()
 
-	gvkToResource := make(map[schema.GroupVersionKind]runtime.Object)
-	for i := range kourierResources {
-		resource := &kourierResources[i]
-		gvkToResource[resource.GroupVersionKind()] = resource
-	}
+	gvkToResource := common.BuildGVKToResourceMap(kourierManifest)
 
 	// append ConsoleCLIDownload type as well to Watch for kn CCD CO
 	gvkToResource[consolev1.GroupVersion.WithKind("ConsoleCLIDownload")] = &consolev1.ConsoleCLIDownload{}

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -86,17 +86,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// common function to enqueue reconcile requests for resources
-	enqueueRequests := handler.ToRequestsFunc(func(obj handler.MapObject) []reconcile.Request {
-		annotations := obj.Meta.GetAnnotations()
-		ownerNamespace := annotations[common.ServingOwnerNamespace]
-		ownerName := annotations[common.ServingOwnerName]
-		if ownerNamespace != "" && ownerName != "" {
-			return []reconcile.Request{{
-				NamespacedName: types.NamespacedName{Namespace: ownerNamespace, Name: ownerName},
-			}}
-		}
-		return nil
-	})
+	enqueueRequests := common.EnqueueRequestByOwnerAnnotations(common.ServingOwnerName, common.ServingOwnerNamespace)
 
 	// Watch for Kourier resources.
 	manifest, err := kourier.RawManifest(mgr.GetClient())

--- a/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
+++ b/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
@@ -143,13 +143,7 @@ func manifest(namespace string, apiclient client.Client, instance *servingv1alph
 	transforms := []mf.Transformer{
 		mf.InjectNamespace(namespace),
 		replaceImageFromEnvironment("IMAGE_", scheme),
-		func(u *unstructured.Unstructured) error {
-			u.SetAnnotations(map[string]string{
-				common.ServingOwnerName:      instance.Name,
-				common.ServingOwnerNamespace: instance.Namespace,
-			})
-			return nil
-		},
+		common.SetOwnerAnnotations(instance.ObjectMeta, common.ServingOwnerName, common.ServingOwnerNamespace),
 		replaceDeploymentInstanceCount(instance.Spec.HighAvailability, scheme),
 	}
 	return manifest.Transform(transforms...)

--- a/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
+++ b/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
@@ -143,7 +143,10 @@ func manifest(namespace string, apiclient client.Client, instance *servingv1alph
 	transforms := []mf.Transformer{
 		mf.InjectNamespace(namespace),
 		replaceImageFromEnvironment("IMAGE_", scheme),
-		common.SetOwnerAnnotations(instance.ObjectMeta, common.ServingOwnerName, common.ServingOwnerNamespace),
+		common.SetAnnotations(map[string]string{
+			common.ServingOwnerName:      instance.Name,
+			common.ServingOwnerNamespace: instance.Namespace,
+		}),
 		replaceDeploymentInstanceCount(instance.Spec.HighAvailability, scheme),
 	}
 	return manifest.Transform(transforms...)


### PR DESCRIPTION
Bases https://github.com/openshift-knative/serverless-operator/pull/496

Does not change any logic, simply does some refactoring. 

Created reusable functions for following:
- injecting owner annotations
- creating reconciliation enqueue request for watched resources
- finding the resource types to watch


EACH in different commits