### PR TITLE
Update CSV for 1.10.1

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -81,7 +81,7 @@ spec:
         - -c
         - |-
           podman login -u $pull_user -p $token image-registry.openshift-image-registry.svc:5000 && \
-          /bin/opm registry add -d index.db --container-tool=podman --mode=replaces -b quay.io/openshift-knative/serverless-bundle:1.7.2,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.8.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.9.0:serverless-bundle,image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle && \
+          /bin/opm registry add -d index.db --container-tool=podman --mode=replaces -b quay.io/openshift-knative/serverless-bundle:1.7.2,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.8.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.9.0:serverless-bundle,registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:serverless-bundle,image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle && \
           /bin/opm registry serve -d index.db -p 50051
 EOF
 

--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -7,8 +7,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=serverless-operator
-LABEL operators.operatorframework.io.bundle.channel.default.v1="4.3"
-LABEL operators.operatorframework.io.bundle.channels.v1="4.5,4.6"
+LABEL operators.operatorframework.io.bundle.channel.default.v1="4.5"
+LABEL operators.operatorframework.io.bundle.channels.v1="4.5"
 
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \

--- a/olm-catalog/serverless-operator/csv.template.yaml
+++ b/olm-catalog/serverless-operator/csv.template.yaml
@@ -28,14 +28,14 @@ metadata:
     capabilities: Full Lifecycle
     categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
     certified: "false"
-    createdAt: "2020-04-20T17:00:00Z"
+    createdAt: "2021-02-09T14:42:00Z"
     description: |-
       Provides a collection of API's based on Knative to support deploying and serving
       of serverless applications and functions.
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
-    olm.skipRange: ">=1.9.0 <1.10.0"
-  name: serverless-operator.v1.10.0
+    olm.skipRange: ">=1.9.0 <1.10.1"
+  name: serverless-operator.v1.10.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -438,5 +438,5 @@ spec:
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-openshift-ingress
-  replaces: serverless-operator.v1.9.0
-  version: 1.10.0
+  replaces: serverless-operator.v1.10.0
+  version: 1.10.1

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -28,42 +28,42 @@ metadata:
     capabilities: Full Lifecycle
     categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
     certified: "false"
-    createdAt: "2020-04-20T17:00:00Z"
+    createdAt: "2021-02-09T14:42:00Z"
     description: |-
       Provides a collection of API's based on Knative to support deploying and serving
       of serverless applications and functions.
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
-    olm.skipRange: ">=1.9.0 <1.10.0"
-  name: serverless-operator.v1.10.0
+    olm.skipRange: ">=1.9.0 <1.10.1"
+  name: serverless-operator.v1.10.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Represents an installation of a particular version of Knative Serving
-      displayName: Knative Serving
-      kind: KnativeServing
-      name: knativeservings.operator.knative.dev
-      statusDescriptors:
-      - description: The version of Knative Serving installed
-        displayName: Version
-        path: version
-      - description: Conditions of Knative Serving installed
-        displayName: Conditions
-        path: conditions
-        x-descriptors:
-        - 'urn:alm:descriptor:io.kubernetes.conditions'
-      version: v1alpha1
-    - description: Represents an installation of a particular version of Knative Eventing
-      displayName: Knative Eventing
-      kind: KnativeEventing
-      name: knativeeventings.operator.knative.dev
-      statusDescriptors:
-      - description: The version of Knative Eventing installed
-        displayName: Version
-        path: version
-      version: v1alpha1
+      - description: Represents an installation of a particular version of Knative Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+          - description: The version of Knative Serving installed
+            displayName: Version
+            path: version
+          - description: Conditions of Knative Serving installed
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+          - description: The version of Knative Eventing installed
+            displayName: Version
+            path: version
+        version: v1alpha1
   minKubeVersion: 1.15.0
   description: |-
     The Red Hat OpenShift Serverless operator provides a collection of APIs that
