### PR TITLE
[RELEASE-1.12][SRVKS-670] Set minAvailable to 1 on activator PDB

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.18.2/2-serving-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.18.2/2-serving-core.yaml
@@ -2106,7 +2106,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.18.2"
 spec:
-  minAvailable: 80%
+  minAvailable: 1
   selector:
     matchLabels:
       app: activator


### PR DESCRIPTION
Upstream introduced activator's PDB has 80%, but it does not work with
default 2 activator replicas.

Hence this patch changes the activator's PDB to `1`

This is a backport of https://github.com/openshift-knative/serverless-operator/pull/715.

/cc @jcrossley3 @skonto @matzew 