### PR TITLE
[1.12] Porting eventing 4640 to Serverless Operator

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/3-in-memory-channel.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/3-in-memory-channel.yaml
@@ -565,6 +565,14 @@ spec:
     metadata:
       labels: *labels
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels: *labels
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       serviceAccountName: imc-dispatcher
       containers:
         - name: dispatcher

--- a/openshift-knative-operator/hack/005-imc-pod_anti_affinity.patch
+++ b/openshift-knative-operator/hack/005-imc-pod_anti_affinity.patch
@@ -1,0 +1,19 @@
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/3-in-memory-channel.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/3-in-memory-channel.yaml
+index 4a976467..c7f7cfef 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/3-in-memory-channel.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/3-in-memory-channel.yaml
+@@ -565,6 +565,14 @@ spec:
+     metadata:
+       labels: *labels
+     spec:
++      affinity:
++        podAntiAffinity:
++          preferredDuringSchedulingIgnoredDuringExecution:
++          - podAffinityTerm:
++              labelSelector:
++                matchLabels: *labels
++              topologyKey: kubernetes.io/hostname
++            weight: 100
+       serviceAccountName: imc-dispatcher
+       containers:
+         - name: dispatcher

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -51,3 +51,6 @@ git apply "$root/openshift-knative-operator/hack/002-openshift-eventing-role.pat
 
 # SRVKE-654: relax the MT adapter replica
 git apply "$root/openshift-knative-operator/hack/004-eventing-pingsource-one-replica.patch"
+
+# Apply port of 4640 to Serverless Operator
+git apply "$root/openshift-knative-operator/hack/005-imc-pod_anti_affinity.patch"


### PR DESCRIPTION
See here: https://github.com/openshift/knative-eventing/pull/1028

I am bringing the port of `knative/eventing #4640` to Serverless Operator.

/assign @maschmid 