### PR TITLE
[SRVCOM-1071] Drop explicit version checks from our code

### DIFF
--- a/knative-operator/deploy/operator.yaml
+++ b/knative-operator/deploy/operator.yaml
@@ -29,8 +29,6 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "knative-openshift"
-            - name: MIN_OPENSHIFT_VERSION
-              value: "4.3.0-0"
             - name: REQUIRED_SERVING_NAMESPACE
               value: "knative-serving"
             - name: REQUIRED_EVENTING_NAMESPACE

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	webhookutil "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/util"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,7 +61,6 @@ func (v *KnativeEventingValidator) validate(ctx context.Context, ke *eventingv1a
 	log := common.Log.WithName("validate")
 	stages := []func(context.Context, *eventingv1alpha1.KnativeEventing) (bool, string, error){
 		v.validateNamespace,
-		v.validateVersion,
 		v.validateLoneliness,
 	}
 	for _, stage := range stages {
@@ -99,11 +97,6 @@ var _ inject.Decoder = (*KnativeEventingValidator)(nil)
 func (v *KnativeEventingValidator) InjectDecoder(d types.Decoder) error {
 	v.decoder = d
 	return nil
-}
-
-// validate minimum openshift version
-func (v *KnativeEventingValidator) validateVersion(ctx context.Context, _ *eventingv1alpha1.KnativeEventing) (bool, string, error) {
-	return webhookutil.ValidateOpenShiftVersion(ctx, v.client)
 }
 
 // validate required namespace, if any

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	. "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativeeventing"
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/testutil"
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,18 +39,6 @@ func TestInvalidNamespace(t *testing.T) {
 	result := validator.Handle(context.TODO(), types.Request{})
 	if result.Response.Allowed {
 		t.Error("The required namespace is wrong, but the request is allowed")
-	}
-}
-
-func TestInvalidVersion(t *testing.T) {
-	os.Clearenv()
-	os.Setenv("MIN_OPENSHIFT_VERSION", "4.1.13")
-	validator := KnativeEventingValidator{}
-	validator.InjectDecoder(&mockDecoder{ke1})
-	validator.InjectClient(fake.NewFakeClient(testutil.MockClusterVersion("3.2.0")))
-	result := validator.Handle(context.TODO(), types.Request{})
-	if result.Response.Allowed {
-		t.Error("The version is too low, but the request is allowed")
 	}
 }
 

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	webhookutil "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/util"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,7 +61,6 @@ func (v *KnativeServingValidator) validate(ctx context.Context, ks *servingv1alp
 	log := common.Log.WithName("validate")
 	stages := []func(context.Context, *servingv1alpha1.KnativeServing) (bool, string, error){
 		v.validateNamespace,
-		v.validateVersion,
 		v.validateLoneliness,
 	}
 	for _, stage := range stages {
@@ -99,11 +97,6 @@ var _ inject.Decoder = (*KnativeServingValidator)(nil)
 func (v *KnativeServingValidator) InjectDecoder(d types.Decoder) error {
 	v.decoder = d
 	return nil
-}
-
-// validate minimum openshift version
-func (v *KnativeServingValidator) validateVersion(ctx context.Context, ks *servingv1alpha1.KnativeServing) (bool, string, error) {
-	return webhookutil.ValidateOpenShiftVersion(ctx, v.client)
 }
 
 // validate required namespace, if any

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/testutil"
-
 	. "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativeserving"
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,48 +39,6 @@ func TestInvalidNamespace(t *testing.T) {
 	result := validator.Handle(context.TODO(), types.Request{})
 	if result.Response.Allowed {
 		t.Error("The required namespace is wrong, but the request is allowed")
-	}
-}
-
-func TestInvalidVersion(t *testing.T) {
-	os.Clearenv()
-	os.Setenv("MIN_OPENSHIFT_VERSION", "4.1.13")
-	validator := KnativeServingValidator{}
-	validator.InjectDecoder(&mockDecoder{ks1})
-	validator.InjectClient(fake.NewFakeClient(testutil.MockClusterVersion("3.2.0")))
-	result := validator.Handle(context.TODO(), types.Request{})
-	if result.Response.Allowed {
-		t.Error("The version is too low, but the request is allowed")
-	}
-}
-
-func TestPreReleaseVersionConstraint(t *testing.T) {
-	os.Clearenv()
-	os.Setenv("MIN_OPENSHIFT_VERSION", "4.3.0-0")
-
-	for _, version := range []string{"4.3.0", "4.4.0", "4.3.5", "4.3.0-alpha", "4.3.0-0.ci-2020-03-11-221411", "4.3.0+build"} {
-		validator := KnativeServingValidator{}
-		validator.InjectDecoder(&mockDecoder{ks1})
-		validator.InjectClient(fake.NewFakeClient(testutil.MockClusterVersion(version)))
-		result := validator.Handle(context.TODO(), types.Request{})
-		if !result.Response.Allowed {
-			t.Errorf("Version %q was supposed to pass but didn't: %v", version, result.Response)
-		}
-	}
-}
-
-func TestInvalidVersionConstraint(t *testing.T) {
-	os.Clearenv()
-	os.Setenv("MIN_OPENSHIFT_VERSION", "4.1.13")
-
-	for _, version := range []string{"4.0.0", "4.1.12", "4.1.13-alpha", "4.1.13-0.ci-2020-03-11-221411"} {
-		validator := KnativeServingValidator{}
-		validator.InjectDecoder(&mockDecoder{ks1})
-		validator.InjectClient(fake.NewFakeClient(testutil.MockClusterVersion(version)))
-		result := validator.Handle(context.TODO(), types.Request{})
-		if result.Response.Allowed {
-			t.Errorf("Version %q was NOT supposed to pass but it did: %v", version, result.Response)
-		}
 	}
 }
 

--- a/knative-operator/pkg/webhook/util/util.go
+++ b/knative-operator/pkg/webhook/util/util.go
@@ -1,51 +1,13 @@
 package util
 
 import (
-	"context"
-	"fmt"
-	"github.com/appscode/jsonpatch"
-	"github.com/coreos/go-semver/semver"
-	configv1 "github.com/openshift/api/config/v1"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"net/http"
-	"os"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/appscode/jsonpatch"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
 )
-
-// ValidateOpenShiftVersion validates the current openshift version against the minimum
-// version specified in MIN_OPENSHIFT_VERSION env var
-func ValidateOpenShiftVersion(ctx context.Context, cl client.Client) (bool, string, error) {
-	version, present := os.LookupEnv("MIN_OPENSHIFT_VERSION")
-	if !present {
-		return true, "", nil
-	}
-	minVersion, err := semver.NewVersion(version)
-	if err != nil {
-		return false, "Unable to validate version; check MIN_OPENSHIFT_VERSION env var", nil
-	}
-
-	clusterVersion := &configv1.ClusterVersion{}
-	if err := cl.Get(ctx, client.ObjectKey{Name: "version"}, clusterVersion); err != nil {
-		return false, "Unable to get ClusterVersion", err
-	}
-
-	current, err := semver.NewVersion(clusterVersion.Status.Desired.Version)
-	if err != nil {
-		return false, "Could not parse version string", err
-	}
-
-	if current.Major == 0 && current.Minor == 0 {
-		return true, "CI build detected, bypassing version check", nil
-	}
-
-	if current.LessThan(*minVersion) {
-		msg := fmt.Sprintf("Version constraint not fulfilled: minimum version: %s, current version: %s", minVersion.String(), current.String())
-		return false, msg, nil
-	}
-	return true, "", nil
-}
 
 // PatchResponseFromRaw takes 2 byte arrays and returns a new response with json patch.
 // The original object should be passed in as raw bytes to avoid the roundtripping problem

--- a/olm-catalog/serverless-operator/csv.template.yaml
+++ b/olm-catalog/serverless-operator/csv.template.yaml
@@ -315,8 +315,6 @@ spec:
                           fieldPath: metadata.name
                     - name: OPERATOR_NAME
                       value: "knative-openshift"
-                    - name: MIN_OPENSHIFT_VERSION
-                      value: "4.3.0-0"
                     - name: REQUIRED_SERVING_NAMESPACE
                       value: "knative-serving"
                     - name: REQUIRED_EVENTING_NAMESPACE

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -367,8 +367,6 @@ spec:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
                         value: "knative-openshift"
-                      - name: MIN_OPENSHIFT_VERSION
-                        value: "4.3.0-0"
                       - name: REQUIRED_SERVING_NAMESPACE
                         value: "knative-serving"
                       - name: REQUIRED_EVENTING_NAMESPACE


### PR DESCRIPTION
As per title, I don't think we're gaining anything by having these checks at this point. They kinda reinforce our channel shipment model for no apparent reason.

/hold

For discussion.