### PR TITLE
Delete all test kservices after upgrades

### DIFF
--- a/test/serving.bash
+++ b/test/serving.bash
@@ -217,9 +217,5 @@ function run_serving_postupgrade_test {
 }
 
 function cleanup_serving_test_services {
-  oc delete --ignore-not-found=true ksvc \
-    pizzaplanet-upgrade-service \
-    scale-to-zero-upgrade-service \
-    upgrade-probe -n serving-tests \
-    || return $?
+  oc delete --all=true ksvc -n serving-tests || return $?
 }


### PR DESCRIPTION
* there are now new uprade tests and we've been failing to delete them