### PR TITLE
Test KafkaChannel in upgrade tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ test-upstream-e2e-no-upgrade:
 
 # Run only upstream upgrade tests.
 test-upstream-upgrade:
-	TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
+	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
+	INSTALL_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
 # Alias.
 test-upgrade: test-upstream-upgrade

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -36,8 +36,16 @@ function install_serverless_previous {
     timeout 120 "[[ \$(oc get namespace ${SERVING_NAMESPACE} ${EVENTING_NAMESPACE} --no-headers | wc -l) != 2 ]]" || return $?
   fi
 
-  deploy_knativeserving_cr || return $?
-  deploy_knativeeventing_cr || return $?
+  if [[ $INSTALL_SERVING == "true" ]]; then
+    deploy_knativeserving_cr || return $?
+  fi
+  if [[ $INSTALL_EVENTING == "true" ]]; then
+    deploy_knativeeventing_cr || return $?
+  fi
+  if [[ $INSTALL_KAFKA == "true" ]]; then
+    deploy_knativekafka_cr || return $?
+  fi
+
   logger.success "Previous version of Serverless is installed: $PREVIOUS_CSV"
 }
 

--- a/test/eventing.bash
+++ b/test/eventing.bash
@@ -33,6 +33,8 @@ function prepare_knative_eventing_tests {
 
 function run_eventing_preupgrade_test {
   logger.info 'Running Eventing pre upgrade tests'
+  local channels
+  channels="${1:?Pass the list of channels as arg[1]}"
 
   cd "${KNATIVE_EVENTING_HOME}" || return $?
 
@@ -42,6 +44,7 @@ function run_eventing_preupgrade_test {
 
   go_test_e2e -tags=preupgrade \
     -timeout=10m ./test/upgrade \
+    -channels="${channels}" \
     --imagetemplate="${image_template}" \
     || return $?
 
@@ -109,7 +112,8 @@ function check_eventing_upgraded {
 
 function run_eventing_postupgrade_test {
   logger.info 'Running Eventing post upgrade tests'
-  local image_template
+  local image_template channels
+  channels="${1:?Pass the list of channels as arg[1]}"
 
   cd "${KNATIVE_EVENTING_HOME}" || return $?
 
@@ -118,6 +122,7 @@ function run_eventing_postupgrade_test {
 
   go_test_e2e -tags=postupgrade \
     -timeout=10m ./test/upgrade \
+    -channels="${channels}" \
     --imagetemplate="${image_template}" \
     || return $?
 


### PR DESCRIPTION
The PreUpgrade and PostUpgrade tests should test KafkaChannel in addition to the InMemoryChannel