### PR TITLE
Rework webhook test method to actually send requests

### DIFF
--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
@@ -32,12 +32,7 @@ var (
 
 func init() {
 	apis.AddToScheme(scheme.Scheme)
-
-	dec, err := admission.NewDecoder(scheme.Scheme)
-	if err != nil {
-		panic(err)
-	}
-	decoder = dec
+	decoder, _ = admission.NewDecoder(scheme.Scheme)
 }
 
 func TestInvalidNamespace(t *testing.T) {

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
@@ -1,4 +1,4 @@
-package knativeeventing_test
+package knativeeventing
 
 import (
 	"context"
@@ -6,36 +6,53 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
-	. "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativeeventing"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+var (
+	ke1 = &eventingv1alpha1.KnativeEventing{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ke1",
+		},
+	}
+	ke2 = &eventingv1alpha1.KnativeEventing{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ke2",
+		},
+	}
+
+	decoder types.Decoder
 )
 
 func init() {
 	apis.AddToScheme(scheme.Scheme)
-}
 
-var ke1 = &eventingv1alpha1.KnativeEventing{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "ke1",
-	},
-}
-var ke2 = &eventingv1alpha1.KnativeEventing{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "ke2",
-	},
+	dec, err := admission.NewDecoder(scheme.Scheme)
+	if err != nil {
+		panic(err)
+	}
+	decoder = dec
 }
 
 func TestInvalidNamespace(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_EVENTING_NAMESPACE", "knative-eventing")
+
 	validator := Validator{}
-	validator.InjectDecoder(&mockDecoder{ke1})
-	result := validator.Handle(context.TODO(), types.Request{})
+	validator.InjectDecoder(decoder)
+
+	req, err := testutil.RequestFor(ke1)
+	if err != nil {
+		t.Fatalf("Failed to generate a request for %v: %v", ke1, err)
+	}
+
+	result := validator.Handle(context.Background(), req)
 	if result.Response.Allowed {
 		t.Error("The required namespace is wrong, but the request is allowed")
 	}
@@ -43,24 +60,18 @@ func TestInvalidNamespace(t *testing.T) {
 
 func TestLoneliness(t *testing.T) {
 	os.Clearenv()
+
 	validator := Validator{}
-	validator.InjectDecoder(&mockDecoder{ke1})
+	validator.InjectDecoder(decoder)
 	validator.InjectClient(fake.NewFakeClient(ke2))
-	result := validator.Handle(context.TODO(), types.Request{})
+
+	req, err := testutil.RequestFor(ke1)
+	if err != nil {
+		t.Fatalf("Failed to generate a request for %v: %v", ke1, err)
+	}
+
+	result := validator.Handle(context.Background(), req)
 	if result.Response.Allowed {
 		t.Errorf("Too many KnativeEventings: %v", result.Response)
 	}
-}
-
-type mockDecoder struct {
-	ke *eventingv1alpha1.KnativeEventing
-}
-
-var _ types.Decoder = (*mockDecoder)(nil)
-
-func (mock *mockDecoder) Decode(_ types.Request, obj runtime.Object) error {
-	if p, ok := obj.(*eventingv1alpha1.KnativeEventing); ok {
-		*p = *mock.ke
-	}
-	return nil
 }

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
@@ -86,12 +86,7 @@ var (
 
 func init() {
 	apis.AddToScheme(scheme.Scheme)
-
-	dec, err := admission.NewDecoder(scheme.Scheme)
-	if err != nil {
-		panic(err)
-	}
-	decoder = dec
+	decoder, _ = admission.NewDecoder(scheme.Scheme)
 }
 
 func TestHappy(t *testing.T) {

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
@@ -32,12 +32,7 @@ var (
 
 func init() {
 	apis.AddToScheme(scheme.Scheme)
-
-	dec, err := admission.NewDecoder(scheme.Scheme)
-	if err != nil {
-		panic(err)
-	}
-	decoder = dec
+	decoder, _ = admission.NewDecoder(scheme.Scheme)
 }
 
 func TestInvalidNamespace(t *testing.T) {

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
@@ -1,4 +1,4 @@
-package knativeserving_test
+package knativeserving
 
 import (
 	"context"
@@ -6,36 +6,53 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
-	. "github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativeserving"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+var (
+	ks1 = &servingv1alpha1.KnativeServing{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ks1",
+		},
+	}
+	ks2 = &servingv1alpha1.KnativeServing{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ks2",
+		},
+	}
+
+	decoder types.Decoder
 )
 
 func init() {
 	apis.AddToScheme(scheme.Scheme)
-}
 
-var ks1 = &servingv1alpha1.KnativeServing{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "ks1",
-	},
-}
-var ks2 = &servingv1alpha1.KnativeServing{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "ks2",
-	},
+	dec, err := admission.NewDecoder(scheme.Scheme)
+	if err != nil {
+		panic(err)
+	}
+	decoder = dec
 }
 
 func TestInvalidNamespace(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_SERVING_NAMESPACE", "knative-serving")
+
 	validator := Validator{}
-	validator.InjectDecoder(&mockDecoder{ks1})
-	result := validator.Handle(context.TODO(), types.Request{})
+	validator.InjectDecoder(decoder)
+
+	req, err := testutil.RequestFor(ks1)
+	if err != nil {
+		t.Fatalf("Failed to generate a request for %v: %v", ks1, err)
+	}
+
+	result := validator.Handle(context.Background(), req)
 	if result.Response.Allowed {
 		t.Error("The required namespace is wrong, but the request is allowed")
 	}
@@ -43,24 +60,18 @@ func TestInvalidNamespace(t *testing.T) {
 
 func TestLoneliness(t *testing.T) {
 	os.Clearenv()
+
 	validator := Validator{}
-	validator.InjectDecoder(&mockDecoder{ks1})
+	validator.InjectDecoder(decoder)
 	validator.InjectClient(fake.NewFakeClient(ks2))
-	result := validator.Handle(context.TODO(), types.Request{})
+
+	req, err := testutil.RequestFor(ks1)
+	if err != nil {
+		t.Fatalf("Failed to generate a request for %v: %v", ks1, err)
+	}
+
+	result := validator.Handle(context.Background(), req)
 	if result.Response.Allowed {
 		t.Errorf("Too many KnativeServings: %v", result.Response)
 	}
-}
-
-type mockDecoder struct {
-	ks *servingv1alpha1.KnativeServing
-}
-
-var _ types.Decoder = (*mockDecoder)(nil)
-
-func (mock *mockDecoder) Decode(_ types.Request, obj runtime.Object) error {
-	if p, ok := obj.(*servingv1alpha1.KnativeServing); ok {
-		*p = *mock.ks
-	}
-	return nil
 }

--- a/knative-operator/pkg/webhook/testutil/testutil.go
+++ b/knative-operator/pkg/webhook/testutil/testutil.go
@@ -1,19 +1,25 @@
 package testutil
 
 import (
-	configv1 "github.com/openshift/api/config/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"encoding/json"
+
+	"k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
 )
 
-func MockClusterVersion(version string) *configv1.ClusterVersion {
-	return &configv1.ClusterVersion{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "version",
-		},
-		Status: configv1.ClusterVersionStatus{
-			Desired: configv1.Update{
-				Version: version,
+// RequestFor generates an admission request for the given object.
+func RequestFor(obj runtime.Object) (types.Request, error) {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return types.Request{}, err
+	}
+	return types.Request{
+		AdmissionRequest: &v1beta1.AdmissionRequest{
+			Object: runtime.RawExtension{
+				Raw:    b,
+				Object: obj,
 			},
 		},
-	}
+	}, nil
 }


### PR DESCRIPTION
Currently, the webhook's objects are mocked through the decoder interface, but the webhooks don't actually get a request. This replaces the decoder with a generic encoder based on the scheme and instead passes a "proper" request to the webhooks under test.

**Note:** Newer versions of controller-runtime no longer have a decoder interface, so this is prep work to have a much smaller diff once bumping the version.