### PR TITLE
Add Kafka Source smoke tests for Plain/TLS/SASL auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v12.0.0+incompatible
-	knative.dev/eventing v0.18.4
-	knative.dev/eventing-contrib v0.18.3
+	knative.dev/eventing v0.18.5-0.20201105155307-650096a39064
+	knative.dev/eventing-contrib v0.18.6
 	knative.dev/networking v0.0.0-20201028144035-3287613a3b41
 	knative.dev/operator v0.18.2
 	knative.dev/pkg v0.0.0-20201026165741-2f75016c1368

--- a/go.sum
+++ b/go.sum
@@ -2671,13 +2671,12 @@ knative.dev/caching v0.0.0-20200122154023-853d6022845c/go.mod h1:dHXFU6CGlLlbzaW
 knative.dev/caching v0.0.0-20200922173540-a6b8bbd6999a h1:oZpwlLcEiOjlP1NDKrp5356ntlcFr6hV5+J2/XazxME=
 knative.dev/caching v0.0.0-20200922173540-a6b8bbd6999a/go.mod h1:P624eQ2AZLjwPBRuSqlnkWjRYoVeGdZ/uGXPrYP/USk=
 knative.dev/eventing v0.14.0/go.mod h1:UxweNv8yXhsdHJitcb9R6rmfNaUD2DFi9GWwNRyIs58=
-knative.dev/eventing v0.18.4-0.20201028193234-25836253934e/go.mod h1:Rv5V1Sk/XeG6vdEpRu+zDhEUDg2SgbkOJWRNssUyt50=
-knative.dev/eventing v0.18.4 h1:WV6MrFwrGeAnz00tZ7vAjlvdYOVlGYhUOiuTnhfwMms=
-knative.dev/eventing v0.18.4/go.mod h1:iL4L4Y2RDWBA7bpMrvFPOS8NhB5nCtkyRLWH89LqK2s=
+knative.dev/eventing v0.18.5-0.20201105155307-650096a39064 h1:o12yrC3+HAy3S1Maf7fqrAzp1Ih3ht9Uo5lD5F8/XzA=
+knative.dev/eventing v0.18.5-0.20201105155307-650096a39064/go.mod h1:iL4L4Y2RDWBA7bpMrvFPOS8NhB5nCtkyRLWH89LqK2s=
 knative.dev/eventing-contrib v0.6.1-0.20190723221543-5ce18048c08b/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
 knative.dev/eventing-contrib v0.11.2/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
-knative.dev/eventing-contrib v0.18.3 h1:XE+PmbMEKS7tTNQopWH06p8MEKGIYt1DkSjmyHT3F/A=
-knative.dev/eventing-contrib v0.18.3/go.mod h1:K2GvdCVQclPgf78tyKl+zw+Mlpee+JdGD63EJ+vB9bA=
+knative.dev/eventing-contrib v0.18.6 h1:6xEzPkbKbY3Iq9LPKNNjLcYiadOXZGw/eVYAdDuIAF4=
+knative.dev/eventing-contrib v0.18.6/go.mod h1:Y3pKSlnqk5pG8r/2wljnPiZa1NPu/qjdQ3bX8ex2WVw=
 knative.dev/networking v0.0.0-20200922180040-a71b40c69b15 h1:UhUyfzy5VTEdkWXlkJAKLDPkPK9MKNpENfn17rlYtcs=
 knative.dev/networking v0.0.0-20200922180040-a71b40c69b15/go.mod h1:WphBxM2NFDmDLc5FAJUOdGdgdXbuD/ALSWa//jKw92I=
 knative.dev/networking v0.0.0-20201028144035-3287613a3b41 h1:Ok/FwVK/SWFO3CfXekx7O0SjYkqgEylCuUyRsBDPzgU=

--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/eventing/pkg/utils"
 
 	kafkabindingv1beta1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1beta1"
 	kafkasourcev1beta1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1beta1"
@@ -37,17 +38,73 @@ const (
 )
 
 var (
-	// TODO: TLS/SASL? --> https://issues.redhat.com/browse/SRVKE-647
-	bootstrapServer = clusterName + "-kafka-bootstrap.kafka:9092"
-	kafkaGVR        = schema.GroupVersionResource{Group: "kafka.strimzi.io", Version: "v1beta1", Resource: "kafkatopics"}
+	baseURI              = "-kafka-bootstrap.kafka:"
+	plainBootstrapServer = clusterName + baseURI + "9092"
+	tlsBootstrapServer   = clusterName + baseURI + "9093"
+	saslBootstrapServer  = clusterName + baseURI + "9094"
+	tlsSecret            = "my-tls-secret"
+	saslSecret           = "my-sasl-secret"
+	kafkaGVR             = schema.GroupVersionResource{Group: "kafka.strimzi.io", Version: "v1beta1", Resource: "kafkatopics"}
+)
 
