### PR TITLE
Explicitly set SYSTEM_NAMESPACE=knative-serving before running serving e2e test

### DIFF
--- a/test/serving.bash
+++ b/test/serving.bash
@@ -57,14 +57,14 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     parallel=2
   fi
 
-  go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel \
+  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     --resolvabledomain --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$image_template"
 
   # Run the helloworld test with an image pulled into the internal registry.
   oc tag -n serving-tests "registry.svc.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-helloworld" "helloworld:latest" --reference-policy=local
-  go_test_e2e -tags=e2e -timeout=30m ./test/e2e -run "^(TestHelloWorld)$" \
+  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=e2e -timeout=30m ./test/e2e -run "^(TestHelloWorld)$" \
     --resolvabledomain --kubeconfig "$KUBECONFIG" \
     --imagetemplate "image-registry.openshift-image-registry.svc:5000/serving-tests/{{.Name}}"
   
@@ -96,7 +96,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
 
   # Run HA tests separately as they're stopping core Knative Serving pods
   # Define short -spoofinterval to ensure frequent probing while stopping pods
-  go_test_e2e -tags=e2e -timeout=15m -failfast -parallel=1 ./test/ha \
+  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=e2e -timeout=15m -failfast -parallel=1 ./test/ha \
     -replicas="${REPLICAS}" -buckets="${BUCKETS}" -spoofinterval="10ms" \
     --resolvabledomain \
     --kubeconfig "$KUBECONFIG" \
@@ -121,7 +121,7 @@ function run_serving_preupgrade_test {
 
   image_template="registry.svc.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-{{.Name}}"
 
-  go_test_e2e -tags=preupgrade -timeout=20m ./test/upgrade \
+  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=preupgrade -timeout=20m ./test/upgrade \
     --imagetemplate "$image_template" \
     --kubeconfig "$KUBECONFIG" \
     --resolvabledomain
@@ -148,7 +148,7 @@ function start_serving_prober {
 
   image_template="registry.svc.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-{{.Name}}"
 
-  go_test_e2e -tags=probe \
+  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=probe \
     -timeout=30m \
     ./test/upgrade \
     -probe.success_fraction=${probe_fraction} \
@@ -210,7 +210,7 @@ function run_serving_postupgrade_test {
 
   image_template="registry.svc.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-{{.Name}}"
 
-  go_test_e2e -tags=postupgrade \
+  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=postupgrade \
     -timeout=20m ./test/upgrade \
     --imagetemplate "$image_template" \
     --kubeconfig "$KUBECONFIG" \


### PR DESCRIPTION
This patch sets `SYSTEM_NAMESPACE=knative-serving` before running serving e2e test.

Currently e2e test is failing as `SYSTEM_NAMESPACE=knative-eventing` was set.
serving and eventing uses both `SYSTEM_NAMESPACE` so it should be explicitly set beforehand
to avoid corruption.