### PR TITLE
Drop redundant config and client creation

### DIFF
--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -103,7 +103,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := setupMonitoring(ctx, cfg); err != nil {
+	if err := setupMonitoring(cfg, mgr.GetClient()); err != nil {
 		log.Error(err, "Failed to start monitoring")
 	}
 
@@ -116,17 +116,7 @@ func main() {
 	}
 }
 
-func setupMonitoring(ctx context.Context, cfg *rest.Config) error {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return fmt.Errorf("failed to create cluster config: %w", err)
-	}
-
-	cl, err := client.New(config, client.Options{})
-	if err != nil {
-		return fmt.Errorf("failed to create a client: %w", err)
-	}
-
+func setupMonitoring(cfg *rest.Config, cl client.Client) error {
 	namespace := os.Getenv(common.NamespaceEnvKey)
 	if namespace == "" {
 		return errors.New("NAMESPACE not provided via environment")
@@ -141,7 +131,7 @@ func setupMonitoring(ctx context.Context, cfg *rest.Config) error {
 		return fmt.Errorf("failed to setup monitoring resources: %w", err)
 	}
 
-	if err := common.SetupServerlessOperatorServiceMonitor(ctx, cfg, cl, metricsPort, metricsHost, operatorMetricsPort); err != nil {
+	if err := common.SetupServerlessOperatorServiceMonitor(cfg, cl, metricsPort, metricsHost, operatorMetricsPort); err != nil {
 		return fmt.Errorf("failed to setup the Service monitor: %w", err)
 	}
 

--- a/knative-operator/pkg/common/service_monitor.go
+++ b/knative-operator/pkg/common/service_monitor.go
@@ -39,7 +39,7 @@ const (
 	TestSourceServicePath                = "TEST_SOURCE_SERVICE_PATH"
 )
 
-func SetupServerlessOperatorServiceMonitor(ctx context.Context, cfg *rest.Config, api client.Client, metricsPort int32, metricsHost string, operatorMetricsPort int32) error {
+func SetupServerlessOperatorServiceMonitor(cfg *rest.Config, api client.Client, metricsPort int32, metricsHost string, operatorMetricsPort int32) error {
 	// Commented below to avoid a stream of these errors at startup:
 	// E1021 22:50:03.372487       1 reflector.go:134] github.com/operator-framework/operator-sdk/pkg/kube-metrics/collector.go:67: Failed to list *unstructured.Unstructured: the server could not find the requested resource
 	if err := serveCRMetrics(cfg, metricsHost, operatorMetricsPort); err != nil {
@@ -52,7 +52,7 @@ func SetupServerlessOperatorServiceMonitor(ctx context.Context, cfg *rest.Config
 		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
-	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
+	service, err := metrics.CreateMetricsService(context.Background(), cfg, servicePorts)
 	if err != nil {
 		return fmt.Errorf("failed to create metrics service: %w", err)
 	}


### PR DESCRIPTION
As per title, it seems unnecessary to create clients and configs twice here. Maybe I'm missing something though.