+func createCronJobObj(name, topic, server string) *batchv1beta1.CronJob {
+	return &batchv1beta1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: batchv1beta1.CronJobSpec{
+			Schedule: "* * * * *",
+			JobTemplate: batchv1beta1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:    "kafka-message-test",
+									Image:   "strimzi/kafka:0.16.2-kafka-2.4.0",
+									Command: []string{"sh", "-c", fmt.Sprintf(`echo "%s" | bin/kafka-console-producer.sh --broker-list %s --topic %s`, helloWorldText, server, topic)},
+								},
+							},
+							RestartPolicy: corev1.RestartPolicyOnFailure,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createKafkaSourceObj(sourceName, sinkName, topicName string, auth kafkabindingv1beta1.KafkaAuthSpec) kafkasourcev1beta1.KafkaSource {
+	return kafkasourcev1beta1.KafkaSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sourceName,
+			Namespace: testNamespace,
+		},
+		Spec: kafkasourcev1beta1.KafkaSourceSpec{
+			KafkaAuthSpec: auth,
+			Topics:        []string{topicName},
+			ConsumerGroup: kafkaConsumerGroup,
+			SourceSpec: duckv1.SourceSpec{
+				Sink: duckv1.Destination{
+					Ref: &duckv1.KReference{
+						APIVersion: ksvcAPIVersion,
+						Kind:       ksvcKind,
+						Name:       sinkName,
+					},
+				},
+			},
+		},
+	}
+}
+func createKafkaTopicObj(topicName string) unstructured.Unstructured {
 	// We use unstructured to avoid having a hard dep on any specific kafka implementation
-	kafkaTopicObj = unstructured.Unstructured{
+	return unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": kafkaAPIVersion,
 			"kind":       kafkaTopicKind,
 			"metadata": map[string]interface{}{
-				"name":      kafkaTopicName,
+				"name":      topicName,
 				"namespace": testNamespace,
 				"labels": map[string]interface{}{
 					strimziClusterLabel: clusterName,
@@ -61,90 +118,150 @@ var (
 		},
 	}
 
-	kafkaSource = kafkasourcev1beta1.KafkaSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kafkaSourceName,
-			Namespace: testNamespace,
+}
+
+func TestKafkaSourceToKnativeService(t *testing.T) {
+	client := test.SetupClusterAdmin(t)
+	cleanup := func() {
+		test.CleanupAll(t, client)
+		client.Clients.Dynamic.Resource(kafkaGVR).Namespace(testNamespace).Delete(context.Background(), kafkaTopicName+"-plain", metav1.DeleteOptions{})
+		client.Clients.Dynamic.Resource(kafkaGVR).Namespace(testNamespace).Delete(context.Background(), kafkaTopicName+"-tls", metav1.DeleteOptions{})
+		client.Clients.Dynamic.Resource(kafkaGVR).Namespace(testNamespace).Delete(context.Background(), kafkaTopicName+"-sasl", metav1.DeleteOptions{})
+		client.Clients.KafkaSource.SourcesV1beta1().KafkaSources(testNamespace).Delete(context.Background(), kafkaSourceName+"-plain", metav1.DeleteOptions{})
+		client.Clients.KafkaSource.SourcesV1beta1().KafkaSources(testNamespace).Delete(context.Background(), kafkaSourceName+"-tls", metav1.DeleteOptions{})
+		client.Clients.KafkaSource.SourcesV1beta1().KafkaSources(testNamespace).Delete(context.Background(), kafkaSourceName+"-sasl", metav1.DeleteOptions{})
+		client.Clients.Kube.BatchV1beta1().CronJobs(testNamespace).Delete(context.Background(), cronJobName+"-plain", metav1.DeleteOptions{})
+		client.Clients.Kube.BatchV1beta1().CronJobs(testNamespace).Delete(context.Background(), cronJobName+"-tls", metav1.DeleteOptions{})
+		client.Clients.Kube.BatchV1beta1().CronJobs(testNamespace).Delete(context.Background(), cronJobName+"-sasl", metav1.DeleteOptions{})
+		client.Clients.Kube.CoreV1().Secrets(testNamespace).Delete(context.Background(), tlsSecret, metav1.DeleteOptions{})
+		client.Clients.Kube.CoreV1().Secrets(testNamespace).Delete(context.Background(), saslSecret, metav1.DeleteOptions{})
+	}
+	test.CleanupOnInterrupt(t, cleanup)
+	defer cleanup()
+
+	// Get Secret Name -> AuthSecretName
+	_, err := utils.CopySecret(client.Clients.Kube.CoreV1(), "default", tlsSecret, testNamespace, "default")
+	if err != nil {
+		t.Fatalf("Could not copy Secret: %s to test namespace: %s", tlsSecret, testNamespace)
+	}
+
+	_, err = utils.CopySecret(client.Clients.Kube.CoreV1(), "default", saslSecret, testNamespace, "default")
+	if err != nil {
+		t.Fatalf("Could not copy Secret: %s to test namespace: %s", saslSecret, testNamespace)
+	}
+
+	tests := map[string]kafkabindingv1beta1.KafkaAuthSpec{
+		"plain": {
+			BootstrapServers: []string{plainBootstrapServer},
 		},
-		Spec: kafkasourcev1beta1.KafkaSourceSpec{
-			KafkaAuthSpec: kafkabindingv1beta1.KafkaAuthSpec{
-				BootstrapServers: []string{bootstrapServer},
-			},
-			Topics:        []string{kafkaTopicName},
-			ConsumerGroup: kafkaConsumerGroup,
-			SourceSpec: duckv1.SourceSpec{
-				Sink: duckv1.Destination{
-					Ref: &duckv1.KReference{
-						APIVersion: ksvcAPIVersion,
-						Kind:       ksvcKind,
-						Name:       helloWorldService,
+		"tls": {
+			BootstrapServers: []string{tlsBootstrapServer},
+			Net: kafkabindingv1beta1.KafkaNetSpec{
+				TLS: kafkabindingv1beta1.KafkaTLSSpec{
+					Enable: true,
+					Cert: kafkabindingv1beta1.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: tlsSecret,
+							},
+							Key: "user.crt",
+						},
+					},
+					Key: kafkabindingv1beta1.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: tlsSecret,
+							},
+							Key: "user.key",
+						},
+					},
+					CACert: kafkabindingv1beta1.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: tlsSecret,
+							},
+							Key: "ca.crt",
+						},
 					},
 				},
 			},
 		},