@@ -156,461 +156,461 @@ spec:
     started](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/serverless_applications/serverless-getting-started)
   displayName: Red Hat OpenShift Serverless
   icon:
-  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
-    mediatype: image/svg+xml
+    - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+      mediatype: image/svg+xml
   install:
     spec:
       clusterPermissions:
-      - rules:
-        - apiGroups:
-          - '*'
-          resources:
-          - '*'
-          verbs:
-          - '*'
-        serviceAccountName: knative-operator
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          - services
-          - events
-          - configmaps
-          verbs:
-          - "*"
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - get
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          - replicasets
-          verbs:
-          - "*"
-        - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - "*"
-        - apiGroups:
-          - networking.k8s.io
-          resources:
-          - networkpolicies
-          verbs:
-          - "*"
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - get
-          - create
-        - apiGroups:
-          - networking.internal.knative.dev
-          resources:
-          - clusteringresses
-          - clusteringresses/status
-          - clusteringresses/finalizers
-          - ingresses
-          - ingresses/status
-          - ingresses/finalizers
-          verbs:
-          - "*"
-        - apiGroups:
-          - route.openshift.io
-          resources:
-          - routes
-          - routes/custom-host
-          - routes/status
-          - routes/finalizers
-          verbs:
-          - "*"
-        - apiGroups:
-          - operator.knative.dev
-          resources:
-          - knativeservings
-          - knativeservings/finalizers
-          verbs:
-          - '*'
-        serviceAccountName: knative-openshift-ingress
+        - rules:
+            - apiGroups:
+                - '*'
+              resources:
+                - '*'
+              verbs:
+                - '*'
+          serviceAccountName: knative-operator
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - services
+                - events
+                - configmaps
+              verbs:
+                - "*"
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - replicasets
+              verbs:
+                - "*"
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - "*"
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - "*"
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - networking.internal.knative.dev
+              resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+              verbs:
+                - "*"
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+              verbs:
+                - "*"
+            - apiGroups:
+                - operator.knative.dev
+              resources:
+                - knativeservings
+                - knativeservings/finalizers
+              verbs:
+                - '*'
+          serviceAccountName: knative-openshift-ingress
       deployments:
