### PR TITLE
Make all Dockerfiles consistent

### DIFF
--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR ${GOPATH}/src/${BASE}
 
 COPY . .
 
-WORKDIR knative-operator
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/knative-operator/cmd/manager
 

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -14,13 +14,4 @@ COPY --from=builder /tmp/operator /ko-app/operator
 ENV KO_DATA_PATH="/var/run/ko"
 COPY openshift-knative-operator/cmd/operator/kodata $KO_DATA_PATH
 
-LABEL \
-    com.redhat.component="openshift-serverless-1-tech-preview-knative-rhel8-operator-container" \
-    name="openshift-serverless-1-tech-preview/knative-rhel8-operator" \
-    version="1.11.0" \
-    summary="Red Hat OpenShift Serverless 1 Openshift Knative Operator" \
-    maintainer="serverless-support@redhat.com" \
-    description="Red Hat OpenShift Serverless 1 Openshift Knative Operator" \
-    io.k8s.display-name="Red Hat OpenShift Serverless 1 Openshift Knative Operator"
-
 ENTRYPOINT ["/ko-app/operator"]


### PR DESCRIPTION
As per title, only one of the current Dockerfiles is sporting the labels we need in production. Talked to @warrenvw and he confirmed he's setting them in the productization cycle anyway, so let's remove them here to avoid confusion.

Also drops a useless WORKDIR instruction to make all Dockerfiles look the same.

/assign @warrenvw @nak3 