-	}
-
-	cj = &batchv1beta1.CronJob{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cronJobName,
-			Namespace: testNamespace,
-		},
-		Spec: batchv1beta1.CronJobSpec{
-			Schedule: "* * * * *",
-			JobTemplate: batchv1beta1.JobTemplateSpec{
-				Spec: batchv1.JobSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name:    "kafka-message-test",
-									Image:   "strimzi/kafka:0.16.2-kafka-2.4.0",
-									Command: []string{"sh", "-c", fmt.Sprintf(`echo "%s" | bin/kafka-console-producer.sh --broker-list %s --topic %s`, helloWorldText, bootstrapServer, kafkaTopicName)},
-								},
+		"sasl": {
+			BootstrapServers: []string{saslBootstrapServer},
+			Net: kafkabindingv1beta1.KafkaNetSpec{
+				TLS: kafkabindingv1beta1.KafkaTLSSpec{
+					Enable: true,
+					CACert: kafkabindingv1beta1.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: tlsSecret,
 							},
-							RestartPolicy: corev1.RestartPolicyOnFailure,
+							Key: "ca.crt",
+						},
+					},
+				},
+				SASL: kafkabindingv1beta1.KafkaSASLSpec{
+					Enable: true,
+					User: kafkabindingv1beta1.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: saslSecret,
+							},
+							Key: "user",
+						},
+					},
+					Password: kafkabindingv1beta1.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: saslSecret,
+							},
+							Key: "password",
+						},
+					},
+					Type: kafkabindingv1beta1.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: saslSecret,
+							},
+							Key: "saslType",
 						},
 					},
 				},
 			},
 		},
 	}
-)
 
