### PR TITLE
Patching product yaml to get the fix from midstream....

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/kafkachannel-v0.18.0.yaml
+++ b/knative-operator/deploy/resources/knativekafka/kafkachannel-v0.18.0.yaml
@@ -203,6 +203,17 @@ rules:
     verbs:
       - create
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

bringing the yaml fix of https://github.com/openshift/knative-eventing-contrib/pull/652  to here

/assign @maschmid 