### PR TITLE
[SRVKS-596] Propagate OpenShift Route labels from Knative Ingress's

### DIFF
--- a/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
+++ b/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
@@ -190,7 +190,9 @@ func TestIngressController(t *testing.T) {
 	tests := []struct {
 		name              string
 		annotations       map[string]string
-		want              map[string]string
+		labels            map[string]string
+		wantAnnotations   map[string]string
+		wantLabels        map[string]string
 		wantRouteErr      func(err error) bool
 		wantNetworkPolicy bool // ServiceMesh required NetworkPolicy but it is no longer necessary. Now we confirm that NetworkPolicy knative-serving-allow-all is always deleted.
 		deleted           bool
@@ -199,7 +201,8 @@ func TestIngressController(t *testing.T) {
 		{
 			name:              "reconcile route with timeout annotation",
 			annotations:       map[string]string{},
-			want:              map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantAnnotations:   map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantLabels:        map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name},
 			wantRouteErr:      func(err error) bool { return err == nil },
 			wantNetworkPolicy: false,
 			deleted:           false,
@@ -207,7 +210,18 @@ func TestIngressController(t *testing.T) {
 		{
 			name:              "reconcile route with taking over annotations",
 			annotations:       map[string]string{serving.CreatorAnnotation: "userA", serving.UpdaterAnnotation: "userB"},
-			want:              map[string]string{serving.CreatorAnnotation: "userA", serving.UpdaterAnnotation: "userB", resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantAnnotations:   map[string]string{serving.CreatorAnnotation: "userA", serving.UpdaterAnnotation: "userB", resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantLabels:        map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name},
+			wantRouteErr:      func(err error) bool { return err == nil },
+			wantNetworkPolicy: false,
+			deleted:           false,
+		},
+		{
+			name:              "reconcile route with taking over labels",
+			annotations:       map[string]string{},
+			labels:            map[string]string{"somekey": "someval"},
+			wantAnnotations:   map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantLabels:        map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name, "somekey": "someval"},
 			wantRouteErr:      func(err error) bool { return err == nil },
 			wantNetworkPolicy: false,
 			deleted:           false,
@@ -215,7 +229,8 @@ func TestIngressController(t *testing.T) {
 		{
 			name:              "do not reconcile with disable route annotation",
 			annotations:       map[string]string{resources.DisableRouteAnnotation: ""},
-			want:              nil,
+			wantAnnotations:   nil,
+			wantLabels:        nil,
 			wantRouteErr:      errors.IsNotFound,
 			wantNetworkPolicy: false,
 			deleted:           false,
@@ -223,7 +238,8 @@ func TestIngressController(t *testing.T) {
 		{
 			name:              "reconcile route with different ingress annotation",
 			annotations:       map[string]string{networking.IngressClassAnnotationKey: "kourier"},
-			want:              map[string]string{networking.IngressClassAnnotationKey: "kourier", resources.TimeoutAnnotation: "5s"},
+			wantAnnotations:   map[string]string{networking.IngressClassAnnotationKey: "kourier", resources.TimeoutAnnotation: "5s"},
+			wantLabels:        map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name},
 			wantRouteErr:      func(err error) bool { return err == nil },
 			wantNetworkPolicy: false,
 			deleted:           false,
@@ -240,6 +256,13 @@ func TestIngressController(t *testing.T) {
 				annotations[k] = v
 			}
 			ingress.SetAnnotations(annotations)
+
+			// Set test labels
+			labels := ingress.GetLabels()
+			for k, v := range test.labels {
+				labels[k] = v
+			}
+			ingress.SetLabels(labels)
 
 			if test.deleted {
 				deletedTime := metav1.Now()
@@ -279,7 +302,8 @@ func TestIngressController(t *testing.T) {
 			err := cl.Get(context.TODO(), types.NamespacedName{Name: routeName0, Namespace: serviceMeshNamespace}, routes)
 
 			assert.True(t, test.wantRouteErr(err))
-			assert.Equal(t, test.want, routes.ObjectMeta.Annotations)
+			assert.Equal(t, test.wantAnnotations, routes.ObjectMeta.Annotations)
+			assert.Equal(t, test.wantLabels, routes.ObjectMeta.Labels)
 		})
 	}
 }

--- a/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
+++ b/serving/ingress/pkg/controller/ingress/ingress_controller_test.go
@@ -188,61 +188,47 @@ func TestIngressController(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 
 	tests := []struct {
-		name              string
-		annotations       map[string]string
-		labels            map[string]string
-		wantAnnotations   map[string]string
-		wantLabels        map[string]string
-		wantRouteErr      func(err error) bool
-		wantNetworkPolicy bool // ServiceMesh required NetworkPolicy but it is no longer necessary. Now we confirm that NetworkPolicy knative-serving-allow-all is always deleted.
-		deleted           bool
-		extraObjs         []runtime.Object
+		name            string
+		annotations     map[string]string
+		labels          map[string]string
+		wantAnnotations map[string]string
+		wantLabels      map[string]string
+		wantRouteErr    func(err error) bool
+		extraObjs       []runtime.Object
 	}{
 		{
-			name:              "reconcile route with timeout annotation",
-			annotations:       map[string]string{},
-			wantAnnotations:   map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
-			wantLabels:        map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name},
-			wantRouteErr:      func(err error) bool { return err == nil },
-			wantNetworkPolicy: false,
-			deleted:           false,
+			name:            "reconcile route with timeout annotation",
+			wantAnnotations: map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantLabels:      map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name},
+			wantRouteErr:    func(err error) bool { return err == nil },
 		},
 		{
-			name:              "reconcile route with taking over annotations",
-			annotations:       map[string]string{serving.CreatorAnnotation: "userA", serving.UpdaterAnnotation: "userB"},
-			wantAnnotations:   map[string]string{serving.CreatorAnnotation: "userA", serving.UpdaterAnnotation: "userB", resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
-			wantLabels:        map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name},
-			wantRouteErr:      func(err error) bool { return err == nil },
-			wantNetworkPolicy: false,
-			deleted:           false,
+			name:            "reconcile route with taking over annotations",
+			annotations:     map[string]string{serving.CreatorAnnotation: "userA", serving.UpdaterAnnotation: "userB"},
+			wantAnnotations: map[string]string{serving.CreatorAnnotation: "userA", serving.UpdaterAnnotation: "userB", resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantLabels:      map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name},
+			wantRouteErr:    func(err error) bool { return err == nil },
 		},
 		{
-			name:              "reconcile route with taking over labels",
-			annotations:       map[string]string{},
-			labels:            map[string]string{"somekey": "someval"},
-			wantAnnotations:   map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
-			wantLabels:        map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name, "somekey": "someval"},
-			wantRouteErr:      func(err error) bool { return err == nil },
-			wantNetworkPolicy: false,
-			deleted:           false,
+			name:            "reconcile route with taking over labels",
+			labels:          map[string]string{"somekey": "someval"},
+			wantAnnotations: map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantLabels:      map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name, "somekey": "someval"},
+			wantRouteErr:    func(err error) bool { return err == nil },
 		},
 		{
-			name:              "do not reconcile with disable route annotation",
-			annotations:       map[string]string{resources.DisableRouteAnnotation: ""},
-			wantAnnotations:   nil,
-			wantLabels:        nil,
-			wantRouteErr:      errors.IsNotFound,
-			wantNetworkPolicy: false,
-			deleted:           false,
+			name:            "do not reconcile with disable route annotation",
+			annotations:     map[string]string{resources.DisableRouteAnnotation: ""},
+			wantAnnotations: nil,
+			wantLabels:      nil,
+			wantRouteErr:    errors.IsNotFound,
 		},
 		{
-			name:              "reconcile route with different ingress annotation",
-			annotations:       map[string]string{networking.IngressClassAnnotationKey: "kourier"},
-			wantAnnotations:   map[string]string{networking.IngressClassAnnotationKey: "kourier", resources.TimeoutAnnotation: "5s"},
-			wantLabels:        map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name},
-			wantRouteErr:      func(err error) bool { return err == nil },
-			wantNetworkPolicy: false,
-			deleted:           false,
+			name:            "reconcile route with different ingress annotation",
+			annotations:     map[string]string{networking.IngressClassAnnotationKey: "kourier"},
+			wantAnnotations: map[string]string{networking.IngressClassAnnotationKey: "kourier", resources.TimeoutAnnotation: "5s"},
+			wantLabels:      map[string]string{serving.RouteNamespaceLabelKey: namespace, serving.RouteLabelKey: name, networking.IngressLabelKey: name},
+			wantRouteErr:    func(err error) bool { return err == nil },
 		},
 	}
 
@@ -263,11 +249,6 @@ func TestIngressController(t *testing.T) {
 				labels[k] = v
 			}
 			ingress.SetLabels(labels)
-
-			if test.deleted {
-				deletedTime := metav1.Now()
-				ingress.SetDeletionTimestamp(&deletedTime)
-			}
 
 			// route object
 			route := &routev1.Route{}

--- a/serving/ingress/pkg/controller/ingress/resources/route.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route.go
@@ -13,7 +13,6 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving"
 )
 
 const (
@@ -92,11 +91,8 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 		}
 	}
 
