### PR TITLE
[SRVKS-679] disable Serving metrics by default

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -18,6 +18,7 @@ import (
 
 const loggingURLTemplate = "https://%s/app/kibana#/discover?_a=(index:.all,query:'kubernetes.labels.serving_knative_dev%%5C%%2FrevisionUID:${REVISION_UID}')"
 const observabilityCMName = "config-observability"
+const observabilityBackendKey = "metrics.backend-destination"
 
 // NewExtension creates a new extension for a Knative Serving controller.
 func NewExtension(ctx context.Context) operator.Extension {
@@ -93,11 +94,11 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	// Until now by default nothing was set and knative/pkg set the backend to `prometheus`
 	// As an exception if the user sets the backend explicitly in the CR the value is not modified.
 	if observCMData, ok := ks.Spec.CommonSpec.Config[observabilityCMName]; ok {
-		if _, ok := observCMData[observabilityCMName]; !ok {
-			common.Configure(&ks.Spec.CommonSpec, observabilityCMName, "metrics.backend-destination", "none")
+		if _, ok := observCMData[observabilityBackendKey]; !ok {
+			common.Configure(&ks.Spec.CommonSpec, observabilityCMName, observabilityBackendKey, "none")
 		}
 	} else {
-		common.Configure(&ks.Spec.CommonSpec, observabilityCMName, "metrics.backend-destination", "none")
+		common.Configure(&ks.Spec.CommonSpec, observabilityCMName, observabilityBackendKey, "none")
 	}
 
 	return nil

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -17,6 +17,7 @@ import (
 )
 
 const loggingURLTemplate = "https://%s/app/kibana#/discover?_a=(index:.all,query:'kubernetes.labels.serving_knative_dev%%5C%%2FrevisionUID:${REVISION_UID}')"
+const observabilityCMName = "config-observability"
 
 // NewExtension creates a new extension for a Knative Serving controller.
 func NewExtension(ctx context.Context) operator.Extension {
@@ -86,6 +87,17 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 			Name: "config-service-ca",
 			Type: "ConfigMap",
 		}
+	}
+
+	// Disable metrics backend by default due to OOM issues, for more check SRVKS-679
+	// Until now by default nothing was set and knative/pkg set the backend to `prometheus`
+	// As an exception if the user sets the backend explicitly in the CR the value is not modified.
+	if observCMData, ok := ks.Spec.CommonSpec.Config[observabilityCMName]; ok {
+		if _, ok := observCMData[observabilityCMName]; !ok {
+			common.Configure(&ks.Spec.CommonSpec, observabilityCMName, "metrics.backend-destination", "none")
+		}
+	} else {
+		common.Configure(&ks.Spec.CommonSpec, observabilityCMName, "metrics.backend-destination", "none")
 	}
 
 	return nil

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -113,6 +113,18 @@ func TestReconcile(t *testing.T) {
 		expected: ks(func(ks *v1alpha1.KnativeServing) {
 			ks.Status.MarkDependenciesInstalled()
 		}),
+	}, {
+		name: "respect already configured metrics backend",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Config: map[string]map[string]string{observabilityCMName: {observabilityBackendKey: "prometheus"}},
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			common.Configure(&ks.Spec.CommonSpec, observabilityCMName, observabilityBackendKey, "prometheus")
+		}),
 	}}
 
 	for _, c := range cases {
@@ -153,6 +165,8 @@ func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
 						"domainTemplate": "{{.Name}}-{{.Namespace}}.{{.Domain}}",
 						"ingress.class":  "kourier.ingress.networking.knative.dev",
 					},
+					// By default backend is none
+					observabilityCMName: {observabilityBackendKey: "none"},
 				},
 				Registry: v1alpha1.Registry{
 					Default: "bar2",


### PR DESCRIPTION
- sets `metrics.backend-destination` to none by default.
- if user sets backend to some value we respect it (eg via console).
- stops autoscaler and other components from restarting due to oom when multiple ksvcs are created and deleted with final number being constant.
```
$ odescribe cm config-observability -n knative-serving
Name:         config-observability
Namespace:    knative-serving
Labels:       serving.knative.dev/release=v0.18.2
Annotations:  knative.dev/example-checksum: 11674c15

Data
====
_example:
----
################################
#                              #
#    EXAMPLE CONFIGURATION     #
#                              #
################################

# This block is not actually functional configuration,
# but serves to illustrate the available configuration
# options and document them in a way that is accessible
# to users that `kubectl edit` this config map.
#
# These sample configuration options may be copied out of
# this example block and unindented to be in the data block
# to actually change the configuration.

# logging.enable-var-log-collection defaults to false.
# The fluentd daemon set will be set up to collect /var/log if
# this flag is true.
logging.enable-var-log-collection: "false"

# logging.revision-url-template provides a template to use for producing the
# logging URL that is injected into the status of each Revision.
# This value is what you might use the the Knative monitoring bundle, and provides
# access to Kibana after setting up kubectl proxy.
logging.revision-url-template: "http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))"

# If non-empty, this enables queue proxy writing user request logs to stdout, excluding probe
# requests.
# NB: after 0.18 release logging.enable-request-log must be explicitly set to true
# in order for request logging to be enabled.
#
# The value determines the shape of the request logs and it must be a valid go text/template.
# It is important to keep this as a single line. Multiple lines are parsed as separate entities
# by most collection agents and will split the request logs into multiple records.
#
# The following fields and functions are available to the template:
#
# Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
# representing an HTTP request received by the server.
#
# Response:
# struct {
#   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
#   Size    int       // An int representing the size of the response.
#   Latency float64   // A float64 representing the latency of the response in seconds.
# }
#
# Revision:
# struct {
#   Name          string  // Knative revision name
#   Namespace     string  // Knative revision namespace
#   Service       string  // Knative service name
#   Configuration string  // Knative configuration name
#   PodName       string  // Name of the pod hosting the revision
#   PodIP         string  // IP of the pod hosting the revision
# }
#
logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'

# If true, the request logging will be enabled.
# NB: up to and including Knative version 0.18 if logging.requst-log-template is non-empty, this value
# will be ignored.
logging.enable-request-log: "false"

# If true, this enables queue proxy writing request logs for probe requests to stdout.
# It uses the same template for user requests, i.e. logging.request-log-template.
logging.enable-probe-request-log: "false"

# metrics.backend-destination field specifies the system metrics destination.
# It supports either prometheus (the default) or stackdriver.
# Note: Using stackdriver will incur additional charges
metrics.backend-destination: prometheus

# metrics.request-metrics-backend-destination specifies the request metrics
# destination. It enables queue proxy to send request metrics.
# Currently supported values: prometheus (the default), stackdriver.
metrics.request-metrics-backend-destination: prometheus

# metrics.stackdriver-project-id field specifies the stackdriver project ID. This
# field is optional. When running on GCE, application default credentials will be
# used if this field is not provided.
metrics.stackdriver-project-id: "<your stackdriver project id>"

# metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
# Stackdriver using "global" resource type and custom metric type if the
# metrics are not supported by "knative_revision" resource type. Setting this
# flag to "true" could cause extra Stackdriver charge.
# If metrics.backend-destination is not Stackdriver, this is ignored.
metrics.allow-stackdriver-custom-metrics: "false"

# profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
# the pods via an HTTP server in the format expected by the pprof visualization tool. When
# enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
# The HTTP context root for profiling is then /debug/pprof/.
profiling.enable: "false"

metrics.backend-destination:
----
none
Events:  <none>
```