### PR TITLE
[SRVKS-670] Set minAvailable to 1 on activator PDB

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.18.2/2-serving-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.18.2/2-serving-core.yaml
@@ -2106,7 +2106,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.18.2"
 spec:
-  minAvailable: 80%
+  minAvailable: 1
   selector:
     matchLabels:
       app: activator

--- a/openshift-knative-operator/hack/003-activator-pdb.patch
+++ b/openshift-knative-operator/hack/003-activator-pdb.patch
@@ -1,0 +1,13 @@
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.18.2/2-serving-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.18.2/2-serving-core.yaml
+index adce83ca..30f47d86 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.18.2/2-serving-core.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.18.2/2-serving-core.yaml
+@@ -2106,7 +2106,7 @@ metadata:
+   labels:
+     serving.knative.dev/release: "v0.18.2"
+ spec:
+-  minAvailable: 80%
++  minAvailable: 1
+   selector:
+     matchLabels:
+       app: activator

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -40,6 +40,10 @@ download serving $KNATIVE_SERVING_VERSION "${serving_files[@]}"
 # TODO: Remove this patch once 0.18.5 of serving or newer is available.
 git apply "$root/openshift-knative-operator/hack/001-liveness.patch"
 
+# TODO: Remove this once upstream fixed https://github.com/knative/operator/issues/376.
+# See also https://issues.redhat.com/browse/SRVKS-670.
+git apply "$root/openshift-knative-operator/hack/003-activator-pdb.patch"
+
 download eventing $KNATIVE_EVENTING_VERSION "${eventing_files[@]}"
 # Extra ClusterRole for downstream, so that users can get the CMs of knative-eventing
 # TODO: propose to upstream


### PR DESCRIPTION
Upstream introduced activator's PDB has 80%, but it does not work with
default 2 activator replicas.

Hence this patch changes the activator's PDB to `1`.

/cc @jcrossley3 @skonto @matzew 