### PR TITLE
nit: running goimports and gofmt

### DIFF
--- a/knative-operator/pkg/common/health_dashboard.go
+++ b/knative-operator/pkg/common/health_dashboard.go
@@ -3,8 +3,9 @@ package common
 import (
 	"context"
 	"fmt"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"os"
+
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 
 	mfc "github.com/manifestival/controller-runtime-client"
 	mf "github.com/manifestival/manifestival"

--- a/knative-operator/pkg/common/service_monitor.go
+++ b/knative-operator/pkg/common/service_monitor.go
@@ -85,12 +85,12 @@ func serveCRMetrics(cfg *rest.Config, metricsHost string, operatorMetricsPort in
 	// will end up with resources the Operator does not have access to eg. `Kind=LimitRange`
 	// The list of resources returned is unrelated to our purposes here, thus the customization.
 	gvkFilterList := []schema.GroupVersionKind{
-		schema.GroupVersionKind{
+		{
 			Group:   "operator.knative.dev",
 			Version: "v1alpha1",
 			Kind:    "KnativeServing",
 		},
-		schema.GroupVersionKind{
+		{
 			Group:   "operator.knative.dev",
 			Version: "v1alpha1",
 			Kind:    "KnativeEventing",

--- a/knative-operator/pkg/common/sources/source_deployment_discovery_controller.go
+++ b/knative-operator/pkg/common/sources/source_deployment_discovery_controller.go
@@ -2,8 +2,9 @@ package sources
 
 import (
 	"context"
+
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/knative-operator/pkg/controller/dashboard/dashboard.go
+++ b/knative-operator/pkg/controller/dashboard/dashboard.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"context"
 	"fmt"
+
 	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 
 	mfc "github.com/manifestival/controller-runtime-client"

--- a/knative-operator/pkg/controller/dashboard/health/healthdashboard_controller.go
+++ b/knative-operator/pkg/controller/dashboard/health/healthdashboard_controller.go
@@ -2,7 +2,7 @@ package health
 
 import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller_test.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller_test.go
@@ -2,9 +2,10 @@ package knativeeventing
 
 import (
 	"context"
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"os"
 	"testing"
+
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/dashboard"

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -3,10 +3,11 @@ package consoleclidownload
 import (
 	"context"
 	"fmt"
-	v1 "github.com/openshift/api/route/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	"os"
 	"strings"
+
+	v1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 
@@ -221,15 +222,15 @@ func populateKnConsoleCLIDownload(baseURL string, instance *servingv1alpha1.Knat
 			DisplayName: "kn - OpenShift Serverless Command Line Interface (CLI)",
 			Description: "The OpenShift Serverless client `kn` is a CLI tool that allows you to fully manage OpenShift Serverless Serving and Eventing resources without writing a single line of YAML.",
 			Links: []consolev1.Link{
-				consolev1.Link{
+				{
 					Text: "Download kn for Linux",
 					Href: baseURL + "/amd64/linux/kn-linux-amd64.tar.gz",
 				},
-				consolev1.Link{
+				{
 					Text: "Download kn for macOS",
 					Href: baseURL + "/amd64/macos/kn-macos-amd64.tar.gz",
 				},
-				consolev1.Link{
+				{
 					Text: "Download kn for Windows",
 					Href: baseURL + "/amd64/windows/kn-windows-amd64.zip",
 				},

--- a/serving/ingress/pkg/reconciler/ingress/ingress_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/ingress_test.go
@@ -143,7 +143,7 @@ func TestReconcile(t *testing.T) {
 			route(ingressNamespace, routeName),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
-			clientgotesting.PatchActionImpl{
+			{
 				Name:       ingName,
 				ActionImpl: clientgotesting.ActionImpl{Namespace: ingNamespace},
 				Patch:      []byte(`{"metadata":{"finalizers":["ocp-ingress"],"resourceVersion":""}}`),
@@ -172,7 +172,7 @@ func TestReconcile(t *testing.T) {
 			Name: routeName,
 		}},
 		WantPatches: []clientgotesting.PatchActionImpl{
-			clientgotesting.PatchActionImpl{
+			{
 				Name:       ingName,
 				ActionImpl: clientgotesting.ActionImpl{Namespace: ingNamespace},
 				Patch:      []byte(`{"metadata":{"finalizers":[],"resourceVersion":""}}`),

--- a/test/servicemesh.go
+++ b/test/servicemesh.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


created by running:

```
gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)

goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party | grep -v .pb.go | grep -v wire_gen.go)

```
