### PR TITLE
Use correct label for cluster-local

### DIFF
--- a/test/servinge2e/service_to_service_test.go
+++ b/test/servinge2e/service_to_service_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"testing"
 
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pkgTest "knative.dev/pkg/test"
-
 	"github.com/openshift-knative/serverless-operator/test"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	network "knative.dev/networking/pkg"
-	nv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 // Smoke tests for networking which access public and cluster-local
@@ -38,7 +37,7 @@ func TestServiceToServiceCalls(t *testing.T) {
 	}, {
 		name: "cluster-local-via-activator",
 		labels: map[string]string{
-			network.VisibilityLabelKey: string(nv1alpha1.IngressVisibilityClusterLocal),
+			network.VisibilityLabelKey: serving.VisibilityClusterLocal,
 		},
 		annotations: map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
@@ -46,7 +45,7 @@ func TestServiceToServiceCalls(t *testing.T) {
 	}, {
 		name: "cluster-local-without-activator",
 		labels: map[string]string{
-			network.VisibilityLabelKey: string(nv1alpha1.IngressVisibilityClusterLocal),
+			network.VisibilityLabelKey: serving.VisibilityClusterLocal,
 		},
 		annotations: map[string]string{
 			autoscaling.TargetBurstCapacityKey: "0",
@@ -71,7 +70,7 @@ func testServiceToService(t *testing.T, ctx *test.Context, namespace string, tc 
 	serviceURL := service.Status.URL.URL()
 
 	// For cluster-local ksvc, we deploy an "HTTP proxy" service, and request that one instead
-	if service.GetLabels()[network.VisibilityLabelKey] == string(nv1alpha1.IngressVisibilityClusterLocal) {
+	if service.GetLabels()[network.VisibilityLabelKey] == serving.VisibilityClusterLocal {
 		// Deploy an "HTTP proxy" towards the ksvc (using an httpproxy image from knative-serving testsuite)
 		httpProxy := withServiceReadyOrFail(ctx, httpProxyService(tc.name+"-proxy", namespace, service.Status.URL.Host))
 		serviceURL = httpProxy.Status.URL.URL()

--- a/test/servinge2e/servicemesh_test.go
+++ b/test/servinge2e/servicemesh_test.go
@@ -28,11 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	network "knative.dev/networking/pkg"
-	nv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/helpers"
 	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/serving"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -117,7 +117,7 @@ func TestKsvcWithServiceMeshSidecar(t *testing.T) {
 		// A cluster-local variant of the "sidecar-via-activator" scenario
 		name: "local-sidecar-via-activator",
 		labels: map[string]string{
-			network.VisibilityLabelKey: string(nv1alpha1.IngressVisibilityClusterLocal),
+			network.VisibilityLabelKey: serving.VisibilityClusterLocal,
 		},
 		annotations: map[string]string{
 			istioInjectKey: "true",
@@ -127,7 +127,7 @@ func TestKsvcWithServiceMeshSidecar(t *testing.T) {
 		// A cluster-local variant of the "sidecar-without-activator" scenario
 		name: "local-sidecar-without-activator",
 		labels: map[string]string{
-			network.VisibilityLabelKey: string(nv1alpha1.IngressVisibilityClusterLocal),
+			network.VisibilityLabelKey: serving.VisibilityClusterLocal,
 		},
 		annotations: map[string]string{
 			istioInjectKey:                     "true",
@@ -309,7 +309,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 		Value: jwks,
 	})
 	jwksKsvc.ObjectMeta.Labels = map[string]string{
-		network.VisibilityLabelKey: string(nv1alpha1.IngressVisibilityClusterLocal),
+		network.VisibilityLabelKey: serving.VisibilityClusterLocal,
 	}
 	jwksKsvc = withServiceReadyOrFail(caCtx, jwksKsvc)
 
@@ -545,7 +545,7 @@ func TestKsvcWithServiceMeshCustomDomain(t *testing.T) {
 	// Deploy a cluster-local ksvc "hello"
 	ksvc := test.Service("hello", serviceMeshTestNamespaceName, "openshift/hello-openshift", nil)
 	ksvc.ObjectMeta.Labels = map[string]string{
-		network.VisibilityLabelKey: string(nv1alpha1.IngressVisibilityClusterLocal),
+		network.VisibilityLabelKey: serving.VisibilityClusterLocal,
 	}
 	ksvc = withServiceReadyOrFail(caCtx, ksvc)
 
@@ -682,7 +682,7 @@ func TestKsvcWithServiceMeshCustomTlsDomain(t *testing.T) {
 	// Deploy a cluster-local ksvc "hello"
 	ksvc := test.Service("hello", serviceMeshTestNamespaceName, "openshift/hello-openshift", nil)
 	ksvc.ObjectMeta.Labels = map[string]string{
-		network.VisibilityLabelKey: string(nv1alpha1.IngressVisibilityClusterLocal),
+		network.VisibilityLabelKey: serving.VisibilityClusterLocal,
 	}
 	ksvc = withServiceReadyOrFail(caCtx, ksvc)
 


### PR DESCRIPTION
As per title. 0.18 will start failing validation for `ClusterLocal`.

/assign @nak3 