### PR TITLE
Running the misspell tool

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -126,7 +126,7 @@ function deploy_knativeserving_cr {
 
   timeout 900 '[[ $(oc get knativeserving.operator.knative.dev knative-serving -n $SERVING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
 
-  logger.success 'Knative Serving has been installed sucessfully.'
+  logger.success 'Knative Serving has been installed successfully.'
 }
 
 function deploy_knativeeventing_cr {
@@ -148,7 +148,7 @@ EOF
 
   timeout 900 '[[ $(oc get knativeeventing.operator.knative.dev knative-eventing -n $EVENTING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
 
-  logger.success 'Knative Eventing has been installed sucessfully.'
+  logger.success 'Knative Eventing has been installed successfully.'
 }
 
 function teardown_serverless {

--- a/knative-operator/pkg/common/monitoring_test.go
+++ b/knative-operator/pkg/common/monitoring_test.go
@@ -54,7 +54,7 @@ func TestSetupMonitoringRequirements(t *testing.T) {
 		t.Errorf("Failed to get created role: %w", err)
 	}
 	if len(role.Rules) == 0 {
-		t.Error("Rules should be non emtpy")
+		t.Error("Rules should be non empty")
 	}
 	rb := v1.RoleBinding{}
 	err = cl.Get(context.TODO(), client.ObjectKey{Name: "knative-serving-prometheus-k8s", Namespace: installedNS}, &rb)
@@ -62,7 +62,7 @@ func TestSetupMonitoringRequirements(t *testing.T) {
 		t.Errorf("Failed to get created rolebinding: %w", err)
 	}
 	if len(rb.Subjects) == 0 {
-		t.Error("Subjects should be non emtpy")
+		t.Error("Subjects should be non empty")
 	}
 	sub := rb.Subjects[0]
 	if sub.Kind != "ServiceAccount" {

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -119,7 +119,7 @@ func TestKnativeKafkaReconcile(t *testing.T) {
 				}
 			}
 
-			// check if things that shouldnot exist is deleted
+			// check if things that shouldnt exist is deleted
 			for _, d := range test.doesNotExist {
 				deployment := &appsv1.Deployment{}
 				err = cl.Get(context.TODO(), d, deployment)

--- a/serving/ingress/pkg/reconciler/ingress/ingress.go
+++ b/serving/ingress/pkg/reconciler/ingress/ingress.go
@@ -61,7 +61,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 	routes, err := resources.MakeRoutes(ing)
 	if err != nil {
 		logger.Warnf("Failed to generate routes from ingress %v", err)
-		// Returning nil aborts the reconcilation. It will be retriggered once the status of the ingress changes.
+		// Returning nil aborts the reconciliation. It will be retriggered once the status of the ingress changes.
 		return nil
 	}
 	for _, route := range routes {

--- a/test/hack/update-deps.sh
+++ b/test/hack/update-deps.sh
@@ -13,7 +13,7 @@ cd ${ROOT_DIR}
 KN_VERSION="release-0.17"
 
 # Controls the version of OCP related dependencies.
-# We currenctly stick to 4.4 as 4.5 needs 0.18 K8s clients, which will come via the 0.18
+# We currency stick to 4.4 as 4.5 needs 0.18 K8s clients, which will come via the 0.18
 # Knative release.
 OCP_VERSION="release-4.4"
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

* running [misspell](https://github.com/client9/misspell)

```
export FILES=( $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*') )
misspell -w "${FILES[@]}"
```
