### PR TITLE
Add the entire team as potential reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,14 +6,18 @@ aliases:
   - markusthoemmes
   - matzew
   - mgencur
-  - vdemeester
   - warrenvw
   serverless-reviewers:
   - alanfx
   - aliok
+  - devguyio
+  - dsimansk
   - jcrossley3
+  - lberk
   - markusthoemmes
   - matzew
   - mgencur
-  - vdemeester
+  - navidshaikh
+  - rhuss
+  - skonto
   - warrenvw


### PR DESCRIPTION
This adds the entire engineering team to the reviewers list to share reviews (and thereby knowledge) across the team better.