### PR TITLE
[Bug] Fix health dashboard

### DIFF
--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-health.yaml
@@ -85,7 +85,7 @@ data:
             },
             "targets": [
                {
-                 "expr": "min by(job)(knative_up{namespace=\"$namespace\", job=\"knative-openshift-metrics\", type=~\"eventing_status|serving_status|kafka_status\"})",
+                 "expr": "min by(job)(knative_up{namespace=\"$namespace\", job=\"knative-openshift-metrics2\", type=~\"eventing_status|serving_status|kafka_status\"})",
                  "intervalFactor": 2,
                  "legendFormat": "",
                  "metric": "knative_up",
@@ -163,7 +163,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=\"serving_status\"}",
+              "expr": "knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics2\", type=\"serving_status\"}",
               "format": "time_series",
               "interval": "",
               "legendFormat": "Status - 1 is Ready, 0 is NotReady",
@@ -259,7 +259,7 @@ data:
        "steppedLine": false,
        "targets": [
          {
-           "expr": "knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=\"eventing_status\"}",
+           "expr": "knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics2\", type=\"eventing_status\"}",
            "format": "time-series",
            "interval": "",
            "legendFormat": "Status - 1 is Ready, 0 is NotReady",
@@ -347,7 +347,7 @@ data:
        "steppedLine": false,
        "targets": [
        {
-           "expr": "knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics\", type=\"kafka_status\"}",
+           "expr": "knative_up{namespace=\"$namespace\", service=\"knative-openshift-metrics2\", type=\"kafka_status\"}",
            "format": "time-series",
            "interval": "",
            "legendFormat": "Status - 1 is Ready, 0 is NotReady",


### PR DESCRIPTION
Due to #761 the health dashboard needs update. These are the new labels:

```
knative_up{endpoint="http-metrics",instance="10.116.0.83:8383",job="knative-openshift-metrics2",namespace="openshift-serverless",pod="knative-openshift-7f69c9db4-vvh57",service="knative-openshift-metrics2",type="eventing_status"} | 1
knative_up{endpoint="http-metrics",instance="10.116.0.83:8383",job="knative-openshift-metrics2",namespace="openshift-serverless",pod="knative-openshift-7f69c9db4-vvh57",service="knative-openshift-metrics2",type="serving_status"}
```
/cc @markusthoemmes 