### PR TITLE
Remove note that eventing is technical preview

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -137,8 +137,6 @@ spec:
 
     ## Knative Eventing
 
-    Knative Eventing is a **[Technology Preview feature](https://access.redhat.com/support/offerings/techpreview)!**
-
     Knative Eventing is a system that is designed to address a common need for cloud native
     development and provides composable primitives to enable late-binding event sources and
     event consumers.

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -137,8 +137,6 @@ spec:
 
     ## Knative Eventing
 
-    Knative Eventing is a **[Technology Preview feature](https://access.redhat.com/support/offerings/techpreview)!**
-
     Knative Eventing is a system that is designed to address a common need for cloud native
     development and provides composable primitives to enable late-binding event sources and
     event consumers.


### PR DESCRIPTION
Eventing is GA as of OpenShift Serverless 1.11, so remove note that it is a technical preview feature.