### PR TITLE
Print subscription when OPENSHIFT_CI is empty

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -93,7 +93,7 @@ spec:
   installPlanApproval: Manual
   startingCSV: "${csv}"
 EOF
-  [ -n "$OPENSHIFT_CI" ] && cat "$tmpfile"
+  cat "$tmpfile"
   oc apply -f "$tmpfile"
 
   # Approve the initial installplan automatically


### PR DESCRIPTION
This patch makes a tiny change which outputs Subscription when OPENSHIFT_CI is empty.

Currently `cat` command is not executed when `OPENSHIFT_CI` is empty. But
we always would like to know the output for debug.

* Current log (it skips to cat `subscription.GSJnnX.yaml`):
```
++ mktemp /tmp/subscription.XXXXXX.yaml
+ tmpfile=/tmp/subscription.GSJnnX.yaml
+ cat
+ '[' -n '' ']'
+ oc apply -f /tmp/subscription.GSJnnX.yaml
subscription.operators.coreos.com/serverless-operator created
```

/cc @cardil 