### PR TITLE
Use Schemes in a more principled and less redundant way

### DIFF
--- a/knative-operator/pkg/common/serving_test.go
+++ b/knative-operator/pkg/common/serving_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -17,7 +18,7 @@ import (
 )
 
 func init() {
-	configv1.AddToScheme(scheme.Scheme)
+	apis.AddToScheme(scheme.Scheme)
 }
 
 func newKs() *servingv1alpha1.KnativeServing {

--- a/knative-operator/pkg/common/sources/source_deployment_discovery_controller_test.go
+++ b/knative-operator/pkg/common/sources/source_deployment_discovery_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -71,17 +72,16 @@ func init() {
 	os.Setenv(common.TestRolePath, "../testdata/role_service_monitor.yaml")
 	os.Setenv(common.TestSourceServiceMonitorPath, "../testdata/source-service-monitor.yaml")
 	os.Setenv(common.TestSourceServicePath, "../testdata/source-service.yaml")
+
+	apis.AddToScheme(scheme.Scheme)
 }
 
 // TestSourceReconcile runs Reconcile to verify if monitoring resources are created/deleted for sources.
 func TestSourceReconcile(t *testing.T) {
 	initObjs := []runtime.Object{&apiserversourceDeployment, &pingsourceDeployment, &defaultNamespace, &eventingNamespace}
 	cl := fake.NewFakeClient(initObjs...)
-	// Register operator types with the runtime scheme.
-	s := scheme.Scheme
-	monitor := &monitoringv1.ServiceMonitor{}
-	scheme.Scheme.AddKnownTypes(monitoringv1.SchemeGroupVersion, monitor)
-	r := &ReconcileSourceDeployment{client: cl, scheme: s}
+
+	r := &ReconcileSourceDeployment{client: cl, scheme: scheme.Scheme}
 	// Reconcile for an api server source
 	if _, err := r.Reconcile(apiserverRequest); err != nil {
 		t.Fatalf("reconcile: (%v)", err)

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	mf "github.com/manifestival/manifestival"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -24,6 +25,10 @@ var (
 		NamespacedName: types.NamespacedName{Namespace: "knative-eventing", Name: "knative-kafka"},
 	}
 )
+
+func init() {
+	apis.AddToScheme(scheme.Scheme)
+}
 
 func TestKnativeKafkaReconcile(t *testing.T) {
 	tests := []struct {
@@ -77,12 +82,7 @@ func TestKnativeKafkaReconcile(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// Register operator types with the runtime scheme.
-			s := scheme.Scheme
-			s.AddKnownTypes(v1alpha1.SchemeGroupVersion, test.instance)
-
 			initObjs := []runtime.Object{test.instance}
-
 			cl := fake.NewFakeClient(initObjs...)
 
 			kafkaChannelManifest, err := mf.ManifestFrom(mf.Path("testdata/kafkachannel-latest.yaml"))
@@ -97,7 +97,7 @@ func TestKnativeKafkaReconcile(t *testing.T) {
 
 			r := &ReconcileKnativeKafka{
 				client:                  cl,
-				scheme:                  s,
+				scheme:                  scheme.Scheme,
 				rawKafkaChannelManifest: kafkaChannelManifest,
 				rawKafkaSourceManifest:  kafkaSourceManifest,
 			}

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	. "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativeeventing"
-	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -16,8 +16,7 @@ import (
 )
 
 func init() {
-	configv1.AddToScheme(scheme.Scheme)
-	eventingv1alpha1.AddToScheme(scheme.Scheme)
+	apis.AddToScheme(scheme.Scheme)
 }
 
 var ke1 = &eventingv1alpha1.KnativeEventing{

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
 	. "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativekafka"
-	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -17,9 +17,7 @@ import (
 )
 
 func init() {
-	configv1.AddToScheme(scheme.Scheme)
-	operatorv1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme)
-	eventingv1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	apis.AddToScheme(scheme.Scheme)
 }
 
 var defaultCR = &operatorv1alpha1.KnativeKafka{

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	. "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativeserving"
-	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -16,8 +16,7 @@ import (
 )
 
 func init() {
-	configv1.AddToScheme(scheme.Scheme)
-	servingv1alpha1.AddToScheme(scheme.Scheme)
+	apis.AddToScheme(scheme.Scheme)
 }
 
 var ks1 = &servingv1alpha1.KnativeServing{


### PR DESCRIPTION
While upgrading controller-runtime, I noticed we are very picky with how our schemes are setup in tests. I don't think we need to be that picky, as tests should always assume the same scheme as the "main" scheme used by the operator anyway. This sets all tests up to do that, rather than being picky.

/assign @aliok 