### PR TITLE
Implement static parts of the serving and eventing extensions

### DIFF
--- a/openshift-knative-operator/cmd/operator/main.go
+++ b/openshift-knative-operator/cmd/operator/main.go
@@ -4,11 +4,14 @@ import (
 	"knative.dev/operator/pkg/reconciler/knativeeventing"
 	"knative.dev/operator/pkg/reconciler/knativeserving"
 	"knative.dev/pkg/injection/sharedmain"
+
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/eventing"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/serving"
 )
 
 func main() {
 	sharedmain.Main("knative-operator",
-		knativeeventing.NewController,
-		knativeserving.NewController,
+		knativeeventing.NewExtendedController(eventing.NewExtension),
+		knativeserving.NewExtendedController(serving.NewExtension),
 	)
 }

--- a/openshift-knative-operator/go.mod
+++ b/openshift-knative-operator/go.mod
@@ -5,8 +5,11 @@ go 1.14
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
+	github.com/google/go-cmp v0.5.2
 	github.com/grpc-ecosystem/grpc-gateway v1.14.8 // indirect
-	k8s.io/api v0.18.8 // indirect
+	github.com/manifestival/manifestival v0.6.1-0.20200803172850-17489fb53356
+	k8s.io/api v0.18.8
+	k8s.io/apimachinery v0.19.1
 	k8s.io/code-generator v0.18.8 // indirect
 	knative.dev/operator v0.17.2
 	knative.dev/pkg v0.0.0-20200831162708-14fb2347fb77

--- a/openshift-knative-operator/pkg/common/config.go
+++ b/openshift-knative-operator/pkg/common/config.go
@@ -1,0 +1,16 @@
+package common
+
+import "knative.dev/operator/pkg/apis/operator/v1alpha1"
+
+// Configure sets a value in the given ConfigMap under the given key.
+func Configure(s *v1alpha1.CommonSpec, cm, key, value string) {
+	if s.Config == nil {
+		s.Config = make(map[string]map[string]string, 1)
+	}
+
+	if s.Config[cm] == nil {
+		s.Config[cm] = make(map[string]string, 1)
+	}
+
+	s.Config[cm][key] = value
+}

--- a/openshift-knative-operator/pkg/common/config_test.go
+++ b/openshift-knative-operator/pkg/common/config_test.go
@@ -1,0 +1,76 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
+
+func TestConfigure(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       v1alpha1.ConfigMapData
+		expected v1alpha1.ConfigMapData
+	}{{
+		name: "all nil",
+		expected: v1alpha1.ConfigMapData{
+			"foo": map[string]string{
+				"bar": "baz",
+			},
+		},
+	}, {
+		name: "first level already set",
+		in: v1alpha1.ConfigMapData{
+			"foo": map[string]string{},
+		},
+		expected: v1alpha1.ConfigMapData{
+			"foo": map[string]string{
+				"bar": "baz",
+			},
+		},
+	}, {
+		name: "override",
+		in: v1alpha1.ConfigMapData{
+			"foo": map[string]string{
+				"bar": "nope",
+			},
+		},
+		expected: v1alpha1.ConfigMapData{
+			"foo": map[string]string{
+				"bar": "baz",
+			},
+		},
+	}, {
+		name: "unrelated values",
+		in: v1alpha1.ConfigMapData{
+			"foo": map[string]string{
+				"bar2": "baz2",
+			},
+			"foo2": map[string]string{
+				"bar": "baz",
+			},
+		},
+		expected: v1alpha1.ConfigMapData{
+			"foo": map[string]string{
+				"bar":  "baz",
+				"bar2": "baz2",
+			},
+			"foo2": map[string]string{
+				"bar": "baz",
+			},
+		},
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := &v1alpha1.CommonSpec{Config: c.in}
+			Configure(s, "foo", "bar", "baz")
+
+			if !cmp.Equal(s.Config, c.expected) {
+				t.Errorf("Got = %v, want: %v, diff:\n%s", s.Config, c.expected, cmp.Diff(s.Config, c.expected))
+			}
+		})
+	}
+}

