### PR TITLE
Adding nodejs to test-image for UI tests

### DIFF
--- a/hack/generate/dockerfile.sh
+++ b/hack/generate/dockerfile.sh
@@ -17,6 +17,7 @@ values[SERVING_VERSION]="$(metadata.get dependencies.serving)"
 values[EVENTING_VERSION]="$(metadata.get dependencies.eventing)"
 values[EVENTING_KAFKA_VERSION]="$(metadata.get dependencies.eventing_kafka)"
 values[GOLANG_VERSION]="$(metadata.get requirements.golang)"
+values[NODEJS_VERSION]="$(metadata.get requirements.nodejs)"
 values[OCP_TARGET_VLIST]="$(metadata.get 'requirements.ocp.*' | sed 's/^/v/' | paste -sd ',' -)"
 
 # Start fresh

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -16,6 +16,7 @@ requirements:
   kube:
     minVersion: 1.15.0
   golang: '1.14'
+  nodejs: 14.x
   ocp:
     - '4.6'
 

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM openshift/origin-release:golang-1.14
+FROM docker.io/openshift/origin-release:golang-1.14
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
@@ -12,3 +12,6 @@ RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd
+
+RUN yum install -y https://rpm.nodesource.com/pub_14.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+RUN yum install -y gcc-c++ make nodejs

--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM openshift/origin-release:golang-__GOLANG_VERSION__
+FROM docker.io/openshift/origin-release:golang-__GOLANG_VERSION__
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
@@ -12,3 +12,6 @@ RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd
+
+RUN yum install -y https://rpm.nodesource.com/pub___NODEJS_VERSION__/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+RUN yum install -y gcc-c++ make nodejs


### PR DESCRIPTION
Nodejs is required to run Console UI tests developed in #804 

This PR needs to be merged first.