### PR TITLE
Set GOFLAGS to empty string

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -7,7 +7,7 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
 RUN yum install -y kubectl ansible httpd-tools
 
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
+RUN GOFLAGS="" GO111MODULE=on go get github.com/mikefarah/yq/v3
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
Fix the `go get: disabled by -mod=vendor` error.