### PR TITLE
Add script to download target releases into the upstream operator

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.17.2/2-eventing-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.17.2/2-eventing-core.yaml
@@ -708,9 +708,9 @@ spec:
           value: "8443"
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.17.3/4-serving-post-install-jobs.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.17.3/4-serving-post-install-jobs.yaml
@@ -18,7 +18,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: storage-version-migration-serving-
+  name: storage-version-migration-serving-0.17.3
   namespace: knative-serving
   labels:
     app: "storage-version-migration-serving"

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+root="$(dirname "${BASH_SOURCE[0]}")/../.."
+
+# Source the main vars file to get the serving/eventing version to be used.
+source "$root/hack/lib/vars.bash"
+
+serving_files=(serving-crds serving-core serving-hpa serving-post-install-jobs)
+eventing_files=(eventing-crds eventing-core in-memory-channel mt-channel-broker eventing-sugar-controller eventing-post-install-jobs)
+
+function download {
+  component=$1
+  version=$2
+  shift
+  shift
+
+  files=("$@")
+
+  target_dir="$root/openshift-knative-operator/cmd/operator/kodata/knative-${component}/${version:1}"
+  rm -r "$target_dir"
+  mkdir -p "$target_dir"
+  
+  for (( i=0; i<${#files[@]}; i++ ));
+  do
+    index=$(( i+1 ))
+    file="${files[$i]}.yaml"
+    target_file="$target_dir/$index-$file"
+    url="https://github.com/knative/$component/releases/download/$version/$file"
+
+    wget --no-check-certificate "$url" -O "$target_file"
+
+    if [[ "$file" == "serving-post-install-jobs.yaml" ]]; then
+      sed -i -e "s/generateName: storage-version-migration-serving-/name: storage-version-migration-serving-${version:1}/g"  $target_file
+    fi
+
+  done
+}
+
+download serving $KNATIVE_SERVING_VERSION "${serving_files[@]}"
+download eventing $KNATIVE_EVENTING_VERSION "${eventing_files[@]}"

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 
+set -Eeuo pipefail
+
 root="$(dirname "${BASH_SOURCE[0]}")/../.."
 
 # Source the main vars file to get the serving/eventing version to be used.
 source "$root/hack/lib/vars.bash"
 
+# These files could in theory change from release to release, though their names should
+# be fairly stable.
 serving_files=(serving-crds serving-core serving-hpa serving-post-install-jobs)
 eventing_files=(eventing-crds eventing-core in-memory-channel mt-channel-broker eventing-sugar-controller eventing-post-install-jobs)
 


### PR DESCRIPTION
As per title, this adds a `hack/update-manifests.sh` script for the upstream operator replacement, that automatically downloads all the manifests from the upstream releases, that we want and places them into the right directories.

The diff kinda proofs this works as expected.

@matzew had the idea to actually use the manifests generated in the knative-serving/knative-eventing forks for this and I think that is valid. I'd like to revisit that separately though as this new operator isn't yet enabled at all and I'd like to get it baking with it being similar in behavior to the current upstream operator.