### PR TITLE
[trivial] Use consistent variable name for knative-eventing variables

### DIFF
--- a/knative-operator/pkg/common/eventing.go
+++ b/knative-operator/pkg/common/eventing.go
@@ -24,6 +24,6 @@ func eventingImagesFromEnviron(ke *eventingv1alpha1.KnativeEventing) {
 	log.Info("Setting", "registry", ke.Spec.Registry)
 }
 
-func ensureEventingWebhookMemoryLimit(ks *eventingv1alpha1.KnativeEventing) {
-	EnsureContainerMemoryLimit(&ks.Spec.CommonSpec, "eventing-webhook", resource.MustParse("1024Mi"))
+func ensureEventingWebhookMemoryLimit(ke *eventingv1alpha1.KnativeEventing) {
+	EnsureContainerMemoryLimit(&ke.Spec.CommonSpec, "eventing-webhook", resource.MustParse("1024Mi"))
 }


### PR DESCRIPTION
It seems like `ks` typically refers to `KnativeServing` components, change a `KnativeEventing` variable name to `ke` instead, similar to other variables in said file.