### PR TITLE
Do not continue script if wait_until_labelled_pods_are_ready() failed

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -124,7 +124,7 @@ spec:
 EOF
 
   logger.info 'Wait for the index pod to be up to avoid inconsistencies with the catalog source.'
-  wait_until_labelled_pods_are_ready app=serverless-index "$OLM_NAMESPACE"
+  wait_until_labelled_pods_are_ready app=serverless-index "$OLM_NAMESPACE" || return $?
 
   logger.info 'Install the catalogsource.'
   cat <<EOF | oc apply -n "$OLM_NAMESPACE" -f - || return $?

--- a/hack/lib/common.bash
+++ b/hack/lib/common.bash
@@ -21,10 +21,11 @@ function wait_until_labelled_pods_are_ready {
   ns="${2:?Pass a namespace as arg[2]}"
 
   # Wait for some pods to sprung
-  timeout 300 "[[ \$(oc get pods -l ${label} -n ${ns} -o name | wc -l) == '0' ]]"
+  timeout 300 "[[ \$(oc get pods -l ${label} -n ${ns} -o name | wc -l) == '0' ]]" || return 1
   # Wait until they are ready to receive communications
   timeout 300 "[[ \$(oc get pods -l ${label} -n ${ns} -o \
-'jsonpath={..status.conditions[?(@.type==\"Ready\")].status}') != 'True' ]]"
+'jsonpath={..status.conditions[?(@.type==\"Ready\")].status}') != 'True' ]]" || return 1
+  return 0
 }
 
 # Loops until duration (car) is exceeded or command (cdr) returns non-zero


### PR DESCRIPTION
When `wait_until_labelled_pods_are_ready()` got timeout, it does not stop script and continue to the script.

Please see the error log below. The script continues after `ERROR 11:41:03.396 Time out of 300 exceeded`.

```
 ...
  DEBUG 11:40:53.040 Execution failed: [[ $(oc get pods -l app=serverless-index -n openshift-marketplace -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != 'True' ]]. Waiting 5 sec (300/300)...
  DEBUG 11:40:58.388 Execution failed: [[ $(oc get pods -l app=serverless-index -n openshift-marketplace -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != 'True' ]]. Waiting 5 sec (305/300)...
  ERROR 11:41:03.396 Time out of 300 exceeded
   INFO 11:41:03.401 Install the catalogsource.
catalogsource.operators.coreos.com/serverless-operator created
SUCCESS 11:41:04.136 CatalogSource installed successfully
 ...
```

This patch fixes it.

/cc @cardil @markusthoemmes 