### PR TITLE
[SRVKS-642] Add request-log-template and enable-probe-request-log to KnativeServing CR for TestRequestLogs

### DIFF
--- a/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
+++ b/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
@@ -33,6 +33,14 @@ spec:
     observability:
       logging.enable-var-log-collection: "false"
       metrics.backend-destination: "prometheus"
+      # logging.request-log-template and logging.enable-probe-request-log are necessary for TestRequestLogs.
+      logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}",
+        "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}",
+        "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent":
+        "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp":
+        "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s",
+        "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+      logging.enable-probe-request-log: "true"
     tracing:
       backend: "none"
       sample-rate: "0.1"


### PR DESCRIPTION
This patch is same with https://github.com/openshift/knative-serving/pull/523.

Without this fix, TestRequestLogs skips some tests.

https://github.com/openshift/knative-serving/blob/release-v0.17.3/test/e2e/logging_test.go#L55-L57
https://github.com/openshift/knative-serving/blob/release-v0.17.3/test/e2e/logging_test.go#L104

/cc @markusthoemmes @mgencur 