--- a/openshift-knative-operator/pkg/common/images.go
+++ b/openshift-knative-operator/pkg/common/images.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"strings"
+)
+
+const imagePrefix = "IMAGE_"
+
+// ImageMapFromEnvironment generates a map of deployment/container to image from
+// the passed environment variables.
+func ImageMapFromEnvironment(env []string) map[string]string {
+	overrideMap := map[string]string{}
+
+	for _, e := range env {
+		pair := strings.SplitN(e, "=", 2)
+		if strings.HasPrefix(pair[0], imagePrefix) {
+			if pair[1] == "" {
+				continue
+			}
+
+			/*
+				converts:
+				IMAGE_container=foo             -> container: foo
+				IMAGE_deployment__container=foo -> deployment/container: foo
+				IMAGE_env_var=foo               -> env_var: foo
+				IMAGE_deployment__env_var=foo   -> deployment/env_var: foo
+			*/
+			name := strings.TrimPrefix(pair[0], imagePrefix)
+			name = strings.Replace(name, "__", "/", 1)
+			overrideMap[name] = pair[1]
+		}
+	}
+	return overrideMap
+}

--- a/openshift-knative-operator/pkg/common/images_test.go
+++ b/openshift-knative-operator/pkg/common/images_test.go
@@ -1,0 +1,90 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestImageMapFromEnvironment(t *testing.T) {
+	cases := []struct {
+		name     string
+		envMap   map[string]string
+		expected map[string]string
+	}{{
+		name: "Simple container name",
+		envMap: map[string]string{
+			"IMAGE_foo": "quay.io/myimage",
+		},
+		expected: map[string]string{
+			"foo": "quay.io/myimage",
+		},
+	}, {
+		name: "Simple env var",
+		envMap: map[string]string{
+			"IMAGE_CRONJOB_RA_IMAGE": "quay.io/myimage",
+		},
+		expected: map[string]string{
+			"CRONJOB_RA_IMAGE": "quay.io/myimage",
+		},
+	}, {
+		name: "Simple env var with deployment name",
+		envMap: map[string]string{
+			"IMAGE_eventing-controller__CRONJOB_RA_IMAGE": "quay.io/myimage",
+		},
+		expected: map[string]string{
+			"eventing-controller/CRONJOB_RA_IMAGE": "quay.io/myimage",
+		},
+	}, {
+		name: "Deployment+container name",
+		envMap: map[string]string{
+			"IMAGE_foo__bar": "quay.io/myimage",
+		},
+		expected: map[string]string{
+			"foo/bar": "quay.io/myimage",
+		},
+	}, {
+		name: "Deployment+container and container name",
+		envMap: map[string]string{
+			"IMAGE_foo__bar": "quay.io/myimage1",
+			"IMAGE_bar":      "quay.io/myimage2",
+		},
+		expected: map[string]string{
+			"foo/bar": "quay.io/myimage1",
+			"bar":     "quay.io/myimage2",
+		},
+	}, {
+		name: "Different prefix",
+		envMap: map[string]string{
+			"X_foo": "quay.io/myimage",
+		},
+		expected: map[string]string{},
+	}, {
+		name: "No env var value",
+		envMap: map[string]string{
+			"IMAGE_foo": "",
+		},
+		expected: map[string]string{},
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			environ := environFromMap(c.envMap)
+			overrideMap := ImageMapFromEnvironment(environ)
+
+			if !cmp.Equal(overrideMap, c.expected) {
+				t.Errorf("Got = %v, want: %v, diff:\n%s", overrideMap, c.expected, cmp.Diff(overrideMap, c.expected))
+			}
+		})
+	}
+}
+
+func environFromMap(envMap map[string]string) []string {
+	e := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		e = append(e, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return e
+}

--- a/openshift-knative-operator/pkg/common/resources.go
+++ b/openshift-knative-operator/pkg/common/resources.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
+
+// EnsureContainerMemoryLimit makes sure the memory limit for the given container is set
+// to the specified amount if not otherwise configured already.
+func EnsureContainerMemoryLimit(s *v1alpha1.CommonSpec, containerName string, memory resource.Quantity) {
+	for i, v := range s.Resources {
+		if v.Container == containerName {
+			if v.Limits == nil {
+				v.Limits = corev1.ResourceList{}
+			}
+			if _, ok := v.Limits[corev1.ResourceMemory]; ok {
+				return
+			}
+			v.Limits[corev1.ResourceMemory] = memory
+			s.Resources[i] = v
+			return
+		}
+	}
+	s.Resources = append(s.Resources, v1alpha1.ResourceRequirementsOverride{
+		Container: containerName,
+		ResourceRequirements: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: memory,
+			},
+		},
+	})
+}

