### PR TITLE
Adding install flags for serving and eventing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ images:
 install:
 	./hack/install.sh
 
+install-serving:
+	INSTALL_EVENTING="false" ./hack/install.sh
+
+install-eventing:
+	INSTALL_SERVING="false" ./hack/install.sh
+
 install-previous:
 	INSTALL_PREVIOUS_VERSION="true" ./hack/install.sh
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Use the appropriate make targets or scripts in `hack`:
 
 - `make dev`: Deploys the serverless-operator without deploying Knative Serving and Eventing.
 - `make install`: Scales the cluster appropriately, deploys serverless-operator, Knative Serving and Eventing.
+- `make install-serving`: Scales the cluster appropriately, deploys serverless-operator and Knative Serving.
+- `make install-eventing`: Scales the cluster appropriately, deploys serverless-operator and Knative Eventing.
 - `make install-previous`: same as `make install` but deploy previous serverless-operator
   version.
 - `make install-mesh`: Install service mesh operator and enable sidecar injections.

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -43,8 +43,13 @@ function remove_installplan {
 
 function install_serverless_latest {
   deploy_serverless_operator_latest || return $?
-  deploy_knativeserving_cr || return $?
-  deploy_knativeeventing_cr || return $?
+
+  if [[ $INSTALL_SERVING == "true" ]]; then
+    deploy_knativeserving_cr || return $?
+  fi
+  if [[ $INSTALL_EVENTING == "true" ]]; then
+    deploy_knativeeventing_cr || return $?
+  fi
 }
 
 function deploy_serverless_operator_latest {

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -65,3 +65,7 @@ export OLM_UPGRADE_CHANNEL="${OLM_UPGRADE_CHANNEL:-"$OLM_CHANNEL"}"
 export OLM_SOURCE="${OLM_SOURCE:-"$OPERATOR"}"
 export TEST_KNATIVE_UPGRADE="${TEST_KNATIVE_UPGRADE:-true}"
 export TEST_KNATIVE_E2E="${TEST_KNATIVE_E2E:-true}"
+
+# Makefile triggers for modular install
+export INSTALL_SERVING="${INSTALL_SERVING:-"true"}"
+export INSTALL_EVENTING="${INSTALL_EVENTING:-"true"}"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

A little bit of more modular installs...

New targets:
* `make install-serving`: Scales the cluster appropriately, deploys serverless-operator and Knative Serving.
* `make install-eventing`: Scales the cluster appropriately, deploys serverless-operator and Knative Eventing.

unchanged behavior for `make install`: continues to install both Serving and Eventing
