### PR TITLE
Kafka auth

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -204,6 +204,79 @@ EOF
   logger.success 'Knative Kafka has been installed sucessfully.'
 }
 
+function ensure_kafka_no_auth {
+  logger.info 'Ensure Knative Kafka using no Kafka auth'
+
+  # Apply Knative Kafka
+  cat <<EOF | oc apply -f - || return $?
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  name: knative-kafka
+  namespace: ${EVENTING_NAMESPACE}
+spec:
+  source:
+    enabled: true
+  channel:
+    enabled: true
+    bootstrapServers: my-cluster-kafka-bootstrap.kafka:9092
+EOF
+
+  timeout 900 '[[ $(oc get knativekafkas.operator.serverless.openshift.io knative-kafka -n $EVENTING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
+
+  logger.success 'Knative Kafka has been set to use no auth sucessfully.'
+}
+
+function ensure_kafka_tls_auth {
+  logger.info 'Ensure Knative Kafka using TLS auth'
+
+  # Apply Knative Kafka
+  cat <<EOF | oc apply -f - || return $?
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  name: knative-kafka
+  namespace: ${EVENTING_NAMESPACE}
+spec:
+  source:
+    enabled: true
+  channel:
+    enabled: true
+    bootstrapServers: my-cluster-kafka-bootstrap.kafka:9093
+    authSecretNamespace: default
+    authSecretName: my-tls-secret
+EOF
+
+  timeout 900 '[[ $(oc get knativekafkas.operator.serverless.openshift.io knative-kafka -n $EVENTING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
+
+  logger.success 'Knative Kafka has been set to use TLS auth sucessfully.'
+}
+
+function ensure_kafka_sasl_auth {
+  logger.info 'Ensure Knative Kafka using SASL auth'
+
+  # Apply Knative Kafka
+  cat <<EOF | oc apply -f - || return $?
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  name: knative-kafka
+  namespace: ${EVENTING_NAMESPACE}
+spec:
+  source:
+    enabled: true
+  channel:
+    enabled: true
+    bootstrapServers: my-cluster-kafka-bootstrap.kafka:9094
+    authSecretNamespace: default
+    authSecretName: my-sasl-secret
+EOF
+
+  timeout 900 '[[ $(oc get knativekafkas.operator.serverless.openshift.io knative-kafka -n $EVENTING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
+
+  logger.success 'Knative Kafka has been set to use SASL auth sucessfully.'
+}
+
 function teardown_serverless {
   logger.warn '😭  Teardown Serverless...'
 

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -222,6 +222,7 @@ spec:
     bootstrapServers: my-cluster-kafka-bootstrap.kafka:9092
 EOF
 
+  # shellcheck disable=SC2016
   timeout 900 '[[ $(oc get knativekafkas.operator.serverless.openshift.io knative-kafka -n $EVENTING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
 
   logger.success 'Knative Kafka has been set to use no auth sucessfully.'
@@ -247,6 +248,7 @@ spec:
     authSecretName: my-tls-secret
 EOF
 
+  # shellcheck disable=SC2016
   timeout 900 '[[ $(oc get knativekafkas.operator.serverless.openshift.io knative-kafka -n $EVENTING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
 
   logger.success 'Knative Kafka has been set to use TLS auth sucessfully.'
@@ -272,6 +274,7 @@ spec:
     authSecretName: my-sasl-secret
 EOF
 
+  # shellcheck disable=SC2016
   timeout 900 '[[ $(oc get knativekafkas.operator.serverless.openshift.io knative-kafka -n $EVENTING_NAMESPACE -o=jsonpath="{.status.conditions[?(@.type==\"Ready\")].status}") != True ]]'  || return 7
 
   logger.success 'Knative Kafka has been set to use SASL auth sucessfully.'

--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -122,7 +122,9 @@ EOF
   header "Creating a Secret, containing SASL from Strimzi"
   SASL_PASSWD=$(oc -n kafka get secret my-sasl-user --template='{{index .data "password"}}' | base64 --decode )
   oc create secret --namespace default generic my-sasl-secret \
+      --from-literal=ca.crt="$STRIMZI_CRT" \
       --from-literal=password="$SASL_PASSWD" \
+      --from-literal=saslType="SCRAM-SHA-512" \
       --from-literal=user="my-sasl-user"
 }
 

