### PR TITLE
Make health status text precise

### DIFF
--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
@@ -105,12 +105,12 @@ data:
                  },
                  {
                    "op": "=",
-                   "text": "Healthy",
+                   "text": "Ready",
                    "value": "1"
                  },
                  {
                    "op": "=",
-                   "text": "Unhealthy",
+                   "text": "NotReady",
                    "value": "0"
                  }
             ],
@@ -166,7 +166,7 @@ data:
               "expr": "knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=\"serving_status\"}",
               "format": "time_series",
               "interval": "",
-              "legendFormat": "Serving status - 1 is up, 0 is down",
+              "legendFormat": "Status - 1 is Ready, 0 is NotReady",
               "refId": "A"
             }
           ],
@@ -174,7 +174,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Knative Health Status - Serving",
+          "title": "Knative Serving Status",
           "tooltip": {
             "shared": true,
             "none": 0,
@@ -262,7 +262,7 @@ data:
            "expr": "knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=\"eventing_status\"}",
            "format": "time-series",
            "interval": "",
-           "legendFormat": "Knative Eventing status - 1 is up, 0 is down",
+           "legendFormat": "Status - 1 is Ready, 0 is NotReady",
            "refId": "B"
          }
        ],
@@ -270,7 +270,7 @@ data:
        "timeFrom": null,
        "timeRegions": [],
        "timeShift": null,
-       "title": "Knative Health Status - Eventing",
+       "title": "Knative Eventing Status",
        "tooltip": {
          "shared": true,
          "sort": 0,
@@ -350,7 +350,7 @@ data:
            "expr": "knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=\"kafka_status\"}",
            "format": "time-series",
            "interval": "",
-           "legendFormat": "Knative Kafka status - 1 is up, 0 is down",
+           "legendFormat": "Status - 1 is Ready, 0 is NotReady",
            "refId": "B"
        }
       ],
@@ -358,7 +358,7 @@ data:
        "timeFrom": null,
        "timeRegions": [],
        "timeShift": null,
-       "title": "Knative Health Status - Kafka",
+       "title": "Knative Kafka Status",
        "tooltip": {
          "shared": true,
          "sort": 0,


### PR DESCRIPTION
- Previously we reported `Healthy` and `Unhealthy` if any component was not ready. Healthiness definition
can be more complex and since we lack a detailed one eg. should we include reconciliation latency etc to it, we should avoid it for now. As a matter of fact maybe its not practical to express everything via one metric here.
- This also simplifies a few labels to make things cleaner.
- For now knative_up metric is not renamed as it does not do harm, although its a contract we expose to the user, it may be updated in the future.
Example of the updates:
`$ make install-all`
![image](https://user-images.githubusercontent.com/7945591/101478770-db5b5300-3959-11eb-9731-4ea45a373a0e.png)
`watch oc delete pods --all -n knative-eventing`
 #Eventing and Kafka go down
![image](https://user-images.githubusercontent.com/7945591/101478789-e31af780-3959-11eb-8654-0a7de7380b3b.png) 
 #stop killing pods
![image](https://user-images.githubusercontent.com/7945591/101478841-f8902180-3959-11eb-896d-ab80cc4ab714.png)

/cc @markito 