### PR TITLE
Fix namespace usage in eventing test and touchups

### DIFF
--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller_test.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/dashboard"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -22,21 +22,21 @@ import (
 )
 
 var (
-	defaultKnativeEventing = v1alpha1.KnativeEventing{
+	ke = &v1alpha1.KnativeEventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "knative-eventing",
 			Namespace: "knative-eventing",
 		},
 	}
-	defaultRequest = reconcile.Request{
-		NamespacedName: types.NamespacedName{Namespace: "knative-eventing", Name: "knative-eventing"},
+	req = reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: ke.Namespace, Name: ke.Name},
 	}
-	dashboardNamespace = corev1.Namespace{
+	dashboardNamespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dashboard.ConfigManagedNamespace,
 		},
 	}
-	eventingNamespace = corev1.Namespace{
+	eventingNamespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "knative-eventing",
 		},
@@ -50,6 +50,8 @@ func init() {
 	os.Setenv(common.TestRolePath, "../dashboard/testdata/role_service_monitor.yaml")
 	os.Setenv(common.TestEventingBrokerServiceMonitorPath, "../dashboard/testdata/broker-service-monitors.yaml")
 	os.Setenv(common.TestMonitor, "true")
+
+	apis.AddToScheme(scheme.Scheme)
 }
 
 // TestEventingReconcile runs Reconcile to verify if eventing resources are created/deleted.
@@ -61,65 +63,51 @@ func TestEventingReconcile(t *testing.T) {
 		ownerName      string
 		ownerNamespace string
 		deleted        bool
-	}{
-		{
-			name:           "reconcile request with same KnativeServing owner",
-			ownerName:      "knative-eventing",
-			ownerNamespace: "knative-eventing",
-			deleted:        true,
-		},
-		{
-			name:           "reconcile request with different KnativeServing owner name",
-			ownerName:      "FOO",
-			ownerNamespace: "knative-eventing",
-			deleted:        false,
-		},
-		{
-			name:           "reconcile request with different KnativeServing owner namespace",
-			ownerName:      "knative-eventing",
-			ownerNamespace: "FOO",
-			deleted:        false,
-		},
-	}
+	}{{
+		name:           "reconcile request with same KnativeEventing owner",
+		ownerName:      "knative-eventing",
+		ownerNamespace: "knative-eventing",
+		deleted:        true,
+	}, {
+		name:           "reconcile request with different KnativeEventing owner name",
+		ownerName:      "FOO",
+		ownerNamespace: "knative-eventing",
+		deleted:        false,
+	}, {
+		name:           "reconcile request with different KnativeEventing owner namespace",
+		ownerName:      "knative-eventing",
+		ownerNamespace: "FOO",
+		deleted:        false,
+	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ke := &defaultKnativeEventing
-			ns := &dashboardNamespace
-			monitor := &monitoringv1.ServiceMonitor{}
-			initObjs := []runtime.Object{ke, ns, &eventingNamespace}
-
-			// Register operator types with the runtime scheme.
-			s := scheme.Scheme
-			s.AddKnownTypes(v1alpha1.SchemeGroupVersion, ke)
-			scheme.Scheme.AddKnownTypes(monitoringv1.SchemeGroupVersion, monitor)
-
-			cl := fake.NewFakeClient(initObjs...)
-			r := &ReconcileKnativeEventing{client: cl, scheme: s}
+			cl := fake.NewFakeClient([]runtime.Object{ke, dashboardNamespace, eventingNamespace}...)
+			r := &ReconcileKnativeEventing{client: cl, scheme: scheme.Scheme}
 
 			// Reconcile to initialize
-			if _, err := r.Reconcile(defaultRequest); err != nil {
+			if _, err := r.Reconcile(req); err != nil {
 				t.Fatalf("reconcile: (%v)", err)
 			}
 			// Check if Eventing dashboard configmaps are available
 			brokerCM := &corev1.ConfigMap{}
-			err := cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-broker", Namespace: ns.Name}, brokerCM)
+			err := cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-broker", Namespace: dashboardNamespace.Name}, brokerCM)
 			if err != nil {
 				t.Fatalf("get: (%v)", err)
 			}
 			sourceCM := &corev1.ConfigMap{}
-			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-source", Namespace: ns.Name}, sourceCM)
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-source", Namespace: dashboardNamespace.Name}, sourceCM)
 			if err != nil {
 				t.Fatalf("get: (%v)", err)
 			}
 			// Check if the eventing service monitors are installed
 			smFilter := &monitoringv1.ServiceMonitor{}
-			err = cl.Get(context.TODO(), types.NamespacedName{Name: "knative-eventing-metrics-broker-filter", Namespace: ns.Namespace}, smFilter)
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "knative-eventing-metrics-broker-filter", Namespace: eventingNamespace.Name}, smFilter)
 			if err != nil {
 				t.Fatalf("get: (%v)", err)
 			}
 			smIngress := &monitoringv1.ServiceMonitor{}
-			err = cl.Get(context.TODO(), types.NamespacedName{Name: "knative-eventing-metrics-broker-ingress", Namespace: ns.Namespace}, smIngress)
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "knative-eventing-metrics-broker-ingress", Namespace: eventingNamespace.Name}, smIngress)
 			if err != nil {
 				t.Fatalf("get: (%v)", err)
 			}
@@ -141,6 +129,7 @@ func TestEventingReconcile(t *testing.T) {
 			if err != nil {
 				t.Fatalf("delete: (%v)", err)
 			}
+
 			// Reconcile again with test requests.
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{Namespace: test.ownerNamespace, Name: test.ownerName},
@@ -161,15 +150,15 @@ func TestEventingReconcile(t *testing.T) {
 				}
 			}
 			// Check again if Eventing dashboard configmaps are available
-			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-broker", Namespace: ns.Name}, brokerCM)
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-broker", Namespace: dashboardNamespace.Name}, brokerCM)
 			checkError(t, err)
-			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-source", Namespace: ns.Name}, sourceCM)
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-source", Namespace: dashboardNamespace.Name}, sourceCM)
 			checkError(t, err)
 
 			// Check again if the eventing service monitors are available
-			err = cl.Get(context.TODO(), types.NamespacedName{Name: "knative-eventing-metrics-broker-filter", Namespace: ns.Namespace}, smFilter)
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "knative-eventing-metrics-broker-filter", Namespace: eventingNamespace.Name}, smFilter)
 			checkError(t, err)
-			err = cl.Get(context.TODO(), types.NamespacedName{Name: "knative-eventing-metrics-broker-ingress", Namespace: ns.Namespace}, smIngress)
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "knative-eventing-metrics-broker-ingress", Namespace: eventingNamespace.Name}, smIngress)
 			checkError(t, err)
 		})
 	}


### PR DESCRIPTION
I have no clue why this even passes on master, but it will start failing on newer controller-runtime versions. Apparently the namespaces aren't correctly matched up on the current one, so this fixes that.

Also contains a few touchups to the test in general.