### PR TITLE
Create an even broader make target for generated files and check them

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -37,7 +37,9 @@ jobs:
           path: ./src/github.com/${{ github.repository }}
 
       - name: Regenerate all generated files
+        working-directory: ./src/github.com/${{ github.repository }}
         run: make generated-files
 
       - name: Check if everything is consistent
+        working-directory: ./src/github.com/${{ github.repository }}
         run: git diff --exit-code

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,6 +16,11 @@ jobs:
     name: Generated files are commited
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14.x
+
       - name: Install prerequisites
         env:
           YQ_VERSION: 3.4.0
@@ -26,8 +31,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Generate release files
-        run: make release-files
+      - name: Regenerate all generated files
+        run: make generated-files
 
       - name: Check if everything is consistent
         run: git diff --exit-code

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -27,6 +27,7 @@ jobs:
         run: |
           sudo wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/bin/yq
           sudo chmod +x /usr/bin/yq
+          sudo apt-get install go-dep
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/bin/yq
           sudo chmod +x /usr/bin/yq
-          sudo apt-get install go-dep
+          curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -15,6 +15,8 @@ jobs:
   generated-files-commited:
     name: Generated files are commited
     runs-on: ubuntu-latest
+    env:
+      GOPATH: ${{ github.workspace }}
     steps:
       - name: Setup Golang
         uses: actions/setup-go@v2
@@ -31,6 +33,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          path: ./src/github.com/${{ github.repository }}
 
       - name: Regenerate all generated files
         run: make generated-files

--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,8 @@ release-files:
 	./hack/generate/dockerfile.sh \
 		templates/build-image.Dockerfile \
 		openshift/ci-operator/build-image/Dockerfile
+
+generated-files: release-files
+	(cd openshift-knative-operator; ./hack/update-codegen.sh; ./hack/update-deps.sh; ./hack/update-manifests.sh)
+	(cd serving/ingress; ./hack/update-deps.sh)
+	(cd knative-operator; dep ensure -v)

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 root="$(dirname "${BASH_SOURCE[0]}")/../.."
 
 # Source the main vars file to get the serving/eventing version to be used.
-source "$root/hack/lib/vars.bash"
+source "$root/hack/lib/__sources__.bash"
 
 # These files could in theory change from release to release, though their names should
 # be fairly stable.


### PR DESCRIPTION
`make generated-files` calls into all of the subproject's dep and generation scripts to make sure vendor directories and generated code is always up to date. This should avoid having diffs in these scripts in the future when just running on HEAD.

/assign @matzew @cardil 