### PR TITLE
Have KafkaSource resources in knative-eventing namespace

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -38,7 +38,6 @@ export OPERATORS_NAMESPACE="${OPERATORS_NAMESPACE:-openshift-serverless}"
 export SERVERLESS_NAMESPACE="${SERVERLESS_NAMESPACE:-serverless}"
 export SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
 export EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-knative-eventing}"
-export EVENTING_SOURCES_NAMESPACE="${EVENTING_SOURCES_NAMESPACE:-knative-sources}"
 # eventing e2e and conformance tests use a container for tracing tests that has hardcoded `istio-system` in it
 export ZIPKIN_NAMESPACE="${ZIPKIN_NAMESPACE:-istio-system}"
 

--- a/knative-operator/deploy/resources/knativekafka/kafkasource-v0.17.1.yaml
+++ b/knative-operator/deploy/resources/knativekafka/kafkasource-v0.17.1.yaml
@@ -1,15 +1,8 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: knative-sources
-  labels:
-    contrib.eventing.knative.dev/release: "v0.17.1"
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kafka-controller-manager
-  namespace: knative-sources
+  namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: "v0.17.1"
 ---
@@ -146,7 +139,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: kafka-controller-manager
-  namespace: knative-sources
+  namespace: knative-eventing
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -161,7 +154,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: kafka-controller-manager
-  namespace: knative-sources
+  namespace: knative-eventing
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -176,7 +169,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: kafka-controller-manager
-  namespace: knative-sources
+  namespace: knative-eventing
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -261,7 +254,7 @@ spec:
     webhookClientConfig:
       service:
         name: kafka-source-webhook
-        namespace: knative-sources
+        namespace: knative-eventing
   additionalPrinterColumns:
   - name: Topics
     type: string
@@ -290,7 +283,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kafka-controller
-  namespace: knative-sources
+  namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: "v0.17.1"
     control-plane: kafka-controller-manager
@@ -305,7 +298,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kafka-controller-manager
-  namespace: knative-sources
+  namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: "v0.17.1"
     control-plane: kafka-controller-manager
@@ -361,7 +354,7 @@ metadata:
     role: webhook
     contrib.eventing.knative.dev/release: "v0.17.1"
   name: kafka-source-webhook
-  namespace: knative-sources
+  namespace: knative-eventing
 spec:
   ports:
   - name: https-webhook
@@ -382,7 +375,7 @@ webhooks:
   clientConfig:
     service:
       name: kafka-source-webhook
-      namespace: knative-sources
+      namespace: knative-eventing
   failurePolicy: Fail
   name: defaulting.webhook.kafka.sources.knative.dev
 ---
@@ -398,7 +391,7 @@ webhooks:
   clientConfig:
     service:
       name: kafka-source-webhook
-      namespace: knative-sources
+      namespace: knative-eventing
   failurePolicy: Fail
   name: kafkabindings.webhook.kafka.sources.knative.dev
 ---
@@ -414,7 +407,7 @@ webhooks:
   clientConfig:
     service:
       name: kafka-source-webhook
-      namespace: knative-sources
+      namespace: knative-eventing
   failurePolicy: Fail
   name: validation.webhook.kafka.sources.knative.dev
 ---
@@ -430,7 +423,7 @@ webhooks:
   clientConfig:
     service:
       name: kafka-source-webhook
-      namespace: knative-sources
+      namespace: knative-eventing
   failurePolicy: Fail
   name: config.webhook.kafka.sources.knative.dev
   namespaceSelector:
@@ -442,6 +435,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: kafka-source-webhook-certs
-  namespace: knative-sources
+  namespace: knative-eventing
   labels:
     contrib.eventing.knative.dev/release: "v0.17.1"

