### PR TITLE
Remove unused CONSOLECLIDOWNLOAD_MANIFEST_PATH env var

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -119,7 +119,6 @@ func init() {
 	os.Setenv("OPERATOR_NAME", "TEST_OPERATOR")
 	os.Setenv("KOURIER_MANIFEST_PATH", "kourier/testdata/kourier-latest.yaml")
 	os.Setenv(dashboard.ServingDashboardPathEnvVar, "../dashboard/testdata/grafana-dash-knative.yaml")
-	os.Setenv("CONSOLECLIDOWNLOAD_MANIFEST_PATH", "consoleclidownload/testdata/console_cli_download_kn_resources.yaml")
 }
 
 // TestKourierReconcile runs Reconcile to verify if expected Kourier resources are deleted.

--- a/olm-catalog/serverless-operator/csv.template.yaml
+++ b/olm-catalog/serverless-operator/csv.template.yaml
@@ -331,8 +331,6 @@ spec:
                       value: "deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml"
                     - name: KOURIER_MANIFEST_PATH
                       value: deploy/resources/kourier/kourier-latest.yaml
-                    - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH
-                      value: deploy/resources/console_cli_download_kn_resources.yaml
                     - name: KAFKACHANNEL_MANIFEST_PATH
                       value: deploy/resources/knativekafka/kafkachannel-latest.yaml
                     - name: KAFKASOURCE_MANIFEST_PATH

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -383,8 +383,6 @@ spec:
                         value: "deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml"
                       - name: KOURIER_MANIFEST_PATH
                         value: deploy/resources/kourier/kourier-latest.yaml
-                      - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH
-                        value: deploy/resources/console_cli_download_kn_resources.yaml
                       - name: KAFKACHANNEL_MANIFEST_PATH
                         value: deploy/resources/knativekafka/kafkachannel-latest.yaml
                       - name: KAFKASOURCE_MANIFEST_PATH


### PR DESCRIPTION
This patch removes unused `CONSOLECLIDOWNLOAD_MANIFEST_PATH` env var
from test code and csv yaml.

It was removed by https://github.com/openshift-knative/serverless-operator/pull/381.

/cc @dsimansk @navidshaikh @rhuss 