### PR TITLE
Setup woke to keep the codebase free of divisive language

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -43,3 +43,53 @@ jobs:
       - name: Check if everything is consistent
         working-directory: ./src/github.com/${{ github.repository }}
         run: git diff --exit-code
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+    steps:
+      - name: Set up Go 1.14.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14.x
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ./src/github.com/${{ github.repository }}
+
+      - name: Install Tools
+        working-directory: ./src/github.com/${{ github.repository }}
+        env:
+          WOKE_VERSION: v0.1.11
+        run: |
+          TEMP_PATH="$(mktemp -d)"
+          cd $TEMP_PATH
+
+          echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog'
+          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" 2>&1
+          echo '::endgroup::'
+
+          echo '::group:: Installing woke ... https://github.com/get-woke/woke'
+          curl -sfL https://raw.githubusercontent.com/get-woke/woke/main/install.sh | sh -s -- -b "${TEMP_PATH}" "${WOKE_VERSION}" 2>&1
+          echo '::endgroup::'
+
+          echo "${TEMP_PATH}" >> $GITHUB_PATH
+
+      # This is mostly copied from https://github.com/get-woke/woke-action-reviewdog/blob/main/entrypoint.sh
+      # since their action is not yet released under a stable version.
+      - name: Language
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        working-directory: ./src/github.com/${{ github.repository }}
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          woke --output simple \
+            | reviewdog -efm="%f:%l:%c: %m" \
+                -name="woke" \
+                -reporter="github-pr-check" \
+                -filter-mode="added" \
+                -fail-on-error="true" \
+                -level="error"

--- a/.wokeignore
+++ b/.wokeignore
@@ -1,0 +1,4 @@
+knative-operator/vendor/*
+openshift-knative-operator/vendor/*
+serving/ingress/vendor/*
+test/vendor/*

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ test-all-e2e: test-e2e test-upstream-e2e
 generate-ci-config:
 	./openshift/ci-operator/generate-ci-config.sh $(BRANCH) > ci-operator-config.yaml
 
+# Generates all files that are templated with release metadata.
 release-files:
 	./hack/generate/csv.sh \
 		templates/csv.yaml \
@@ -82,8 +83,14 @@ release-files:
 		templates/build-image.Dockerfile \
 		openshift/ci-operator/build-image/Dockerfile
 
+# Generates all files that can be generated, includes release files, code generation
+# and updates vendoring.
 generated-files: release-files
 	(cd openshift-knative-operator; ./hack/update-codegen.sh; ./hack/update-deps.sh; ./hack/update-manifests.sh)
 	(cd serving/ingress; ./hack/update-deps.sh)
 	(cd test; ./hack/update-deps.sh)
 	(cd knative-operator; dep ensure -v)
+
+# Runs the checks that our Github Actions do.
+checks:
+	woke

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,6 @@ generated-files: release-files
 	(cd test; ./hack/update-deps.sh)
 	(cd knative-operator; dep ensure -v)
 
-# Runs the checks that our Github Actions do.
-checks:
+# Runs the lints Github Actions do too.
+lint:
 	woke

--- a/README.md
+++ b/README.md
@@ -249,3 +249,12 @@ To uninstall service mesh operator, run `make uninstall-mesh`.
 ```
 make uninstall-mesh
 ```
+
+## Contributing
+
+### Code style checks
+
+To run the code style checks that CI is running, you can use `make checks`.
+The required tools are:
+
+- [`woke`](https://github.com/get-woke/woke) to detect non-inclusive language

--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ make uninstall-mesh
 
 ## Contributing
 
-### Code style checks
+### Linting
 
-To run the code style checks that CI is running, you can use `make checks`.
-The required tools are:
+To run the linters that CI is running, you can use `make lint`.
+The required linters for that are:
 
 - [`woke`](https://github.com/get-woke/woke) to detect non-inclusive language

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -283,7 +283,7 @@ func TestCustomCertsConfigMap(t *testing.T) {
 			cm("test-cm", nil, serviceCAAnnotations, map[string]string{"test": "foo"}, "1"),
 		},
 		out: []*corev1.ConfigMap{
-			cm("test-cm", nil, nil, nil, "1"), // TODO: maybe we shouldn't stomp, retaining behavior from master though.
+			cm("test-cm", nil, nil, nil, "1"), // TODO: maybe we shouldn't stomp, retaining current behavior though.
 			cm("test-cm-service-ca", nil, serviceCAAnnotations, nil, ""),
 			cm("test-cm-trusted-ca", trustedCALabels, nil, nil, ""),
 		},


### PR DESCRIPTION
We use this tool upstream to keep the language in check too, so it should be fine here too.

A quick manual check yielded nothing, so we should be mostly clear anyway.