### PR TITLE
Fix monitoring on master

### DIFF
--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -106,7 +106,7 @@ func main() {
 	// Kafka Webhooks
 	hookServer.Register("/validate-knativekafkas", &webhook.Admission{Handler: &knativekafka.Validator{}})
 
-	if err := setupMonitoring(cfg, mgr.GetClient()); err != nil {
+	if err := setupMonitoring(cfg); err != nil {
 		log.Error(err, "Failed to start monitoring")
 	}
 
@@ -119,7 +119,11 @@ func main() {
 	}
 }
 
-func setupMonitoring(cfg *rest.Config, cl client.Client) error {
+func setupMonitoring(cfg *rest.Config) error {
+	cl, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return fmt.Errorf("failed to create a client: %w", err)
+	}
 	namespace := os.Getenv(common.NamespaceEnvKey)
 	if namespace == "" {
 		return errors.New("NAMESPACE not provided via environment")


### PR DESCRIPTION
- Monitoring is failing on master. Fixes the following error:
```
{"level":"error","ts":"2020-11-02T10:27:53.126Z","logger":"cmd","msg":"Failed to start monitoring","error":"the cache is not started, can not read objects","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/openshift-knative/serverless-operator/knative-operator/vendor/github.com/go-logr/zapr/zapr.go:132\nmain.main\n\t/go/src/github.com/openshift-knative/serverless-operator/knative-operator/cmd/manager/main.go:110\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203"}
```
The recommendation at this early stage is to use our own [client](https://github.com/jaegertracing/jaeger-operator/issues/809#issue-532751170).
