### PR TITLE
Bump to OLM 1.12 metadata

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -81,7 +81,7 @@ spec:
         - -c
         - |-
           podman login -u $pull_user -p $token image-registry.openshift-image-registry.svc:5000 && \
-          /bin/opm registry add -d index.db --container-tool=podman --mode=replaces -b quay.io/openshift-knative/serverless-bundle:1.7.2,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.8.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.9.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:serverless-bundle,image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle && \
+          /bin/opm registry add -d index.db --container-tool=podman --mode=replaces -b quay.io/openshift-knative/serverless-bundle:1.7.2,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.8.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.9.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:serverless-bundle,,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.11.0:serverless-bundleimage-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle && \
           /bin/opm registry serve -d index.db -p 50051
 EOF
 

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -81,7 +81,7 @@ spec:
         - -c
         - |-
           podman login -u $pull_user -p $token image-registry.openshift-image-registry.svc:5000 && \
-          /bin/opm registry add -d index.db --container-tool=podman --mode=replaces -b quay.io/openshift-knative/serverless-bundle:1.7.2,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.8.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.9.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:serverless-bundle,,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.11.0:serverless-bundleimage-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle && \
+          /bin/opm registry add -d index.db --container-tool=podman --mode=replaces -b quay.io/openshift-knative/serverless-bundle:1.7.2,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.8.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.9.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.11.0:serverless-bundle,image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle && \
           /bin/opm registry serve -d index.db -p 50051
 EOF
 

--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.bundle.channels.v1="4.6"
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
       name="openshift-serverless-1/serverless-operator-bundle" \
-      version="1.11.0" \
+      version="1.12.0" \
       summary="Red Hat OpenShift Serverless Bundle" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -48,8 +48,8 @@ metadata:
       of serverless applications and functions.
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
-    olm.skipRange: '>=1.10.0 <1.11.0'
-  name: serverless-operator.v1.11.0
+    olm.skipRange: '>=1.11.0 <1.12.0'
+  name: serverless-operator.v1.12.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -659,5 +659,5 @@ spec:
       image: "registry.svc.ci.openshift.org/openshift/knative-v0.17.1:knative-eventing-sources-kafka-channel-dispatcher"
     - name: "KAFKA_IMAGE_kafka-webhook__kafka-webhook"
       image: "registry.svc.ci.openshift.org/openshift/knative-v0.17.1:knative-eventing-sources-kafka-channel-webhook"
-  replaces: serverless-operator.v1.10.0
-  version: 1.11.0
+  replaces: serverless-operator.v1.11.0
+  version: 1.12.0

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -1,11 +1,11 @@
 ---
 project:
   name: serverless-operator
-  version: 1.11.0
+  version: 1.12.0
 
 olm:
-  replaces: 1.10.0
-  skipRange: '>=1.10.0 <1.11.0'
+  replaces: 1.11.0
+  skipRange: '>=1.11.0 <1.12.0'
   channels:
     default: '4.6'
     list:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

This needs to wait until we have the 

```
registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.11.0:serverless-bundle
```

Image from CI 

/hold