--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -69,7 +69,6 @@ EOF
   oc wait kafka --all --timeout=-1s --for=condition=Ready -n kafka
 
   header "Applying Strimzi TLS Admin user"
-
   cat <<-EOF | oc apply -f -
 apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaUser
@@ -118,8 +117,8 @@ spec:
         host: "*"
 EOF
 
-header_text "Applying Strimzi SASL Admin User"
-cat <<-EOF | oc apply -f -
+  header "Applying Strimzi SASL Admin User"
+  cat <<-EOF | oc apply -f -
 apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaUser
 metadata:
@@ -180,7 +179,7 @@ EOF
       --from-literal=user.crt="$TLSUSER_CRT" \
       --from-literal=user.key="$TLSUSER_KEY"
 
-  header_text "Creating a Secret, containing SASL from Strimzi"
+  header "Creating a Secret, containing SASL from Strimzi"
   SASL_PASSWD=$(oc -n kafka get secret my-sasl-user --template='{{index .data "password"}}' | base64 --decode )
   oc create secret --namespace default generic my-sasl-secret \
       --from-literal=password="$SASL_PASSWD" \

--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -98,8 +98,16 @@ EOF
   oc wait kafkauser --all --timeout=-1s --for=condition=Ready -n kafka
 
   header "Deleting existing Kafka user secrets"
-  oc delete secret -n default my-tls-secret || true
-  oc delete secret -n default my-sasl-secret || true
+
+  if oc get secret my-tls-secret -n default >/dev/null 2>&1
+  then
+    oc delete secret -n default my-tls-secret
+  fi
+
+  if oc get secret my-sasl-secret -n default >/dev/null 2>&1
+  then
+    oc delete secret -n default my-sasl-secret
+  fi
 
   header "Creating a Secret, containing TLS from Strimzi"
   STRIMZI_CRT=$(oc -n kafka get secret my-cluster-cluster-ca-cert --template='{{index .data "ca.crt"}}' | base64 --decode )

--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -169,6 +169,10 @@ EOF
   header "Waiting for Strimzi admin users to become ready"
   oc wait kafkauser --all --timeout=-1s --for=condition=Ready -n kafka
 
+  header "Deleting existing Kafka user secrets"
+  oc delete secret -n default my-tls-secret || true
+  oc delete secret -n default my-sasl-secret || true
+
   header "Creating a Secret, containing TLS from Strimzi"
   STRIMZI_CRT=$(oc -n kafka get secret my-cluster-cluster-ca-cert --template='{{index .data "ca.crt"}}' | base64 --decode )
   TLSUSER_CRT=$(oc -n kafka get secret my-tls-user --template='{{index .data "user.crt"}}' | base64 --decode )

