### PR TITLE
Use --kubeconfig instead of deprecated --config

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -18,7 +18,7 @@ function install_catalogsource {
   pull_user="puller"
   add_user "$pull_user" "puller"
   oc -n "$OLM_NAMESPACE" policy add-role-to-user registry-viewer "$pull_user"
-  token=$(oc --config=$pull_user.kubeconfig whoami -t)
+  token=$(oc --kubeconfig=$pull_user.kubeconfig whoami -t)
 
   csv="${rootdir}/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml"
   # Create a backup of the CSV so we don't pollute the repository.
@@ -110,7 +110,7 @@ function delete_catalog_source {
   oc delete catalogsource --ignore-not-found=true -n "$OLM_NAMESPACE" "$OPERATOR" || return 10
   [ -f "$CATALOG_SOURCE_FILENAME" ] && rm -v "$CATALOG_SOURCE_FILENAME"
   logger.info "Wait for the ${OPERATOR} pod to disappear"
-  timeout 900 "[[ \$(oc get pods -n ${OPERATORS_NAMESPACE} | grep -c ${OPERATOR}) -gt 0 ]]" || return 11
+  timeout 300 "[[ \$(oc get pods -n ${OPERATORS_NAMESPACE} | grep -c ${OPERATOR}) -gt 0 ]]" || return 11
   logger.success 'CatalogSource deleted'
 }
 
@@ -137,6 +137,6 @@ function add_user {
 
   logger.info 'Generate kubeconfig'
   cp "${KUBECONFIG}" "$name.kubeconfig"
-  occmd="bash -c '! oc login --config=$name.kubeconfig --username=$name --password=$pass > /dev/null'"
-  timeout 900 "${occmd}" || return 1
+  occmd="bash -c '! oc login --kubeconfig=$name.kubeconfig --username=$name --password=$pass > /dev/null'"
+  timeout 180 "${occmd}" || return 1
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -195,8 +195,8 @@ function create_htpasswd_users {
   logger.info 'Generate kubeconfig for each user'
   for i in $(seq 1 $num_users); do
     cp "${KUBECONFIG}" "user${i}.kubeconfig"
-    occmd="bash -c '! oc login --config=user${i}.kubeconfig --username=user${i} --password=password${i} > /dev/null'"
-    timeout 900 "${occmd}" || return 1
+    occmd="bash -c '! oc login --kubeconfig=user${i}.kubeconfig --username=user${i} --password=password${i} > /dev/null'"
+    timeout 180 "${occmd}" || return 1
   done
 }
 


### PR DESCRIPTION
This patch replaces deprecated `--config` flag with `--kubeconfig`.

Currently there are many warning message like this:

```
INFO 12:28:09.725 Generate kubeconfig
Flag --config has been deprecated, use --kubeconfig instead
DEBUG 12:28:10.865 Execution failed: bash -c '! oc login --config=puller.kubeconfig --username=puller --password=puller > /dev/null'. Waiting 5 sec (5/900)...
Flag --config has been deprecated, use --kubeconfig instead
DEBUG 12:28:16.838 Execution failed: bash -c '! oc login --config=puller.kubeconfig --username=puller --password=puller > /dev/null'. Waiting 5 sec (10/900)...
Flag --config has been deprecated, use --kubeconfig instead
DEBUG 12:28:22.949 Execution failed: bash -c '! oc login --config=puller.kubeconfig --username=puller --password=puller > /dev/null'. Waiting 5 sec (15/900)...
Flag --config has been deprecated, use --kubeconfig instead
DEBUG 12:28:29.225 Execution failed: bash -c '! oc login --config=puller.kubeconfig --username=puller --password=puller > /dev/null'. Waiting 5 sec (20/900)...
Flag --config has been deprecated, use --kubeconfig instead
DEBUG 12:28:35.341 Execution failed: bash -c '! oc login --config=puller.kubeconfig --username=puller --password=puller > /dev/null'. Waiting 5 sec (25/900)...
Flag --config has been deprecated, use --kubeconfig instead
clusterrole.rbac.authorization.k8s.io/registry-viewer added: "puller"
Flag --config has been deprecated, use --kubeconfig instead
apiVersion: operators.coreos.com/v1alpha1
kind: ClusterServiceVersion
metadata:
```

Additionally this patch decreases the timeout to 180 sec. As you can see above
log, `oc login` works within 30 sec in general.

/cc @mgencur @cardil 