### PR TITLE
Wait for metrics in health integration subtest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,6 @@ require (
 	github.com/operator-framework/operator-sdk v0.19.4
 	github.com/prometheus-operator/prometheus-operator v0.43.0
 	github.com/prometheus/client_golang v1.8.0
-	github.com/prometheus/client_model v0.2.0
-	github.com/prometheus/common v0.14.0
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.15.0
 	google.golang.org/genproto v0.0.0-20200914193844-75d14daec038 // indirect

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,64 +1,16 @@
 package e2e
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"net/url"
 
 	"github.com/openshift-knative/serverless-operator/test"
 	v1 "github.com/openshift/api/route/v1"
-	ioprometheusclient "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/expfmt"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	pkgTest "knative.dev/pkg/test"
 )
-
-func extractMetricData(body io.Reader, metricName string) (float64, error) {
-	var parser expfmt.TextParser
-	metricFamilies, err := parser.TextToMetricFamilies(body)
-	if err != nil {
-		return -1, fmt.Errorf("reading text format failed: %v", err)
-	}
-	pm := prometheusMetric(metricFamilies, "knative_up")
-	if pm == nil {
-		return -1, errors.New("could not get metric family `knative_up` from prometheus exported metrics")
-	}
-	status := getMetricValueByTypeLabel(metricName, pm)
-	if status == nil {
-		return -1, fmt.Errorf("could not get metric type `%s` from prometheus metric `knative_up`", metricName)
-	}
-	return *status, nil
-}
-
-func prometheusMetric(metricFamilies map[string]*ioprometheusclient.MetricFamily, key string) []*ioprometheusclient.Metric {
-	if metric, ok := metricFamilies[key]; ok && len(metric.Metric) > 0 {
-		return metric.Metric
-	}
-	return nil
-}
-
-func getMetricValueByTypeLabel(label string, metrics []*ioprometheusclient.Metric) *float64 {
-	for _, metric := range metrics {
-		if len(metric.Label) == 0 {
-			break
-		}
-		// we expect one label
-		if metric.Label[0] == nil {
-			break
-		}
-		if metric.Label[0].Name == nil || metric.Label[0].Value == nil {
-			break
-		}
-		if (*metric.Label[0].Name) == "type" && (*metric.Label[0].Value) == label {
-			return metric.Gauge.Value
-		}
-	}
-	return nil
-}
 
 func setupMetricsRoute(caCtx *test.Context, name string) (*v1.Route, error) {
 	metricsRoute := &v1.Route{
@@ -88,7 +40,7 @@ func setupMetricsRoute(caCtx *test.Context, name string) (*v1.Route, error) {
 	return r, nil
 }
 
-func verifyHealthStatusMetric(caCtx *test.Context, metricsPath string, metricName string, expectedValue float64) {
+func verifyHealthStatusMetric(caCtx *test.Context, metricsPath string, metricLabel string, expectedValue int) {
 	// Check if Operator's service monitor service is available
 	_, err := caCtx.Clients.Kube.CoreV1().Services("openshift-serverless").Get(context.Background(), "knative-openshift-metrics", meta.GetOptions{})
 	if err != nil {
@@ -98,23 +50,17 @@ func verifyHealthStatusMetric(caCtx *test.Context, metricsPath string, metricNam
 	if err != nil {
 		caCtx.T.Fatalf("Error parsing url for metrics: %v", err)
 	}
-	// Wait until the endpoint is actually working
-	resp, err := pkgTest.WaitForEndpointState(
+	expectedStr := fmt.Sprintf(`knative_up{type="%s"} %d`, metricLabel, expectedValue)
+	// Wait until the endpoint is actually working and we get the expected value back
+	_, err = pkgTest.WaitForEndpointState(
 		context.Background(),
 		&pkgTest.KubeClient{Kube: caCtx.Clients.Kube},
 		caCtx.T.Logf,
 		metricsURL,
-		pkgTest.EventuallyMatchesBody("# TYPE knative_up gauge"),
+		pkgTest.EventuallyMatchesBody(expectedStr),
 		"WaitForMetricsToServeText",
 		true)
 	if err != nil {
-		caCtx.T.Fatalf("Failed to access the operator metrics endpoint : %v", err)
-	}
-	stat, err := extractMetricData(bytes.NewReader(resp.Body), metricName)
-	if err != nil {
-		caCtx.T.Fatalf("Failed to get metrics from operator's prometheus endpoint: %v", err)
-	}
-	if stat != expectedValue {
-		caCtx.T.Errorf("Got = %v, want: %v for metric type: %s", stat, expectedValue, metricName)
+		caCtx.T.Fatalf("Failed to access the operator metrics endpoint and get the metric value expected: %v", err)
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -233,10 +233,8 @@ github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.2.0
-## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.14.0
-## explicit
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/log


### PR DESCRIPTION
- Fixes integration test failing [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/697/pull-ci-openshift-knative-serverless-operator-master-4.6-operator-e2e-aws-ocp-46/1328961123575140352). Previously we assumed that the Serverless Operator would have the same state update of the tested CR as the one in tests but this is not necessarily true.
- Simplifies the code a bit.
