### PR TITLE
[RELEASE-1.13] Drop placeholder namespaces from bundled resources

### DIFF
--- a/olm-catalog/serverless-operator/manifests/knative-operator.service.yaml
+++ b/olm-catalog/serverless-operator/manifests/knative-operator.service.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     name: knative-openshift
   name: knative-openshift-metrics2
-  namespace: placeholder
 spec:
   ports:
   - name: http-metrics

--- a/olm-catalog/serverless-operator/manifests/knative-operator.servicemonitor.yaml
+++ b/olm-catalog/serverless-operator/manifests/knative-operator.servicemonitor.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     name: knative-openshift
   name: knative-openshift-metrics2
-  namespace: placeholder
 spec:
   endpoints:
   - port: http-metrics


### PR DESCRIPTION
To prevent errors like

```
Value knative-openshift-metrics2: error validating object: metadata.namespace: Forbidden: not allowed on this type.
```

In productization.