### PR TITLE
Fix quotes in serving resource dashboard

### DIFF
--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-serving-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-serving-resources.yaml
@@ -88,7 +88,7 @@ data:
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total CPU Usage (rate per minute)"",
+          "title": "Total CPU Usage (rate per minute)",
           "tooltip": {
             "shared": true,
             "sort": 2,


### PR DESCRIPTION
This somehow went in from #760. Note: if there is a bug in dashboards all dashboards on dev console are failing.