### PR TITLE
Make sure namespaces are created before start testing

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -152,6 +152,9 @@ spec:
   sourceType: grpc
 EOF
 
+  logger.info 'Wait for the namespaces to be created.'
+  timeout 120 "[[ \$(oc get namespace ${SERVING_NAMESPACE} ${EVENTING_NAMESPACE} --no-headers | wc -l) != 2 ]]" || return 1
+
   logger.success "CatalogSource installed successfully"
 }
 


### PR DESCRIPTION
As [build log](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/672/pull-ci-openshift-knative-serverless-operator-master-4.6-operator-e2e-aws-ocp-46/1324560439375302656) exposed, sometimes tests fail due to namespace not found error.

```
=== RUN   TestKnativeEventing/create_subscription_and_wait_for_CSV_to_succeed
=== RUN   TestKnativeEventing/deploy_knativeeventing_cr_and_wait_for_it_to_be_ready
    knative_eventing_test.go:39: Failed to deploy KnativeEventing namespaces "knative-eventing" not found
--- FAIL: TestKnativeEventing (61.82s)
```

It seems too early to start testing after CatalogSource was created. 

```
04:46:15.341 SUCCESS: CatalogSource installed successfully
04:46:15.343 SUCCESS: 🚀 Cluster prepared for testing.
04:46:15.345 INFO:    Running tests
```

Hence this patch makes sure namespaces are created in `install_catalogsource()`.