### PR TITLE
Wait for the Kafka CRD to be ready

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -9,6 +9,9 @@ function install_strimzi {
   | sed 's/namespace: .*/namespace: kafka/' \
   | oc -n kafka apply -f -
 
+  # Wait for the CRD we need to actually be active
+  oc wait crd --timeout=-1s kafkas.kafka.strimzi.io --for=condition=Established
+
   header "Applying Strimzi Cluster file"
   oc -n kafka apply -f "https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/${strimzi_version}/examples/kafka/kafka-persistent.yaml"
 


### PR DESCRIPTION
There is a rare race where this isn't ready when we apply the Kafka CR so let's wait for it to be established.

This avoids

```
error: unable to recognize "https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.19.0/examples/kafka/kafka-persistent.yaml": no matches for kind "Kafka" in version "kafka.strimzi.io/v1beta1"
```