### PR TITLE
[SRVKS-654]Improve health status

### DIFF
--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
@@ -94,7 +94,7 @@ data:
                }
             ],
             "thresholds": "",
-            "title": "Knative Current Status",
+            "title": "Knative Status",
             "type": "singlestat",
             "valueFontSize": "200%",
             "valueMaps": [

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
@@ -85,7 +85,7 @@ data:
             },
             "targets": [
                {
-                 "expr": "avg_over_time ((sum(knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=~\"eventing_status|serving_status\"}) / (sum(knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=~\"eventing_status|serving_status\"})))[1m:30s]) >bool 0.95",
+                 "expr": "min by (type)(knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=~\"eventing_status|serving_status\"})",
                  "intervalFactor": 2,
                  "legendFormat": "",
                  "metric": "knative_up",

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
@@ -85,7 +85,7 @@ data:
             },
             "targets": [
                {
-                 "expr": "floor(sum(knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=~\"eventing_status|serving_status\"})/2)",
+                 "expr": "avg_over_time ((sum(knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=~\"eventing_status|serving_status\"}) / (sum(knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=~\"eventing_status|serving_status\"})))[1m:30s]) >bool 0.95",
                  "intervalFactor": 2,
                  "legendFormat": "",
                  "metric": "knative_up",
@@ -94,7 +94,7 @@ data:
                }
             ],
             "thresholds": "",
-            "title": "Knative Status",
+            "title": "Knative Current Status",
             "type": "singlestat",
             "valueFontSize": "200%",
             "valueMaps": [

--- a/knative-operator/pkg/common/health_metrics.go
+++ b/knative-operator/pkg/common/health_metrics.go
@@ -6,20 +6,19 @@ import (
 )
 
 var (
-	knativeUp = prometheus.NewGaugeVec(
+	KnativeUp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "knative_up",
 			Help: "Reports if a Knative component is up",
 		},
 		[]string{"type"},
 	)
-	KnativeServingUpG  = knativeUp.WithLabelValues("serving_status")
-	KnativeEventingUpG = knativeUp.WithLabelValues("eventing_status")
-	KnativeKafkaUpG    = knativeUp.WithLabelValues("kafka_status")
+	KnativeServingUpG  prometheus.Gauge
+	KnativeEventingUpG prometheus.Gauge
+	KnativeKafkaUpG    = KnativeUp.WithLabelValues("kafka_status")
 )
 
 func init() {
 	// Register custom metrics with the global prometheus registry
-	metrics.Registry.MustRegister(knativeUp)
-	knativeUp.DeleteLabelValues()
+	metrics.Registry.MustRegister(KnativeUp)
 }

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -198,7 +198,7 @@ func (r *ReconcileKnativeEventing) installDashboards(instance *eventingv1alpha1.
 // general clean-up, mostly resources in different namespaces from eventingv1alpha1.KnativeEventing.
 func (r *ReconcileKnativeEventing) delete(instance *eventingv1alpha1.KnativeEventing) error {
 	// Stop telemetry
-	defer func () {
+	defer func() {
 		r.telemetry.TryStop()
 		common.KnativeUp.DeleteLabelValues("eventing_status")
 	}()

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -116,7 +116,7 @@ func (r *ReconcileKnativeEventing) Reconcile(request reconcile.Request) (reconci
 			return reconcile.Result{}, fmt.Errorf("failed to update status: %w", err)
 		}
 	}
-
+	common.KnativeEventingUpG = common.KnativeUp.WithLabelValues("eventing_status")
 	if instance.Status.IsReady() {
 		common.KnativeEventingUpG.Set(1)
 		if err := r.telemetry.TryStart(r.client, r.mgr); err != nil {
@@ -198,7 +198,11 @@ func (r *ReconcileKnativeEventing) installDashboards(instance *eventingv1alpha1.
 // general clean-up, mostly resources in different namespaces from eventingv1alpha1.KnativeEventing.
 func (r *ReconcileKnativeEventing) delete(instance *eventingv1alpha1.KnativeEventing) error {
 	// Stop telemetry
-	defer r.telemetry.TryStop()
+	defer func () {
+		r.telemetry.TryStop()
+		common.KnativeUp.DeleteLabelValues("eventing_status")
+	}()
+
 	finalizers := sets.NewString(instance.GetFinalizers()...)
 
 	if !finalizers.Has(finalizerName) {

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -170,6 +170,7 @@ func (r *ReconcileKnativeServing) Reconcile(request reconcile.Request) (reconcil
 		}
 	}
 
+	common.KnativeServingUpG = common.KnativeUp.WithLabelValues("serving_status")
 	if instance.Status.IsReady() {
 		common.KnativeServingUpG.Set(1)
 		if err := r.telemetry.TryStart(r.client, r.mgr); err != nil {
@@ -378,7 +379,10 @@ func (r *ReconcileKnativeServing) installDashboard(instance *servingv1alpha1.Kna
 // general clean-up, mostly resources in different namespaces from servingv1alpha1.KnativeServing.
 func (r *ReconcileKnativeServing) delete(instance *servingv1alpha1.KnativeServing) error {
 	// Stop telemetry
-	defer r.telemetry.TryStop()
+	defer func() {
+		r.telemetry.TryStop()
+		common.KnativeUp.DeleteLabelValues("serving_status")
+	}()
 	finalizers := sets.NewString(instance.GetFinalizers()...)
 
 	if !finalizers.Has(finalizerName) {


### PR DESCRIPTION
Followed this [best practice](https://www.robustperception.io/booleans-logic-and-math) to check if all installed components are up. The goal is to make health status reliable and correct since now we require both components to be present to report a healthy installation (Kafka status will be added in another PR, independently of this).

We keep metrics only for the lifecycle of the corresponding CR, will use the avg over time to create an OCP alert in the future.
The 3 signals used are `0` for when we are installing or never reached ready state in general, `no data` (prometheus no data) when a component does not exist and `1` for being up.

 Here is a sample run:
* Installing only eventing, status is 0:
![image](https://user-images.githubusercontent.com/7945591/98691756-0b253400-2377-11eb-82d8-9e0f6eda8642.png)

* Eventing is up
![image](https://user-images.githubusercontent.com/7945591/98691580-d5804b00-2376-11eb-8b46-805e16fa0e4f.png)
* Uninstalling it, no data:
![image](https://user-images.githubusercontent.com/7945591/98691662-ef219280-2376-11eb-85ab-fd5a61526793.png)

Another scenario:
* Installing both Serving, Eventing:
![image](https://user-images.githubusercontent.com/7945591/98820897-7d5d4d80-2437-11eb-9b13-dc1448c9cb4d.png)
* Both are up:
![image](https://user-images.githubusercontent.com/7945591/98820954-8ea65a00-2437-11eb-9690-ff3e6ba2a55b.png)
* Uninstalled Eventing:
![image](https://user-images.githubusercontent.com/7945591/98821021-a5e54780-2437-11eb-97cd-eb1b6aa6132d.png)
Status is 1 since we only run one component.
* Re-installing Eventing:
![image](https://user-images.githubusercontent.com/7945591/98821071-b5fd2700-2437-11eb-8876-55600f511cb1.png)


