### PR TITLE
[1.12] Create the Secrets for SASL/TLS, needed on upstream KafkaSource tests

### DIFF
--- a/test/eventing-contrib.bash
+++ b/test/eventing-contrib.bash
@@ -32,6 +32,8 @@ function upstream_knative_eventing_contrib_e2e {
 
   # run_e2e_tests defined in eventing-contrib
   logger.info 'Starting eventing-contrib tests'
+  (( !failed )) && create_auth_secrets || failed=$?
+
   (( !failed )) && run_e2e_tests || failed=$?
 
   return $failed

--- a/test/eventing-contrib.bash
+++ b/test/eventing-contrib.bash
@@ -30,7 +30,7 @@ function upstream_knative_eventing_contrib_e2e {
 
   failed=0
 
-  # run_e2e_tests defined in eventing-contrib
+  # create_auth_secrets and run_e2e_tests defined in eventing-contrib
   logger.info 'Starting eventing-contrib tests'
   (( !failed )) && create_auth_secrets || failed=$?
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

In mid/upstream we create a secret for TLS and SALS based on the configured KAfka (Strimzi with PLAIN, TLS, SASL listeners) and their `StrimziUsers`.

This test suite lacks the creation of the secrets, doing so here.

/assign @lberk 
/assign @aliok 

The other option would be to create the secrets on the midstream's `run_e2e_tests` function...
