### PR TITLE
Adjust images to use root as their context directory

### DIFF
--- a/hack/images.sh
+++ b/hack/images.sh
@@ -12,12 +12,12 @@ fi
 
 repo=$1
 
-docker build -t "$repo/openshift-knative-operator" openshift-knative-operator
+docker build -t "$repo/openshift-knative-operator" -f openshift-knative-operator/Dockerfile .
 docker push "$repo/openshift-knative-operator"
 
-docker build -t "$repo/knative-operator" knative-operator
+docker build -t "$repo/knative-operator" -f knative-operator/Dockerfile .
 docker push "$repo/knative-operator"
 
-docker build -t "$repo/knative-openshift-ingress" serving/ingress
+docker build -t "$repo/knative-openshift-ingress" -f serving/ingress/Dockerfile .
 docker push "$repo/knative-openshift-ingress"
 

--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -1,11 +1,13 @@
 FROM openshift/origin-release:golang-1.14 AS builder
 COPY . .
+
+WORKDIR knative-operator
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ./cmd/manager
 
 FROM openshift/origin-base
 COPY --from=builder /tmp/operator /ko-app/operator
 # install manifest[s]
-COPY deploy /deploy
+COPY knative-operator/deploy /deploy
 
 ENTRYPOINT ["/ko-app/operator"]

--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -1,9 +1,13 @@
 FROM openshift/origin-release:golang-1.14 AS builder
+
+ENV BASE=github.com/openshift-knative/serverless-operator
+WORKDIR ${GOPATH}/src/${BASE}
+
 COPY . .
 
 WORKDIR knative-operator
 ENV GOFLAGS="-mod=vendor"
-RUN go build -o /tmp/operator ./cmd/manager
+RUN go build -o /tmp/operator ${BASE}/knative-operator/cmd/manager
 
 FROM openshift/origin-base
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -1,5 +1,7 @@
 FROM openshift/origin-release:golang-1.14 AS builder
 COPY . .
+
+WORKDIR openshift-knative-operator
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ./cmd/operator
 
@@ -7,7 +9,7 @@ FROM openshift/origin-base
 COPY --from=builder /tmp/operator /ko-app/operator
 
 ENV KO_DATA_PATH="/var/run/ko"
-COPY cmd/operator/kodata $KO_DATA_PATH
+COPY openshift-knative-operator/cmd/operator/kodata $KO_DATA_PATH
 
 LABEL \
     com.redhat.component="openshift-serverless-1-tech-preview-knative-rhel8-operator-container" \

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -1,9 +1,12 @@
 FROM openshift/origin-release:golang-1.14 AS builder
+
+ENV BASE=github.com/openshift-knative/serverless-operator
+WORKDIR ${GOPATH}/src/${BASE}
+
 COPY . .
 
-WORKDIR openshift-knative-operator
 ENV GOFLAGS="-mod=vendor"
-RUN go build -o /tmp/operator ./cmd/operator
+RUN go build -o /tmp/operator ${BASE}/openshift-knative-operator/cmd/operator
 
 FROM openshift/origin-base
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -1,11 +1,14 @@
 FROM openshift/origin-release:golang-1.14 AS builder
+
+ENV BASE=github.com/openshift-knative/serverless-operator
+WORKDIR ${GOPATH}/src/${BASE}
+
 COPY . .
 
-WORKDIR serving/ingress
 ENV GOFLAGS="-mod=vendor"
-RUN go build -o /tmp/operator ./cmd/controller
+RUN go build -o /tmp/operator ${BASE}/serving/ingress/cmd/controller
 
 FROM openshift/origin-base
 COPY --from=builder /tmp/operator /ko-app/operator
 
-ENTRYPOINT ["/ko-app/operator"] 
+ENTRYPOINT ["/ko-app/operator"]

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -1,5 +1,7 @@
 FROM openshift/origin-release:golang-1.14 AS builder
 COPY . .
+
+WORKDIR serving/ingress
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ./cmd/controller
 


### PR DESCRIPTION
This is a stepping stone towards #669. It changes the context directory of our images to be the repo's root rather than the nested directories of the respective components. This will allows us to frontload config changes and test the big vendor change in a PR properly.

This needs to be coupled with a change in ci-operator.