### PR TITLE
[1.12] Revert the patch to set replica:1 - we stay as default with 0

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
@@ -667,7 +667,8 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.18.6"
 spec:
-  replicas: 1
+  # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
+  replicas: 0
   selector:
     matchLabels:
       eventing.knative.dev/source: ping-source-controller

--- a/openshift-knative-operator/hack/004-eventing-pingsource-one-replica.patch
+++ b/openshift-knative-operator/hack/004-eventing-pingsource-one-replica.patch
@@ -1,18 +1,4 @@
 diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
-index 8e4ec0cf..279e67b0 100644
---- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
-+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
-@@ -667,8 +667,7 @@ metadata:
-   labels:
-     eventing.knative.dev/release: "v0.18.6"
- spec:
--  # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
--  replicas: 0
-+  replicas: 1
-   selector:
-     matchLabels:
-       eventing.knative.dev/source: ping-source-controller
-diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
 index 279e67b0..4114d70e 100644
 --- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml
 +++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.18.6/2-eventing-core.yaml


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Reverting one of the patches for 654... as the operator will be patched, to ignore the replicas and the ENV_VARs for the PINGSOURCE Deployment...