### PR TITLE
[SRVKS-610] Update Kourier to 0.17

### DIFF
--- a/knative-operator/deploy/resources/kourier/download.sh
+++ b/knative-operator/deploy/resources/kourier/download.sh
@@ -16,7 +16,6 @@ if [ $? != 0 ]; then
 fi
 
 # TODO: [SRVKS-610] These values should be replaced by operator instead of sed.
-sed -i -e 's/value: "kourier-system"/value: "knative-serving-ingress"/g'                 kourier-${KOURIER_VERSION}.yaml
 sed -i -e 's/kourier-control.knative-serving/kourier-control.knative-serving-ingress/g'  kourier-${KOURIER_VERSION}.yaml
 
 if [ -L "kourier-latest.yaml" ]; then

--- a/knative-operator/deploy/resources/kourier/download.sh
+++ b/knative-operator/deploy/resources/kourier/download.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-KOURIER_VERSION=release-0.16
+KOURIER_VERSION=release-0.17
 DOWNLOAD_URL=https://raw.githubusercontent.com/openshift-knative/net-kourier/${KOURIER_VERSION}/deploy/kourier-knative.yaml
 
 if [ -f "kourier-${KOURIER_VERSION}.yaml" ]; then
@@ -14,6 +14,10 @@ if [ $? != 0 ]; then
   echo "Failed to download kourier yaml"
   exit 1
 fi
+
+# TODO: [SRVKS-610] These values should be replaced by operator instead of sed.
+sed -i -e 's/value: "kourier-system"/value: "knative-serving-ingress"/g'                 kourier-${KOURIER_VERSION}.yaml
+sed -i -e 's/kourier-control.knative-serving/kourier-control.knative-serving-ingress/g'  kourier-${KOURIER_VERSION}.yaml
 
 if [ -L "kourier-latest.yaml" ]; then
   unlink kourier-latest.yaml

--- a/knative-operator/deploy/resources/kourier/kourier-latest.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier-latest.yaml
@@ -1,1 +1,1 @@
-kourier-release-0.16.yaml
+kourier-release-0.17.yaml

--- a/knative-operator/deploy/resources/kourier/kourier-release-0.17.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier-release-0.17.yaml
@@ -116,7 +116,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: KOURIER_GATEWAY_NAMESPACE
-              value: "knative-serving-ingress"
+              value: "kourier-system"
           ports:
           - name: http2-xds
             containerPort: 18000

--- a/knative-operator/deploy/resources/kourier/kourier-release-0.17.yaml
+++ b/knative-operator/deploy/resources/kourier/kourier-release-0.17.yaml
@@ -6,73 +6,6 @@ metadata:
     networking.knative.dev/ingress-provider: kourier
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: kourier-system
-  labels:
-    networking.knative.dev/ingress-provider: kourier
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: kourier-system
-  labels:
-    networking.knative.dev/ingress-provider: kourier
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-leader-election
-  namespace: kourier-system
-  labels:
-    networking.knative.dev/ingress-provider: kourier
-data:
-  _example: |
-        ################################
-        #                              #
-        #    EXAMPLE CONFIGURATION     #
-        #                              #
-        ################################
-
-        # This block is not actually functional configuration,
-        # but serves to illustrate the available configuration
-        # options and document them in a way that is accessible
-        # to users that `kubectl edit` this config map.
-        #
-        # These sample configuration options may be copied out of
-        # this example block and unindented to be in the data block
-        # to actually change the configuration.
-
-        # resourceLock controls which API resource is used as the basis for the
-        # leader election lock. Valid values are:
-        #
-        # - leases -> use the coordination API
-        # - configmaps -> use configmaps
-        # - endpoints -> use endpoints
-        resourceLock: "leases"
-
-        # leaseDuration is how long non-leaders will wait to try to acquire the
-        # lock; 15 seconds is the value used by core kubernetes controllers.
-        leaseDuration: "15s"
-        # renewDeadline is how long a leader will try to renew the lease before
-        # giving up; 10 seconds is the value used by core kubernetes controllers.
-        renewDeadline: "10s"
-        # retryPeriod is how long the leader election client waits between tries of
-        # actions; 2 seconds is the value used by core kubernetes controllers.
-        retryPeriod: "2s"
-        # enabledComponents is a comma-delimited list of component names for which
-        # leader election is enabled. Valid values are:
-        # - controller
-        # - hpaautoscaler
-        # - certcontroller
-        # - istiocontroller
-        # - nscontroller
-        # - kourier
-  enabledComponents: kourier
----
-apiVersion: v1
 kind: Service
 metadata:
   name: kourier
@@ -111,13 +44,12 @@ spec:
     spec:
       containers:
         - args:
-            - --base-id
-            - "1"
-            - -c
-            - /tmp/config/envoy-bootstrap.yaml
+            - --base-id 1
+            - -c /tmp/config/envoy-bootstrap.yaml
+            - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/maistra/proxyv2-ubi8:1.1.1
+          image: docker.io/maistra/proxyv2-ubi8:1.1.5
           imagePullPolicy: Always
           name: kourier-gateway
           ports:
@@ -136,7 +68,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["curl","-X","POST","--unix","/tmp/envoy.admin","http://localhost/healthcheck/fail"]
+                command: ["/bin/sh","-c","curl -X POST --unix /tmp/envoy.admin http://localhost/healthcheck/fail; sleep 15"]
           readinessProbe:
             httpGet:
               httpHeaders:
@@ -157,7 +89,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: 3scale-kourier-control
-  namespace: kourier-system
+  namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
 spec:
@@ -183,6 +115,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: KOURIER_GATEWAY_NAMESPACE
+              value: "knative-serving-ingress"
           ports:
           - name: http2-xds
             containerPort: 18000
@@ -194,13 +128,19 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: 3scale-kourier
-  namespace: kourier-system
+  namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
 rules:
   - apiGroups: [""]
-    resources: ["pods", "endpoints", "namespaces", "services", "secrets", "configmaps"]
+    resources: ["events"]
+    verbs: ["create","update","patch"]
+  - apiGroups: [""]
+    resources: ["pods", "endpoints", "namespaces", "services", "secrets"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch","update","create"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
@@ -218,7 +158,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: 3scale-kourier
-  namespace: kourier-system
+  namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
 ---
@@ -235,7 +175,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: 3scale-kourier
-    namespace: kourier-system
+    namespace: knative-serving
 ---
 apiVersion: v1
 kind: Service
@@ -258,7 +198,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kourier-control
-  namespace: kourier-system
+  namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
 spec:
@@ -337,7 +277,7 @@ data:
           connect_timeout: 1s
           hosts:
             - socket_address:
-                address: "kourier-control"
+                address: "kourier-control.knative-serving-ingress"
                 port_value: 18000
           http2_protocol_options: {}
           type: STRICT_DNS

--- a/knative-operator/pkg/common/deployment.go
+++ b/knative-operator/pkg/common/deployment.go
@@ -30,7 +30,7 @@ func ApplyEnvironmentToDeployment(namespace, name string, env map[string]string,
 		for k, v := range env {
 			// If value is not empty then update deployment controller with env
 			if v != "" {
-				deploy.Spec.Template.Spec.Containers[c].Env = appendUnique(deploy.Spec.Template.Spec.Containers[c].Env, k, v)
+				deploy.Spec.Template.Spec.Containers[c].Env = AppendUnique(deploy.Spec.Template.Spec.Containers[c].Env, k, v)
 			} else {
 				// If value is empty then remove those keys from deployment controller
 				deploy.Spec.Template.Spec.Containers[c].Env = remove(deploy.Spec.Template.Spec.Containers[c].Env, k)
@@ -58,7 +58,7 @@ func remove(env []v1.EnvVar, key string) []v1.EnvVar {
 	return env
 }
 
-func appendUnique(orgEnv []v1.EnvVar, key, value string) []v1.EnvVar {
+func AppendUnique(orgEnv []v1.EnvVar, key, value string) []v1.EnvVar {
 	// Set the value if the key is already present.
 	for i := range orgEnv {
 		if orgEnv[i].Name == key {

--- a/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
+++ b/knative-operator/pkg/controller/knativeserving/kourier/kourier.go
@@ -129,6 +129,29 @@ func replaceDeploymentInstanceCount(availability *servingv1alpha1.HighAvailabili
 	}
 }
 
+// replaceEnvValue replaces KOURIER_GATEWAY_NAMESPACE value in Kourier controller.
+func replaceEnvValue(namespace string, scheme *runtime.Scheme) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() == "Deployment" && u.GetName() == "3scale-kourier-control" {
+			deploy := &appsv1.Deployment{}
+			if err := scheme.Convert(u, deploy, nil); err != nil {
+				return err
+			}
+			containers := deploy.Spec.Template.Spec.Containers
+			for _, container := range containers {
+				if "3scale-"+container.Name == u.GetName() {
+					container.Env = common.AppendUnique(container.Env, "KOURIER_GATEWAY_NAMESPACE", namespace)
+					break
+				}
+			}
+			if err := scheme.Convert(deploy, u, nil); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
 // RawManifest returns kourier raw manifest without transformations
 func RawManifest(apiclient client.Client) (mf.Manifest, error) {
 	return mfc.NewManifest(manifestPath(), apiclient, mf.UseLogger(log.WithName("mf")))
@@ -148,6 +171,7 @@ func manifest(namespace string, apiclient client.Client, instance *servingv1alph
 			common.ServingOwnerNamespace: instance.Namespace,
 		}),
 		replaceDeploymentInstanceCount(instance.Spec.HighAvailability, scheme),
+		replaceEnvValue(namespace, scheme),
 	}
 	return manifest.Transform(transforms...)
 }


### PR DESCRIPTION
This patch updates Kourier to 0.17.

This patch solved SRVKS-610 by `sed` command as:

```
sed -i -e 's/kourier-control.knative-serving/kourier-control.knative-serving-ingress/g'  kourier-${KOURIER_VERSION}.yaml
```

but we should replace it with operator.

/cc @markusthoemmes 