### PR TITLE
Drop unnecessary WORKDIR commands and simplify manifest copying

### DIFF
--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -1,5 +1,4 @@
 FROM openshift/origin-release:golang-1.14 AS builder
-WORKDIR ${GOPATH}/src/github.com/openshift-knative/serverless-operator/openshift-knative-operator
 COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ./cmd/manager

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -1,14 +1,14 @@
 FROM openshift/origin-release:golang-1.14 AS builder
-WORKDIR ${GOPATH}/src/github.com/openshift-knative/serverless-operator/openshift-knative-operator
 COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ./cmd/operator
-RUN cp -Lr ${GOPATH}/src/github.com/openshift-knative/serverless-operator/openshift-knative-operator/cmd/operator/kodata /tmp
 
 FROM openshift/origin-base
 COPY --from=builder /tmp/operator /ko-app/operator
-COPY --from=builder /tmp/kodata/ /var/run/ko
+
 ENV KO_DATA_PATH="/var/run/ko"
+COPY cmd/operator/kodata $KO_DATA_PATH
+
 LABEL \
     com.redhat.component="openshift-serverless-1-tech-preview-knative-rhel8-operator-container" \
     name="openshift-serverless-1-tech-preview/knative-rhel8-operator" \

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -1,5 +1,4 @@
 FROM openshift/origin-release:golang-1.14 AS builder
-WORKDIR ${GOPATH}/src/github.com/openshift-knative/serverless-operator/openshift-knative-operator
 COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ./cmd/controller


### PR DESCRIPTION
1. It's not necessary to build our components in specific locations anymore, as they are now go module based.
2. It's unnecessary to copy manifests in the builder image only to then copy them again.