### PR TITLE
[WIP] Remove redundant Elasticsearch install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test-e2e:
 	./test/e2e-tests.sh
 
 # Run E2E tests from the current repo for serving+eventing+knativeKafka
-test-e2e-with-kafka:
+test-e2e-with-kafka: install-mesh
 	INSTALL_KAFKA=true TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
 
 # Run both unit and E2E tests from the current repo.

--- a/hack/lib/mesh.bash
+++ b/hack/lib/mesh.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
   
 istio_deployments="istio-citadel istio-galley istio-pilot istio-sidecar-injector kiali"
-mesh_deployments="elasticsearch-operator istio-operator jaeger-operator kiali-operator"
+mesh_deployments=(istio-operator jaeger-operator kiali-operator)
 
 function install_mesh {
   deploy_servicemesh_operators
@@ -23,18 +23,6 @@ function uninstall_mesh {
 function deploy_servicemesh_operators {
   logger.info "Installing service mesh operators in namespace openshift-operators"
   cat <<EOF | oc apply -f -
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: elasticsearch-operator
-  namespace: openshift-operators
-spec:
-  channel: preview
-  name: elasticsearch-operator
-  installPlanApproval: Automatic
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -73,8 +61,8 @@ spec:
 EOF
 
   logger.info "Waiting until service mesh operators are available"
-  timeout 600 "[[ \$(oc get deploy -n openshift-operators ${mesh_deployments} --no-headers | wc -l) != 4 ]]"
-  oc wait --for=condition=Available deployment "${mesh_deployments}" --timeout=300s -n openshift-operators
+  timeout 600 "[[ \$(oc get deploy -n openshift-operators ${mesh_deployments[*]} --no-headers | wc -l) != ${#mesh_deployments[*]} ]]"
+  oc wait --for=condition=Available deployment "${mesh_deployments[@]}" --timeout=300s -n openshift-operators
 }
 
 


### PR DESCRIPTION
Link to the failure that we try to fix with this PR: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-master-4.6-azure-e2e-azure-ocp-46-continuous/1345520395955998720 (affects weekly tests on Azure, GCP, vSphere)