-func TestKafkaSourceToKnativeService(t *testing.T) {
-	client := test.SetupClusterAdmin(t)
-	cleanup := func() {
-		test.CleanupAll(t, client)
-		client.Clients.Dynamic.Resource(kafkaGVR).Namespace(testNamespace).Delete(context.Background(), kafkaTopicName, metav1.DeleteOptions{})
-		client.Clients.KafkaSource.SourcesV1beta1().KafkaSources(testNamespace).Delete(context.Background(), kafkaSourceName, metav1.DeleteOptions{})
-		client.Clients.Kube.BatchV1beta1().CronJobs(testNamespace).Delete(context.Background(), cronJobName, metav1.DeleteOptions{})
+	for name, tc := range tests {
+		name := name
+		// Setup a knative service
+		ksvc, err := test.WithServiceReady(client, helloWorldService+"-"+name, testNamespace, image)
+		if err != nil {
+			t.Fatalf("Knative Service(%s) not ready: %v", ksvc.GetName(), err)
+		}
+
+		// Create kafkatopic
+		kafkaTopicObj := createKafkaTopicObj(kafkaTopicName + "-" + name)
+		_, err = client.Clients.Dynamic.Resource(kafkaGVR).Namespace(testNamespace).Create(context.Background(), &kafkaTopicObj, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Unable to create KafkaTopic(%s): %v", kafkaTopicObj.GetName(), err)
+		}
+
+		// create kafka source
+		kafkaSource := createKafkaSourceObj(kafkaSourceName+"-"+name, helloWorldService+"-"+name, kafkaTopicName+"-"+name, tc)
+		_, err = client.Clients.KafkaSource.SourcesV1beta1().KafkaSources(testNamespace).Create(context.Background(), &kafkaSource, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Unable to create kafkaSource(%s): %v", kafkaSource.GetName(), err)
+		}
+
+		// send event to kafka topic
+		cj := createCronJobObj(cronJobName+"-"+name, kafkaTopicName+"-"+name, kafkaSource.Spec.BootstrapServers[0])
+		_, err = client.Clients.Kube.BatchV1beta1().CronJobs(testNamespace).Create(context.Background(), cj, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Unable to create batch cronjob(%s): %v", cj.GetName(), err)
+		}
+
+		servinge2e.WaitForRouteServingText(t, client, ksvc.Status.URL.URL(), helloWorldText)
 	}
-	test.CleanupOnInterrupt(t, cleanup)
-	defer cleanup()
-
-	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, testNamespace, image)
-	if err != nil {
-		t.Fatal("Knative Service not ready", err)
-	}
-
-	// Create kafkatopic
-	_, err = client.Clients.Dynamic.Resource(kafkaGVR).Namespace(testNamespace).Create(context.Background(), &kafkaTopicObj, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create KafkaTopic: ", err)
-	}
-
-	// create kafka source
-	_, err = client.Clients.KafkaSource.SourcesV1beta1().KafkaSources(testNamespace).Create(context.Background(), &kafkaSource, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create kafkaSource: ", err)
-	}
-
-	// send event to kafka topic
-	_, err = client.Clients.Kube.BatchV1beta1().CronJobs(testNamespace).Create(context.Background(), cj, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create batch cronjob: ", err)
-	}
-
-	servinge2e.WaitForRouteServingText(t, client, ksvc.Status.URL.URL(), helloWorldText)
+	// cleanup if everything ends smoothly
+	cleanup()
 }

