### PR TITLE
Kafka source support and minor fixes

### DIFF
--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml
@@ -579,7 +579,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Broker (broker-ingress): Event Dispatch Latency ",
+          "title": "Broker (broker-ingress): Event Dispatch Latency (ms)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1065,7 +1065,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Trigger (broker-filter): Event Dispatch Latency ",
+          "title": "Trigger (broker-filter): Event Dispatch Latency (ms)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1178,7 +1178,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Trigger (broker-filter): Event Processing Latency ",
+          "title": "Trigger (broker-filter): Event Processing Latency (ms)",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml
@@ -127,7 +127,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Broker (broker-ingress): Event Count",
+          "title": "Broker (broker-ingress): Event Count (rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -215,7 +215,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Broker (broker-ingress): Success Rate  (2xx Event)",
+          "title": "Broker (broker-ingress): Success Rate  (2xx Event, rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -283,7 +283,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Broker (broker-ingress): Event Count by Event Type",
+          "title": "Broker (broker-ingress): Event Count by Event Type (rate per minute)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -396,7 +396,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Broker (broker-ingress): Failure Rate (non-2xx Event)",
+          "title": "Broker (broker-ingress): Failure Rate (non-2xx Event, fraction of rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -465,7 +465,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Broker (broker-ingress): Event Count by Response Code Class",
+          "title": "Broker (broker-ingress): Event Count by Response Code Class (rate per minute)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -706,7 +706,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Trigger (broker-filter): Event Count",
+          "title": "Trigger (broker-filter): Event Count (rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -794,7 +794,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Trigger (broker-filter): Success Rate  (2xx Event)",
+          "title": "Trigger (broker-filter): Success Rate  (2xx Event, fraction rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -863,7 +863,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Trigger (broker-filter): Event Count by Response Code Class",
+          "title": "Trigger (broker-filter): Event Count by Response Code Class (rate per minute)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -978,7 +978,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Trigger (broker-filter): Failure Rate (non-2xx Event)",
+          "title": "Trigger (broker-filter): Failure Rate (non-2xx Event, fraction rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
@@ -64,7 +64,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$sprefix-$source-.+\", container != \"POD\", container != \"\"}[1m])) by (container)",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$sprefix-$source-.+|pingsource-mt-adapter-.+\", container != \"POD\", container != \"\"}[1m])) by (container)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{container}}",
@@ -144,7 +144,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$sprefix-$source-.+\", container != \"POD\", container != \"\"}) by (container)",
+              "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$sprefix-$source-.+|pingsource-mt-adapter-.+\", container != \"POD\", container != \"\"}) by (container)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{container}}",
@@ -229,14 +229,14 @@ data:
             "steppedLine": false,
             "targets": [
              {
-                "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+\"}[1m]))",
+                "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "received bytes",
                 "refId": "A"
               },
               {
-                "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+\"}[1m]))",
+                "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
                 "legendFormat": "transmitted bytes",
                 "refId": "B"
               }
@@ -324,14 +324,14 @@ data:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+\"}[1m]))",
+                "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat":  "receive errors",
                 "refId": "A"
               },
               {
-                "expr": "sum(rate(container_network_transmit_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+\"}[1m]))",
+                "expr": "sum(rate(container_network_transmit_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
                 "format": "time_series",
                 "instant": false,
                 "legendFormat": "transmit errors",

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
@@ -74,7 +74,7 @@ data:
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total CPU Usage",
+          "title": "Total CPU Usage (rate per minute)",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -154,7 +154,7 @@ data:
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total Memory Usage",
+          "title": "Total Memory Usage (rate per minute)",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -245,7 +245,7 @@ data:
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Total Network I/O ",
+            "title": "Total Network I/O (rate per minute)",
             "tooltip": {
               "shared": true,
               "sort": 2,
@@ -288,7 +288,7 @@ data:
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
-            "description": "Network I/O errors ",
+            "description": "Network I/O errors (rate per minute)",
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
@@ -342,7 +342,7 @@ data:
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Total Network Errors",
+            "title": "Total Network Errors (rate per minute)",
             "tooltip": {
               "shared": true,
               "sort": 2,

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-source.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-source.yaml
@@ -127,7 +127,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "ApiServerSource: Event Count",
+          "title": "ApiServerSource: Event Count (rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -215,7 +215,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "ApiServerSource: Success Rate  (2xx Event)",
+          "title": "ApiServerSource: Success Rate (2xx Event, fraction rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -284,7 +284,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "ApiServerSource: Event Count by Response Code Class",
+          "title": "ApiServerSource: Event Count by Response Code Class (rate per minute)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -399,7 +399,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "ApiServerSource: Failure Rate (non-2xx Event)",
+          "title": "ApiServerSource: Failure Rate (non-2xx Event, fraction rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -501,7 +501,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "MT PingSource: Event Count",
+          "title": "MT PingSource: Event Count (rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -589,7 +589,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "MT PingSource: Success Rate  (2xx Event)",
+          "title": "MT PingSource: Success Rate  (2xx Event, fraction rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -658,7 +658,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "MT PingSource: Event Count by Response Code Class",
+          "title": "MT PingSource: Event Count by Response Code Class (rate per minute)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -773,7 +773,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "MT PingSource: Failure Rate (non-2xx Event)",
+          "title": "MT PingSource: Failure Rate (non-2xx Event, fraction rate per minute)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -875,7 +875,7 @@ data:
              "thresholds": "",
              "timeFrom": null,
              "timeShift": null,
-             "title": "Kafka: Event Count",
+             "title": "Kafka: Event Count (rate per minute)",
              "type": "singlestat",
              "valueFontSize": "80%",
              "valueMaps": [
@@ -963,7 +963,7 @@ data:
              "thresholds": "",
              "timeFrom": null,
              "timeShift": null,
-             "title": "KafkaSource: Success Rate (2xx Event)",
+             "title": "KafkaSource: Success Rate (2xx Event, fraction rate per minute)",
              "type": "singlestat",
              "valueFontSize": "80%",
              "valueMaps": [
@@ -1032,7 +1032,7 @@ data:
              "timeFrom": null,
              "timeRegions": [],
              "timeShift": null,
-             "title": "KafkaSource: Event Count by Response Code Class",
+             "title": "KafkaSource: Event Count by Response Code Class (rate per minute)",
              "tooltip": {
                "shared": true,
                "sort": 0,
@@ -1147,7 +1147,7 @@ data:
              "thresholds": "",
              "timeFrom": null,
              "timeShift": null,
-             "title": "KafkaSource: Failure Rate (non-2xx Event)",
+             "title": "KafkaSource: Failure Rate (non-2xx Event, fraction rate per minute)",
              "type": "singlestat",
              "valueFontSize": "80%",
              "valueMaps": [

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-source.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-source.yaml
@@ -118,7 +118,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(apiserversource_event_count[1m]))",
+              "expr": "sum(rate(apiserversource_event_count{namespace=\"$namespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -206,7 +206,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(apiserversource_event_count{response_code_class=\"2xx\"}[1m])) / sum(rate(apiserversource_event_count[1m]))",
+              "expr": "sum(rate(apiserversource_event_count{namespace=\"$namespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(apiserversource_event_count{namespace=\"$namespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -272,7 +272,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(apiserversource_event_count[1m])) by (response_code_class)",
+              "expr": "sum(rate(apiserversource_event_count{namespace=\"$namespace\"}[1m])) by (response_code_class)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -390,7 +390,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(apiserversource_event_count{response_code_class!=\"2xx\"}[1m])) / sum(rate(apiserversource_event_count[1m]))",
+              "expr": "sum(rate(apiserversource_event_count{namespace=\"$namespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(apiserversource_event_count{namespace=\"$namespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -492,7 +492,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(pingsource_event_count[1m]))",
+              "expr": "sum(rate(pingsource_event_count{namespace=\"$namespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -580,7 +580,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(pingsource_event_count{response_code_class=\"2xx\"}[1m])) / sum(rate(pingsource_event_count[1m]))",
+              "expr": "sum(rate(pingsource_event_count{namespace=\"$namespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(pingsource_event_count{namespace=\"$namespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -646,7 +646,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(pingsource_event_count[1m])) by (response_code_class)",
+              "expr": "sum(rate(pingsource_event_count{namespace=\"$namespace\"}[1m])) by (response_code_class)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -764,7 +764,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(pingsource_event_count{response_code_class!=\"2xx\"}[1m])) / sum(rate(pingsource_event_count[1m]))",
+              "expr": "sum(rate(pingsource_event_count{namespace=\"$namespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(pingsource_event_count{namespace=\"$namespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -784,15 +784,410 @@ data:
             }
           ],
           "valueName": "current"
-        }
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 19
+          },
+            "id": 42,
+            "panels": [],
+            "repeat": null,
+            "title": "KafkaSource",
+            "type": "row"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "#299c46",
+              "rgba(237, 129, 40, 0.89)",
+              "#d44a3a"
+            ],
+            "datasource": "prometheus",
+             "decimals": 3,
+             "description": "",
+             "format": "ops",
+             "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+             },
+             "gridPos": {
+               "h": 8,
+               "w": 4,
+               "x": 0,
+               "y": 20
+             },
+             "id": 43,
+             "interval": "",
+             "links": [],
+             "mappingType": 1,
+             "mappingTypes": [
+               {
+                 "name": "value to text",
+                 "value": 1
+               },
+               {
+                 "name": "range to text",
+                 "value": 2
+               }
+             ],
+             "maxDataPoints": 100,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {},
+             "pluginVersion": "6.3.3",
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+               {
+                 "from": "null",
+                 "text": "N/A",
+                 "to": "null"
+               }
+             ],
+             "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": true,
+               "ymax": null,
+               "ymin": null
+             },
+             "tableColumn": "",
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkasource_event_count{namespace=\"$namespace\"}[1m]))",
+                 "format": "time_series",
+                 "instant": false,
+                 "refId": "A"
+               }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Kafka: Event Count",
+             "type": "singlestat",
+             "valueFontSize": "80%",
+             "valueMaps": [
+               {
+                 "op": "=",
+                 "text": "N/A",
+                 "value": "null"
+               }
+             ],
+             "valueName": "current"
+           },
+           {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+               "#299c46",
+               "rgba(237, 129, 40, 0.89)",
+               "#d44a3a"
+             ],
+             "datasource": "prometheus",
+             "decimals": 2,
+             "description": "",
+             "format": "none",
+             "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+             },
+             "gridPos": {
+               "h": 4,
+               "w": 4,
+               "x": 4,
+               "y": 20
+             },
+             "id": 44,
+             "interval": "",
+             "links": [],
+             "mappingType": 1,
+             "mappingTypes": [
+               {
+                 "name": "value to text",
+                 "value": 1
+               },
+               {
+                 "name": "range to text",
+                 "value": 2
+               }
+             ],
+             "maxDataPoints": 100,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {},
+             "pluginVersion": "6.3.3",
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+               {
+                 "from": "null",
+                 "text": "N/A",
+                 "to": "null"
+               }
+             ],
+             "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": true,
+               "ymax": null,
+               "ymin": null
+             },
+             "tableColumn": "",
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkasource_event_count{namespace=\"$namespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(kafkasource_event_count{namespace=\"$namespace\"}[1m]))",
+                 "format": "time_series",
+                 "instant": false,
+                 "refId": "A"
+               }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "KafkaSource: Success Rate (2xx Event)",
+             "type": "singlestat",
+             "valueFontSize": "80%",
+             "valueMaps": [
+               {
+                 "op": "=",
+                 "text": "N/A",
+                 "value": "null"
+               }
+             ],
+             "valueName": "current"
+           },
+           {
+             "aliasColors": {},
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus",
+             "decimals": 3,
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+               "h": 8,
+               "w": 16,
+               "x": 8,
+               "y": 20
+             },
+             "id": 45,
+             "legend": {
+               "alignAsTable": true,
+               "avg": false,
+               "current": true,
+               "hideEmpty": false,
+               "hideZero": false,
+               "max": false,
+               "min": false,
+               "rightSide": true,
+               "show": true,
+               "total": false,
+               "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "nullPointMode": "null",
+             "options": {
+               "dataLinks": []
+             },
+             "percentage": false,
+             "pointradius": 2,
+             "points": false,
+             "renderer": "flot",
+             "seriesOverrides": [],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkasource_event_count{namespace=\"$namespace\"}[1m])) by (response_code_class)",
+                 "format": "time_series",
+                 "hide": false,
+                 "instant": false,
+                 "legendFormat": "{{response_code_class}}",
+                 "refId": "A"
+               }
+             ],
+             "thresholds": [],
+             "timeFrom": null,
+             "timeRegions": [],
+             "timeShift": null,
+             "title": "KafkaSource: Event Count by Response Code Class",
+             "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": []
+             },
+             "yaxes": [
+               {
+                 "decimals": 3,
+                 "format": "ops",
+                 "label": null,
+                 "logBase": 1,
+                 "max": null,
+                 "min": null,
+                 "show": true
+               },
+               {
+                 "decimals": 3,
+                 "format": "short",
+                 "label": null,
+                 "logBase": 1,
+                 "max": null,
+                 "min": null,
+                 "show": true
+               }
+             ],
+             "yaxis": {
+               "align": false,
+               "alignLevel": null
+             }
+           },
+           {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+               "#299c46",
+               "rgba(237, 129, 40, 0.89)",
+               "#d44a3a"
+             ],
+             "datasource": "prometheus",
+             "decimals": 2,
+             "description": "",
+             "format": "none",
+             "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+             },
+             "gridPos": {
+               "h": 4,
+               "w": 4,
+               "x": 4,
+               "y": 24
+             },
+             "id": 46,
+             "interval": "",
+             "links": [],
+             "mappingType": 1,
+             "mappingTypes": [
+               {
+                 "name": "value to text",
+                 "value": 1
+               },
+               {
+                 "name": "range to text",
+                 "value": 2
+               }
+             ],
+             "maxDataPoints": 100,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {},
+             "pluginVersion": "6.3.3",
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+               {
+                 "from": "null",
+                 "text": "N/A",
+                 "to": "null"
+               }
+             ],
+             "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": true,
+               "ymax": null,
+               "ymin": null
+             },
+             "tableColumn": "",
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkasource_event_count{namespace=\"$namespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(kafkasource_event_count{namespace=\"$namespace\"}[1m]))",
+                 "format": "time_series",
+                 "instant": false,
+                 "refId": "A"
+               }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "KafkaSource: Failure Rate (non-2xx Event)",
+             "type": "singlestat",
+             "valueFontSize": "80%",
+             "valueMaps": [
+               {
+                 "op": "=",
+                 "text": "N/A",
+                 "value": "null"
+               }
+             ],
+             "valueName": "current"
+           }
       ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {},
