### PR TITLE
Fix all shellcheck issues and add it to local lint target

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -83,10 +83,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          find . -type f \
-            -path './hack/*.*sh' \
-            -o -path './test/*.*.sh' \
-            -not -path '*vendor*' | xargs -r shellcheck --format=checkstyle \
+          find . -type f -path './**/*.*sh' -not -path '*vendor*' | xargs -r shellcheck --format=checkstyle \
             | reviewdog -f=checkstyle \
                 -name="shellcheck" \
                 -reporter="github-pr-review" \

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -83,7 +83,9 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          find . -type f -path './**/*.*sh' -not -path '*vendor*' | xargs -r shellcheck --format=checkstyle \
+          find . -type f \
+            -path './**/*.*sh' \
+            -not -path '*vendor*' | xargs -r shellcheck --format=checkstyle \
             | reviewdog -f=checkstyle \
                 -name="shellcheck" \
                 -reporter="github-pr-review" \

--- a/Makefile
+++ b/Makefile
@@ -112,3 +112,4 @@ generated-files: release-files
 lint:
 	woke
 	golangci-lint run
+	find . -type f -path './**/*.*sh' -not -path '*vendor*' | xargs -r shellcheck

--- a/README.md
+++ b/README.md
@@ -345,3 +345,4 @@ The required linters for that are:
 
 - [`woke`](https://github.com/get-woke/woke) to detect non-inclusive language
 - [`golangci-lint`](https://golangci-lint.run/) to lint golang code
+- [`shellcheck`](https://www.shellcheck.net/) to lint shell files

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -176,6 +176,7 @@ function add_user {
   logger.info "Creating user $name:***"
   if kubectl get secret htpass-secret -n openshift-config -o jsonpath='{.data.htpasswd}' 2>/dev/null | base64 -d > users.htpasswd; then
     logger.debug 'Secret htpass-secret already existed, updating it.'
+    # shellcheck disable=SC1003
     sed -i -e '$a\' users.htpasswd
   else
     touch users.htpasswd

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -176,8 +176,8 @@ function add_user {
   logger.info "Creating user $name:***"
   if kubectl get secret htpass-secret -n openshift-config -o jsonpath='{.data.htpasswd}' 2>/dev/null | base64 -d > users.htpasswd; then
     logger.debug 'Secret htpass-secret already existed, updating it.'
-    # shellcheck disable=SC1003
-    sed -i -e '$a\' users.htpasswd
+    # Add a newline to the end of the file if not already present (htpasswd will butcher it otherwise).
+    [ -n "$(tail -c1 users.htpasswd)" ] && echo >> users.htpasswd
   else
     touch users.htpasswd
   fi

--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -33,7 +33,7 @@ function scale_up_workers {
     fi
     (( idx++ )) || true
     logger.debug "Bump ${mset} to ${replicas}"
-    oc scale "${mset}" -n openshift-machine-api --replicas=${replicas}
+    oc scale "${mset}" -n openshift-machine-api --replicas="${replicas}"
   done
   wait_until_machineset_scales_up "${SCALE_UP}"
 }

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-readonly ROOT_DIR=$(dirname $0)/..
+readonly ROOT_DIR=$(dirname "$0")/..
 
 # shellcheck disable=SC1091,SC1090
 source "${ROOT_DIR}/vendor/knative.dev/hack/library.sh"
@@ -9,7 +9,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-cd ${ROOT_DIR}
+cd "${ROOT_DIR}"
 
 # This controls the knative release version we track.
 KN_VERSION="release-0.19"
@@ -46,7 +46,7 @@ done
 readonly GO_GET
 
 if (( GO_GET )); then
-  go get -d ${FLOATING_DEPS[@]}
+  go get -d "${FLOATING_DEPS[@]}"
 fi
 
 # Prune modules.

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -5,6 +5,7 @@ set -Eeuo pipefail
 root="$(dirname "${BASH_SOURCE[0]}")/../.."
 
 # Source the main vars file to get the serving/eventing version to be used.
+# shellcheck disable=SC1091,SC1090
 source "$root/hack/lib/__sources__.bash"
 
 version=${KOURIER_VERSION:-v$(metadata.get dependencies.kourier)}

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -5,6 +5,7 @@ set -Eeuo pipefail
 root="$(dirname "${BASH_SOURCE[0]}")/../.."
 
 # Source the main vars file to get the serving/eventing version to be used.
+# shellcheck disable=SC1091,SC1090
 source "$root/hack/lib/__sources__.bash"
 
 # These files could in theory change from release to release, though their names should
@@ -36,13 +37,13 @@ function download {
   done
 }
 
-download serving $KNATIVE_SERVING_VERSION "${serving_files[@]}"
+download serving "$KNATIVE_SERVING_VERSION" "${serving_files[@]}"
 
 # TODO: Remove this once upstream fixed https://github.com/knative/operator/issues/376.
 # See also https://issues.redhat.com/browse/SRVKS-670.
 git apply "$root/openshift-knative-operator/hack/003-serving-pdb.patch"
 
-download eventing $KNATIVE_EVENTING_VERSION "${eventing_files[@]}"
+download eventing "$KNATIVE_EVENTING_VERSION" "${eventing_files[@]}"
 # Extra ClusterRole for downstream, so that users can get the CMs of knative-eventing
 # TODO: propose to upstream
 git apply "$root/openshift-knative-operator/hack/002-openshift-eventing-role.patch"

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -389,8 +389,7 @@ function create_htpasswd_users {
   if kubectl get secret htpass-secret -n openshift-config -o jsonpath='{.data.htpasswd}' 2>/dev/null | base64 -d > users.htpasswd; then
     logger.info 'Secret htpass-secret already existed, updating it.'
     # Add a newline to the end of the file if not already present (htpasswd will butcher it otherwise).
-    # shellcheck disable=SC1003
-    sed -i -e '$a\' users.htpasswd
+    [ -n "$(tail -c1 users.htpasswd)" ] && echo >> users.htpasswd
   else
     touch users.htpasswd
   fi

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -389,13 +389,14 @@ function create_htpasswd_users {
   if kubectl get secret htpass-secret -n openshift-config -o jsonpath='{.data.htpasswd}' 2>/dev/null | base64 -d > users.htpasswd; then
     logger.info 'Secret htpass-secret already existed, updating it.'
     # Add a newline to the end of the file if not already present (htpasswd will butcher it otherwise).
+    # shellcheck disable=SC1003
     sed -i -e '$a\' users.htpasswd
   else
     touch users.htpasswd
   fi
 
   logger.info 'Add users to htpasswd'
-  for i in $(seq 1 $num_users); do
+  for i in $(seq 1 "$num_users"); do
     htpasswd -b users.htpasswd "user${i}" "password${i}"
   done
 
@@ -406,7 +407,7 @@ function create_htpasswd_users {
   oc apply -f openshift/identity/htpasswd.yaml
 
   logger.info 'Generate kubeconfig for each user'
-  for i in $(seq 1 $num_users); do
+  for i in $(seq 1 "$num_users"); do
     cp "${KUBECONFIG}" "user${i}.kubeconfig"
     occmd="bash -c '! oc login --kubeconfig=user${i}.kubeconfig --username=user${i} --password=password${i} > /dev/null'"
     timeout 180 "${occmd}"

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -5,13 +5,13 @@ set -e
 
 function wait_for_knative_serving_ingress_ns_deleted {
   local NS="${SERVING_NAMESPACE}-ingress"
-  timeout 180 '[[ $(oc get ns $NS --no-headers | wc -l) == 1 ]]' || true
+  timeout 180 "[[ \$(oc get ns $NS --no-headers | wc -l) == 1 ]]" || true
   # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1798282 on Azure - if loadbalancer status is empty
   # it's safe to remove the finalizer.
-  if oc -n $NS get svc kourier >/dev/null 2>&1 && [ "$(oc -n $NS get svc kourier -ojsonpath="{.status.loadBalancer.*}")" = "" ]; then
-    oc -n $NS patch services/kourier --type=json --patch='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
+  if oc -n "$NS" get svc kourier >/dev/null 2>&1 && [ "$(oc -n "$NS" get svc kourier -ojsonpath="{.status.loadBalancer.*}")" = "" ]; then
+    oc -n "$NS" patch services/kourier --type=json --patch='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
   fi
-  timeout 180 '[[ $(oc get ns $NS --no-headers | wc -l) == 1 ]]'
+  timeout 180 "[[ \$(oc get ns $NS --no-headers | wc -l) == 1 ]]"
 }
 
 function prepare_knative_serving_tests {
@@ -112,7 +112,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
 
   # Restore the original maxReplicas for any tests running after this test suite
   oc -n "$SERVING_NAMESPACE" patch hpa activator --patch \
-    '{"spec": {"maxReplicas": '${max_replicas}', "minReplicas": '${min_replicas}'}}'
+    '{"spec": {"maxReplicas": '"${max_replicas}"', "minReplicas": '"${min_replicas}"'}}'
 }
 
 function actual_serving_version {


### PR DESCRIPTION
As per title, this

1. Lints all shell files
2. Fixes all existing issues
3. Adds shellcheck to `make lint` so it can be run locally easily

/assign @cardil 