--- a/openshift-knative-operator/pkg/common/resources_test.go
+++ b/openshift-knative-operator/pkg/common/resources_test.go
@@ -1,0 +1,97 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
+
+func TestEnsureContainerMemoryLimit(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       []v1alpha1.ResourceRequirementsOverride
+		expected []v1alpha1.ResourceRequirementsOverride
+	}{{
+		name: "all nil",
+		expected: []v1alpha1.ResourceRequirementsOverride{{
+			Container: "foo",
+			ResourceRequirements: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1024Mi"),
+				},
+			},
+		}},
+	}, {
+		name: "don't override",
+		in: []v1alpha1.ResourceRequirementsOverride{{
+			Container: "foo",
+			ResourceRequirements: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2048Mi"),
+				},
+			},
+		}},
+		expected: []v1alpha1.ResourceRequirementsOverride{{
+			Container: "foo",
+			ResourceRequirements: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2048Mi"),
+				},
+			},
+		}},
+	}, {
+		name: "leave other values alone",
+		in: []v1alpha1.ResourceRequirementsOverride{{
+			Container: "foo",
+			ResourceRequirements: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
+				},
+			},
+		}},
+		expected: []v1alpha1.ResourceRequirementsOverride{{
+			Container: "foo",
+			ResourceRequirements: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("1024Mi"),
+				},
+			},
+		}},
+	}, {
+		name: "leave request values alone",
+		in: []v1alpha1.ResourceRequirementsOverride{{
+			Container: "foo",
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
+				},
+			},
+		}},
+		expected: []v1alpha1.ResourceRequirementsOverride{{
+			Container: "foo",
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1024Mi"),
+				},
+			},
+		}},
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := &v1alpha1.CommonSpec{Resources: c.in}
+			EnsureContainerMemoryLimit(s, "foo", resource.MustParse("1024Mi"))
+
+			if !cmp.Equal(s.Resources, c.expected) {
+				t.Errorf("Got = %v, want: %v, diff:\n%s", s.Resources, c.expected, cmp.Diff(s.Resources, c.expected))
+			}
+		})
+	}
+}

--- a/openshift-knative-operator/pkg/eventing/extension.go
+++ b/openshift-knative-operator/pkg/eventing/extension.go
@@ -2,12 +2,16 @@ package eventing
 
 import (
 	"context"
+	"os"
 
 	mf "github.com/manifestival/manifestival"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	operator "knative.dev/operator/pkg/reconciler/common"
 )
 
+// NewExtension creates a new extension for a Knative Eventing controller.
 func NewExtension(ctx context.Context) operator.Extension {
 	return &extension{}
 }
@@ -19,6 +23,16 @@ func (e *extension) Transformers(v1alpha1.KComponent) []mf.Transformer {
 }
 
 func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) error {
+	ke := comp.(*v1alpha1.KnativeEventing)
+
+	// Override images.
+	images := common.ImageMapFromEnvironment(os.Environ())
+	ke.Spec.Registry.Override = images
+	ke.Spec.Registry.Default = images["default"]
+
+	// Ensure webhook has 1G of memory.
+	common.EnsureContainerMemoryLimit(&ke.Spec.CommonSpec, "eventing-webhook", resource.MustParse("1024Mi"))
+
 	return nil
 }
 

--- a/openshift-knative-operator/pkg/eventing/extension.go
+++ b/openshift-knative-operator/pkg/eventing/extension.go
@@ -26,6 +26,7 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	ke := comp.(*v1alpha1.KnativeEventing)
 
 	// Override images.
+	// TODO(SRVCOM-1069): Rethink overriding behavior and/or error surfacing.
 	images := common.ImageMapFromEnvironment(os.Environ())
 	ke.Spec.Registry.Override = images
 	ke.Spec.Registry.Default = images["default"]

--- a/openshift-knative-operator/pkg/eventing/extension.go
+++ b/openshift-knative-operator/pkg/eventing/extension.go
@@ -1,0 +1,27 @@
+package eventing
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operator "knative.dev/operator/pkg/reconciler/common"
+)
+
+func NewExtension(ctx context.Context) operator.Extension {
+	return &extension{}
+}
+
+type extension struct{}
+
+func (e *extension) Transformers(v1alpha1.KComponent) []mf.Transformer {
+	return nil
+}
+
+func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) error {
+	return nil
+}
+
+func (e *extension) Finalize(context.Context, v1alpha1.KComponent) error {
+	return nil
+}

