### PR TITLE
Some fix for the MT PingSource adapter

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
@@ -700,7 +700,7 @@ spec:
             - name: K_NO_SHUTDOWN_AFTER
               value: ''
             - name: K_SINK_TIMEOUT
-              value: ''
+              value: '-1'
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
@@ -667,8 +667,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.18.6"
 spec:
-  # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       eventing.knative.dev/source: ping-source-controller

--- a/openshift-knative-operator/hack/004-eventing-pingsource-one-replica.patch
+++ b/openshift-knative-operator/hack/004-eventing-pingsource-one-replica.patch
@@ -12,3 +12,16 @@ index 8e4ec0cf..279e67b0 100644
    selector:
      matchLabels:
        eventing.knative.dev/source: ping-source-controller
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+index 279e67b0..4114d70e 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+@@ -700,7 +700,7 @@ spec:
+             - name: K_NO_SHUTDOWN_AFTER
+               value: ''
+             - name: K_SINK_TIMEOUT
+-              value: ''
++              value: '-1'
+             - name: POD_NAME
+               valueFrom:
+                 fieldRef:

--- a/openshift-knative-operator/hack/004-eventing-pingsource-one-replica.patch
+++ b/openshift-knative-operator/hack/004-eventing-pingsource-one-replica.patch
@@ -1,0 +1,14 @@
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+index 8e4ec0cf..279e67b0 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+@@ -667,8 +667,7 @@ metadata:
+   labels:
+     eventing.knative.dev/release: "v0.18.6"
+ spec:
+-  # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
+-  replicas: 0
++  replicas: 1
+   selector:
+     matchLabels:
+       eventing.knative.dev/source: ping-source-controller

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -48,3 +48,6 @@ download eventing $KNATIVE_EVENTING_VERSION "${eventing_files[@]}"
 # Extra ClusterRole for downstream, so that users can get the CMs of knative-eventing
 # TODO: propose to upstream
 git apply "$root/openshift-knative-operator/hack/002-openshift-eventing-role.patch"
+
+# SRVKE-654: relax the MT adapter replica
+git apply "$root/openshift-knative-operator/hack/004-eventing-pingsource-one-replica.patch"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

We have now a backport of some upstream fix for better scaling: https://github.com/openshift/knative-eventing/pull/1020

and now, we just ship w/ 1 replica - instead of `0` ....