--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -40,8 +40,6 @@ function install_strimzi {
             tls: true
             authentication:
               type: scram-sha-512
-        authorization:
-          type: simple
         config:
           offsets.topic.replication.factor: 3
           transaction.state.log.replication.factor: 3

--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -78,41 +78,6 @@ metadata:
 spec:
   authentication:
     type: tls
-  authorization:
-    type: simple
-    acls:
-      # Example ACL rules for consuming from knative-messaging-kafka using consumer group my-group
-      - resource:
-          type: topic
-          name: "*"
-        operation: Read
-        host: "*"
-      - resource:
-          type: topic
-          name: "*"
-        operation: Describe
-        host: "*"
-      - resource:
-          type: group
-          name: "*"
-        operation: Read
-        host: "*"
-      # Example ACL rules for producing to topic knative-messaging-kafka
-      - resource:
-          type: topic
-          name: "*"
-        operation: Write
-        host: "*"
-      - resource:
-          type: topic
-          name: "*"
-        operation: Create
-        host: "*"
-      - resource:
-          type: topic
-          name: "*"
-        operation: Describe
-        host: "*"
 EOF
 
   header "Applying Strimzi SASL Admin User"
@@ -127,41 +92,6 @@ metadata:
 spec:
   authentication:
     type: scram-sha-512
-  authorization:
-    type: simple
-    acls:
-      # Example ACL rules for consuming from knative-messaging-kafka using consumer group my-group
-      - resource:
-          type: topic
-          name: "*"
-        operation: Read
-        host: "*"
-      - resource:
-          type: topic
-          name: "*"
-        operation: Describe
-        host: "*"
-      - resource:
-          type: group
-          name: "*"
-        operation: Read
-        host: "*"
-      # Example ACL rules for producing to topic knative-messaging-kafka
-      - resource:
-          type: topic
-          name: "*"
-        operation: Write
-        host: "*"
-      - resource:
-          type: topic
-          name: "*"
-        operation: Create
-        host: "*"
-      - resource:
-          type: topic
-          name: "*"
-        operation: Describe
-        host: "*"
 EOF
 
   header "Waiting for Strimzi admin users to become ready"

--- a/knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
+++ b/knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
@@ -45,6 +45,14 @@ spec:
                     description: Enabled defines if the KafkaChannel installation
                       is enabled
                     type: boolean
+                  authSecretNamespace:
+                    description: AuthSecretNamespace is the namespace of the secret that contains Kafka
+                      auth configuration.
+                    type: string
+                  authSecretName:
+                    description: AuthSecretName is the name of the secret that contains Kafka
+                      auth configuration.
+                    type: string
                 required:
                 - enabled
                 type: object

--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
@@ -60,6 +60,16 @@ type Channel struct {
 	// KafkaChannels will use
 	// +optional
 	BootstrapServers string `json:"bootstrapServers"`
+
+	// AuthSecretNamespace is the namespace of the secret that contains Kafka
+	// auth configuration.
+	// +optional
+	AuthSecretNamespace string `json:"authSecretNamespace"`
+
+	// AuthSecretName is the name of the secret that contains Kafka
+	// auth configuration.
+	// +optional
+	AuthSecretName string `json:"authSecretName"`
 }
 
 func init() {

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -395,7 +395,7 @@ func setBootstrapServers(bootstrapServers string) mf.Transformer {
 func setAuthSecret(secretNamespace, secretName string) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "ConfigMap" && u.GetName() == "config-kafka" {
-			log.Info("Found ConfigMap config-kafka, updating it with bootstrapServers from spec")
+			log.Info("Found ConfigMap config-kafka, updating it with authSecretName and authSecretNamespace from spec")
 			if err := unstructured.SetNestedField(u.Object, secretNamespace, "data", "authSecretNamespace"); err != nil {
 				return err
 			}

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -407,7 +407,6 @@ func makeCr(mods ...func(*v1alpha1.KnativeKafka)) *v1alpha1.KnativeKafka {
 			Channel: v1alpha1.Channel{
 				Enabled:          false,
 				BootstrapServers: "foo.bar.com",
-				// TODO
 			},
 		},
 	}

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating.go
@@ -112,6 +112,12 @@ func (v *Validator) validateShape(_ context.Context, ke *operatorv1alpha1.Knativ
 	if ke.Spec.Channel.Enabled && ke.Spec.Channel.BootstrapServers == "" {
 		return false, "spec.channel.bootStrapServers is a required detail when spec.channel.enabled is true", nil
 	}
+	if ke.Spec.Channel.AuthSecretName != "" && ke.Spec.Channel.AuthSecretNamespace == "" {
+		return false, "spec.channel.authSecretNamespace is required when spec.channel.authSecretName is defined", nil
+	}
+	if ke.Spec.Channel.AuthSecretNamespace != "" && ke.Spec.Channel.AuthSecretName == "" {
+		return false, "spec.channel.authSecretName is required when spec.channel.authSecretNamespace is defined", nil
+	}
 	return true, "", nil
 }
 

--- a/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
+++ b/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
@@ -45,6 +45,14 @@ spec:
                     description: Enabled defines if the KafkaChannel installation
                       is enabled
                     type: boolean
+                  authSecretNamespace:
+                    description: AuthSecretNamespace is the namespace of the secret that contains Kafka
+                      auth configuration.
+                    type: string
+                  authSecretName:
+                    description: AuthSecretName is the name of the secret that contains Kafka
+                      auth configuration.
+                    type: string
                 required:
                 - enabled
                 type: object

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -35,10 +35,10 @@ fi
 if [[ $TEST_KNATIVE_KAFKA == true ]]; then
  (( !failed )) && ensure_kafka_no_auth || failed=8
  (( !failed )) && downstream_knative_kafka_e2e_tests || failed=9
- (( !failed )) && ensure_kafka_tls_auth || failed=10
- (( !failed )) && downstream_knative_kafka_e2e_tests || failed=11
- (( !failed )) && ensure_kafka_sasl_auth || failed=12
- (( !failed )) && downstream_knative_kafka_e2e_tests || failed=13
+# (( !failed )) && ensure_kafka_tls_auth || failed=10
+# (( !failed )) && downstream_knative_kafka_e2e_tests || failed=11
+# (( !failed )) && ensure_kafka_sasl_auth || failed=12
+# (( !failed )) && downstream_knative_kafka_e2e_tests || failed=13
 fi
 
 (( failed )) && dump_state

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -33,7 +33,12 @@ fi
 (( !failed )) && downstream_eventing_e2e_tests || failed=7
 
 if [[ $TEST_KNATIVE_KAFKA == true ]]; then
- (( !failed )) && downstream_knative_kafka_e2e_tests || failed=8
+ (( !failed )) && ensure_kafka_no_auth || failed=8
+ (( !failed )) && downstream_knative_kafka_e2e_tests || failed=9
+ (( !failed )) && ensure_kafka_tls_auth || failed=10
+ (( !failed )) && downstream_knative_kafka_e2e_tests || failed=11
+ (( !failed )) && ensure_kafka_sasl_auth || failed=12
+ (( !failed )) && downstream_knative_kafka_e2e_tests || failed=13
 fi
 
 (( failed )) && dump_state

--- a/test/eventing-contrib.bash
+++ b/test/eventing-contrib.bash
@@ -30,9 +30,6 @@ function upstream_knative_eventing_contrib_e2e {
 
   failed=0
 
-  logger.info 'Installing Strimzi'
-  (( !failed )) && install_strimzi || failed=$?
-
   # run_e2e_tests defined in eventing-contrib
   logger.info 'Starting eventing-contrib tests'
   (( !failed )) && run_e2e_tests || failed=$?

--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -37,6 +37,7 @@ const (
 )
 
 var (
+	// TODO: TLS/SASL? --> https://issues.redhat.com/browse/SRVKE-647
 	bootstrapServer = clusterName + "-kafka-bootstrap.kafka:9092"
 	kafkaGVR        = schema.GroupVersionResource{Group: "kafka.strimzi.io", Version: "v1beta1", Resource: "kafkatopics"}
 


### PR DESCRIPTION
Changes:
- Add auth options to KnativeKafka CRD for channel
- Run downstream smoke tests with plain (already existing), with TLS and with SASL auth --> UPDATE: disabled tests with TLS and SASL since the eventing code supporting it is not there yet.

```
kind: KnativeKafka
...
spec:
  source:
    enabled: true
  channel:
    enabled: true
    bootstrapServers: my-cluster-kafka-bootstrap.kafka:9093
    authSecretNamespace: default
    authSecretName: my-tls-secret
```

This basically is propagated to `config-kafka` configmap:
```
kind: ConfigMap
metadata:
  name: config-kafka
  namespace: knative-eventing
data:
  bootstrapServers: my-cluster-kafka-bootstrap.kafka:9093
  authSecretNamespace: default
  authSecretName: my-tls-secret
```

Notes:
- Knative Kafka components will start using it when https://github.com/knative/eventing-contrib/pull/1667 is merged.
- 1667 is going to be updated to use `authSecretNamespace` and `authSecretName`.
- KafkaSource TLS and SASL is out of scope of this PR. However, I noticed we don't have any TLS/SASL downstream smoke tests for KafkaSource and I created https://issues.redhat.com/browse/SRVKE-647