--- a/openshift-knative-operator/pkg/eventing/extension_test.go
+++ b/openshift-knative-operator/pkg/eventing/extension_test.go
@@ -1,0 +1,70 @@
+package eventing
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
+
+func TestReconcile(t *testing.T) {
+	os.Setenv("IMAGE_foo", "bar")
+	os.Setenv("IMAGE_default", "bar2")
+
+	cases := []struct {
+		name     string
+		in       *v1alpha1.KnativeEventing
+		expected *v1alpha1.KnativeEventing
+	}{{
+		name:     "all nil",
+		in:       &v1alpha1.KnativeEventing{},
+		expected: ke(),
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ks := c.in.DeepCopy()
+			ext := NewExtension(context.Background())
+			ext.Reconcile(context.Background(), ks)
+
+			if !cmp.Equal(ks, c.expected) {
+				t.Errorf("Got = %v, want: %v, diff:\n%s", ks, c.expected, cmp.Diff(ks, c.expected))
+			}
+		})
+	}
+}
+
+func ke(mods ...func(*v1alpha1.KnativeEventing)) *v1alpha1.KnativeEventing {
+	base := &v1alpha1.KnativeEventing{
+		Spec: v1alpha1.KnativeEventingSpec{
+			CommonSpec: v1alpha1.CommonSpec{
+				Registry: v1alpha1.Registry{
+					Default: "bar2",
+					Override: map[string]string{
+						"default": "bar2",
+						"foo":     "bar",
+					},
+				},
+				Resources: []v1alpha1.ResourceRequirementsOverride{{
+					Container: "eventing-webhook",
+					ResourceRequirements: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("1024Mi"),
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	for _, mod := range mods {
+		mod(base)
+	}
+
+	return base
+}

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -1,0 +1,27 @@
+package serving
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operator "knative.dev/operator/pkg/reconciler/common"
+)
+
+func NewExtension(ctx context.Context) operator.Extension {
+	return &extension{}
+}
+
+type extension struct{}
+
+func (e *extension) Transformers(v1alpha1.KComponent) []mf.Transformer {
+	return nil
+}
+
+func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) error {
+	return nil
+}
+
+func (e *extension) Finalize(context.Context, v1alpha1.KComponent) error {
+	return nil
+}

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -26,6 +26,7 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	ks := comp.(*v1alpha1.KnativeServing)
 
 	// Override images.
+	// TODO(SRVCOM-1069): Rethink overriding behavior and/or error surfacing.
 	images := common.ImageMapFromEnvironment(os.Environ())
 	ks.Spec.Registry.Override = common.ImageMapFromEnvironment(os.Environ())
 	ks.Spec.Registry.Default = images["default"]
@@ -39,9 +40,11 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	}
 
 	// Use Kourier.
+	// TODO(SRVCOM-1069): Rethink overriding behavior and/or error surfacing.
 	common.Configure(&ks.Spec.CommonSpec, "network", "ingress.class", "kourier.ingress.networking.knative.dev")
 
 	// Override the default domainTemplate to use $name-$ns rather than $name.$ns.
+	// TODO(SRVCOM-1069): Rethink overriding behavior and/or error surfacing.
 	common.Configure(&ks.Spec.CommonSpec, "network", "domainTemplate", "{{.Name}}-{{.Namespace}}.{{.Domain}}")
 
 	// Ensure webhook has 1G of memory.

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -2,12 +2,16 @@ package serving
 
 import (
 	"context"
+	"os"
 
 	mf "github.com/manifestival/manifestival"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	operator "knative.dev/operator/pkg/reconciler/common"
 )
 
+// NewExtension creates a new extension for a Knative Serving controller.
 func NewExtension(ctx context.Context) operator.Extension {
 	return &extension{}
 }
@@ -19,6 +23,39 @@ func (e *extension) Transformers(v1alpha1.KComponent) []mf.Transformer {
 }
 
 func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) error {
+	ks := comp.(*v1alpha1.KnativeServing)
+
+	// Override images.
+	images := common.ImageMapFromEnvironment(os.Environ())
+	ks.Spec.Registry.Override = common.ImageMapFromEnvironment(os.Environ())
+	ks.Spec.Registry.Default = images["default"]
+	common.Configure(&ks.Spec.CommonSpec, "deployment", "queueSidecarImage", images["queue-proxy"])
+
+	// Default to 2 replicas.
+	if ks.Spec.HighAvailability == nil {
+		ks.Spec.HighAvailability = &v1alpha1.HighAvailability{
+			Replicas: 2,
+		}
+	}
+
+	// Use Kourier.
+	common.Configure(&ks.Spec.CommonSpec, "network", "ingress.class", "kourier.ingress.networking.knative.dev")
+
+	// Override the default domainTemplate to use $name-$ns rather than $name.$ns.
+	common.Configure(&ks.Spec.CommonSpec, "network", "domainTemplate", "{{.Name}}-{{.Namespace}}.{{.Domain}}")
+
+	// Ensure webhook has 1G of memory.
+	common.EnsureContainerMemoryLimit(&ks.Spec.CommonSpec, "webhook", resource.MustParse("1024Mi"))
+
+	// Add custom-certificates to the deployments (ConfigMap creation remains in the old
+	// operator for now)
+	if ks.Spec.ControllerCustomCerts == (v1alpha1.CustomCerts{}) {
+		ks.Spec.ControllerCustomCerts = v1alpha1.CustomCerts{
+			Name: "config-service-ca",
+			Type: "ConfigMap",
+		}
+	}
+
 	return nil
 }
 

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -1,0 +1,129 @@
+package serving
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
+
+func TestReconcile(t *testing.T) {
+	os.Setenv("IMAGE_foo", "bar")
+	os.Setenv("IMAGE_default", "bar2")
+	os.Setenv("IMAGE_queue-proxy", "baz")
+
+	cases := []struct {
+		name     string
+		in       *v1alpha1.KnativeServing
+		expected *v1alpha1.KnativeServing
+	}{{
+		name:     "all nil",
+		in:       &v1alpha1.KnativeServing{},
+		expected: ks(),
+	}, {
+		name: "different HA settings",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				HighAvailability: &v1alpha1.HighAvailability{
+					Replicas: 3,
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			ks.Spec.HighAvailability.Replicas = 3
+		}),
+	}, {
+		name: "different certificate settings",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				ControllerCustomCerts: v1alpha1.CustomCerts{
+					Type: "Secret",
+					Name: "foo",
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			ks.Spec.ControllerCustomCerts.Type = "Secret"
+			ks.Spec.ControllerCustomCerts.Name = "foo"
+		}),
+	}, {
+		name: "override image settings",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Registry: v1alpha1.Registry{
+						Override: map[string]string{
+							"foo":         "not",
+							"queue-proxy": "correct",
+						},
+					},
+				},
+			},
+		},
+		expected: ks(),
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ks := c.in.DeepCopy()
+			ext := NewExtension(context.Background())
+			ext.Reconcile(context.Background(), ks)
+
+			if !cmp.Equal(ks, c.expected) {
+				t.Errorf("Got = %v, want: %v, diff:\n%s", ks, c.expected, cmp.Diff(ks, c.expected))
+			}
+		})
+	}
+}
+
+func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
+	base := &v1alpha1.KnativeServing{
+		Spec: v1alpha1.KnativeServingSpec{
+			CommonSpec: v1alpha1.CommonSpec{
+				Config: v1alpha1.ConfigMapData{
+					"deployment": map[string]string{
+						"queueSidecarImage": "baz",
+					},
+					"network": map[string]string{
+						"domainTemplate": "{{.Name}}-{{.Namespace}}.{{.Domain}}",
+						"ingress.class":  "kourier.ingress.networking.knative.dev",
+					},
+				},
+				Registry: v1alpha1.Registry{
+					Default: "bar2",
+					Override: map[string]string{
+						"default":     "bar2",
+						"foo":         "bar",
+						"queue-proxy": "baz",
+					},
+				},
+				Resources: []v1alpha1.ResourceRequirementsOverride{{
+					Container: "webhook",
+					ResourceRequirements: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("1024Mi"),
+						},
+					},
+				}},
+			},
+			ControllerCustomCerts: v1alpha1.CustomCerts{
+				Type: "ConfigMap",
+				Name: "config-service-ca",
+			},
+			HighAvailability: &v1alpha1.HighAvailability{
+				Replicas: 2,
+			},
+		},
+	}
+
+	for _, mod := range mods {
+		mod(base)
+	}
+
+	return base
+}

--- a/openshift-knative-operator/vendor/modules.txt
+++ b/openshift-knative-operator/vendor/modules.txt
@@ -114,6 +114,7 @@ github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/go-cmp v0.5.2
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
@@ -155,6 +156,7 @@ github.com/mailru/easyjson/jwriter
 github.com/manifestival/client-go-client
 github.com/manifestival/client-go-client/pkg/dynamic
 # github.com/manifestival/manifestival v0.6.1-0.20200803172850-17489fb53356
+## explicit
 github.com/manifestival/manifestival
 github.com/manifestival/manifestival/internal/overlay
 github.com/manifestival/manifestival/internal/patch
@@ -527,6 +529,7 @@ k8s.io/api/storage/v1beta1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 # k8s.io/apimachinery v0.19.1 => k8s.io/apimachinery v0.17.6
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta


### PR DESCRIPTION
This has gotten somewhat big but the business logic itself should be fairly small in surface. The tests are fairly large. Please let me know if this should be cut smaller, I didn't want to get too spammy with PRs either.