### PR TITLE
Import CLI directly in Dockerfile

### DIFF
--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -1,5 +1,5 @@
 FROM src
 
-COPY oc /usr/bin/oc
+COPY --from=registry.svc.ci.openshift.org/ocp/4.5:cli /usr/bin/oc /usr/bin/oc
 COPY --from=registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-src /go/src/knative.dev/serving/ /go/src/knative.dev/serving/
 COPY --from=registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-src /go/src/knative.dev/eventing/ /go/src/knative.dev/eventing/


### PR DESCRIPTION
This should fix the issue with post-submit build failures where CLI image is not available. From discussion on forum-testplatform it seems that the CLI image is not imported in time. Let's move this import to a later time and don't depend on CI image imports.

Related to https://github.com/openshift/release/pull/12599 . The PR cleans up some stuff.