### PR TITLE
Introduce a new e2e target, that runs all (Serving/Eventing and event…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ test-unit:
 test-e2e:
 	./test/e2e-tests.sh
 
+# TODO: that will - soon... run the Kafka operator e2e hook
+test-e2e-kafka:
+	echo "Noop for now"
+
 # Run both unit and E2E tests from the current repo.
 test-operator: test-unit test-e2e
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


## Motivation

To keep the standard `test-e2e` small (no added Strimzi etc), and just run the "operator e2e" for Serving/Eventing, we are introducing a new target `test-e2e-all` that runs the "operator e2e" tests for Kafka as well (e.g. to check if the deployments are there).

**NEW TARGET** is `test-e2e-all`, and will be added with life in:
* https://github.com/openshift-knative/serverless-operator/pull/587
* https://github.com/openshift-knative/serverless-operator/pull/587/commits/b03ea43f8df13dbfb1c4841b187774c3181e5299#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R39-R42

## Enabling 

Config for "openshift/release" is also already PR'd, here: https://github.com/openshift/release/pull/12939
(But I think that only really flies, when we have that `test-e2e-all` target on the master branch)

/assign @markusthoemmes 
