### PR TITLE
[SRVCOM-776] Remove webhook self-registration to unblock c-r bumps

### DIFF
--- a/knative-operator/hack/certnames.patch
+++ b/knative-operator/hack/certnames.patch
@@ -1,0 +1,16 @@
+diff --git a/knative-operator/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/writer/certwriter.go b/knative-operator/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/writer/certwriter.go
+index ed6b5110..c0c67e16 100644
+--- a/knative-operator/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/writer/certwriter.go
++++ b/knative-operator/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/writer/certwriter.go
+@@ -33,9 +33,9 @@ const (
+ 	// CACertName is the name of the CA certificate
+ 	CACertName = "ca-cert.pem"
+ 	// ServerKeyName is the name of the server private key
+-	ServerKeyName = "key.pem"
++	ServerKeyName = "apiserver.key"
+ 	// ServerCertName is the name of the serving certificate
+-	ServerCertName = "cert.pem"
++	ServerCertName = "apiserver.crt"
+ )
+ 
+ // CertWriter provides method to handle webhooks.

--- a/knative-operator/hack/update-deps.sh
+++ b/knative-operator/hack/update-deps.sh
@@ -13,6 +13,10 @@ go mod vendor
 # TODO: Remove this once we bump kubernetes versions.
 git apply "$ROOT_DIR/hack/manifestival.patch"
 
