### PR TITLE
Use default timeout constant from serving

### DIFF
--- a/serving/ingress/pkg/reconciler/ingress/resources/route.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route.go
@@ -13,6 +13,7 @@ import (
 	networkingv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/config"
 )
 
 const (
@@ -20,6 +21,8 @@ const (
 	DisableRouteAnnotation = "serving.knative.openshift.io/disableRoute"
 	KourierHTTPPort        = "http2"
 )
+
+var defaultTimeout = fmt.Sprintf("%vs", config.DefaultMaxRevisionTimeoutSeconds)
 
 // ErrNoValidLoadbalancerDomain indicates that the current ingress does not have a DomainInternal field, or
 // said field does not contain a value we can work with.
@@ -82,10 +85,7 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 				// So, in order to make openshift route to work converting it into seconds.
 				annotations[TimeoutAnnotation] = fmt.Sprintf("%vs", rule.HTTP.Paths[i].Timeout.Duration.Seconds())
 			} else {
-				/* Currently v0.5.0 of serving code does not have "DefaultMaxRevisionTimeoutSeconds" So hard coding "timeout" value.
-				Once serving updated to latest version then will remove hard coded value and update with
-				annotations[TimeoutAnnotation] = fmt.Sprintf("%vs", config.DefaultMaxRevisionTimeoutSeconds) */
-				annotations[TimeoutAnnotation] = "600s"
+				annotations[TimeoutAnnotation] = defaultTimeout
 			}
 
 		}

--- a/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
@@ -60,7 +60,7 @@ func TestMakeRoute(t *testing.T) {
 						serving.RouteNamespaceLabelKey: "default",
 					},
 					Annotations: map[string]string{
-						TimeoutAnnotation: "600s",
+						TimeoutAnnotation: defaultTimeout,
 					},
 					Namespace: lbNamespace,
 					Name:      routeName0,
@@ -145,7 +145,7 @@ func TestMakeRoute(t *testing.T) {
 						serving.RouteNamespaceLabelKey: "default",
 					},
 					Annotations: map[string]string{
-						TimeoutAnnotation: "600s",
+						TimeoutAnnotation: defaultTimeout,
 					},
 					Namespace: lbNamespace,
 					Name:      routeName0,
@@ -174,7 +174,7 @@ func TestMakeRoute(t *testing.T) {
 						serving.RouteNamespaceLabelKey: "default",
 					},
 					Annotations: map[string]string{
-						TimeoutAnnotation: "600s",
+						TimeoutAnnotation: defaultTimeout,
 					},
 					Namespace: lbNamespace,
 					Name:      routeName1,
@@ -212,7 +212,7 @@ func TestMakeRoute(t *testing.T) {
 						serving.RouteNamespaceLabelKey: "default",
 					},
 					Annotations: map[string]string{
-						TimeoutAnnotation: "600s",
+						TimeoutAnnotation: defaultTimeout,
 					},
 					Namespace: lbNamespace,
 					Name:      routeName1,


### PR DESCRIPTION
As per title. This has been there for ages now, no need to hardcode on our end.

/assign @nak3 