### PR TITLE
[SRVCOM-1125] Fix regression for CR metrics

### DIFF
--- a/knative-operator/pkg/common/service_monitor.go
+++ b/knative-operator/pkg/common/service_monitor.go
@@ -48,7 +48,7 @@ func SetupServerlessOperatorServiceMonitor(ctx context.Context, cfg *rest.Config
 	// Add to the below struct any other metrics ports you want to expose.
 	servicePorts := []v1.ServicePort{
 		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
-		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
+	//	{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
 	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)

--- a/knative-operator/pkg/common/service_monitor.go
+++ b/knative-operator/pkg/common/service_monitor.go
@@ -48,7 +48,7 @@ func SetupServerlessOperatorServiceMonitor(ctx context.Context, cfg *rest.Config
 	// Add to the below struct any other metrics ports you want to expose.
 	servicePorts := []v1.ServicePort{
 		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
-	//	{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
+		// {Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
 	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)


### PR DESCRIPTION
This seems a regression, adding this [fix](https://github.com/openshift-knative/serverless-operator/pull/454) on 1.11 branch.
I will completely remove CR metrics on master with another PR, something is wrong with that endpoint which works ok locally but fails on QE setup.