-      - name: knative-operator
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              name: knative-operator
-          template:
-            metadata:
-              annotations:
-                sidecar.istio.io/inject: "false"
-              labels:
+        - name: knative-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 name: knative-operator
-            spec:
-              containers:
-              - env:
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: OPERATOR_NAME
-                  value: knative-operator
-                - name: SYSTEM_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: METRICS_DOMAIN
-                  value: knative.dev/serving-operator
-                - name: "IMAGE_DISPATCHER_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
-                - name: "IMAGE_KN_CLI_ARTIFACTS"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.1:kn-cli-artifacts"
-                - name: "IMAGE_autoscaler"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler"
-                - name: "IMAGE_imc-dispatcher__dispatcher"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
-                - name: "IMAGE_3scale-kourier-gateway"
-                  value: "docker.io/maistra/proxyv2-ubi8:1.1.0"
-                - name: "IMAGE_PING_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-ping"
-                - name: "IMAGE_APISERVER_RA_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-apiserver-receive-adapter"
-                - name: "IMAGE_BROKER_FILTER_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-filter"
-                - name: "IMAGE_imc-controller__controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-controller"
-                - name: "IMAGE_mt-broker-filter__filter"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter"
-                - name: "IMAGE_eventing-webhook__eventing-webhook"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-webhook"
-                - name: "IMAGE_queue-proxy"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-queue"
-                - name: "IMAGE_activator"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-activator"
-                - name: "IMAGE_eventing-controller__eventing-controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-controller"
-                - name: "IMAGE_controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-controller"
-                - name: "IMAGE_mt-broker-controller__mt-broker-controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtchannel-broker"
-                - name: "IMAGE_broker-controller__broker-controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-broker"
-                - name: "IMAGE_mt-broker-ingress__ingress"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress"
-                - name: "IMAGE_storage-version-migration-eventing__migrate"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-storage-version-migration"
-                - name: "IMAGE_3scale-kourier-control"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:kourier"
-                - name: "IMAGE_broker-filter__filter"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-filter"
-                - name: "IMAGE_webhook"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-webhook"
-                - name: "IMAGE_MT_PING_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtping"
-                - name: "IMAGE_broker-ingress__ingress"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-ingress"
-                - name: "IMAGE_BROKER_INGRESS_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-ingress"
-                - name: "IMAGE_storage-version-migration-serving-0.16.0__migrate"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-storage-version-migration"
-                - name: "IMAGE_autoscaler-hpa"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler-hpa"
-                - name: "IMAGE_v0.16.0-broker-cleanup__brokers"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-cleanup"
-                - name: "IMAGE_sugar-controller__controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-sugar-controller"
-                image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-operator
-                imagePullPolicy: IfNotPresent
-                name: knative-operator
-                ports:
-                - containerPort: 9090
-                  name: metrics
-              serviceAccountName: knative-operator
-      - name: knative-openshift
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              name: knative-openshift
-          template:
-            metadata:
-              labels:
+            template:
+              metadata:
+                annotations:
+                  sidecar.istio.io/inject: "false"
+                labels:
+                  name: knative-operator
+              spec:
+                containers:
+                  - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-operator
+                      - name: "IMAGE_DISPATCHER_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
+                      - name: "IMAGE_KN_CLI_ARTIFACTS"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.1:kn-cli-artifacts"
+                      - name: "IMAGE_autoscaler"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler"
+                      - name: "IMAGE_imc-dispatcher__dispatcher"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
+                      - name: "IMAGE_3scale-kourier-gateway"
+                        value: "docker.io/maistra/proxyv2-ubi8:1.1.0"
+                      - name: "IMAGE_PING_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-ping"
+                      - name: "IMAGE_APISERVER_RA_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-apiserver-receive-adapter"
+                      - name: "IMAGE_BROKER_FILTER_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-filter"
+                      - name: "IMAGE_imc-controller__controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-controller"
+                      - name: "IMAGE_mt-broker-filter__filter"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter"
+                      - name: "IMAGE_eventing-webhook__eventing-webhook"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-webhook"
+                      - name: "IMAGE_queue-proxy"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-queue"
+                      - name: "IMAGE_activator"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-activator"
+                      - name: "IMAGE_eventing-controller__eventing-controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-controller"
+                      - name: "IMAGE_controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-controller"
+                      - name: "IMAGE_mt-broker-controller__mt-broker-controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtchannel-broker"
+                      - name: "IMAGE_broker-controller__broker-controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-broker"
+                      - name: "IMAGE_mt-broker-ingress__ingress"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress"
+                      - name: "IMAGE_storage-version-migration-eventing__migrate"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-storage-version-migration"
+                      - name: "IMAGE_3scale-kourier-control"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:kourier"
+                      - name: "IMAGE_broker-filter__filter"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-filter"
+                      - name: "IMAGE_webhook"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-webhook"
+                      - name: "IMAGE_MT_PING_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtping"
+                      - name: "IMAGE_broker-ingress__ingress"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-ingress"
+                      - name: "IMAGE_BROKER_INGRESS_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-ingress"
+                      - name: "IMAGE_storage-version-migration-serving-0.16.0__migrate"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-storage-version-migration"
+                      - name: "IMAGE_autoscaler-hpa"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler-hpa"
+                      - name: "IMAGE_v0.16.0-broker-cleanup__brokers"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-cleanup"
+                      - name: "IMAGE_sugar-controller__controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-sugar-controller"
+                    image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-operator
+                    imagePullPolicy: IfNotPresent
+                    name: knative-operator
+                    ports:
+                      - containerPort: 9090
+                        name: metrics
+                serviceAccountName: knative-operator
+        - name: knative-openshift
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 name: knative-openshift
-                app: openshift-admission-server
-            spec:
-              serviceAccountName: knative-operator
-              containers:
-              - name: knative-openshift
-                # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-operator
-                command:
-                - knative-openshift
-                imagePullPolicy: Always
-                env:
-                - name: WATCH_NAMESPACE
-                  value: ""
-                - name: NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: DEPLOYMENT_NAME
-                  value: "knative-openshift"
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: OPERATOR_NAME
-                  value: "knative-openshift"
-                - name: MIN_OPENSHIFT_VERSION
-                  value: "4.3.0-0"
-                - name: REQUIRED_SERVING_NAMESPACE
-                  value: "knative-serving"
-                - name: REQUIRED_EVENTING_NAMESPACE
-                  value: "knative-eventing"
-                - name: KOURIER_MANIFEST_PATH
-                  value: deploy/resources/kourier/kourier-latest.yaml
-                - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH
-                  value: deploy/resources/console_cli_download_kn_resources.yaml
-                - name: KAFKACHANNEL_MANIFEST_PATH
-                  value: deploy/resources/knativekafka/kafkachannel-latest.yaml
-                - name: KAFKASOURCE_MANIFEST_PATH
-                  value: deploy/resources/knativekafka/kafkasource-latest.yaml
-                - name: "IMAGE_DISPATCHER_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
-                - name: "IMAGE_KN_CLI_ARTIFACTS"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.1:kn-cli-artifacts"
-                - name: "IMAGE_autoscaler"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler"
-                - name: "IMAGE_imc-dispatcher__dispatcher"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
-                - name: "IMAGE_3scale-kourier-gateway"
-                  value: "docker.io/maistra/proxyv2-ubi8:1.1.0"
-                - name: "IMAGE_PING_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-ping"
-                - name: "IMAGE_APISERVER_RA_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-apiserver-receive-adapter"
-                - name: "IMAGE_BROKER_FILTER_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-filter"
-                - name: "IMAGE_imc-controller__controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-controller"
-                - name: "IMAGE_mt-broker-filter__filter"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter"
-                - name: "IMAGE_eventing-webhook__eventing-webhook"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-webhook"
-                - name: "IMAGE_queue-proxy"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-queue"
-                - name: "IMAGE_activator"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-activator"
-                - name: "IMAGE_eventing-controller__eventing-controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-controller"
-                - name: "IMAGE_controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-controller"
-                - name: "IMAGE_mt-broker-controller__mt-broker-controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtchannel-broker"
-                - name: "IMAGE_broker-controller__broker-controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-broker"
-                - name: "IMAGE_mt-broker-ingress__ingress"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress"
-                - name: "IMAGE_storage-version-migration-eventing__migrate"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-storage-version-migration"
-                - name: "IMAGE_3scale-kourier-control"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:kourier"
-                - name: "IMAGE_broker-filter__filter"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-filter"
-                - name: "IMAGE_webhook"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-webhook"
-                - name: "IMAGE_MT_PING_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtping"
-                - name: "IMAGE_broker-ingress__ingress"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-ingress"
-                - name: "IMAGE_BROKER_INGRESS_IMAGE"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-ingress"
-                - name: "IMAGE_storage-version-migration-serving-0.16.0__migrate"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-storage-version-migration"
-                - name: "IMAGE_autoscaler-hpa"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler-hpa"
-                - name: "IMAGE_v0.16.0-broker-cleanup__brokers"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-cleanup"
-                - name: "IMAGE_sugar-controller__controller"
-                  value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-sugar-controller"
-      - name: knative-openshift-ingress
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              name: knative-openshift-ingress
-          template:
-            metadata:
-              labels:
+            template:
+              metadata:
+                labels:
+                  name: knative-openshift
+                  app: openshift-admission-server
+              spec:
+                serviceAccountName: knative-operator
+                containers:
+                  - name: knative-openshift
+                    # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
+                    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-operator
+                    command:
+                      - knative-openshift
+                    imagePullPolicy: Always
+                    env:
+                      - name: WATCH_NAMESPACE
+                        value: ""
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: DEPLOYMENT_NAME
+                        value: "knative-openshift"
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: "knative-openshift"
+                      - name: MIN_OPENSHIFT_VERSION
+                        value: "4.3.0-0"
+                      - name: REQUIRED_SERVING_NAMESPACE
+                        value: "knative-serving"
+                      - name: REQUIRED_EVENTING_NAMESPACE
+                        value: "knative-eventing"
+                      - name: KOURIER_MANIFEST_PATH
+                        value: deploy/resources/kourier/kourier-latest.yaml
+                      - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH
+                        value: deploy/resources/console_cli_download_kn_resources.yaml
+                      - name: KAFKACHANNEL_MANIFEST_PATH
+                        value: deploy/resources/knativekafka/kafkachannel-latest.yaml
+                      - name: KAFKASOURCE_MANIFEST_PATH
+                        value: deploy/resources/knativekafka/kafkasource-latest.yaml
+                      - name: "IMAGE_DISPATCHER_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
+                      - name: "IMAGE_KN_CLI_ARTIFACTS"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.1:kn-cli-artifacts"
+                      - name: "IMAGE_autoscaler"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler"
+                      - name: "IMAGE_imc-dispatcher__dispatcher"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
+                      - name: "IMAGE_3scale-kourier-gateway"
+                        value: "docker.io/maistra/proxyv2-ubi8:1.1.0"
+                      - name: "IMAGE_PING_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-ping"
+                      - name: "IMAGE_APISERVER_RA_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-apiserver-receive-adapter"
+                      - name: "IMAGE_BROKER_FILTER_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-filter"
+                      - name: "IMAGE_imc-controller__controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-controller"
+                      - name: "IMAGE_mt-broker-filter__filter"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter"
+                      - name: "IMAGE_eventing-webhook__eventing-webhook"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-webhook"
+                      - name: "IMAGE_queue-proxy"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-queue"
+                      - name: "IMAGE_activator"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-activator"
+                      - name: "IMAGE_eventing-controller__eventing-controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-controller"
+                      - name: "IMAGE_controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-controller"
+                      - name: "IMAGE_mt-broker-controller__mt-broker-controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtchannel-broker"
+                      - name: "IMAGE_broker-controller__broker-controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-broker"
+                      - name: "IMAGE_mt-broker-ingress__ingress"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress"
+                      - name: "IMAGE_storage-version-migration-eventing__migrate"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-storage-version-migration"
+                      - name: "IMAGE_3scale-kourier-control"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:kourier"
+                      - name: "IMAGE_broker-filter__filter"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-filter"
+                      - name: "IMAGE_webhook"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-webhook"
+                      - name: "IMAGE_MT_PING_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtping"
+                      - name: "IMAGE_broker-ingress__ingress"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-ingress"
+                      - name: "IMAGE_BROKER_INGRESS_IMAGE"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-ingress"
+                      - name: "IMAGE_storage-version-migration-serving-0.16.0__migrate"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-storage-version-migration"
+                      - name: "IMAGE_autoscaler-hpa"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler-hpa"
+                      - name: "IMAGE_v0.16.0-broker-cleanup__brokers"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-cleanup"
+                      - name: "IMAGE_sugar-controller__controller"
+                        value: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-sugar-controller"
+        - name: knative-openshift-ingress
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 name: knative-openshift-ingress
-            spec:
-              serviceAccountName: knative-openshift-ingress
-              containers:
-              - name: knative-openshift-ingress
-                # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-openshift-ingress
-                command:
-                - knative-openshift-ingress
-                imagePullPolicy: Always
-                env:
-                - name: WATCH_NAMESPACE
-                  value: "" # watch all namespaces for ClusterIngress
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: OPERATOR_NAME
-                  value: "knative-openshift-ingress"
+            template:
+              metadata:
+                labels:
+                  name: knative-openshift-ingress
+              spec:
+                serviceAccountName: knative-openshift-ingress
+                containers:
+                  - name: knative-openshift-ingress
+                    # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
+                    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-openshift-ingress
+                    command:
+                      - knative-openshift-ingress
+                    imagePullPolicy: Always
+                    env:
+                      - name: WATCH_NAMESPACE
+                        value: "" # watch all namespaces for ClusterIngress
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: "knative-openshift-ingress"
       permissions:
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          - services
-          - endpoints
-          - persistentvolumeclaims
-          - events
-          - configmaps
-          - secrets
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - get
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
-          verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - get
-          - create
-        - apiGroups:
-          - apps
-          resourceNames:
-          - knative-operator
-          resources:
-          - deployments/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - operator.knative.dev
-          resources:
-          - '*'
-          verbs:
-          - '*'
-        serviceAccountName: knative-operator
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - apps
+              resourceNames:
+                - knative-operator
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.knative.dev
+              resources:
+                - '*'
+              verbs:
+                - '*'
+          serviceAccountName: knative-operator
     strategy: deployment
   installModes:
