### PR TITLE
Add kafka to health status

### DIFF
--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
@@ -47,7 +47,7 @@ data:
              "thresholdLabels": false,
              "thresholdMarkers": true
            },
-           "id": 29,
+           "id": 1,
            "interval": null,
            "isNew": true,
            "links": [],
@@ -85,7 +85,7 @@ data:
             },
             "targets": [
                {
-                 "expr": "min by (type)(knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=~\"eventing_status|serving_status\"})",
+                 "expr": "min by(job)(knative_up{namespace=\"$namespace\", job=\"knative-openshift-metrics\", type=~\"eventing_status|serving_status|kafka_status\"})",
                  "intervalFactor": 2,
                  "legendFormat": "",
                  "metric": "knative_up",
@@ -130,6 +130,7 @@ data:
           },
           "fill": 1,
           "fillGradient": 0,
+          "collapsed": false,
           "gridPos": {
             "h": 9,
             "w": 12,
@@ -149,7 +150,7 @@ data:
           },
           "lines": true,
           "linewidth": 1,
-          "span": 6,
+          "span": 12,
           "nullPointMode": "null",
           "percentage": false,
           "pluginVersion": "7.1.0",
@@ -233,7 +234,7 @@ data:
          "y": 0
        },
        "hiddenSeries": false,
-       "id": 2,
+       "id": 3,
        "legend": {
          "avg": false,
          "current": false,
@@ -251,7 +252,7 @@ data:
        "pointradius": 2,
        "points": false,
        "renderer": "flot",
-       "span": 6,
+       "span": 12,
        "seriesOverrides": [],
        "spaceLength": 10,
        "stack": false,
@@ -261,7 +262,7 @@ data:
            "expr": "knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=\"eventing_status\"}",
            "format": "time-series",
            "interval": "",
-           "legendFormat": "Eventing status - 1 is up, 0 is down",
+           "legendFormat": "Knative Eventing status - 1 is up, 0 is down",
            "refId": "B"
          }
        ],
@@ -304,7 +305,95 @@ data:
        "yaxis": {
        "align": false,
        "alignLevel": null
-      }
+       }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fieldConfig": {
+         "defaults": {
+         "custom": {}
+        },
+        "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "hiddenSeries": false,
+        "id": 4,
+        "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+        },
+       "lines": true,
+       "linewidth": 1,
+       "nullPointMode": "null",
+       "percentage": false,
+       "pluginVersion": "7.1.0",
+       "pointradius": 2,
+       "points": false,
+       "renderer": "flot",
+       "span": 6,
+       "seriesOverrides": [],
+       "spaceLength": 10,
+       "stack": false,
+       "steppedLine": false,
+       "targets": [
+       {
+           "expr": "knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=\"kafka_status\"}",
+           "format": "time-series",
+           "interval": "",
+           "legendFormat": "Knative Kafka status - 1 is up, 0 is down",
+           "refId": "B"
+       }
+      ],
+       "thresholds": [],
+       "timeFrom": null,
+       "timeRegions": [],
+       "timeShift": null,
+       "title": "Knative Health Status - Kafka",
+       "tooltip": {
+         "shared": true,
+         "sort": 0,
+         "value_type": "individual"
+       },
+       "type": "graph",
+       "xaxis": {
+         "buckets": null,
+         "mode": "time",
+         "name": null,
+         "show": true,
+         "values": []
+       },
+       "yaxes": [
+         {
+           "format": "none",
+           "label": null,
+           "logBase": 1,
+           "max": 1,
+           "min": 0,
+           "show": false
+         },
+         {
+           "format": "none",
+           "label": null,
+           "logBase": 1,
+           "max": 1,
+           "min": 0,
+           "show": false
+         }
+       ],
+       "yaxis": {
+       "align": false,
+       "alignLevel": null
+       }
       }
      ],
      "schemaVersion": 26,

--- a/knative-operator/pkg/common/health_metrics.go
+++ b/knative-operator/pkg/common/health_metrics.go
@@ -15,7 +15,7 @@ var (
 	)
 	KnativeServingUpG  prometheus.Gauge
 	KnativeEventingUpG prometheus.Gauge
-	KnativeKafkaUpG    = KnativeUp.WithLabelValues("kafka_status")
+	KnativeKafkaUpG    prometheus.Gauge
 )
 
 func init() {

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -146,6 +146,7 @@ func (r *ReconcileKnativeKafka) Reconcile(request reconcile.Request) (reconcile.
 		}
 	}
 
+	common.KnativeKafkaUpG = common.KnativeUp.WithLabelValues("kafka_status")
 	if instance.Status.IsReady() {
 		common.KnativeKafkaUpG.Set(1)
 	} else {
@@ -302,6 +303,7 @@ func isDeploymentAvailable(d *appsv1.Deployment) bool {
 
 // general clean-up. required for the resources that cannot be garbage collected with the owner reference mechanism
 func (r *ReconcileKnativeKafka) delete(instance *operatorv1alpha1.KnativeKafka) error {
+	defer common.KnativeUp.DeleteLabelValues("kafka_status")
 	finalizers := sets.NewString(instance.GetFinalizers()...)
 
 	if !finalizers.Has(finalizerName) {


### PR DESCRIPTION
- Adds kafka component to health status and a panel to view component's status. This follows again the idea [here](https://www.robustperception.io/booleans-logic-and-math).
Here is an example of state transition. 
Installing knative kafka but bootstrap servers are not accessible:
![image](https://user-images.githubusercontent.com/7945591/99249069-262df300-2812-11eb-94c6-a35a1577ed90.png)
```$ oc get pods -n knative-eventing
...
kafka-ch-dispatcher-5f744f66df-m5l9g               0/1     CrashLoopBackOff   1          16s
...
```
Installation stuck in zero status and knative global state is 0 which maps to `unhealthy`.
Now we remove knative-kafka and status is again up.
![image](https://user-images.githubusercontent.com/7945591/99249190-5e353600-2812-11eb-8a65-26788a6dd97c.png)
Next we have only Knative Kafka installed along with Knative Eventing, global status is 1 or `healthy`:
![image](https://user-images.githubusercontent.com/7945591/99274089-8f256300-2832-11eb-9de7-c4adabd9c3bc.png)
This is tested with crc 4.5.9 (mapsValues `healthy`, `unhealthy` are available in 4.6.x).