+# This patch is required to make sure the cert names read by the webhook setup is equal
+# to the names chosen by OLM. We can drop this once we bump to newer versions of c-r.
+git apply "$ROOT_DIR/hack/certnames.patch"
+
 find vendor/ \( -name "OWNERS" \
   -o -name "OWNERS_ALIASES" \
   -o -name "BUILD" \

--- a/knative-operator/pkg/webhook/webhook.go
+++ b/knative-operator/pkg/webhook/webhook.go
@@ -1,10 +1,6 @@
 package webhook
 
 import (
-	"errors"
-	"os"
-
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -31,26 +27,12 @@ func AddToManager(m manager.Manager) error {
 	}
 
 	log.Info("Setting up webhook server")
-	operatorNs := os.Getenv(common.NamespaceEnvKey)
-	if operatorNs == "" {
-		return errors.New("NAMESPACE not provided via environment")
-	}
 	// This will be started when the Manager is started
+	truePtr := true
 	as, err := webhook.NewServer("admission-webhook-server", m, webhook.ServerOptions{
-		Port:    9876,
-		CertDir: "/tmp/cert",
-		BootstrapOptions: &webhook.BootstrapOptions{
-			MutatingWebhookConfigName:   "mutating-knative-openshift",
-			ValidatingWebhookConfigName: "validating-knative-openshift",
-			Service: &webhook.Service{
-				Namespace: operatorNs,
-				Name:      "admission-server-service",
-				// Selectors should select the pods that runs this webhook server.
-				Selectors: map[string]string{
-					"app": "openshift-admission-server",
-				},
-			},
-		},
+		Port:                          9876,
+		CertDir:                       "/apiserver.local.config/certificates",
+		DisableWebhookConfigInstaller: &truePtr,
 	})
 	if err != nil {
 		log.Error(err, "Unable to create a new webhook server")

--- a/knative-operator/pkg/webhook/webhook.go
+++ b/knative-operator/pkg/webhook/webhook.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -28,11 +29,10 @@ func AddToManager(m manager.Manager) error {
 
 	log.Info("Setting up webhook server")
 	// This will be started when the Manager is started
-	truePtr := true
 	as, err := webhook.NewServer("admission-webhook-server", m, webhook.ServerOptions{
 		Port:                          9876,
 		CertDir:                       "/apiserver.local.config/certificates",
-		DisableWebhookConfigInstaller: &truePtr,
+		DisableWebhookConfigInstaller: ptr.Bool(true),
 	})
 	if err != nil {
 		log.Error(err, "Unable to create a new webhook server")

--- a/knative-operator/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/writer/certwriter.go
+++ b/knative-operator/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/writer/certwriter.go
@@ -33,9 +33,9 @@ const (
 	// CACertName is the name of the CA certificate
 	CACertName = "ca-cert.pem"
 	// ServerKeyName is the name of the server private key
-	ServerKeyName = "key.pem"
+	ServerKeyName = "apiserver.key"
 	// ServerCertName is the name of the serving certificate
-	ServerCertName = "cert.pem"
+	ServerCertName = "apiserver.crt"
 )
 
 // CertWriter provides method to handle webhooks.

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -559,6 +559,102 @@ spec:
                 - '*'
           serviceAccountName: knative-operator
     strategy: deployment
+  webhookdefinitions:
+    - generateName: validating.knativeeventings.operator.serverless.openshift.io
+      type: ValidatingAdmissionWebhook
+      deploymentName: knative-openshift
+      admissionReviewVersions:
+        - v1beta1
+      containerPort: 9876
+      failurePolicy: Ignore
+      rules:
+        - apiGroups:
+            - operator.knative.dev
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - knativeeventings
+      sideEffects: None
+      webhookPath: /validate-knativeeventings
+    - generateName: validating.knativeservings.operator.serverless.openshift.io
+      type: ValidatingAdmissionWebhook
+      deploymentName: knative-openshift
+      admissionReviewVersions:
+        - v1beta1
+      containerPort: 9876
+      failurePolicy: Ignore
+      rules:
+        - apiGroups:
+            - operator.knative.dev
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - knativeservings
+      sideEffects: None
+      webhookPath: /validate-knativeservings
+    - generateName: validating.knativekafkas.operator.serverless.openshift.io
+      type: ValidatingAdmissionWebhook
+      deploymentName: knative-openshift
+      admissionReviewVersions:
+        - v1beta1
+      containerPort: 9876
+      failurePolicy: Ignore
+      rules:
+        - apiGroups:
+            - operator.serverless.openshift.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - knativekafkas
+      sideEffects: None
+      webhookPath: /validate-knativekafkas
+    - generateName: mutating.knativeeventings.operator.serverless.openshift.io
+      type: MutatingAdmissionWebhook
+      deploymentName: knative-openshift
+      admissionReviewVersions:
+        - v1beta1
+      containerPort: 9876
+      failurePolicy: Ignore
+      rules:
+        - apiGroups:
+            - operator.knative.dev
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - knativeeventings
+      sideEffects: None
+      webhookPath: /mutate-knativeeventings
+    - generateName: mutating.knativeservings.operator.serverless.openshift.io
+      type: MutatingAdmissionWebhook
+      deploymentName: knative-openshift
+      admissionReviewVersions:
+        - v1beta1
+      containerPort: 9876
+      failurePolicy: Ignore
+      rules:
+        - apiGroups:
+            - operator.knative.dev
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - knativeservings
+      sideEffects: None
+      webhookPath: /mutate-knativeservings
   installModes:
     - supported: false
       type: OwnNamespace

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -443,6 +443,102 @@ spec:
           - '*'
         serviceAccountName: knative-operator
     strategy: deployment
+  webhookdefinitions:
+  - generateName: validating.knativeeventings.operator.serverless.openshift.io
+    type: ValidatingAdmissionWebhook
+    deploymentName: knative-openshift
+    admissionReviewVersions:
+    - v1beta1
+    containerPort: 9876
+    failurePolicy: Ignore
+    rules:
+    - apiGroups:
+      - operator.knative.dev
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - knativeeventings
+    sideEffects: None
+    webhookPath: /validate-knativeeventings
+  - generateName: validating.knativeservings.operator.serverless.openshift.io
+    type: ValidatingAdmissionWebhook
+    deploymentName: knative-openshift
+    admissionReviewVersions:
+    - v1beta1
+    containerPort: 9876
+    failurePolicy: Ignore
+    rules:
+    - apiGroups:
+      - operator.knative.dev
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - knativeservings
+    sideEffects: None
+    webhookPath: /validate-knativeservings
+  - generateName: validating.knativekafkas.operator.serverless.openshift.io
+    type: ValidatingAdmissionWebhook
+    deploymentName: knative-openshift
+    admissionReviewVersions:
+    - v1beta1
+    containerPort: 9876
+    failurePolicy: Ignore
+    rules:
+    - apiGroups:
+      - operator.serverless.openshift.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - knativekafkas
+    sideEffects: None
+    webhookPath: /validate-knativekafkas
+  - generateName: mutating.knativeeventings.operator.serverless.openshift.io
+    type: MutatingAdmissionWebhook
+    deploymentName: knative-openshift
+    admissionReviewVersions:
+    - v1beta1
+    containerPort: 9876
+    failurePolicy: Ignore
+    rules:
+    - apiGroups:
+      - operator.knative.dev
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - knativeeventings
+    sideEffects: None
+    webhookPath: /mutate-knativeeventings
+  - generateName: mutating.knativeservings.operator.serverless.openshift.io
+    type: MutatingAdmissionWebhook
+    deploymentName: knative-openshift
+    admissionReviewVersions:
+    - v1beta1
+    containerPort: 9876
+    failurePolicy: Ignore
+    rules:
+    - apiGroups:
+      - operator.knative.dev
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - knativeservings
+    sideEffects: None
+    webhookPath: /mutate-knativeservings
   installModes:
   - supported: false
     type: OwnNamespace


### PR DESCRIPTION
As per title. Apart from fixing an important certificate related issue (https://issues.redhat.com/browse/SRVCOM-1053) this will allow us to move forward with our controller-runtime and operator-sdk versions to something muuuuuch more recent.

This is a first step towards that. No version bumps just yet to keep the number of moving parts lowish.

This changes the way the webhooks get registered for our knative-operator deployment. Instead of it generating a cert and registering itself (which is dropped from newer controller-runtime versions anyway), this defers all that to the CSV. OLM auto-generates and injects (and rolls) certificates to the deployments specified in the webhook configurations.

**Note:** This contains a small "patch" that is required for this to work on such an old version. We can drop this on newer versions of controller-runtime.