### PR TITLE
Install yq in ci-operator/build-image

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -7,5 +7,7 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
 RUN yum install -y kubectl ansible httpd-tools
 
+RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
+
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
Install yq into the build image so we can dynamically generate $CURRENT_CSV and $PREVIOUS_CSV based on values from the CSV. CI will fail until #414 is merged.