### PR TITLE
Increase parallel to make sure the Prober test actually runs

### DIFF
--- a/test/serving.bash
+++ b/test/serving.bash
@@ -161,7 +161,7 @@ function start_serving_prober {
 
   image_template="registry.svc.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-{{.Name}}"
 
-  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=probe \
+  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=probe -parallel=3 \
     -timeout=30m \
     ./test/upgrade \
     -probe.success_fraction=${probe_fraction} \


### PR DESCRIPTION
* without parallel the Autoscale test could run first and block the
Prober test, resulting in all the "probing" tests to fail. 

Fixes an issues like this one: https://master-jenkins-csb-serverless-qe.apps.ocp4.prod.psi.redhat.com/job/functional_tests/job/stream1_13/job/rolling-upgrade-1.13/6/

In the next release (1.14) we'll use the new framework for upgrade tests where this will be fixed in a different way.