### PR TITLE
Ensure bundle image is only built for x86_64

### DIFF
--- a/olm-catalog/serverless-operator/container.yaml
+++ b/olm-catalog/serverless-operator/container.yaml
@@ -1,3 +1,6 @@
+platforms:
+  only:
+  - x86_64
 operator_manifests:
     manifests_dir: manifests
     enable_digest_pinning: false


### PR DESCRIPTION
See title. I'm told the bundle image is not required for any other architecture.