### PR TITLE
SRVKE-565: Adding cluster role for downstream

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
@@ -4503,3 +4503,31 @@ webhooks:
     timeoutSeconds: 2
 
 ---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: knative-eventing
+  name: openshift-serverless-view-eventing-configmaps
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-serverless-view-eventing-configmaps
+  namespace: knative-eventing
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-serverless-view-eventing-configmaps

--- a/openshift-knative-operator/hack/002-openshift-eventing-role.patch
+++ b/openshift-knative-operator/hack/002-openshift-eventing-role.patch
@@ -1,0 +1,36 @@
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+index a6f1de61..8e4ec0cf 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+@@ -4503,3 +4503,31 @@ webhooks:
+     timeoutSeconds: 2
+ 
+ ---
++kind: Role
++apiVersion: rbac.authorization.k8s.io/v1
++metadata:
++  namespace: knative-eventing
++  name: openshift-serverless-view-eventing-configmaps
++rules:
++- apiGroups:
++  - ""
++  resources:
++  - configmaps
++  verbs:
++  - get
++  - list
++  - watch
++---
++kind: RoleBinding
++apiVersion: rbac.authorization.k8s.io/v1
++metadata:
++  name: openshift-serverless-view-eventing-configmaps
++  namespace: knative-eventing
++subjects:
++- kind: Group
++  name: system:authenticated
++  apiGroup: rbac.authorization.k8s.io
++roleRef:
++  apiGroup: rbac.authorization.k8s.io
++  kind: Role
++  name: openshift-serverless-view-eventing-configmaps

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -41,3 +41,6 @@ download serving $KNATIVE_SERVING_VERSION "${serving_files[@]}"
 git apply "$root/openshift-knative-operator/hack/001-liveness.patch"
 
 download eventing $KNATIVE_EVENTING_VERSION "${eventing_files[@]}"
+# Extra ClusterRole for downstream, so that users can get the CMs of knative-eventing
+# TODO: propose to upstream
+git apply "$root/openshift-knative-operator/hack/002-openshift-eventing-role.patch"


### PR DESCRIPTION
See: https://issues.redhat.com/browse/SRVKE-565

basically patching here, instead of fork (e.g. via: https://github.com/openshift-knative/operator/pull/56)

/assign @maschmid  

