### PR TITLE
Use "oc patch" instead of apply for installplan approval

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -114,9 +114,8 @@ function approve_csv {
   timeout 900 "[[ -z \$(find_install_plan ${csv_version}) ]]"
 
   install_plan=$(find_install_plan "${csv_version}")
-  oc get "$install_plan" -n "${OPERATORS_NAMESPACE}" -o yaml \
-    | sed 's/\(.*approved:\) false/\1 true/' \
-    | oc replace -f -
+  oc patch "$install_plan" -n "${OPERATORS_NAMESPACE}" \
+    --type merge --patch '{"spec":{"approved":true}}'
 
   if ! timeout 300 "[[ \$(oc get ClusterServiceVersion $csv_version -n ${OPERATORS_NAMESPACE} -o jsonpath='{.status.phase}') != Succeeded ]]" ; then
     oc get ClusterServiceVersion "$csv_version" -n "${OPERATORS_NAMESPACE}" -o yaml || true


### PR DESCRIPTION
Sometimes I get

```Error from server (Conflict): error when replacing "STDIN": Operation cannot be fulfilled on installplans.operators.coreos.com "install-b7tnq": the object has been modified; please apply your changes to the latest version and try again```

Using "oc patch" instead should not lead into a conflict.