### PR TITLE
Revert "[SRVKS-679] disable Serving metrics by default (#772) (#773)"

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -17,8 +17,6 @@ import (
 )
 
 const loggingURLTemplate = "https://%s/app/kibana#/discover?_a=(index:.all,query:'kubernetes.labels.serving_knative_dev%%5C%%2FrevisionUID:${REVISION_UID}')"
-const observabilityCMName = "observability"
-const observabilityBackendKey = "metrics.backend-destination"
 
 // NewExtension creates a new extension for a Knative Serving controller.
 func NewExtension(ctx context.Context) operator.Extension {
@@ -52,7 +50,7 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 
 	// Attempt to locate kibana route which is available if openshift-logging has been configured
 	if loggingHost := e.fetchLoggingHost(ctx); loggingHost != "" {
-		common.Configure(&ks.Spec.CommonSpec, observabilityCMName, "logging.revision-url-template",
+		common.Configure(&ks.Spec.CommonSpec, "observability", "logging.revision-url-template",
 			fmt.Sprintf(loggingURLTemplate, loggingHost))
 	}
 
@@ -88,13 +86,6 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 			Name: "config-service-ca",
 			Type: "ConfigMap",
 		}
-	}
-
-	// Disable metrics backend by default due to OOM issues, for more check SRVKS-679
-	// Until now by default nothing was set and knative/pkg set the backend to `prometheus`
-	// As an exception if the user sets the backend explicitly in the CR the value is not modified.
-	if _, ok := ks.Spec.CommonSpec.Config[observabilityCMName][observabilityBackendKey]; !ok {
-		common.Configure(&ks.Spec.CommonSpec, observabilityCMName, observabilityBackendKey, "none")
 	}
 
 	return nil

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -113,18 +113,6 @@ func TestReconcile(t *testing.T) {
 		expected: ks(func(ks *v1alpha1.KnativeServing) {
 			ks.Status.MarkDependenciesInstalled()
 		}),
-	}, {
-		name: "respect already configured metrics backend",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
-					Config: map[string]map[string]string{observabilityCMName: {observabilityBackendKey: "prometheus"}},
-				},
-			},
-		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
-			common.Configure(&ks.Spec.CommonSpec, observabilityCMName, observabilityBackendKey, "prometheus")
-		}),
 	}}
 
 	for _, c := range cases {
@@ -165,8 +153,6 @@ func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
 						"domainTemplate": "{{.Name}}-{{.Namespace}}.{{.Domain}}",
 						"ingress.class":  "kourier.ingress.networking.knative.dev",
 					},
-					// By default backend is none
-					observabilityCMName: {observabilityBackendKey: "none"},
 				},
 				Registry: v1alpha1.Registry{
 					Default: "bar2",


### PR DESCRIPTION
This reverts disabling metrics by default since [fix](https://github.com/knative/pkg/pull/1741) already exists in [0.19](https://github.com/openshift/knative-serving/blob/release-v0.19.0/vendor/knative.dev/pkg/metrics/resource_view.go) and we are arleady targeting 0.19 for 1.13.
/cc @markusthoemmes @maschmid 