### PR TITLE
Patch pingsource yamls

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
@@ -667,8 +667,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.18.6"
 spec:
-  # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       eventing.knative.dev/source: ping-source-controller
@@ -701,7 +700,7 @@ spec:
             - name: K_NO_SHUTDOWN_AFTER
               value: ''
             - name: K_SINK_TIMEOUT
-              value: ''
+              value: '-1'
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/openshift-knative-operator/hack/004-eventing-pingsource-one-replica.patch
+++ b/openshift-knative-operator/hack/004-eventing-pingsource-one-replica.patch
@@ -1,0 +1,27 @@
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+index 8e4ec0cf..279e67b0 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+@@ -667,8 +667,7 @@ metadata:
+   labels:
+     eventing.knative.dev/release: "v0.18.6"
+ spec:
+-  # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
+-  replicas: 0
++  replicas: 1
+   selector:
+     matchLabels:
+       eventing.knative.dev/source: ping-source-controller
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+index 279e67b0..4114d70e 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+@@ -700,7 +700,7 @@ spec:
+             - name: K_NO_SHUTDOWN_AFTER
+               value: ''
+             - name: K_SINK_TIMEOUT
+-              value: ''
++              value: '-1'
+             - name: POD_NAME
+               valueFrom:
+                 fieldRef:

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -48,3 +48,6 @@ download eventing $KNATIVE_EVENTING_VERSION "${eventing_files[@]}"
 # Extra ClusterRole for downstream, so that users can get the CMs of knative-eventing
 # TODO: propose to upstream
 git apply "$root/openshift-knative-operator/hack/002-openshift-eventing-role.patch"
+
+# SRVKE-654: relax the MT adapter replica
+git apply "$root/openshift-knative-operator/hack/004-eventing-pingsource-one-replica.patch"


### PR DESCRIPTION
@maschmid @lberk  Please check.

FWIW, I dont know why... but looks like both:
* https://github.com/openshift-knative/serverless-operator/pull/732
* https://github.com/openshift-knative/serverless-operator/pull/733

were PR'd against MASTER ... LOL and 733 had than no diff :see_no_evil: 

anyway this one here, tries to land the same fix as 732 on the 1.12 branch ...