### PR TITLE
[RELEASE-1.13] [SRVKS-667] Install Service related quickstart manifests

### DIFF
--- a/knative-operator/deploy/resources/quickstart/serverless-application-quickstart.yaml
+++ b/knative-operator/deploy/resources/quickstart/serverless-application-quickstart.yaml
@@ -1,0 +1,215 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  name: serverless-application
+spec:
+  conclusion: >-
+    You just learned how to use Serverless applications in your cluster! To
+    learn more about building Serverless apps, take a look at our [Knative
+    Cookbook](https://redhat-developer-demos.github.io/knative-tutorial/knative-tutorial/index.html).
+  description: Learn how to create a Serverless application.
+  displayName: Exploring Serverless applications
+  durationMinutes: 15
+  icon: >-
+    data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+  introduction: >-
+    This quick start guides you through creating and using a serverless
+    application.
+  nextQuickStart:
+    - ''
+  prerequisites:
+    - ''
+  tasks:
+    - description: >-
+        ### To create a serverless application:
+
+        1. From the **Developer** perspective, in the navigation menu, click
+        [+Add](/add).
+
+        2. At the top of the page, in the **Projects** list, select a project to
+        create the application in. You can also create a new one.
+
+        3. Click **From Git**.
+
+        4. In the **Git Repo URL** field, type
+        `https://github.com/sclorg/django-ex.git`.
+
+        5. Under Resources, select **Knative Service**.
+
+        6. At the end of the page, click **Create**.
+
+
+        The **Topology** view displays your new Serverless application. The
+        application is represented by the light gray area with the white border.
+        The Knative Service is the darker gray area with the dotted border. The
+        Pod ring in the middle represents the revision.
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again, or [read
+          more](https://docs.openshift.com/container-platform/4.6/serverless/serving-creating-managing-apps.html#creating-serverless-applications-using-the-openshift-container-platform-web-console)
+          about this topic.
+        instructions: >-
+          #### To verify the application was successfully created:
+
+          From the **Topology** view, look for your new application. Wait for
+          the build to complete. It may take a few minutes.
+
+          After the build completes, a green checkmark appears in the lower-left
+          corner of the service. Your application will say  “No Revisions” in
+          the center.
+
+          Do you see the completed application and build?
+      summary:
+        failed: Try the steps again.
+        success: You just created a Serverless app!
+      title: Creating a serverless application
+    - description: >
+        ### To see your application scale:
+
+        1. From the **Display Options** list at the top of the **Topology**
+        view, click **Pod Count**.
+
+        2. Wait for the Pod count to scale down to zero Pods. Scaling down may
+        take a few minutes.
+
+        3. Click the **Open URL** icon in the upper-right corner of the Knative
+        Service panel. The application opens in a new tab.
+
+        4. Close the new browser tab and return to the **Topology** view.
+
+        In the **Topology** view, you can see that your application scaled up to
+        one Pod to accommodate your request.  After a few minutes, your
+        application scales back down to zero Pods.
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again, or [read
+          more](https://docs.openshift.com/container-platform/4.6/applications/application_life_cycle_management/odc-viewing-application-composition-using-topology-view.html#odc-scaling-application-pods-and-checking-builds-and-routes_viewing-application-composition-using-topology-view)
+          about this topic.
+        instructions: >-
+          #### To verify the application scaled down:
+
+          1. Click the revision inside your service. The badges under the Pod
+          ring and at the top of the side panel should be (REV).
+
+          2. Click the **Details** tab in the side panel.
+
+          Is the Pod ring autoscaled to zero?
+      summary:
+        failed: Try the steps again.
+        success: You just scaled up your application to accomodate a traffic request!
+      title: Demoing scalability
+    - description: >-
+        ### To connect an event source to your Knative Service:
+
+        1. On the **Topology** View, hover over your service with your cursor.
+        You should see a blue arrow.
+
+        2. Click and drag the blue arrow, then drop it anywhere outside the
+        service.
+
+        3. In the list that appears, click **Event Source**.
+
+        4. Under the **Type** field, click **PingSource**.
+
+        5. In the **Data** field, type `This message is from PingSource`. This
+        message is posted when the service is called.
+
+        6. In the **Schedule** field, type `* * * * *`.  This means that the
+        PingSource will make a call every minute.
+
+        7. In the **Application** field, select **Sample Serverless App**.
+
+        8. Click **Create**.
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again, or [read
+          more](https://docs.openshift.com/container-platform/4.6/serverless/event_sources/knative-event-sources.html)
+          about this topic.
+        instructions: >-
+          #### To verify that the event connected to your Knative service:
+
+          Go to the **Topology** view.
+
+          Do you see a PingSource connected by a gray line to the side of your
+          application?
+      summary:
+        failed: Try the steps again.
+        success: You just wired an Event Source to your Knative Service!
+      title: Connecting an event source to your Knative Service
+    - description: >-
+        ### To force a revision and set traffic distribution:
+
+        1. In **Topology**, click the revision inside your service to view its
+        details. The badges under the Pod ring and at the top of the detail
+        panel should be (REV).
+
+        2. In the side panel, click the **Resources** tab.
+
+        3. Scroll down and click the configuration associated with your service.
+
+        4. Go to the resource’s **YAML** tab.
+
+        5. Scroll all the way down until you see `timeoutSeconds`.
+
+        6. Change the value from `300` to `30` and click **Save**.
+
+        7. Go back to the **Topology** view.
+
+        8. Click your service. The badge at the top of the side panel should be
+        (KSVC).
+
+        9. In the side panel, click the **Resources** tab.
+
+        10. Next to **Revisions**, click **Set Traffic Distribution**.
+
+        11. Click **Add Revision**.
+
+        12. In the **Revision** dropdown, select the new revision.
+
+        13. In the **Split** column, set both revisions to **50**.
+
+        14. Click **Save**.
+
+        You should now be able to watch as the Pod rings for each revision scale
+        up and down each time the application is pinged.
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again, or [read
+          more](https://docs.openshift.com/container-platform/4.6/serverless/knative_serving/splitting-traffic-between-revisions.html)
+          about this topic.
+        instructions: >-
+          #### To verify that you forced a new revision and set traffic
+          distribution:
+
+          Make sure you are still in **Topology** view.
+
+          Do you see two revisions in your Knative Service?
+      summary:
+        failed: Try the steps again.
+        success: You just set a traffic distribution for your Serverless app!
+      title: Forcing a new revision and set traffic distribution
+    - description: >-
+        ### To delete the application you just created:
+
+        1. Click your application’s name. The badge at the top of the side panel
+        should be (A).
+
+        2. At the top of the resource details panel, click the **Actions** list.
+
+        3. Click **Delete application**.
+
+        4. To confirm deletion, type the application’s name in the **Name**
+        field, and then click **Delete**.
+      review:
+        failedTaskHelp: >-
+          This task is not verified yet. Try the task again, or [read
+          more](https://docs.openshift.com/container-platform/4.6/applications/application_life_cycle_management/odc-deleting-applications.html)
+          about this topic.
+        instructions: |-
+          #### To verify you deleted your application:          :
+          Make sure you are still in **Topology** view.
+          Has the Sample Serverless App been removed?
+      summary:
+        failed: Try the steps again.
+        success: You just deleted your Serverless app!
+      title: Deleting your application

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/dashboard"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleclidownload"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/kourier"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/quickstart"
 	consolev1 "github.com/openshift/api/console/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -171,6 +172,7 @@ func (r *ReconcileKnativeServing) reconcileKnativeServing(instance *servingv1alp
 		r.installKourier,
 		r.installDashboard,
 		r.ensureProxySettings,
+		r.installQuickstarts,
 		r.installKnConsoleCLIDownload,
 	}
 	for _, stage := range stages {
@@ -347,6 +349,13 @@ func (r *ReconcileKnativeServing) installKourier(instance *servingv1alpha1.Knati
 	return nil
 }
 
+func (r *ReconcileKnativeServing) installQuickstarts(instance *servingv1alpha1.KnativeServing) error {
+	if err := quickstart.Apply(instance, r.client); err != nil {
+		return err
+	}
+	return nil
+}
+
 // installKnConsoleCLIDownload creates CR for kn CLI download link
 func (r *ReconcileKnativeServing) installKnConsoleCLIDownload(instance *servingv1alpha1.KnativeServing) error {
 	return consoleclidownload.Apply(instance, r.client, r.scheme)
@@ -381,6 +390,11 @@ func (r *ReconcileKnativeServing) delete(instance *servingv1alpha1.KnativeServin
 	log.Info("Deleting dashboard")
 	if err := dashboard.Delete(os.Getenv(dashboard.ServingResourceDashboardPathEnvVar), instance, r.client); err != nil {
 		return fmt.Errorf("failed to delete dashboard configmap: %w", err)
+	}
+
+	log.Info("Deleting quickstart")
+	if err := quickstart.Delete(instance, r.client); err != nil {
+		return fmt.Errorf("failed to delete quickstarts: %w", err)
 	}
 
 	// The above might take a while, so we refetch the resource again in case it has changed.

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/dashboard"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/quickstart"
 	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -113,6 +114,7 @@ var (
 func init() {
 	os.Setenv("OPERATOR_NAME", "TEST_OPERATOR")
 	os.Setenv("KOURIER_MANIFEST_PATH", "kourier/testdata/kourier-latest.yaml")
+	os.Setenv(quickstart.EnvKey, "../../../deploy/resources/quickstart/serverless-application-quickstart.yaml")
 	os.Setenv(dashboard.ServingResourceDashboardPathEnvVar, "../dashboard/testdata/grafana-dash-knative-serving-resources.yaml")
 
 	apis.AddToScheme(scheme.Scheme)

--- a/knative-operator/pkg/controller/knativeserving/quickstart/quickstart.go
+++ b/knative-operator/pkg/controller/knativeserving/quickstart/quickstart.go
@@ -1,0 +1,59 @@
+package quickstart
+
+import (
+	"fmt"
+	"os"
+
+	mfc "github.com/manifestival/controller-runtime-client"
+	mf "github.com/manifestival/manifestival"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
+	apierrs "k8s.io/apimachinery/pkg/api/meta"
+	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EnvKey is the environment variable that decides which manifest to load
+const EnvKey = "QUICKSTART_MANIFEST_PATH"
+
+var log = common.Log.WithName("quickstart")
+
+// Apply applies Quickstart resources.
+func Apply(instance *servingv1alpha1.KnativeServing, api client.Client) error {
+	manifest, err := mfc.NewManifest(manifestPath(), api, mf.UseLogger(log.WithName("mf")))
+	if err != nil {
+		return fmt.Errorf("failed to load quickstart manifest: %w", err)
+	}
+
+	log.Info("Installing Quickstarts")
+	if err := manifest.Apply(); err != nil {
+		if apierrs.IsNoMatchError(err) {
+			log.Info("ConsoleQuickStart CRD not installed, skipping quickstart installation")
+			return nil
+		}
+		return fmt.Errorf("failed to apply quickstart manifest: %w", err)
+	}
+	log.Info("Quickstarts installed")
+	return nil
+}
+
+// Delete deletes Quickstart resources.
+func Delete(instance *servingv1alpha1.KnativeServing, api client.Client) error {
+	log.Info("Deleting Quickstarts")
+	manifest, err := mfc.NewManifest(manifestPath(), api, mf.UseLogger(log.WithName("mf")))
+	if err != nil {
+		return fmt.Errorf("failed to load quickstart manifest: %w", err)
+	}
+
+	if err := manifest.Delete(); err != nil {
+		if apierrs.IsNoMatchError(err) {
+			log.Info("ConsoleQuickStart CRD not installed, skipping quickstart installation")
+			return nil
+		}
+		return fmt.Errorf("failed to delete quickstart manifest: %w", err)
+	}
+	return nil
+}
+
+func manifestPath() string {
+	return os.Getenv(EnvKey)
+}

--- a/knative-operator/pkg/controller/knativeserving/quickstart/quickstart_test.go
+++ b/knative-operator/pkg/controller/knativeserving/quickstart/quickstart_test.go
@@ -1,0 +1,70 @@
+package quickstart
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
+	apierrs "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func init() {
+	os.Setenv(EnvKey, "../../../../deploy/resources/quickstart/serverless-application-quickstart.yaml")
+	apis.AddToScheme(scheme.Scheme)
+}
+
+func TestQuickstartErrors(t *testing.T) {
+	ks := &servingv1alpha1.KnativeServing{}
+	someErr := errors.New("test")
+
+	tests := []struct {
+		err      error
+		expected error
+	}{{
+		err:      nil,
+		expected: nil,
+	}, {
+		err:      someErr,
+		expected: someErr,
+	}, {
+		err:      &apierrs.NoKindMatchError{},
+		expected: nil,
+	}}
+
+	for _, test := range tests {
+		if err := Apply(ks, &fakeClient{err: test.err}); !errors.Is(err, test.expected) {
+			t.Errorf("Apply() = %v, want %v", err, test.expected)
+		}
+		if err := Delete(ks, &fakeClient{err: test.err}); !errors.Is(err, test.expected) {
+			t.Errorf("Delete() = %v, want %v", err, test.expected)
+		}
+	}
+}
+
+type fakeClient struct {
+	client.Client
+
+	err error
+}
+
+func (f *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	return f.err
+}
+
+func (f *fakeClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+	return f.err
+}
+
+func (f *fakeClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	return f.err
+}
+
+func (f *fakeClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+	return f.err
+}

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -417,6 +417,8 @@ spec:
                         value: deploy/resources/knativekafka/kafkachannel-latest.yaml
                       - name: KAFKASOURCE_MANIFEST_PATH
                         value: deploy/resources/knativekafka/kafkasource-latest.yaml
+                      - name: QUICKSTART_MANIFEST_PATH
+                        value: "deploy/resources/quickstart/serverless-application-quickstart.yaml"
                       - name: "IMAGE_queue-proxy"
                         value: "registry.svc.ci.openshift.org/openshift/knative-v0.19.0:knative-serving-queue"
                       - name: "IMAGE_activator"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -369,6 +369,8 @@ spec:
                       value: deploy/resources/knativekafka/kafkachannel-latest.yaml
                     - name: KAFKASOURCE_MANIFEST_PATH
                       value: deploy/resources/knativekafka/kafkasource-latest.yaml
+                    - name: QUICKSTART_MANIFEST_PATH
+                      value: "deploy/resources/quickstart/serverless-application-quickstart.yaml"
       - name: knative-openshift-ingress
         spec:
           replicas: 1


### PR DESCRIPTION
As per SRVKS-667, this installs Service creation related quickstart manifests once Knative Serving is getting installed. It ignores NoMatchFound errors, which indicate that the given CRD is not present in this cluster (which is the case for 4.6 clusters for example).

/assign @skonto @mgencur