### PR TITLE
Skip TLS verification with oc login

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -191,6 +191,6 @@ function add_user {
 
   logger.debug 'Generate kubeconfig'
   cp "${KUBECONFIG}" "$name.kubeconfig"
-  occmd="bash -c '! oc login --kubeconfig=${name}.kubeconfig --username=${name} --password=${pass} > /dev/null'"
+  occmd="bash -c '! oc login --kubeconfig=${name}.kubeconfig --username=${name} --password=${pass} --insecure-skip-tls-verify=true > /dev/null'"
   timeout 180 "${occmd}" || return 1
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -415,7 +415,7 @@ function create_htpasswd_users {
   logger.info 'Generate kubeconfig for each user'
   for i in $(seq 1 $num_users); do
     cp "${KUBECONFIG}" "user${i}.kubeconfig"
-    occmd="bash -c '! oc login --kubeconfig=user${i}.kubeconfig --username=user${i} --password=password${i} > /dev/null'"
+    occmd="bash -c '! oc login --kubeconfig=user${i}.kubeconfig --username=user${i} --password=password${i} --insecure-skip-tls-verify=true > /dev/null'"
     timeout 180 "${occmd}" || return $?
   done
 }


### PR DESCRIPTION
I had problems because of this. The `oc login` command with `timeout` was simply waiting.

I updated both `crc` and `oc` recently locally. not sure which caused this problem.

