### PR TITLE
[SRVKS-666] Fix race condition in Serving readiness

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -36,6 +36,11 @@ func (e *extension) Transformers(v1alpha1.KComponent) []mf.Transformer {
 func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) error {
 	ks := comp.(*v1alpha1.KnativeServing)
 
+	// Mark the Kourier dependency as installing to avoid race conditions with readiness.
+	if ks.Status.GetCondition(v1alpha1.DependenciesInstalled).IsUnknown() {
+		ks.Status.MarkDependencyInstalling("Kourier")
+	}
+
 	// Set the default host to the cluster's host.
 	if domain, err := e.fetchClusterHost(ctx); err != nil {
 		return fmt.Errorf("failed to fetch cluster host: %w", err)

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -68,11 +68,6 @@ func TestKnativeServing(t *testing.T) {
 		}
 		// Check the status of deployments in the ingress namespace.
 		for _, deployment := range []string{"3scale-kourier-control", "3scale-kourier-gateway"} {
-			// Workaround for https://issues.redhat.com/browse/SRVCOM-1008 - wait for Kourier deployments to
-			// be ready before checking their scales.
-			if _, err := test.WithDeploymentReady(caCtx, deployment, servingNamespace+"-ingress"); err != nil {
-				t.Fatal("Failed", err)
-			}
 			if err := test.CheckDeploymentScale(caCtx, servingNamespace+"-ingress", deployment, haReplicas); err != nil {
 				t.Fatalf("Failed to verify default HA settings: %v", err)
 			}


### PR DESCRIPTION
Depending on which operator picks the Serving resource up first, there is a potential race where the upstream code defaults the dependencies condition to True before the downstream code even sees it and can mark it as False.
This sets the correct default in upstream code so the API never actually observes the race.

/assign @nak3