### PR TITLE
Prow noticeable style of ERROR message

### DIFF
--- a/hack/lib/ui.bash
+++ b/hack/lib/ui.bash
@@ -74,22 +74,22 @@ function logger.__log {
 
 if [[ "${SHOULD_COLOR}" == "false" ]]; then
   function logger.debug {
-    echo 'DEBUG' "$(date '+%H:%M:%S.%3N')" "$*"
+    echo "$(date '+%H:%M:%S.%3N') DEBUG:   $*"
   }
 
   function logger.info {
-    echo 'INFO' "$(date '+%H:%M:%S.%3N')" "$*"
+    echo "$(date '+%H:%M:%S.%3N') INFO:    $*"
   }
 
   function logger.success {
-    echo 'SUCCESS' "$(date '+%H:%M:%S.%3N')" "$*"
+    echo "$(date '+%H:%M:%S.%3N') SUCCESS: $*"
   }
 
   function logger.warn {
-    echo 'WARNING' "$(date '+%H:%M:%S.%3N')" "$*"
+    echo "$(date '+%H:%M:%S.%3N') WARNING: $*"
   }
 
   function logger.error {
-    echo 'ERROR' "$(date '+%H:%M:%S.%3N')" "$*"
+    echo "$(date '+%H:%M:%S.%3N') ERROR:   $*"
   }
 fi


### PR DESCRIPTION
Prow notice the errors if they have format of `error:`. This small PR adjust our logger to use that format. 

That will cause the visibility of ERRORs to be greatly enhanced. Example here: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/613/pull-ci-openshift-knative-serverless-operator-master-4.6-upstream-e2e-aws-ocp-46/1319783544649682944#1:build-log.txt%3A1391