### PR TITLE
Move references to v1.10.0 and add missing images

### DIFF
--- a/olm-catalog/serverless-operator/csv.template.yaml
+++ b/olm-catalog/serverless-operator/csv.template.yaml
@@ -290,7 +290,7 @@ spec:
               containers:
                 - name: knative-openshift
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-operator
                   command:
                   - knative-openshift
                   imagePullPolicy: Always
@@ -338,7 +338,7 @@ spec:
               containers:
                 - name: knative-openshift-ingress
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-openshift-ingress
                   command:
                   - knative-openshift-ingress
                   imagePullPolicy: Always
@@ -432,5 +432,11 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
+    - name: knative-openshift
+      # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-operator
+    - name: knative-openshift-ingress
+      # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-openshift-ingress
   replaces: serverless-operator.v1.9.0
   version: 1.10.0

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -348,7 +348,7 @@ spec:
               containers:
               - name: knative-openshift
                 # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-operator
                 command:
                 - knative-openshift
                 imagePullPolicy: Always
@@ -454,7 +454,7 @@ spec:
               containers:
               - name: knative-openshift-ingress
                 # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-openshift-ingress
                 command:
                 - knative-openshift-ingress
                 imagePullPolicy: Always
@@ -548,6 +548,12 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
+  - name: knative-openshift
+    # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
+    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-operator
+  - name: knative-openshift-ingress
+    # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
+    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-openshift-ingress
   - name: "IMAGE_DISPATCHER_IMAGE"
     image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
   - name: "IMAGE_KN_CLI_ARTIFACTS"


### PR DESCRIPTION
Supersedes #519 and adds the missing images to relatedImages.

/assign @matzew 