### PR TITLE
Refactor some tests to use withServiceReadyOrFail util

### DIFF
--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgTest "knative.dev/pkg/test"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func WaitForRouteServingText(t *testing.T, caCtx *test.Context, routeURL *url.URL, expectedText string) {
@@ -21,4 +23,24 @@ func WaitForRouteServingText(t *testing.T, caCtx *test.Context, routeURL *url.UR
 		true); err != nil {
 		t.Fatalf("The Route at domain %s didn't serve the expected text \"%s\": %v", routeURL, expectedText, err)
 	}
+}
+
+func withServiceReadyOrFail(ctx *test.Context, service *servingv1.Service) *servingv1.Service {
+	service, err := ctx.Clients.Serving.ServingV1().Services(service.Namespace).Create(context.Background(), service, meta.CreateOptions{})
+	if err != nil {
+		ctx.T.Fatalf("Error creating ksvc: %v", err)
+	}
+
+	// Let the ksvc be deleted after test
+	ctx.AddToCleanup(func() error {
+		ctx.T.Logf("Cleaning up Knative Service '%s/%s'", service.Namespace, service.Name)
+		return ctx.Clients.Serving.ServingV1().Services(service.Namespace).Delete(context.Background(), service.Name, meta.DeleteOptions{})
+	})
+
+	service, err = test.WaitForServiceState(ctx, service.Name, service.Namespace, test.IsServiceReady)
+	if err != nil {
+		ctx.T.Fatalf("Error waiting for ksvc readiness: %v", err)
+	}
+
+	return service
 }

--- a/test/servinge2e/servicemesh_test.go
+++ b/test/servinge2e/servicemesh_test.go
@@ -75,26 +75,6 @@ func httpProxyService(name, namespace, host string) *servingv1.Service {
 	return proxy
 }
 
-func withServiceReadyOrFail(ctx *test.Context, service *servingv1.Service) *servingv1.Service {
-	service, err := ctx.Clients.Serving.ServingV1().Services(service.Namespace).Create(context.Background(), service, meta.CreateOptions{})
-	if err != nil {
-		ctx.T.Fatalf("Error creating ksvc: %v", err)
-	}
-
-	// Let the ksvc be deleted after test
-	ctx.AddToCleanup(func() error {
-		ctx.T.Logf("Cleaning up Knative Service '%s/%s'", service.Namespace, service.Name)
-		return ctx.Clients.Serving.ServingV1().Services(service.Namespace).Delete(context.Background(), service.Name, meta.DeleteOptions{})
-	})
-
-	service, err = test.WaitForServiceState(ctx, service.Name, service.Namespace, test.IsServiceReady)
-	if err != nil {
-		ctx.T.Fatalf("Error waiting for ksvc readiness: %v", err)
-	}
-
-	return service
-}
-
 // Skipped unless ServiceMesh has been installed via "make install-mesh"
 func TestKsvcWithServiceMeshSidecar(t *testing.T) {
 


### PR DESCRIPTION
This patch refactors to:
- move `withServiceReadyOrFail()` to helper.go
- use `withServiceReadyOrFail()` in service_to_servig test

/cc @mgencur @maschmid 