--- a/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
@@ -61,7 +61,7 @@ kind: %q`, channelAPIVersion, kafkaChannelKind),
 				Ref: &duckv1.KReference{
 					APIVersion: ksvcAPIVersion,
 					Kind:       ksvcKind,
-					Name:       helloWorldService,
+					Name:       helloWorldService + "-broker",
 				},
 			},
 		},
@@ -99,7 +99,7 @@ func TestSourceToKafkaBrokerToKnativeService(t *testing.T) {
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()
 
-	ksvc, err := test.WithServiceReady(client, helloWorldService, testNamespace, image)
+	ksvc, err := test.WithServiceReady(client, helloWorldService+"-broker", testNamespace, image)
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
@@ -10,6 +10,7 @@ import (
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	eventingsourcesv1beta1 "knative.dev/eventing/pkg/apis/sources/v1beta1"
+	"knative.dev/eventing/pkg/utils"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/openshift-knative/serverless-operator/test"
@@ -95,9 +96,21 @@ func TestSourceToKafkaBrokerToKnativeService(t *testing.T) {
 		client.Clients.Eventing.SourcesV1beta1().PingSources(testNamespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
 		client.Clients.Eventing.EventingV1().Triggers(testNamespace).Delete(context.Background(), kafkatriggerName, metav1.DeleteOptions{})
 		client.Clients.Kube.CoreV1().ConfigMaps(testNamespace).Delete(context.Background(), cmName, metav1.DeleteOptions{})
+		client.Clients.Kube.CoreV1().Secrets(testNamespace).Delete(context.Background(), tlsSecret, metav1.DeleteOptions{})
+		client.Clients.Kube.CoreV1().Secrets(testNamespace).Delete(context.Background(), saslSecret, metav1.DeleteOptions{})
 	}
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()
+
+	_, err := utils.CopySecret(client.Clients.Kube.CoreV1(), "default", tlsSecret, testNamespace, "default")
+	if err != nil {
+		t.Fatalf("Could not copy Secret: %s to test namespace: %s", tlsSecret, testNamespace)
+	}
+
+	_, err = utils.CopySecret(client.Clients.Kube.CoreV1(), "default", saslSecret, testNamespace, "default")
+	if err != nil {
+		t.Fatalf("Could not copy Secret: %s to test namespace: %s", saslSecret, testNamespace)
+	}
 
 	ksvc, err := test.WithServiceReady(client, helloWorldService+"-broker", testNamespace, image)
 	if err != nil {

--- a/vendor/knative.dev/eventing-contrib/kafka/channel/pkg/utils/util.go
+++ b/vendor/knative.dev/eventing-contrib/kafka/channel/pkg/utils/util.go
@@ -17,9 +17,14 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/logging"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,8 +34,17 @@ import (
 
 const (
 	BrokerConfigMapKey           = "bootstrapServers"
+	AuthSecretName               = "authSecretName"
+	AuthSecretNamespace          = "authSecretNamespace"
 	MaxIdleConnectionsKey        = "maxIdleConns"
 	MaxIdleConnectionsPerHostKey = "maxIdleConnsPerHost"
+
+	TlsCacert    = "ca.crt"
+	TlsUsercert  = "user.crt"
+	TlsUserkey   = "user.key"
+	SaslUser     = "user"
+	SaslPassword = "password"
+	SaslType     = "saslType"
 
 	KafkaChannelSeparator = "."
 
@@ -50,6 +64,57 @@ type KafkaConfig struct {
 	Brokers             []string
 	MaxIdleConns        int32
 	MaxIdleConnsPerHost int32
+	AuthSecretName      string
+	AuthSecretNamespace string
+}
+
+type KafkaAuthConfig struct {
+	TLS  *KafkaTlsConfig
+	SASL *KafkaSaslConfig
+}
+
+type KafkaTlsConfig struct {
+	Cacert   string
+	Usercert string
+	Userkey  string
+}
+
+type KafkaSaslConfig struct {
+	User     string
+	Password string
+	SaslType string
+}
+
+func GetKafkaAuthData(ctx context.Context, secretname string, secretNS string) *KafkaAuthConfig {
+
+	k8sClient := kubeclient.Get(ctx)
+	secret, err := k8sClient.CoreV1().Secrets(secretNS).Get(ctx, secretname, metav1.GetOptions{})
+
+	if err != nil || secret == nil {
+		logging.FromContext(ctx).Errorf("Referenced Auth Secret not found")
+		return nil
+	}
+
+	kafkaAuthConfig := &KafkaAuthConfig{}
+	// check for TLS
+	if string(secret.Data[TlsCacert]) != "" {
+		tls := &KafkaTlsConfig{
+			Cacert:   string(secret.Data[TlsCacert]),
+			Usercert: string(secret.Data[TlsUsercert]),
+			Userkey:  string(secret.Data[TlsUserkey]),
+		}
+		kafkaAuthConfig.TLS = tls
+	}
+
+	if string(secret.Data[SaslUser]) != "" {
+		sasl := &KafkaSaslConfig{
+			User:     string(secret.Data[SaslUser]),
+			Password: string(secret.Data[SaslPassword]),
+			SaslType: string(secret.Data[SaslType]),
+		}
+		kafkaAuthConfig.SASL = sasl
+	}
+	return kafkaAuthConfig
 }
 
 // GetKafkaConfig returns the details of the Kafka cluster.
@@ -64,9 +129,13 @@ func GetKafkaConfig(configMap map[string]string) (*KafkaConfig, error) {
 	}
 
 	var bootstrapServers string
+	var authSecretNamespace string
+	var authSecretName string
 
 	err := configmap.Parse(configMap,
 		configmap.AsString(BrokerConfigMapKey, &bootstrapServers),
+		configmap.AsString(AuthSecretName, &authSecretName),
+		configmap.AsString(AuthSecretNamespace, &authSecretNamespace),
 		configmap.AsInt32(MaxIdleConnectionsKey, &config.MaxIdleConns),
 		configmap.AsInt32(MaxIdleConnectionsPerHostKey, &config.MaxIdleConnsPerHost),
 	)
@@ -84,6 +153,8 @@ func GetKafkaConfig(configMap map[string]string) (*KafkaConfig, error) {
 		}
 	}
 	config.Brokers = bootstrapServersSplitted
+	config.AuthSecretName = authSecretName
+	config.AuthSecretNamespace = authSecretNamespace
 
 	return config, nil
 }

--- a/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1alpha1/kafka_conversion.go
+++ b/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1alpha1/kafka_conversion.go
@@ -83,6 +83,9 @@ func (source *KafkaAuthSpec) ConvertTo(_ context.Context, obj apis.Convertible) 
 				},
 				Password: bindingsv1beta1.SecretValueFromSource{
 					SecretKeyRef: source.Net.SASL.Password.SecretKeyRef},
+				Type: bindingsv1beta1.SecretValueFromSource{
+					SecretKeyRef: source.Net.SASL.Type.SecretKeyRef,
+				},
 			},
 			TLS: bindingsv1beta1.KafkaTLSSpec{
 				Enable: source.Net.TLS.Enable,
@@ -117,6 +120,9 @@ func (sink *KafkaAuthSpec) ConvertFrom(_ context.Context, obj apis.Convertible) 
 				},
 				Password: SecretValueFromSource{
 					SecretKeyRef: source.Net.SASL.Password.SecretKeyRef},
+				Type: SecretValueFromSource{
+					SecretKeyRef: source.Net.SASL.Type.SecretKeyRef,
+				},
 			},
 			TLS: KafkaTLSSpec{
 				Enable: source.Net.TLS.Enable,

--- a/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1alpha1/kafka_lifecycle.go
+++ b/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1alpha1/kafka_lifecycle.go
@@ -102,6 +102,11 @@ func (kfb *KafkaBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: kfb.Spec.Net.SASL.Password.SecretKeyRef,
 				},
+			}, corev1.EnvVar{
+				Name: "KAFKA_NET_SASL_TYPE",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: kfb.Spec.Net.SASL.Type.SecretKeyRef,
+				},
 			})
 		}
 		if kfb.Spec.Net.TLS.Enable {
@@ -147,6 +152,11 @@ func (kfb *KafkaBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: kfb.Spec.Net.SASL.Password.SecretKeyRef,
 				},
+			}, corev1.EnvVar{
+				Name: "KAFKA_NET_SASL_TYPE",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: kfb.Spec.Net.SASL.Type.SecretKeyRef,
+				},
 			})
 		}
 		if kfb.Spec.Net.TLS.Enable {
@@ -184,7 +194,7 @@ func (kfb *KafkaBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		for j, ev := range c.Env {
 			switch ev.Name {
 			case "KAFKA_NET_TLS_ENABLE", "KAFKA_NET_TLS_CERT", "KAFKA_NET_TLS_KEY", "KAFKA_NET_TLS_CA_CERT",
-				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD",
+				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD", "KAFKA_NET_SASL_TYPE",
 				"KAFKA_BOOTSTRAP_SERVERS":
 
 				continue
@@ -203,7 +213,7 @@ func (kfb *KafkaBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		for j, ev := range c.Env {
 			switch ev.Name {
 			case "KAFKA_NET_TLS_ENABLE", "KAFKA_NET_TLS_CERT", "KAFKA_NET_TLS_KEY", "KAFKA_NET_TLS_CA_CERT",
-				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD",
+				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD", "KAFKA_NET_SASL_TYPE",
 				"KAFKA_BOOTSTRAP_SERVERS":
 				continue
 			default:

--- a/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1alpha1/kafka_types.go
+++ b/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1alpha1/kafka_types.go
@@ -56,6 +56,10 @@ type KafkaSASLSpec struct {
 	// Password is the Kubernetes secret containing the SASL password.
 	// +optional
 	Password SecretValueFromSource `json:"password,omitempty"`
+
+	// Type of saslType, defaults to plain (vs SCRAM-SHA-512 or SCRAM-SHA-256)
+	// +optional
+	Type SecretValueFromSource `json:"type,omitempty"`
 }
 
 type KafkaTLSSpec struct {

--- a/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1alpha1/zz_generated.deepcopy.go
@@ -166,6 +166,7 @@ func (in *KafkaSASLSpec) DeepCopyInto(out *KafkaSASLSpec) {
 	*out = *in
 	in.User.DeepCopyInto(&out.User)
 	in.Password.DeepCopyInto(&out.Password)
+	in.Type.DeepCopyInto(&out.Type)
 	return
 }
 

--- a/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1beta1/kafka_lifecycle.go
+++ b/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1beta1/kafka_lifecycle.go
@@ -102,6 +102,11 @@ func (kfb *KafkaBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: kfb.Spec.Net.SASL.Password.SecretKeyRef,
 				},
+			}, corev1.EnvVar{
+				Name: "KAFKA_NET_SASL_TYPE",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: kfb.Spec.Net.SASL.Type.SecretKeyRef,
+				},
 			})
 		}
 		if kfb.Spec.Net.TLS.Enable {
@@ -147,6 +152,11 @@ func (kfb *KafkaBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: kfb.Spec.Net.SASL.Password.SecretKeyRef,
 				},
+			}, corev1.EnvVar{
+				Name: "KAFKA_NET_SASL_TYPE",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: kfb.Spec.Net.SASL.Type.SecretKeyRef,
+				},
 			})
 		}
 		if kfb.Spec.Net.TLS.Enable {
@@ -184,7 +194,7 @@ func (kfb *KafkaBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		for j, ev := range c.Env {
 			switch ev.Name {
 			case "KAFKA_NET_TLS_ENABLE", "KAFKA_NET_TLS_CERT", "KAFKA_NET_TLS_KEY", "KAFKA_NET_TLS_CA_CERT",
-				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD",
+				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD", "KAFKA_NET_SASL_TYPE",
 				"KAFKA_BOOTSTRAP_SERVERS":
 
 				continue
@@ -203,7 +213,7 @@ func (kfb *KafkaBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		for j, ev := range c.Env {
 			switch ev.Name {
 			case "KAFKA_NET_TLS_ENABLE", "KAFKA_NET_TLS_CERT", "KAFKA_NET_TLS_KEY", "KAFKA_NET_TLS_CA_CERT",
-				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD",
+				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD", "KAFKA_NET_SASL_TYPE",
 				"KAFKA_BOOTSTRAP_SERVERS":
 				continue
 			default:

--- a/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1beta1/kafka_types.go
+++ b/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1beta1/kafka_types.go
@@ -56,6 +56,10 @@ type KafkaSASLSpec struct {
 	// Password is the Kubernetes secret containing the SASL password.
 	// +optional
 	Password SecretValueFromSource `json:"password,omitempty"`
+
+	// Type of saslType, defaults to plain (vs SCRAM-SHA-512 or SCRAM-SHA-256)
+	// +optional
+	Type SecretValueFromSource `json:"type,omitempty"`
 }
 
 type KafkaTLSSpec struct {

--- a/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1beta1/zz_generated.deepcopy.go
+++ b/vendor/knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1beta1/zz_generated.deepcopy.go
@@ -166,6 +166,7 @@ func (in *KafkaSASLSpec) DeepCopyInto(out *KafkaSASLSpec) {
 	*out = *in
 	in.User.DeepCopyInto(&out.User)
 	in.Password.DeepCopyInto(&out.Password)
+	in.Type.DeepCopyInto(&out.Type)
 	return
 }
 

--- a/vendor/knative.dev/eventing/pkg/utils/headers.go
+++ b/vendor/knative.dev/eventing/pkg/utils/headers.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"net/http"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// TODO make propagated headers/prefixes configurable (configmap?)
+
+var (
+	// These MUST be lowercase strings, as they will be compared against lowercase strings.
+	forwardHeaders = sets.NewString(
+		// tracing
+		"x-request-id",
+	)
+	// These MUST be lowercase strings, as they will be compared against lowercase strings.
+	// Removing CloudEvents ce- prefixes on purpose as they should be set in the CloudEvent itself as extensions.
+	// Then the SDK will set them as ce- headers when sending them through HTTP. Otherwise, when using replies we would
+	// duplicate ce- headers.
+	forwardPrefixes = []string{
+		// knative
+		"knative-",
+	}
+)
+
+// PassThroughHeaders extracts the headers from headers that are in the `forwardHeaders` set
+// or has any of the prefixes in `forwardPrefixes`.
+func PassThroughHeaders(headers http.Header) http.Header {
+	h := http.Header{}
+
+	for n, v := range headers {
+		lower := strings.ToLower(n)
+		if forwardHeaders.Has(lower) {
+			h[n] = v
+			continue
+		}
+		for _, prefix := range forwardPrefixes {
+			if strings.HasPrefix(lower, prefix) {
+				h[n] = v
+				break
+			}
+		}
+	}
+	return h
+}

--- a/vendor/knative.dev/eventing/pkg/utils/secret.go
+++ b/vendor/knative.dev/eventing/pkg/utils/secret.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// CopySecret will copy a secret from one namespace into another.
+// If a ServiceAccount name is provided then it'll add it as a PullSecret to
+// it.
+// It'll either return a pointer to the new Secret or and error indicating
+// why it couldn't do it.
+func CopySecret(corev1Input clientcorev1.CoreV1Interface, srcNS string, srcSecretName string, tgtNS string, svcAccount string) (*corev1.Secret, error) {
+	tgtNamespaceSvcAcct := corev1Input.ServiceAccounts(tgtNS)
+	srcSecrets := corev1Input.Secrets(srcNS)
+	tgtNamespaceSecrets := corev1Input.Secrets(tgtNS)
+
+	// First try to find the secret we're supposed to copy
+	srcSecret, err := srcSecrets.Get(context.Background(), srcSecretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// check for nil source secret
+	if srcSecret == nil {
+		return nil, errors.New("error copying secret; there is no error but secret is nil")
+	}
+
+	// Found the secret, so now make a copy in our new namespace
+	newSecret, err := tgtNamespaceSecrets.Create(
+		context.Background(),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: srcSecretName,
+			},
+			Data: srcSecret.Data,
+			Type: srcSecret.Type,
+		},
+		metav1.CreateOptions{})
+
+	// If the secret already exists then that's ok - may have already been created
+	if err != nil && !apierrs.IsAlreadyExists(err) {
+		return nil, fmt.Errorf("error copying the Secret: %s", err)
+	}
+
+	_, err = tgtNamespaceSvcAcct.Patch(context.Background(), svcAccount, types.StrategicMergePatchType,
+		[]byte(`{"imagePullSecrets":[{"name":"`+srcSecretName+`"}]}`), metav1.PatchOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("patch failed on NS/SA (%s/%s): %s",
+			tgtNS, srcSecretName, err)
+	}
+	return newSecret, nil
+}

--- a/vendor/knative.dev/eventing/pkg/utils/utils.go
+++ b/vendor/knative.dev/eventing/pkg/utils/utils.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	resolverFileName  = "/etc/resolv.conf"
+	defaultDomainName = "cluster.local"
+
+	// Number of characters to keep available just in case the prefix used in generateName
+	// exceeds the maximum allowed for k8s names.
+	generateNameSafety = 10
+)
+
+var (
+	domainName string
+	once       sync.Once
+
+	// Only allow alphanumeric, '-' or '.'.
+	validChars = regexp.MustCompile(`[^-\.a-z0-9]+`)
+)
+
+// GetClusterDomainName returns cluster's domain name or an error
+// Closes issue: https://github.com/knative/eventing/issues/714
+func GetClusterDomainName() string {
+	once.Do(func() {
+		f, err := os.Open(resolverFileName)
+		if err == nil {
+			defer f.Close()
+			domainName = getClusterDomainName(f)
+
+		} else {
+			domainName = defaultDomainName
+		}
+	})
+
+	return domainName
+}
+
+func getClusterDomainName(r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		elements := strings.Split(scanner.Text(), " ")
+		if elements[0] != "search" {
+			continue
+		}
+		for i := 1; i < len(elements)-1; i++ {
+			if strings.HasPrefix(elements[i], "svc.") {
+				return elements[i][4:]
+			}
+		}
+	}
+	// For all abnormal cases return default domain name
+	return defaultDomainName
+}
+
+func ObjectRef(obj metav1.Object, gvk schema.GroupVersionKind) corev1.ObjectReference {
+	// We can't always rely on the TypeMeta being populated.
+	// See: https://github.com/knative/serving/issues/2372
+	// Also: https://github.com/kubernetes/apiextensions-apiserver/issues/29
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+	return corev1.ObjectReference{
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Namespace:  obj.GetNamespace(),
+		Name:       obj.GetName(),
+	}
+}
+
+// ToDNS1123Subdomain converts 'name' to a valid DNS1123 subdomain, required for object names in
+// K8s.
+func ToDNS1123Subdomain(name string) string {
+	// If it is not a valid DNS1123 subdomain, make it a valid one.
+	if msgs := validation.IsDNS1123Subdomain(name); len(msgs) != 0 {
+		// If the length exceeds the max, cut it and leave some room for a potential generated UUID.
+		if len(name) > validation.DNS1123SubdomainMaxLength {
+			name = name[:validation.DNS1123SubdomainMaxLength-generateNameSafety]
+		}
+		name = strings.ToLower(name)
+		name = validChars.ReplaceAllString(name, "")
+		// Only start/end with alphanumeric.
+		name = strings.Trim(name, "-.")
+	}
+	return name
+}
+
+// GenerateFixedName generates a fixed name for the given owning resource and human readable prefix.
+// The name's length will be short enough to be valid for K8s Services.
+//
+// Deprecated, use knative.dev/pkg/kmeta.ChildName instead.
+func GenerateFixedName(owner metav1.Object, prefix string) string {
+	uid := string(owner.GetUID())
+
+	pl := validation.DNS1123LabelMaxLength - len(uid)
+	if pl < len(prefix) {
+		prefix = prefix[:pl]
+	}
+
+	// Make sure the UID is separated from the prefix by a leading dash.
+	if !strings.HasSuffix(prefix, "-") && !strings.HasPrefix(uid, "-") {
+		uid = "-" + uid
+		if len(prefix) == pl {
+			prefix = prefix[:len(prefix)-1]
+		}
+	}
+
+	// A dot must be followed by [a-z0-9] to be DNS1123 compliant. Make sure we are not joining a dot and a dash.
+	return strings.TrimSuffix(prefix, ".") + uid
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -863,7 +863,7 @@ k8s.io/utils/trace
 # knative.dev/caching v0.0.0-20200922173540-a6b8bbd6999a
 knative.dev/caching/pkg/apis/caching
 knative.dev/caching/pkg/apis/caching/v1alpha1
-# knative.dev/eventing v0.18.4
+# knative.dev/eventing v0.18.5-0.20201105155307-650096a39064
 ## explicit
 knative.dev/eventing/pkg/apis/config
 knative.dev/eventing/pkg/apis/configs
@@ -898,7 +898,8 @@ knative.dev/eventing/pkg/client/clientset/versioned/typed/messaging/v1beta1
 knative.dev/eventing/pkg/client/clientset/versioned/typed/sources/v1alpha1
 knative.dev/eventing/pkg/client/clientset/versioned/typed/sources/v1alpha2
 knative.dev/eventing/pkg/client/clientset/versioned/typed/sources/v1beta1
-# knative.dev/eventing-contrib v0.18.3
+knative.dev/eventing/pkg/utils
+# knative.dev/eventing-contrib v0.18.6
 ## explicit
 knative.dev/eventing-contrib/kafka/channel/pkg/apis/messaging
 knative.dev/eventing-contrib/kafka/channel/pkg/apis/messaging/v1alpha1


### PR DESCRIPTION
related: SRVKE-647

Create three cronjob sources, three kafka topics, and three kafkasources, each one specific for an auth type (plain, tls, and sasl)

update eventing-contrib deps to 0.18.6 to include the sasl spec changes