-  - supported: false
-    type: OwnNamespace
-  - supported: false
-    type: SingleNamespace
-  - supported: false
-    type: MultiNamespace
-  - supported: true
-    type: AllNamespaces
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
   keywords:
-  - serverless
-  - FaaS
-  - microservices
-  - scale to zero
-  - knative
-  - serving
-  - eventing
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
   links:
-  - name: Documentation
-    url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/serverless_applications/index
-  - name: Source Repository
-    url: https://github.com/openshift-knative/serverless-operator
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/serverless_applications/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
   maintainers:
-  - email: serverless-support@redhat.com
-    name: Serverless Team
+    - email: serverless-support@redhat.com
+      name: Serverless Team
   maturity: stable
   provider:
     name: Red Hat
   relatedImages:
-  - name: knative-openshift
-    # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-operator
-  - name: knative-openshift-ingress
-    # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-    image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-openshift-ingress
-  - name: "IMAGE_DISPATCHER_IMAGE"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
-  - name: "IMAGE_KN_CLI_ARTIFACTS"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.1:kn-cli-artifacts"
-  - name: "IMAGE_autoscaler"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler"
-  - name: "IMAGE_imc-dispatcher__dispatcher"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
-  - name: "IMAGE_3scale-kourier-gateway"
-    image: "docker.io/maistra/proxyv2-ubi8:1.1.0"
-  - name: "IMAGE_PING_IMAGE"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-ping"
-  - name: "IMAGE_APISERVER_RA_IMAGE"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-apiserver-receive-adapter"
-  - name: "IMAGE_BROKER_FILTER_IMAGE"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-filter"
-  - name: "IMAGE_imc-controller__controller"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-controller"
-  - name: "IMAGE_mt-broker-filter__filter"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter"
-  - name: "IMAGE_eventing-webhook__eventing-webhook"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-webhook"
-  - name: "IMAGE_queue-proxy"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-queue"
-  - name: "IMAGE_activator"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-activator"
-  - name: "IMAGE_eventing-controller__eventing-controller"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-controller"
-  - name: "IMAGE_controller"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-controller"
-  - name: "IMAGE_mt-broker-controller__mt-broker-controller"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtchannel-broker"
-  - name: "IMAGE_broker-controller__broker-controller"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-broker"
-  - name: "IMAGE_mt-broker-ingress__ingress"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress"
-  - name: "IMAGE_storage-version-migration-eventing__migrate"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-storage-version-migration"
-  - name: "IMAGE_3scale-kourier-control"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:kourier"
-  - name: "IMAGE_broker-filter__filter"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-filter"
-  - name: "IMAGE_webhook"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-webhook"
-  - name: "IMAGE_MT_PING_IMAGE"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtping"
-  - name: "IMAGE_broker-ingress__ingress"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-ingress"
-  - name: "IMAGE_BROKER_INGRESS_IMAGE"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-ingress"
-  - name: "IMAGE_storage-version-migration-serving-0.16.0__migrate"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-storage-version-migration"
-  - name: "IMAGE_autoscaler-hpa"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler-hpa"
-  - name: "IMAGE_v0.16.0-broker-cleanup__brokers"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-cleanup"
-  - name: "IMAGE_sugar-controller__controller"
-    image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-sugar-controller"
-  replaces: serverless-operator.v1.9.0
-  version: 1.10.0
+    - name: knative-openshift
+      # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-operator
+    - name: knative-openshift-ingress
+      # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
+      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-openshift-ingress
+    - name: "IMAGE_DISPATCHER_IMAGE"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
+    - name: "IMAGE_KN_CLI_ARTIFACTS"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.1:kn-cli-artifacts"
+    - name: "IMAGE_autoscaler"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler"
+    - name: "IMAGE_imc-dispatcher__dispatcher"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher"
+    - name: "IMAGE_3scale-kourier-gateway"
+      image: "docker.io/maistra/proxyv2-ubi8:1.1.0"
+    - name: "IMAGE_PING_IMAGE"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-ping"
+    - name: "IMAGE_APISERVER_RA_IMAGE"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-apiserver-receive-adapter"
+    - name: "IMAGE_BROKER_FILTER_IMAGE"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-filter"
+    - name: "IMAGE_imc-controller__controller"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-controller"
+    - name: "IMAGE_mt-broker-filter__filter"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter"
+    - name: "IMAGE_eventing-webhook__eventing-webhook"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-webhook"
+    - name: "IMAGE_queue-proxy"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-queue"
+    - name: "IMAGE_activator"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-activator"
+    - name: "IMAGE_eventing-controller__eventing-controller"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-controller"
+    - name: "IMAGE_controller"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-controller"
+    - name: "IMAGE_mt-broker-controller__mt-broker-controller"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtchannel-broker"
+    - name: "IMAGE_broker-controller__broker-controller"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-channel-broker"
+    - name: "IMAGE_mt-broker-ingress__ingress"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress"
+    - name: "IMAGE_storage-version-migration-eventing__migrate"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-storage-version-migration"
+    - name: "IMAGE_3scale-kourier-control"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:kourier"
+    - name: "IMAGE_broker-filter__filter"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-filter"
+    - name: "IMAGE_webhook"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-webhook"
+    - name: "IMAGE_MT_PING_IMAGE"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtping"
+    - name: "IMAGE_broker-ingress__ingress"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-broker-ingress"
+    - name: "IMAGE_BROKER_INGRESS_IMAGE"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-ingress"
+    - name: "IMAGE_storage-version-migration-serving-0.16.0__migrate"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-storage-version-migration"
+    - name: "IMAGE_autoscaler-hpa"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-serving-autoscaler-hpa"
+    - name: "IMAGE_v0.16.0-broker-cleanup__brokers"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-cleanup"
+    - name: "IMAGE_sugar-controller__controller"
+      image: "registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-sugar-controller"
+  replaces: serverless-operator.v1.10.0
+  version: 1.10.1

--- a/olm-catalog/serverless-operator/metadata/annotations.yaml
+++ b/olm-catalog/serverless-operator/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-    operators.operatorframework.io.bundle.channel.default.v1: "4.3"
-    operators.operatorframework.io.bundle.channels.v1: "4.5,4.6"
+    operators.operatorframework.io.bundle.channel.default.v1: "4.5"
+    operators.operatorframework.io.bundle.channels.v1: "4.5"
     operators.operatorframework.io.bundle.manifests.v1: manifests/
     operators.operatorframework.io.bundle.mediatype.v1: registry+v1
     operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
Updated CSV template to reference 1.10.1, and executed `make csv` to render `olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml`.