### PR TITLE
Enable smoke tests for Kafka auth

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -35,10 +35,10 @@ fi
 if [[ $TEST_KNATIVE_KAFKA == true ]]; then
  (( !failed )) && ensure_kafka_no_auth || failed=8
  (( !failed )) && downstream_knative_kafka_e2e_tests || failed=9
-# (( !failed )) && ensure_kafka_tls_auth || failed=10
-# (( !failed )) && downstream_knative_kafka_e2e_tests || failed=11
-# (( !failed )) && ensure_kafka_sasl_auth || failed=12
-# (( !failed )) && downstream_knative_kafka_e2e_tests || failed=13
+ (( !failed )) && ensure_kafka_tls_auth || failed=10
+ (( !failed )) && downstream_knative_kafka_e2e_tests || failed=11
+ (( !failed )) && ensure_kafka_sasl_auth || failed=12
+ (( !failed )) && downstream_knative_kafka_e2e_tests || failed=13
 fi
 
 (( failed )) && dump_state


### PR DESCRIPTION
Couldn't enable them during https://github.com/openshift-knative/serverless-operator/pull/699 because we didn't have the TLS/SASL support backported. Should be good now since these are backported and we use eventing-contrib 0.18 in CSV.