### PR TITLE
Replace oauth resource if already exists

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -187,7 +187,12 @@ function add_user {
     --from-file=htpasswd="$(pwd)/users.htpasswd" \
     -n openshift-config \
     --dry-run=client -o yaml | kubectl apply -f -
-  oc apply -f openshift/identity/htpasswd.yaml
+
+  if oc get oauth.config.openshift.io cluster > /dev/null 2>&1; then
+    oc replace -f openshift/identity/htpasswd.yaml
+  else
+    oc apply -f openshift/identity/htpasswd.yaml
+  fi
 
   logger.debug 'Generate kubeconfig'
   cp "${KUBECONFIG}" "$name.kubeconfig"

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -382,7 +382,12 @@ function create_htpasswd_users {
     --from-file=htpasswd="$(pwd)/users.htpasswd" \
     -n openshift-config \
     --dry-run=client -o yaml | kubectl apply -f -
-  oc apply -f openshift/identity/htpasswd.yaml
+
+  if oc get oauth.config.openshift.io cluster > /dev/null 2>&1; then
+    oc replace -f openshift/identity/htpasswd.yaml
+  else
+    oc apply -f openshift/identity/htpasswd.yaml
+  fi
 
   logger.info 'Generate kubeconfig for each user'
   for i in $(seq 1 $num_users); do


### PR DESCRIPTION
This patch uses `oc replace` when `oauth/cluster` is already eixts.

`oc apply` command always fail with the following error if it was already exist.

```
$ oc apply -f openshift/identity/htpasswd.yaml
Warning: oc apply should be used on resource created by either oc create --save-config or oc apply
Error from server (UnsupportedMediaType): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"config.openshift.io/v1\",\"kind\":\"OAuth\",\"metadata\":{\"annotations\":{},\"name\":\"cluster\"},\"spec\":{\"identityProviders\":[{\"htpasswd\":{\"fileData\":{\"name\":\"htpass-secret\"}},\"mappingMethod\":\"claim\",\"name\":\"my_htpasswd_provider\",\"type\":\"HTPasswd\"}]}}\n"}}}
to:
Resource: "config.openshift.io/v1, Resource=oauths", GroupVersionKind: "config.openshift.io/v1, Kind=OAuth"
Name: "cluster", Namespace: ""
Object: &{map["apiVersion":"config.openshift.io/v1" "kind":"OAuth" "metadata":map["annotations":map["release.openshift.io/create-only":"true"] "creationTimestamp":"2020-12-08T00:42:34Z" "generation":'\x02' "managedFields":[map["apiVersion":"config.openshift.io/v1" "fieldsType":"FieldsV1" "fieldsV1":map["f:metadata":map["f:annotations":map[".":map[] "f:release.openshift.io/create-only":map[]]] "f:spec":map[]] "manager":"cluster-version-operator" "operation":"Update" "time":"2020-12-08T00:42:34Z"] map["apiVersion":"config.openshift.io/v1" "fieldsType":"FieldsV1" "fieldsV1":map["f:spec":map["f:identityProviders":map[]]] "manager":"oc" "operation":"Update" "time":"2020-12-08T01:24:21Z"]] "name":"cluster" "resourceVersion":"30735" "selfLink":"/apis/config.openshift.io/v1/oauths/cluster" "uid":"c74805f1-0721-410c-b15b-35e54cea4ee4"] "spec":map["identityProviders":[map["htpasswd":map["fileData":map["name":"htpass-secret"]] "mappingMethod":"claim" "name":"my_htpasswd_provider" "type":"HTPasswd"]]]]}
for: "openshift/identity/htpasswd.yaml": the body of the request was in an unknown format - accepted media types include: application/json-patch+json, application/merge-patch+json, application/apply-patch+yaml
```

Fixes https://github.com/openshift-knative/serverless-operator/issues/441 https://github.com/openshift-knative/serverless-operator/issues/444