+            "datasource": "prometheus",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(kube_pod_labels{label_eventing_knative_dev_source=~\".+\"}, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
       "refresh": false,
       "schemaVersion": 19,
       "style": "dark",
       "tags": [],
-      "templating": {
-        "list": []
-      },
       "time": {
         "from": "now-6h",
         "to": "now"

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-serving-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-serving-resources.yaml
@@ -88,7 +88,7 @@ data:
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total CPU Usage",
+          "title": "Total CPU Usage (rate per minute)"",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -168,7 +168,7 @@ data:
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total Memory Usage",
+          "title": "Total Memory Usage (rate per minute)",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -207,7 +207,7 @@ data:
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
-            "description": "Network I/O at the pod level",
+            "description": "Network I/O at the pod level (rate per minute)",
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
@@ -259,7 +259,7 @@ data:
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Total Network I/O ",
+            "title": "Total Network I/O (rate per minute)",
             "tooltip": {
               "shared": true,
               "sort": 2,
@@ -356,7 +356,7 @@ data:
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Total Network Errors",
+            "title": "Total Network Errors (rate per minute)",
             "tooltip": {
               "shared": true,
               "sort": 2,


### PR DESCRIPTION
- Adds support for the kafka source in our dashboards
- Updates dashboards titles to include more useful info for the end user.
- Fixes an issue with ping source which has an adapter that resides in the knative-eventing ns and was not being detected.
- Aligns all eventing dashboards to have a namespace template var so user can focus in a given namespace.

Screenshots:
Dashboard grafana-dashboard-definition-knative-eventing-source:
![image](https://user-images.githubusercontent.com/7945591/102223299-30b0da80-3eed-11eb-82d1-878322d2dad1.png)

![image](https://user-images.githubusercontent.com/7945591/102223248-1e36a100-3eed-11eb-9823-6eba0bd9838f.png)

![image](https://user-images.githubusercontent.com/7945591/102223198-0eb75800-3eed-11eb-8d77-a5a43511f42e.png)

![image](https://user-images.githubusercontent.com/7945591/102223275-27277280-3eed-11eb-89de-e24f24b26959.png)

Dashboard grafana-dashboard-definition-knative-eventing-resources : 

![image](https://user-images.githubusercontent.com/7945591/102223613-9dc47000-3eed-11eb-91f1-ae031aad4819.png)


This was tested using this [repo](https://github.com/skonto/ocp-serverless-test-observability) to create sources.

/cc @aliok pls review.