### PR TITLE
Install kntest in build-image

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -7,7 +7,8 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
 RUN yum install -y kubectl ansible httpd-tools
 
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
+RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
+  knative.dev/test-infra/kntest/cmd/kntest
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd

--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -7,7 +7,8 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
 RUN yum install -y kubectl ansible httpd-tools
 
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
+RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
+  knative.dev/test-infra/kntest/cmd/kntest
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
This is to suppress failures such as:
```
--- FAIL: kntest not installed, please clone test-infra repo and run `go install ./kntest/cmd/kntest` to install it
```