### PR TITLE
[1.12] Going with the latest version of the release-0.18 operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	knative.dev/eventing v0.18.5-0.20201105155307-650096a39064
 	knative.dev/eventing-contrib v0.18.6
 	knative.dev/networking v0.0.0-20201028144035-3287613a3b41
-	knative.dev/operator v0.18.2
+	knative.dev/operator v0.18.5-0.20201211161442-1011b0729ba9
 	knative.dev/pkg v0.0.0-20201026165741-2f75016c1368
 	knative.dev/serving v0.18.2
 	knative.dev/test-infra v0.0.0-20200921012245-37f1a12adbd3

--- a/go.sum
+++ b/go.sum
@@ -2681,8 +2681,8 @@ knative.dev/networking v0.0.0-20200922180040-a71b40c69b15 h1:UhUyfzy5VTEdkWXlkJA
 knative.dev/networking v0.0.0-20200922180040-a71b40c69b15/go.mod h1:WphBxM2NFDmDLc5FAJUOdGdgdXbuD/ALSWa//jKw92I=
 knative.dev/networking v0.0.0-20201028144035-3287613a3b41 h1:Ok/FwVK/SWFO3CfXekx7O0SjYkqgEylCuUyRsBDPzgU=
 knative.dev/networking v0.0.0-20201028144035-3287613a3b41/go.mod h1:ufoHg7bjiTnAG56pHhd6fpHOJAp5TFQO/buMlz8Wys4=
-knative.dev/operator v0.18.2 h1:MlWIMMYUiRsFdcMmDoAGTp9n3d8ETCG/K6hUavZTE1s=
-knative.dev/operator v0.18.2/go.mod h1:OzNClxJsIRJxtEv9t6a/TnwUUn+o9rRFMEjcBb5wvuY=
+knative.dev/operator v0.18.5-0.20201211161442-1011b0729ba9 h1:xqLHY63234jgI0JxdMNeJk4uwPMZQiDLuXPJPVPNPe0=
+knative.dev/operator v0.18.5-0.20201211161442-1011b0729ba9/go.mod h1:OzNClxJsIRJxtEv9t6a/TnwUUn+o9rRFMEjcBb5wvuY=
 knative.dev/pkg v0.0.0-20191101194912-56c2594e4f11/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 knative.dev/pkg v0.0.0-20191111150521-6d806b998379/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 knative.dev/pkg v0.0.0-20200207155214-fef852970f43/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=

--- a/vendor/knative.dev/operator/pkg/reconciler/knativeeventing/common/replicasenvvarstransform.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/knativeeventing/common/replicasenvvarstransform.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	mf "github.com/manifestival/manifestival"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+type unstructuredGetter interface {
+	Get(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+}
+
+// ReplicasEnvVarsTransform keeps the number of replicas and the env vars, if the deployment
+// pingsource-mt-adapter exists in the cluster.
+func ReplicasEnvVarsTransform(client unstructuredGetter) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() == "Deployment" && u.GetName() == "pingsource-mt-adapter" {
+			currentU, err := client.Get(u)
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			apply := &appsv1.Deployment{}
+			if err := scheme.Scheme.Convert(u, apply, nil); err != nil {
+				return err
+			}
+			current := &appsv1.Deployment{}
+			if err := scheme.Scheme.Convert(currentU, current, nil); err != nil {
+				return err
+			}
+
+			// Keep the existing number of replicas in the cluster for the deployment
+			apply.Spec.Replicas = current.Spec.Replicas
+
+			for index := range current.Spec.Template.Spec.Containers {
+				currentContainer := current.Spec.Template.Spec.Containers[index]
+				for j := range apply.Spec.Template.Spec.Containers {
+					applyContainer := &apply.Spec.Template.Spec.Containers[j]
+					if currentContainer.Name == applyContainer.Name {
+						applyContainer.Env = currentContainer.Env
+					}
+				}
+			}
+
+			if err := scheme.Scheme.Convert(apply, u, nil); err != nil {
+				return err
+			}
+			// The zero-value timestamp defaulted by the conversion causes
+			// superfluous updates
+			u.SetCreationTimestamp(metav1.Time{})
+		}
+		return nil
+	}
+}

--- a/vendor/knative.dev/operator/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -121,6 +121,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 	extra := []mf.Transformer{
 		kec.DefaultBrokerConfigMapTransform(instance, logger),
 		kec.SinkBindingSelectionModeTransform(instance, logger),
+		kec.ReplicasEnvVarsTransform(manifest.Client),
 	}
 	extra = append(extra, r.extension.Transformers(instance)...)
 	return common.Transform(ctx, manifest, instance, extra...)

--- a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/common/ingress_service.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/common/ingress_service.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	mf "github.com/manifestival/manifestival"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// IngressServiceTransform pins the namespace to istio-system for the service named knative-local-gateway.
+func IngressServiceTransform() mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetAPIVersion() == "v1" && u.GetKind() == "Service" && u.GetName() == "knative-local-gateway" {
+			u.SetNamespace("istio-system")
+		}
+		return nil
+	}
+}

--- a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
@@ -128,6 +128,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 		ksc.AggregationRuleTransform(manifest.Client),
 	}
 	extra = append(extra, r.extension.Transformers(instance)...)
+	extra = append(extra, ksc.IngressServiceTransform())
 	return common.Transform(ctx, manifest, instance, extra...)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -940,7 +940,7 @@ knative.dev/networking/pkg/client/injection/informers/factory
 knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/ingress
 knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/ingress
 knative.dev/networking/pkg/client/listers/networking/v1alpha1
-# knative.dev/operator v0.18.2
+# knative.dev/operator v0.18.5-0.20201211161442-1011b0729ba9
 ## explicit
 knative.dev/operator/pkg/apis/operator/v1alpha1
 knative.dev/operator/pkg/client/clientset/versioned


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

For 654:

applying a new version, that includes upstream's `knative/operator` PR 390.
- to ignore `replica` and `EVN_VAR`s from the operator owned manifest of the pingsource 