### PR TITLE
[RELEASE-1.12] Point CSV to the 'released' image names

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -345,7 +345,7 @@ spec:
                       - name: "IMAGE_KN_CLI_ARTIFACTS"
                         value: "registry.svc.ci.openshift.org/openshift/knative-v0.18.4:kn-cli-artifacts"
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+                    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:openshift-knative-operator
                     imagePullPolicy: IfNotPresent
                     name: knative-operator
                     ports:
@@ -368,7 +368,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -482,7 +482,7 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:knative-openshift-ingress
                     imagePullPolicy: Always
                     env:
                       - name: WATCH_NAMESPACE
@@ -677,13 +677,13 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:knative-openshift-ingress
     - name: "IMAGE_queue-proxy"
       image: "registry.svc.ci.openshift.org/openshift/knative-v0.18.2:knative-serving-queue"
     - name: "IMAGE_activator"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -301,7 +301,7 @@ spec:
                 - name: METRICS_DOMAIN
                   value: knative.dev/serving-operator
                 # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+                image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:openshift-knative-operator
                 imagePullPolicy: IfNotPresent
                 name: knative-operator
                 ports:
@@ -324,7 +324,7 @@ spec:
               containers:
                 - name: knative-openshift
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:knative-operator
                   imagePullPolicy: Always
                   readinessProbe:
                     httpGet:
@@ -382,7 +382,7 @@ spec:
               containers:
                 - name: knative-openshift-ingress
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:knative-openshift-ingress
                   imagePullPolicy: Always
                   env:
                     - name: WATCH_NAMESPACE
@@ -577,12 +577,12 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.12.0:knative-openshift-ingress
   replaces:
   version:


### PR DESCRIPTION
As per title. This is necessary for local installs to work as expected.

/assign @mgencur