### PR TITLE
Drop unnecessary logger shenanigans in unit tests

### DIFF
--- a/knative-operator/pkg/common/sources/source_deployment_discovery_controller_test.go
+++ b/knative-operator/pkg/common/sources/source_deployment_discovery_controller_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var (
@@ -76,7 +75,6 @@ func init() {
 
 // TestSourceReconcile runs Reconcile to verify if monitoring resources are created/deleted for sources.
 func TestSourceReconcile(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
 	initObjs := []runtime.Object{&apiserversourceDeployment, &pingsourceDeployment, &defaultNamespace, &eventingNamespace}
 	cl := fake.NewFakeClient(initObjs...)
 	// Register operator types with the runtime scheme.

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller_test.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller_test.go
@@ -18,7 +18,6 @@ import (
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var (
@@ -54,8 +53,6 @@ func init() {
 
 // TestEventingReconcile runs Reconcile to verify if eventing resources are created/deleted.
 func TestEventingReconcile(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-
 	tests := []struct {
 		name           string
 		ownerName      string

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var (
@@ -27,8 +26,6 @@ var (
 )
 
 func TestKnativeKafkaReconcile(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-
 	tests := []struct {
 		name         string
 		instance     *v1alpha1.KnativeKafka
@@ -159,8 +156,6 @@ func TestKnativeKafkaReconcile(t *testing.T) {
 }
 
 func TestSetBootstrapServers(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-
 	tests := []struct {
 		name             string
 		obj              *unstructured.Unstructured

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -25,7 +25,6 @@ import (
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/dashboard"
 )
@@ -123,8 +122,6 @@ func init() {
 
 // TestKourierReconcile runs Reconcile to verify if expected Kourier resources are deleted.
 func TestKourierReconcile(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-
 	tests := []struct {
 		name           string
 		ownerName      string
@@ -374,8 +371,6 @@ func TestCustomCertsConfigMap(t *testing.T) {
 
 // TestKnativeServingStatus tests KnativeServing CR status with Kourier's installation failure.
 func TestKnativeServingStatus(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-
 	ks := &defaultKnativeServing
 	ingress := &defaultIngress
 	knService := &defaultKnService


### PR DESCRIPTION
As per title, setting these loggers is not necessary.