### PR TITLE
Fix health status

### DIFF
--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
@@ -22,7 +22,7 @@ data:
         "list": []
       },
       "editable": false,
-      "description" : "Knative Health status - Serving",
+      "description" : "Knative Health status",
       "gnetId": null,
       "graphTooltip": 0,
       "links": [],
@@ -85,7 +85,7 @@ data:
             },
             "targets": [
                {
-                 "expr": "sum(knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=\"serving_status\"})",
+                 "expr": "floor(sum(knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\"})/2)",
                  "intervalFactor": 2,
                  "legendFormat": "",
                  "metric": "knative_up",

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
@@ -85,7 +85,7 @@ data:
             },
             "targets": [
                {
-                 "expr": "floor(sum(knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\"})/2)",
+                 "expr": "floor(sum(knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=~\"eventing_status|serving_status\"})/2)",
                  "intervalFactor": 2,
                  "legendFormat": "",
                  "metric": "knative_up",


### PR DESCRIPTION
Knative status didnt take into consideration the eventing status, only the serving one, which is wrong.
Note: this is tested on 4.5.9, on 4.6 we should see text (mapped values) instead of numbers.
With the fix:
Kill all eventing pods
![image](https://user-images.githubusercontent.com/7945591/96984813-3b707400-1529-11eb-80ee-8932673ec136.png)

![image](https://user-images.githubusercontent.com/7945591/96983626-dc126400-1528-11eb-86cc-c7c16ca473f8.png)
Kill serving pods
![image](https://user-images.githubusercontent.com/7945591/96984214-124fe380-1529-11eb-8d71-bdc023231407.png)
![image](https://user-images.githubusercontent.com/7945591/96984300-17ad2e00-1529-11eb-9d09-3ebabc90ef53.png)