-	ingressLabels := ci.GetLabels()
 	labels := kmeta.UnionMaps(ci.Labels, map[string]string{
-		networking.IngressLabelKey:     ci.GetName(),
-		serving.RouteLabelKey:          ingressLabels[serving.RouteLabelKey],
-		serving.RouteNamespaceLabelKey: ingressLabels[serving.RouteNamespaceLabelKey],
+		networking.IngressLabelKey: ci.GetName(),
 	})
 
 	name := routeName(string(ci.GetUID()), host)

--- a/serving/ingress/pkg/controller/ingress/resources/route.go
+++ b/serving/ingress/pkg/controller/ingress/resources/route.go
@@ -9,6 +9,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
@@ -91,12 +92,12 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 		}
 	}
 
-	labels := make(map[string]string)
-	labels[networking.IngressLabelKey] = ci.GetName()
-
 	ingressLabels := ci.GetLabels()
-	labels[serving.RouteLabelKey] = ingressLabels[serving.RouteLabelKey]
-	labels[serving.RouteNamespaceLabelKey] = ingressLabels[serving.RouteNamespaceLabelKey]
+	labels := kmeta.UnionMaps(ci.Labels, map[string]string{
+		networking.IngressLabelKey:     ci.GetName(),
+		serving.RouteLabelKey:          ingressLabels[serving.RouteLabelKey],
+		serving.RouteNamespaceLabelKey: ingressLabels[serving.RouteNamespaceLabelKey],
+	})
 
 	name := routeName(string(ci.GetUID()), host)
 	serviceName := ""


### PR DESCRIPTION
This patch changes:
- to propagate OpenShift Route labels from Knative Ingress
- to trigger reconcile if OpenShift Route's labels or annotations are different from desired.

/cc @markusthoemmes @bbrowning 