### PR TITLE
 Point images to the 'new' registry

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -363,7 +363,7 @@ spec:
                       - name: "IMAGE_KN_CLI_ARTIFACTS"
                         value: "registry.svc.ci.openshift.org/openshift/knative-v0.19.1:kn-cli-artifacts"
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:openshift-knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:openshift-knative-operator
                     imagePullPolicy: IfNotPresent
                     name: knative-operator
                     ports:
@@ -386,7 +386,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -520,7 +520,7 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-openshift-ingress
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-openshift-ingress
                     imagePullPolicy: Always
                     env:
                       - name: WATCH_NAMESPACE
@@ -715,13 +715,13 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:openshift-knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-openshift-ingress
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-openshift-ingress
     - name: "IMAGE_queue-proxy"
       image: "registry.svc.ci.openshift.org/openshift/knative-v0.19.0:knative-serving-queue"
     - name: "IMAGE_activator"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -301,7 +301,7 @@ spec:
                 - name: METRICS_DOMAIN
                   value: knative.dev/serving-operator
                 # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:openshift-knative-operator
+                image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:openshift-knative-operator
                 imagePullPolicy: IfNotPresent
                 name: knative-operator
                 ports:
@@ -324,7 +324,7 @@ spec:
               containers:
                 - name: knative-openshift
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-operator
+                  image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-operator
                   imagePullPolicy: Always
                   readinessProbe:
                     httpGet:
@@ -384,7 +384,7 @@ spec:
               containers:
                 - name: knative-openshift-ingress
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                  image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-openshift-ingress
+                  image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-openshift-ingress
                   imagePullPolicy: Always
                   env:
                     - name: WATCH_NAMESPACE
@@ -579,12 +579,12 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:openshift-knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-openshift-ingress
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:knative-openshift-ingress
   replaces:
   version:


### PR DESCRIPTION
The "svc" based registry seems to be deprecated, images have been promoted to the one in the PR. We probably need to fix this throughout the S-O soonish.