### PR TITLE
Wait for namespaces when installing previous releases

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -31,6 +31,11 @@ function install_serverless_previous {
 
   deploy_serverless_operator "$PREVIOUS_CSV"  || return $?
 
+  # TODO: Remove this when the previous release has readiness checks available (since 1.12).
+  if versions.le "$(metadata.get olm.replaces)" 1.11.0; then
+    timeout 120 "[[ \$(oc get namespace ${SERVING_NAMESPACE} ${EVENTING_NAMESPACE} --no-headers | wc -l) != 2 ]]" || return $?
+  fi
+
   deploy_knativeserving_cr || return $?
   deploy_knativeeventing_cr || return $?
   logger.success "Previous version of Serverless is installed: $PREVIOUS_CSV"
@@ -39,11 +44,6 @@ function install_serverless_previous {
 function install_serverless_latest {
   logger.info "Installing latest version of Serverless..."
   deploy_serverless_operator_latest || return $?
-
-  # TODO: Remove this when the previous release has readiness checks available (since 1.12).
-  if versions.le "$(metadata.get olm.replaces)" 1.11.0; then
-    timeout 120 "[[ \$(oc get namespace ${SERVING_NAMESPACE} ${EVENTING_NAMESPACE} --no-headers | wc -l) != 2 ]]" || return $?
-  fi
 
   if [[ $INSTALL_SERVING == "true" ]]; then
     deploy_knativeserving_cr || return $?

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -40,6 +40,11 @@ function install_serverless_latest {
   logger.info "Installing latest version of Serverless..."
   deploy_serverless_operator_latest || return $?
 
+  # TODO: Remove this when the previous release has readiness checks available (since 1.12).
+  if versions.le "$(metadata.get olm.replaces)" 1.11.0; then
+    timeout 120 "[[ \$(oc get namespace ${SERVING_NAMESPACE} ${EVENTING_NAMESPACE} --no-headers | wc -l) != 2 ]]" || return $?
+  fi
+
   if [[ $INSTALL_SERVING == "true" ]]; then
     deploy_knativeserving_cr || return $?
   fi

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -241,6 +241,8 @@ function teardown_serverless {
   for csv in $(set +o pipefail && oc get csv -n "${OPERATORS_NAMESPACE}" | grep serverless-operator | cut -f1 -d' '); do
     oc delete csv -n "${OPERATORS_NAMESPACE}" "${csv}"
   done
+  oc delete namespace openshift-serverless --ignore-not-found=true
+
   logger.success 'Serverless has been uninstalled.'
 }
 

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -37,6 +37,7 @@ export OLM_NAMESPACE="${OLM_NAMESPACE:-openshift-marketplace}"
 export OPERATORS_NAMESPACE="${OPERATORS_NAMESPACE:-openshift-serverless}"
 export SERVERLESS_NAMESPACE="${SERVERLESS_NAMESPACE:-serverless}"
 export SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
+export INGRESS_NAMESPACE="${INGRESS_NAMESPACE:-knative-serving-ingress}"
 export EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-knative-eventing}"
 # eventing e2e and conformance tests use a container for tracing tests that has hardcoded `istio-system` in it
 export ZIPKIN_NAMESPACE="${ZIPKIN_NAMESPACE:-istio-system}"

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -31,7 +31,7 @@ function prepare_knative_serving_tests {
   add_systemnamespace_label
 
   export GATEWAY_OVERRIDE="kourier"
-  export GATEWAY_NAMESPACE_OVERRIDE="${SERVING_NAMESPACE}-ingress"
+  export GATEWAY_NAMESPACE_OVERRIDE="${INGRESS_NAMESPACE}"
 }
 
 function upstream_knative_serving_e2e_and_conformance_tests {


### PR DESCRIPTION
This should resolve issues like these in upgrade tests:
```
Error from server (NotFound): namespaces "knative-serving-ingress" not found
01:49:06.299 INFO:    Testing with pre upgrade tests
01:49:06.301 INFO:    Running Serving pre upgrade tests
```
This error is thrown when the scripts are trying to label the namespace with `system-namespace`. This prevents the ingress from functioning later in upgrade tests.
Readiness checks will be available since 1.12 (https://github.com/openshift-knative/serverless-operator/pull/660) and until that time we need to wait for the namespaces in upgrade tests because they're installing a previous version which doesn't have them yet.