### PR TITLE
Remove deprecated timeout setting for OpenShift Route

### DIFF
--- a/serving/ingress/pkg/reconciler/ingress/ingress_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/ingress_test.go
@@ -231,11 +231,6 @@ func ing(ns, name string, opts ...ingressOption) *v1alpha1.Ingress {
 		Spec: v1alpha1.IngressSpec{
 			Rules: []v1alpha1.IngressRule{{
 				Hosts: []string{domainName},
-				HTTP: &v1alpha1.HTTPIngressRuleValue{
-					Paths: []v1alpha1.HTTPIngressPath{{
-						DeprecatedTimeout: &metav1.Duration{Duration: 5 * time.Second},
-					}},
-				},
 			}},
 		},
 		Status: v1alpha1.IngressStatus{
@@ -267,14 +262,14 @@ func route(ns, name string, opts ...routeOption) *routev1.Route {
 				resources.OpenShiftIngressNamespaceLabelKey: "testNs",
 			},
 			Annotations: map[string]string{
-				resources.TimeoutAnnotation:          "5s",
+				resources.TimeoutAnnotation:          resources.DefaultTimeout,
 				networking.IngressClassAnnotationKey: "kourier.ingress.networking.knative.dev",
 			},
 		},
 		Spec: routev1.RouteSpec{
 			Host: domainName,
 			Port: &routev1.RoutePort{
-				TargetPort: intstr.FromString("http2"),
+				TargetPort: intstr.FromString(resources.KourierHTTPPort),
 			},
 			To: routev1.RouteTargetReference{
 				Kind:   "Service",

--- a/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	routev1 "github.com/openshift/api/route/v1"
@@ -62,7 +61,7 @@ func TestMakeRoute(t *testing.T) {
 						OpenShiftIngressNamespaceLabelKey: "default",
 					},
 					Annotations: map[string]string{
-						TimeoutAnnotation: defaultTimeout,
+						TimeoutAnnotation: DefaultTimeout,
 					},
 					Namespace: lbNamespace,
 					Name:      routeName0,
@@ -98,44 +97,6 @@ func TestMakeRoute(t *testing.T) {
 			want:    []*routev1.Route{},
 		},
 		{
-			name: "valid, with timeout",
-			ingress: ingress(withRules(
-				rule(withHosts([]string{localDomain, externalDomain}), withTimeout(1*time.Hour))),
-			),
-			want: []*routev1.Route{{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						networking.IngressLabelKey:        "ingress",
-						serving.RouteLabelKey:             "route1",
-						serving.RouteNamespaceLabelKey:    "default",
-						OpenShiftIngressLabelKey:          "ingress",
-						OpenShiftIngressNamespaceLabelKey: "default",
-					},
-					Annotations: map[string]string{
-						TimeoutAnnotation: "3600s",
-					},
-					Namespace: lbNamespace,
-					Name:      routeName0,
-				},
-				Spec: routev1.RouteSpec{
-					Host: externalDomain,
-					To: routev1.RouteTargetReference{
-						Kind:   "Service",
-						Name:   lbService,
-						Weight: ptr.Int32(100),
-					},
-					Port: &routev1.RoutePort{
-						TargetPort: intstr.FromString(KourierHTTPPort),
-					},
-					TLS: &routev1.TLSConfig{
-						Termination:                   routev1.TLSTerminationEdge,
-						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
-					},
-					WildcardPolicy: routev1.WildcardPolicyNone,
-				},
-			}},
-		},
-		{
 			name: "valid, multiple rules",
 			ingress: ingress(withRules(
 				rule(withHosts([]string{localDomain, externalDomain})),
@@ -151,7 +112,7 @@ func TestMakeRoute(t *testing.T) {
 						OpenShiftIngressNamespaceLabelKey: "default",
 					},
 					Annotations: map[string]string{
-						TimeoutAnnotation: defaultTimeout,
+						TimeoutAnnotation: DefaultTimeout,
 					},
 					Namespace: lbNamespace,
 					Name:      routeName0,
@@ -182,7 +143,7 @@ func TestMakeRoute(t *testing.T) {
 						OpenShiftIngressNamespaceLabelKey: "default",
 					},
 					Annotations: map[string]string{
-						TimeoutAnnotation: defaultTimeout,
+						TimeoutAnnotation: DefaultTimeout,
 					},
 					Namespace: lbNamespace,
 					Name:      routeName1,
@@ -222,7 +183,7 @@ func TestMakeRoute(t *testing.T) {
 						OpenShiftIngressNamespaceLabelKey: "default",
 					},
 					Annotations: map[string]string{
-						TimeoutAnnotation: defaultTimeout,
+						TimeoutAnnotation: DefaultTimeout,
 					},
 					Namespace: lbNamespace,
 					Name:      routeName1,
@@ -341,15 +302,5 @@ func withLocalVisibilityRule(rule *networkingv1alpha1.IngressRule) {
 func withHosts(hosts []string) ruleOption {
 	return func(rule *networkingv1alpha1.IngressRule) {
 		rule.Hosts = hosts
-	}
-}
-
-func withTimeout(timeout time.Duration) ruleOption {
-	return func(rule *networkingv1alpha1.IngressRule) {
-		rule.HTTP = &networkingv1alpha1.HTTPIngressRuleValue{
-			Paths: []networkingv1alpha1.HTTPIngressPath{{
-				DeprecatedTimeout: &metav1.Duration{Duration: timeout},
-			}},
-		}
 	}
 }


### PR DESCRIPTION
This patch removes timeout setting from DeprecatedTimeout

Timeout in Kingress was deprecated and `DeprecatedTimeout` was not used anymore.
For OpenShift Route, it should be safe to set it from `DefaultMaxRevisionTimeoutSeconds`.

/cc @markusthoemmes 