### PR TITLE
[SRVKS-689] Improve sm rbac setup

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -171,7 +171,6 @@ func (r *ReconcileKnativeServing) reconcileKnativeServing(instance *servingv1alp
 		r.ensureCustomCertsConfigMap,
 		r.installKourier,
 		r.installDashboard,
-		r.installMonitoringRequirements,
 		r.ensureProxySettings,
 		r.installQuickstarts,
 		r.installKnConsoleCLIDownload,
@@ -364,11 +363,6 @@ func (r *ReconcileKnativeServing) installKnConsoleCLIDownload(instance *servingv
 // installDashboard installs dashboard for OpenShift webconsole
 func (r *ReconcileKnativeServing) installDashboard(instance *servingv1alpha1.KnativeServing) error {
 	return dashboard.Apply(os.Getenv(dashboard.ServingResourceDashboardPathEnvVar), instance, r.client)
-}
-
-func (r *ReconcileKnativeServing) installMonitoringRequirements(instance *servingv1alpha1.KnativeServing) error {
-	log.Info("Installing Serving Monitoring requirements")
-	return common.SetupMonitoringRequirements(r.client, instance)
 }
 
 // general clean-up, mostly resources in different namespaces from servingv1alpha1.KnativeServing.

--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.20.0/0-rbac-proxy.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.20.0/0-rbac-proxy.yaml
@@ -1,3 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: knative-serving-prometheus-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: knative-serving-prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: knative-serving-prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/openshift-knative-operator/hack/004-rbac-proxy.patch
+++ b/openshift-knative-operator/hack/004-rbac-proxy.patch
@@ -1,9 +1,9 @@
 diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.20.0/0-rbac-proxy.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.20.0/0-rbac-proxy.yaml
 new file mode 100644
-index 00000000..d9df9652
+index 00000000..83c826d2
 --- /dev/null
 +++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.20.0/0-rbac-proxy.yaml
-@@ -0,0 +1,314 @@
+@@ -0,0 +1,342 @@
 +apiVersion: rbac.authorization.k8s.io/v1
 +kind: Role
 +metadata:
@@ -571,7 +571,7 @@ index a980952f..bcee5d5d 100644
 +        - name: secret-domain-mapping-sm-service-tls
 +          secret:
 +            secretName: domain-mapping-sm-service-tls
- 
+
  ---
  # Copyright 2020 The Knative Authors
 @@ -265,6 +287,8 @@ spec:

--- a/openshift-knative-operator/hack/004-rbac-proxy.patch
+++ b/openshift-knative-operator/hack/004-rbac-proxy.patch
@@ -1,9 +1,37 @@
 diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.20.0/0-rbac-proxy.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.20.0/0-rbac-proxy.yaml
 new file mode 100644
-index 00000000..37558cd9
+index 00000000..d9df9652
 --- /dev/null
 +++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.20.0/0-rbac-proxy.yaml
 @@ -0,0 +1,314 @@
++apiVersion: rbac.authorization.k8s.io/v1
++kind: Role
++metadata:
++  name: knative-serving-prometheus-k8s
++rules:
++  - apiGroups:
++      - ""
++    resources:
++      - services
++      - endpoints
++      - pods
++    verbs:
++      - get
++      - list
++      - watch
++---
++apiVersion: rbac.authorization.k8s.io/v1
++kind: RoleBinding
++metadata:
++  name: knative-serving-prometheus-k8s
++roleRef:
++  apiGroup: rbac.authorization.k8s.io
++  kind: Role
++  name: knative-serving-prometheus-k8s
++subjects:
++  - kind: ServiceAccount
++    name: prometheus-k8s
++    namespace: openshift-monitoring
 +---
 +apiVersion: rbac.authorization.k8s.io/v1
 +kind: ClusterRole

--- a/openshift-knative-operator/pkg/monitoring/monitoring.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring.go
@@ -9,62 +9,84 @@ import (
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
-	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"knative.dev/pkg/logging"
 )
 
 const (
-	DisableMonitoringEnvVar      = "DISABLE_SERVING_MONITORING_BY_DEFAULT"
+	EnableMonitoringEnvVar       = "ENABLE_SERVING_MONITORING_BY_DEFAULT"
 	EnableMonitoringLabel        = "openshift.io/cluster-monitoring"
 	ObservabilityCMName          = "observability"
 	ObservabilityBackendKey      = "metrics.backend-destination"
 	OpenshiftMonitoringNamespace = "openshift-monitoring"
 )
 
-func SetupServingMonitoring(api kubernetes.Interface, ks *v1alpha1.KnativeServing, log *zap.SugaredLogger) error {
-	if shouldDisableMonitoring(ks.Spec.CommonSpec.Config) {
-		log.Info("Disabling Serving monitoring")
-		if err := disableMonitoring(api, ks); err != nil {
-			return fmt.Errorf("failed to disable monitoring %w ", err)
+const (
+	prometheusRoleName        = "knative-serving-prometheus-k8s"
+	prometheusClusterRoleName = "rbac-proxy-metrics-prom"
+)
+
+func SetupServingMonitoring(ctx context.Context, api kubernetes.Interface, ks *v1alpha1.KnativeServing) error {
+	backend, isSet := ks.Spec.CommonSpec.Config[ObservabilityCMName][ObservabilityBackendKey]
+	if shouldEnableMonitoring(backend) {
+		log := logging.FromContext(ctx)
+		log.Info("Enabling Serving monitoring")
+		if err := setMonitoringLabelToNamespace(ctx, ks.Namespace, api, true); err != nil {
+			return fmt.Errorf("failed to enable monitoring %w ", err)
 		}
 		return nil
 	}
-	if err := setMonitoringLabelToNamespace(ks.Namespace, api, true); err != nil {
+	if err := setMonitoringLabelToNamespace(ctx, ks.Namespace, api, false); err != nil {
 		return err
+	}
+	if !isSet {
+		common.Configure(&ks.Spec.CommonSpec, ObservabilityCMName, ObservabilityBackendKey, "none")
 	}
 	return nil
 }
 
-func shouldDisableMonitoring(cfg v1alpha1.ConfigMapData) bool {
-	_, disableByDefault := os.LookupEnv(DisableMonitoringEnvVar)
-	backend, backendIsSet := cfg[ObservabilityCMName][ObservabilityBackendKey]
-	return (disableByDefault && !backendIsSet) || backend == "none"
-}
-
-func disableMonitoring(api kubernetes.Interface, ks *v1alpha1.KnativeServing) error {
-	// Disable metrics backend by default in case we need to eg. SRVKS-679
-	if _, ok := ks.Spec.CommonSpec.Config[ObservabilityCMName][ObservabilityBackendKey]; !ok {
-		common.Configure(&ks.Spec.CommonSpec, ObservabilityCMName, ObservabilityBackendKey, "none")
+func shouldEnableMonitoring(backend string) bool {
+	enable, present := os.LookupEnv(EnableMonitoringEnvVar)
+	// Skip setup from env if feature toggle is off, use whatever the user defines in the Serving CR.
+	if !present && backend != "none" {
+		return true
 	}
-	return setMonitoringLabelToNamespace(ks.Namespace, api, false)
+	parsedEnable, _ := strconv.ParseBool(enable)
+	// Let the user enable monitoring with a proper backend value even if feature toggle is off.
+	if !parsedEnable && backend != "none" && backend != "" {
+		return true
+	}
+	return parsedEnable
 }
 
-func setMonitoringLabelToNamespace(namespace string, api kubernetes.Interface, enable bool) error {
-	ns, err := api.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+func setMonitoringLabelToNamespace(ctx context.Context, namespace string, api kubernetes.Interface, enable bool) error {
+	ns, err := api.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
+	if shouldSkipSettingLabel(ns.Labels) {
+		return nil
+	}
 	if ns.Labels == nil {
-		ns.Labels = map[string]string{}
+		ns.Labels = make(map[string]string, 1)
 	}
 	ns.Labels[EnableMonitoringLabel] = strconv.FormatBool(enable)
 	if _, err := api.CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("could not add label %q to namespace %q: %w", EnableMonitoringLabel, namespace, err)
 	}
 	return nil
+}
+
+func shouldSkipSettingLabel(labels map[string]string) bool {
+	if labelVal, found := labels[EnableMonitoringLabel]; found {
+		if parsedLabelVal, _ := strconv.ParseBool(labelVal); parsedLabelVal {
+			return parsedLabelVal
+		}
+	}
+	return false
 }
 
 // InjectNamespaceWithSubject uses a custom transformation to avoid operator overriding everything with the current namespace including
@@ -74,9 +96,9 @@ func InjectNamespaceWithSubject(resourceNamespace string, subjectNamespace strin
 	return func(u *unstructured.Unstructured) error {
 		kind := strings.ToLower(u.GetKind())
 		// Only touch the related manifests.
-		if kind == "role" && u.GetName() == "knative-serving-prometheus-k8s" {
+		if kind == "role" && u.GetName() == prometheusRoleName {
 			u.SetNamespace(resourceNamespace)
-		} else if (kind == "clusterrolebinding" && u.GetName() == "rbac-proxy-metrics-prom") || (kind == "rolebinding" && u.GetName() == "knative-serving-prometheus-k8s") {
+		} else if (kind == "clusterrolebinding" && u.GetName() == prometheusClusterRoleName) || (kind == "rolebinding" && u.GetName() == prometheusRoleName) {
 			if kind == "rolebinding" {
 				u.SetNamespace(resourceNamespace)
 			}

--- a/openshift-knative-operator/pkg/monitoring/monitoring.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring.go
@@ -1,0 +1,93 @@
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
+
+const (
+	DisableMonitoringEnvVar      = "DISABLE_SERVING_MONITORING_BY_DEFAULT"
+	EnableMonitoringLabel        = "openshift.io/cluster-monitoring"
+	ObservabilityCMName          = "observability"
+	ObservabilityBackendKey      = "metrics.backend-destination"
+	OpenshiftMonitoringNamespace = "openshift-monitoring"
+)
+
+func SetupServingMonitoring(api kubernetes.Interface, ks *v1alpha1.KnativeServing, log *zap.SugaredLogger) error {
+	if shouldDisableMonitoring(ks.Spec.CommonSpec.Config) {
+		log.Info("Disabling Serving monitoring")
+		if err := disableMonitoring(api, ks); err != nil {
+			return fmt.Errorf("failed to disable monitoring %w ", err)
+		}
+		return nil
+	}
+	if err := setMonitoringLabelToNamespace(ks.Namespace, api, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func shouldDisableMonitoring(cfg v1alpha1.ConfigMapData) bool {
+	_, disableByDefault := os.LookupEnv(DisableMonitoringEnvVar)
+	backend, backendIsSet := cfg[ObservabilityCMName][ObservabilityBackendKey]
+	return (disableByDefault && !backendIsSet) || backend == "none"
+}
+
+func disableMonitoring(api kubernetes.Interface, ks *v1alpha1.KnativeServing) error {
+	// Disable metrics backend by default in case we need to eg. SRVKS-679
+	if _, ok := ks.Spec.CommonSpec.Config[ObservabilityCMName][ObservabilityBackendKey]; !ok {
+		common.Configure(&ks.Spec.CommonSpec, ObservabilityCMName, ObservabilityBackendKey, "none")
+	}
+	return setMonitoringLabelToNamespace(ks.Namespace, api, false)
+}
+
+func setMonitoringLabelToNamespace(namespace string, api kubernetes.Interface, enable bool) error {
+	ns, err := api.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if ns.Labels == nil {
+		ns.Labels = map[string]string{}
+	}
+	ns.Labels[EnableMonitoringLabel] = strconv.FormatBool(enable)
+	if _, err := api.CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("could not add label %q to namespace %q: %w", EnableMonitoringLabel, namespace, err)
+	}
+	return nil
+}
+
+// InjectNamespaceWithSubject uses a custom transformation to avoid operator overriding everything with the current namespace including
+// subjects ns. Here we break the assumption of the operator about all resources being in the same namespace
+// since we need to setup RBAC for the prometheus-k8s account which resides in openshift-monitoring ns.
+func InjectNamespaceWithSubject(resourceNamespace string, subjectNamespace string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		kind := strings.ToLower(u.GetKind())
+		// Only touch the related manifests.
+		if kind == "role" && u.GetName() == "knative-serving-prometheus-k8s" {
+			u.SetNamespace(resourceNamespace)
+		} else if (kind == "clusterrolebinding" && u.GetName() == "rbac-proxy-metrics-prom") || (kind == "rolebinding" && u.GetName() == "knative-serving-prometheus-k8s") {
+			if kind == "rolebinding" {
+				u.SetNamespace(resourceNamespace)
+			}
+			subjects, _, _ := unstructured.NestedFieldNoCopy(u.Object, "subjects")
+			for _, subject := range subjects.([]interface{}) {
+				m := subject.(map[string]interface{})
+				if _, ok := m["namespace"]; ok {
+					m["namespace"] = subjectNamespace
+				}
+			}
+		}
+		return nil
+	}
+}

--- a/openshift-knative-operator/pkg/monitoring/monitoring_test.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_test.go
@@ -1,0 +1,117 @@
+package monitoring
+
+import (
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/manifestival/manifestival/fake"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const servingNamespace = "knative-serving"
+
+func TestSetupServingRbacTrasfmormation(t *testing.T) {
+	client := fake.New()
+	manifest, err := mf.NewManifest("../testdata/rbac.yaml", mf.UseClient(client))
+	if err != nil {
+		t.Errorf("Unable to load test manifest: %w", err)
+	}
+	transforms := []mf.Transformer{InjectNamespaceWithSubject(servingNamespace, OpenshiftMonitoringNamespace)}
+	if manifest, err = manifest.Transform(transforms...); err != nil {
+		t.Errorf("Unable to transform test manifest: %w", err)
+	}
+	if err := manifest.Apply(); err != nil {
+		t.Errorf("Unable to apply the test manifest %w", err)
+	}
+	u := createRole(prometheusRoleName, servingNamespace)
+	_, err = client.Get(u)
+	if err != nil {
+		t.Errorf("Unable to get the role %w", err)
+	}
+	u = createRole("test-role", "default")
+	_, err = client.Get(u)
+	if err != nil {
+		t.Errorf("Unable to get the role %w", err)
+	}
+	u = createClusterRole()
+	_, err = client.Get(u)
+	if err != nil {
+		t.Errorf("Unable to get the cluster role %w", err)
+	}
+	u = createRoleBinding(prometheusRoleName, servingNamespace)
+	resultRoleBinding, err := client.Get(u)
+	if err != nil {
+		t.Errorf("Unable to get the rolebinding %w", err)
+	}
+	checkSubjects(t, resultRoleBinding.Object, OpenshiftMonitoringNamespace)
+	u = createRoleBinding("test-rb", "default")
+	resultRoleBinding, err = client.Get(u)
+	if err != nil {
+		t.Errorf("Unable to get the rolebinding %w", err)
+	}
+	checkSubjects(t, resultRoleBinding.Object, "default")
+	u = createClusterRoleBinding()
+	resultClusterRoleBinding, err := client.Get(u)
+	if err != nil {
+		t.Errorf("Unable to get the cluster rolebinding %w", err)
+	}
+	checkSubjects(t, resultClusterRoleBinding.Object, OpenshiftMonitoringNamespace)
+	// Make sure unrelated resources are not touched
+	u = createService("activator-sm-service", "test")
+	_, err = client.Get(u)
+	if err != nil {
+		t.Errorf("Unable to get the service %w", err)
+	}
+}
+
+func checkSubjects(t *testing.T, object map[string]interface{}, ns string) {
+	subjects, _, _ := unstructured.NestedFieldNoCopy(object, "subjects")
+	subjs := subjects.([]interface{})
+	m := subjs[0].(map[string]interface{})
+	if m["namespace"] != ns {
+		t.Errorf("got %q, want %q", m["namespace"], ns)
+	}
+}
+
+func createService(name string, ns string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetKind("Service")
+	u.SetAPIVersion("v1")
+	u.SetName(name)
+	u.SetNamespace(ns)
+	return u
+}
+
+func createRole(name string, ns string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetKind("Role")
+	u.SetAPIVersion("rbac.authorization.k8s.io/v1")
+	u.SetName(name)
+	u.SetNamespace(ns)
+	return u
+}
+
+func createClusterRole() *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetKind("ClusterRole")
+	u.SetAPIVersion("rbac.authorization.k8s.io/v1")
+	u.SetName(prometheusClusterRoleName)
+	return u
+}
+
+func createRoleBinding(name string, ns string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetKind("RoleBinding")
+	u.SetAPIVersion("rbac.authorization.k8s.io/v1")
+	u.SetName(name)
+	u.SetNamespace(ns)
+	return u
+}
+
+func createClusterRoleBinding() *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetKind("ClusterRoleBinding")
+	u.SetAPIVersion("rbac.authorization.k8s.io/v1")
+	u.SetName(prometheusClusterRoleName + "-rb")
+	return u
+}

--- a/openshift-knative-operator/pkg/monitoring/monitoring_test.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_test.go
@@ -10,7 +10,7 @@ import (
 
 const servingNamespace = "knative-serving"
 
-func TestSetupServingRbacTrasfmormation(t *testing.T) {
+func TestSetupServingRbacTransformation(t *testing.T) {
 	client := fake.New()
 	manifest, err := mf.NewManifest("../testdata/rbac.yaml", mf.UseClient(client))
 	if err != nil {

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 	"github.com/openshift-knative/serverless-operator/pkg/client/clientset/versioned"
 	ocpclient "github.com/openshift-knative/serverless-operator/pkg/client/injection/client"
-	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -27,14 +26,12 @@ func NewExtension(ctx context.Context) operator.Extension {
 	return &extension{
 		ocpclient:  ocpclient.Get(ctx),
 		kubeclient: kubeclient.Get(ctx),
-		logger:     logging.FromContext(ctx),
 	}
 }
 
 type extension struct {
 	ocpclient  versioned.Interface
 	kubeclient kubernetes.Interface
-	logger     *zap.SugaredLogger
 }
 
 func (e *extension) Transformers(ks v1alpha1.KComponent) []mf.Transformer {
@@ -96,11 +93,11 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 		}
 	}
 
-	e.logger.Info("Installing Serving Monitoring Requirements")
-	if err := monitoring.SetupServingMonitoring(e.kubeclient, ks, e.logger); err != nil {
+	logger := logging.FromContext(ctx)
+	logger.Info("Installing Serving Monitoring Requirements")
+	if err := monitoring.SetupServingMonitoring(ctx, e.kubeclient, ks); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -16,7 +16,6 @@ import (
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	operator "knative.dev/operator/pkg/reconciler/common"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	"knative.dev/pkg/logging"
 )
 
 const loggingURLTemplate = "https://%s/app/kibana#/discover?_a=(index:.all,query:'kubernetes.labels.serving_knative_dev%%5C%%2FrevisionUID:${REVISION_UID}')"
@@ -92,10 +91,7 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 			Type: "ConfigMap",
 		}
 	}
-
-	logger := logging.FromContext(ctx)
-	logger.Info("Installing Serving Monitoring Requirements")
-	if err := monitoring.SetupServingMonitoring(ctx, e.kubeclient, ks); err != nil {
+	if err := monitoring.ReconcileServingMonitoring(ctx, e.kubeclient, ks); err != nil {
 		return err
 	}
 	return nil

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -306,9 +306,8 @@ func TestMonitoring(t *testing.T) {
 func toggleEnvVar(toggle string) (bool, error) {
 	if err := os.Setenv(monitoring.EnableMonitoringEnvVar, toggle); err != nil {
 		return false, nil
-	} else {
-		return true, nil
 	}
+	return true, nil
 }
 
 func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -7,18 +7,26 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
+	ocpfake "github.com/openshift-knative/serverless-operator/pkg/client/injection/client/fake"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"knative.dev/pkg/apis"
-
-	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
-	ocpfake "github.com/openshift-knative/serverless-operator/pkg/client/injection/client/fake"
+	"knative.dev/pkg/injection"
 )
+
+var servingNamespace = corev1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "knative-serving",
+	},
+}
 
 func TestReconcile(t *testing.T) {
 	os.Setenv("IMAGE_foo", "bar")
@@ -35,14 +43,16 @@ func TestReconcile(t *testing.T) {
 	}
 
 	cases := []struct {
-		name     string
-		in       *v1alpha1.KnativeServing
-		objs     []runtime.Object
-		expected *v1alpha1.KnativeServing
+		name                    string
+		in                      *v1alpha1.KnativeServing
+		objs                    []runtime.Object
+		expected                *v1alpha1.KnativeServing
+		shouldDisableMonitoring bool
 	}{{
-		name:     "all nil",
-		in:       &v1alpha1.KnativeServing{},
-		expected: ks(),
+		name:                    "all nil",
+		in:                      &v1alpha1.KnativeServing{},
+		expected:                ks(),
+		shouldDisableMonitoring: false,
 	}, {
 		name: "different HA settings",
 		in: &v1alpha1.KnativeServing{
@@ -55,6 +65,7 @@ func TestReconcile(t *testing.T) {
 		expected: ks(func(ks *v1alpha1.KnativeServing) {
 			ks.Spec.HighAvailability.Replicas = 3
 		}),
+		shouldDisableMonitoring: false,
 	}, {
 		name: "different certificate settings",
 		in: &v1alpha1.KnativeServing{
@@ -69,6 +80,7 @@ func TestReconcile(t *testing.T) {
 			ks.Spec.ControllerCustomCerts.Type = "Secret"
 			ks.Spec.ControllerCustomCerts.Name = "foo"
 		}),
+		shouldDisableMonitoring: false,
 	}, {
 		name: "existing logging route",
 		in:   &v1alpha1.KnativeServing{},
@@ -87,7 +99,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		expected: ks(func(ks *v1alpha1.KnativeServing) {
-			common.Configure(&ks.Spec.CommonSpec, "observability", "logging.revision-url-template",
+			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, "logging.revision-url-template",
 				fmt.Sprintf(loggingURLTemplate, "logging.example.com"))
 		}),
 	}, {
@@ -113,26 +125,60 @@ func TestReconcile(t *testing.T) {
 		expected: ks(func(ks *v1alpha1.KnativeServing) {
 			ks.Status.MarkDependenciesInstalled()
 		}),
+		shouldDisableMonitoring: false,
+	}, {
+		name: "respect already configured metrics backend",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "prometheus"}},
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "prometheus")
+		}),
+		shouldDisableMonitoring: false,
+	}, {
+		name: "disable monitoring by default",
+		in:   &v1alpha1.KnativeServing{},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
+		}),
+		shouldDisableMonitoring: true,
 	}}
-
+	ctx, _ := injection.EnableInjectionOrDie(context.Background(), nil)
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			objs := c.objs
 			if objs == nil {
 				objs = []runtime.Object{defaultIngress}
 			}
-			ctx, _ := ocpfake.With(context.Background(), objs...)
-
 			ks := c.in.DeepCopy()
-			ext := NewExtension(ctx)
+			ks.Namespace = "knative-serving"
+			c.expected.Namespace = ks.Namespace
+			ctx, _ = ocpfake.With(ctx, objs...)
+			ext := NewExtension(ctx).(*extension)
+			ext.kubeclient = fakekubeclientset.NewSimpleClientset([]runtime.Object{&servingNamespace}...)
+			if c.shouldDisableMonitoring {
+				os.Setenv(monitoring.DisableMonitoringEnvVar, "true")
+			}
 			ext.Reconcile(context.Background(), ks)
-
 			// Ignore time differences.
 			opt := cmp.Comparer(func(apis.VolatileTime, apis.VolatileTime) bool {
 				return true
 			})
 			if !cmp.Equal(ks, c.expected, opt) {
 				t.Errorf("Got = %v, want: %v, diff:\n%s", ks, c.expected, cmp.Diff(ks, c.expected, opt))
+			}
+			if !c.shouldDisableMonitoring {
+				ns, err := ext.kubeclient.CoreV1().Namespaces().Get(context.Background(), ks.Namespace, metav1.GetOptions{})
+				if err != nil {
+					t.Errorf("Namespace %s not found %w", ns, err)
+				}
+				if len(ns.Labels) != 1 && ns.Labels[monitoring.EnableMonitoringLabel] != "true" {
+					t.Errorf("Label is missing for namespace %s ", ks.Namespace)
+				}
 			}
 		})
 	}

--- a/openshift-knative-operator/pkg/testdata/rbac.yaml
+++ b/openshift-knative-operator/pkg/testdata/rbac.yaml
@@ -1,0 +1,123 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: knative-serving-prometheus-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: knative-serving-prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: knative-serving-prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-role
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-rb
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbac-proxy-metrics-prom
+rules:
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbac-proxy-metrics-prom-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rbac-proxy-metrics-prom
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbac-proxy-reviews-prom
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources:
+      - tokenreviews
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources:
+      - subjectaccessreviews
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbac-proxy-reviews-prom-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rbac-proxy-reviews-prom
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: knative-serving
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: activator-sm-service-tls
+  labels:
+    name: activator-sm-service
+  name: activator-sm-service
+  namespace: test
+spec:
+  ports:
+    - name: https
+      port: 8444
+  selector:
+    app: activator

--- a/vendor/github.com/manifestival/manifestival/fake/client.go
+++ b/vendor/github.com/manifestival/manifestival/fake/client.go
@@ -1,0 +1,102 @@
+package fake
+
+import (
+	"fmt"
+
+	mf "github.com/manifestival/manifestival"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var _ mf.Client = &Client{}
+
+// A convenient way to stub out a Client for test fixtures. Default
+// behavior does nothing and returns a nil error.
+type Client struct {
+	Stubs
+}
+
+// Override any of the Client functions
+type Stubs struct {
+	Create mutator
+	Update mutator
+	Delete mutator
+	Get    accessor
+}
+
+type mutator func(obj *unstructured.Unstructured) error
+type accessor func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+
+// New returns a fully-functioning Client, "persisting" resources in a
+// map, optionally initialized with some API objects
+func New(objs ...runtime.Object) Client {
+	store := map[string]*unstructured.Unstructured{}
+	key := func(u *unstructured.Unstructured) string {
+		return fmt.Sprintf("%s, %s/%s", u.GroupVersionKind(), u.GetNamespace(), u.GetName())
+	}
+	for _, obj := range objs {
+		u := &unstructured.Unstructured{}
+		if err := scheme.Scheme.Convert(obj, u, nil); err != nil {
+			panic(err)
+		}
+		store[key(u)] = u
+	}
+	apply := func(u *unstructured.Unstructured) error {
+		store[key(u)] = u
+		return nil
+	}
+	return Client{
+		Stubs{
+			Create: apply,
+			Update: apply,
+			Delete: func(u *unstructured.Unstructured) error {
+				delete(store, key(u))
+				return nil
+			},
+			Get: func(u *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				v, found := store[key(u)]
+				if !found {
+					gvk := u.GroupVersionKind()
+					gr := schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind}
+					return nil, errors.NewNotFound(gr, u.GetName())
+				}
+				return v, nil
+			},
+		},
+	}
+}
+
+// Manifestival.Client.Create
+func (c Client) Create(obj *unstructured.Unstructured, options ...mf.ApplyOption) error {
+	if c.Stubs.Create != nil {
+		return c.Stubs.Create(obj)
+	}
+	return nil
+}
+
+// Manifestival.Client.Update
+func (c Client) Update(obj *unstructured.Unstructured, options ...mf.ApplyOption) error {
+	if c.Stubs.Update != nil {
+		return c.Stubs.Update(obj)
+	}
+	return nil
+}
+
+// Manifestival.Client.Delete
+func (c Client) Delete(obj *unstructured.Unstructured, options ...mf.DeleteOption) error {
+	if c.Stubs.Delete != nil {
+		return c.Stubs.Delete(obj)
+	}
+	return nil
+}
+
+// Manifestival.Client.Get
+func (c Client) Get(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	if c.Stubs.Get != nil {
+		return c.Stubs.Get(obj)
+	}
+	return nil, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,6 +214,7 @@ github.com/manifestival/controller-runtime-client
 # github.com/manifestival/manifestival v0.7.0
 ## explicit
 github.com/manifestival/manifestival
+github.com/manifestival/manifestival/fake
 github.com/manifestival/manifestival/internal/overlay
 github.com/manifestival/manifestival/internal/patch
 github.com/manifestival/manifestival/internal/sources


### PR DESCRIPTION
-  adds a feature toggle for serving monitoring, in the future I will do that for eventing as well (at some point all monitoring will be managed a single flag).
- moves rbac setup for serving monitoring to the extension side.
/cc @markusthoemmes 