### PR TITLE
Explicitly call out how to just install things

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,29 @@
 Provides a collection of API's to support deploying and serving of serverless
 applications and functions.
 
+## Requirements
+
+For the scripts in this repository to work properly, the following requirements apply.
+
+- `podman` aliased to `docker` or `docker` (17.05 or newer) (only if you need/want to
+build images from code)
+- `bash` (4.0.0 or newer)
+- `make`
+- `yq` (3.4.0)
+
+## Install an unreleased version
+
+To install an unreleased version (either **nightly** from master or the respective version
+from an already cut branch), you can follow these steps. You can replace the `crc start`
+step with whatever cluster you might want to use. Also make sure to check out the respective
+branch of the version you want to install first.
+
+```
+$ crc start --cpus=6 --memory 16384
+$ unset DOCKER_REPO_OVERRIDE # This makes sure that pre-built images are used
+$ make install
+```
+
 ## Development and private cluster testing
 
 ### tl;dr
@@ -12,17 +35,9 @@ the CI environment), use these commands:
 
 ```
 $ crc start --cpus=6 --memory 16384
+$ export DOCKER_REPO_OVERRIDE=docker.io/username
 $ make images test-operator
 ```
-
-### Requirements
-
-- `podman` aliased to `docker` or `docker` (17.05 or newer)
-- `podman` or `docker` is logged into a repository you can push to
-- `DOCKER_REPO_OVERRIDE` points to that repository
-- `bash` (4.0.0 or newer)
-- `make`
-- `yq` (3.4.0)
 
 ### CRC-based cluster
 


### PR DESCRIPTION
This simplifies the README a bit for people who just want to quickly setup a system with an unreleased version of the serverless-operator.