--- a/knative-operator/deploy/resources/knativekafka/manifest_test.go
+++ b/knative-operator/deploy/resources/knativekafka/manifest_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	mf "github.com/manifestival/manifestival"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var notAllowed = mf.Any(
@@ -11,6 +12,7 @@ var notAllowed = mf.Any(
 	mf.All(mf.ByKind("ConfigMap"), mf.ByName("config-observability")),
 	mf.All(mf.ByKind("ConfigMap"), mf.ByName("config-logging")),
 	mf.All(mf.ByKind("ConfigMap"), mf.ByName("config-leader-election-kafka")),
+	mf.All(byNamespace("knative-sources")),
 )
 
 func TestUnallowedResourcesInManifest(t *testing.T) {
@@ -32,6 +34,9 @@ func TestUnallowedResourcesInManifest(t *testing.T) {
 	}, {
 		path:  "./testdata/config-tracing.yaml",
 		fails: true,
+	}, {
+		path:  "./testdata/knative-sources-namespace.yaml",
+		fails: true,
 	}}
 
 	for _, test := range tests {
@@ -46,5 +51,11 @@ func TestUnallowedResourcesInManifest(t *testing.T) {
 		if len(manifest.Resources()) == 0 && test.fails {
 			t.Fatalf("Manifest at path '%s' should have unallowed resources, but it does not. Perhaps the check for unallowed resources is not working?", test.path)
 		}
+	}
+}
+
+func byNamespace(namespace string) mf.Predicate {
+	return func(u *unstructured.Unstructured) bool {
+		return u.GetNamespace() == namespace
 	}
 }

--- a/knative-operator/deploy/resources/knativekafka/manifest_test.go
+++ b/knative-operator/deploy/resources/knativekafka/manifest_test.go
@@ -12,7 +12,7 @@ var notAllowed = mf.Any(
 	mf.All(mf.ByKind("ConfigMap"), mf.ByName("config-observability")),
 	mf.All(mf.ByKind("ConfigMap"), mf.ByName("config-logging")),
 	mf.All(mf.ByKind("ConfigMap"), mf.ByName("config-leader-election-kafka")),
-	mf.All(byNamespace("knative-sources")),
+	byNamespace("knative-sources"),
 )
 
 func TestUnallowedResourcesInManifest(t *testing.T) {

--- a/knative-operator/deploy/resources/knativekafka/testdata/config-leader-election-kafka.yaml
+++ b/knative-operator/deploy/resources/knativekafka/testdata/config-leader-election-kafka.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-leader-election-kafka
-  namespace: knative-sources
+  namespace: knative-eventing
 data:
   resourceLock: "leases"
   leaseDuration: "15s"

--- a/knative-operator/deploy/resources/knativekafka/testdata/config-logging.yaml
+++ b/knative-operator/deploy/resources/knativekafka/testdata/config-logging.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-logging
-  namespace: knative-sources
+  namespace: knative-eventing
 data:
   zap-logger-config: |
     {

--- a/knative-operator/deploy/resources/knativekafka/testdata/config-observability.yaml
+++ b/knative-operator/deploy/resources/knativekafka/testdata/config-observability.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-observability
-  namespace: knative-sources
+  namespace: knative-eventing
 data:
   _example: |
     logging.enable-var-log-collection: false

--- a/knative-operator/deploy/resources/knativekafka/testdata/knative-sources-namespace.yaml
+++ b/knative-operator/deploy/resources/knativekafka/testdata/knative-sources-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-controller-manager
+  namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: "v0.17.1"

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -209,7 +209,7 @@ func (r *ReconcileKnativeKafka) ensureFinalizers(_ *mf.Manifest, instance *opera
 func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *operatorv1alpha1.KnativeKafka) error {
 	log.Info("Transforming manifest")
 	m, err := manifest.Transform(
-		injectOwner(instance),
+		mf.InjectOwner(instance),
 		common.SetAnnotations(map[string]string{
 			common.KafkaOwnerName:      instance.Name,
 			common.KafkaOwnerNamespace: instance.Namespace,
@@ -367,23 +367,6 @@ func setBootstrapServers(bootstrapServers string) mf.Transformer {
 			}
 		}
 		return nil
-	}
-}
-
-// InjectOwner creates a Tranformer which adds an OwnerReference pointing to
-// `owner` to namespace-scoped objects.
-//
-// The difference from Manifestival's Inject owner is, it only does it for
-// resources that are in the same namespace as the owner.
-// For the resources that are in the same namespace, it fallbacks to
-// Manifestival's InjectOwner
-func injectOwner(owner mf.Owner) mf.Transformer {
-	return func(u *unstructured.Unstructured) error {
-		if u.GetNamespace() == owner.GetNamespace() {
-			return mf.InjectOwner(owner)(u)
-		} else {
-			return nil
-		}
 	}
 }
 

--- a/test/e2ekafka/knative_kafka_test.go
+++ b/test/e2ekafka/knative_kafka_test.go
@@ -9,11 +9,10 @@ import (
 )
 
 const (
-	eventingName                 = "knative-eventing"
-	eventingNamespace            = "knative-eventing"
-	knativeKafkaName             = "knative-kafka"
-	knativeKafkaChannelNamespace = "knative-eventing"
-	knativeKafkaSourceNamespace  = "knative-sources"
+	eventingName          = "knative-eventing"
+	eventingNamespace     = "knative-eventing"
+	knativeKafkaName      = "knative-kafka"
+	knativeKafkaNamespace = "knative-eventing"
 )
 
 var knativeKafkaChannelControlPlaneDeploymentNames = []string{
@@ -51,7 +50,7 @@ func TestKnativeKafka(t *testing.T) {
 	t.Run("verify correct deployment shape for KafkaChannel", func(t *testing.T) {
 		for i := range knativeKafkaChannelControlPlaneDeploymentNames {
 			deploymentName := knativeKafkaChannelControlPlaneDeploymentNames[i]
-			if _, err := test.WithDeploymentReady(caCtx, deploymentName, knativeKafkaChannelNamespace); err != nil {
+			if _, err := test.WithDeploymentReady(caCtx, deploymentName, knativeKafkaNamespace); err != nil {
 				t.Fatalf("Deployment %s is not ready: %v", deploymentName, err)
 			}
 		}
@@ -60,15 +59,14 @@ func TestKnativeKafka(t *testing.T) {
 	t.Run("verify correct deployment shape for KafkaSource", func(t *testing.T) {
 		for i := range knativeKafkaSourceControlPlaneDeploymentNames {
 			deploymentName := knativeKafkaSourceControlPlaneDeploymentNames[i]
-			if _, err := test.WithDeploymentReady(caCtx, deploymentName, knativeKafkaSourceNamespace); err != nil {
+			if _, err := test.WithDeploymentReady(caCtx, deploymentName, knativeKafkaNamespace); err != nil {
 				t.Fatalf("Deployment %s is not ready: %v", deploymentName, err)
 			}
 		}
 	})
 
 	t.Run("make sure no gcr.io references are there", func(t *testing.T) {
-		e2e.VerifyNoDisallowedImageReference(t, caCtx, knativeKafkaChannelNamespace)
-		e2e.VerifyNoDisallowedImageReference(t, caCtx, knativeKafkaSourceNamespace)
+		e2e.VerifyNoDisallowedImageReference(t, caCtx, knativeKafkaNamespace)
 	})
 
 	t.Run("remove knativekafka cr", func(t *testing.T) {
@@ -78,14 +76,14 @@ func TestKnativeKafka(t *testing.T) {
 
 		for i := range knativeKafkaChannelControlPlaneDeploymentNames {
 			deploymentName := knativeKafkaChannelControlPlaneDeploymentNames[i]
-			if err := test.WithDeploymentGone(caCtx, deploymentName, knativeKafkaChannelNamespace); err != nil {
+			if err := test.WithDeploymentGone(caCtx, deploymentName, knativeKafkaNamespace); err != nil {
 				t.Fatalf("Deployment %s is not gone: %v", deploymentName, err)
 			}
 		}
 
 		for i := range knativeKafkaSourceControlPlaneDeploymentNames {
 			deploymentName := knativeKafkaSourceControlPlaneDeploymentNames[i]
-			if err := test.WithDeploymentGone(caCtx, deploymentName, knativeKafkaSourceNamespace); err != nil {
+			if err := test.WithDeploymentGone(caCtx, deploymentName, knativeKafkaNamespace); err != nil {
 				t.Fatalf("Deployment %s is not gone: %v", deploymentName, err)
 			}
 		}


### PR DESCRIPTION
- Move KafkaSource reosources in `knative-eventing` namespace
- Get rid of custom `injectOwner` that was skipping resources from other namespaces
- Get rid of other references to `knative-sources` namespace