### PR TITLE
Do not scale up if previous phase failed

### DIFF
--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -36,7 +36,7 @@ fi
 # Run upstream knative serving & eventing tests
 if [[ $TEST_KNATIVE_E2E == true ]]; then
   # Need 6 worker nodes when running upstream.
-  SCALE_UP=6 scale_up_workers || failed=10
+  (( !failed )) && SCALE_UP=6 scale_up_workers || failed=10
   (( !failed )) && ensure_serverless_installed || failed=7
   (( !failed )) && upstream_knative_serving_e2e_and_conformance_tests || failed=8
   (( !failed )) && upstream_knative_eventing_e2e || failed=9


### PR DESCRIPTION
* i.e. fail quickly

E.g. this [run](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-master-4.6-e2e-aws-ocp-46-continuous/1318341259533750272) shows that teardown_serverless failed but the job was scaling up the cluster anyway, just to fail in the next step and make the failure confusing.