### PR TITLE
SRVKS-698 Enable Autoscaling tests during upgrades

### DIFF
--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -35,12 +35,8 @@ func TestServerlessUpgrade(t *testing.T) {
 	suite := pkgupgrade.Suite{
 		Tests: pkgupgrade.Tests{
 			PreUpgrade:    preUpgradeTests(),
-			PostUpgrade:   postUpgradeTests(),
-			Continual:     []pkgupgrade.BackgroundOperation{
-				// TODO(mgencur): SRVKS-698 Investigate failing Autoscale tests.
-				servingupgrade.ProbeTest(),
-				eventingupgrade.ContinualTest(),
-			},
+			PostUpgrade:   append(servingupgrade.ServingPostUpgradeTests(), eventingupgrade.PostUpgradeTest()),
+			Continual:     append(servingupgrade.ContinualTests(), eventingupgrade.ContinualTest()),
 		},
 		Installations: pkgupgrade.Installations{
 			UpgradeWith: []pkgupgrade.Operation{ installation.UpgradeServerless() },
@@ -57,7 +53,7 @@ func TestClusterUpgrade(t *testing.T) {
 	suite := pkgupgrade.Suite{
 		Tests: pkgupgrade.Tests{
 			PreUpgrade:    preUpgradeTests(),
-			PostUpgrade:   postUpgradeTests(),
+			PostUpgrade:   append(servingupgrade.ServingPostUpgradeTests(), eventingupgrade.PostUpgradeTest()),
 			// Do not include continual tests as they're failing across cluster upgrades.
 		},
 		Installations: pkgupgrade.Installations{
@@ -77,11 +73,6 @@ func preUpgradeTests() []pkgupgrade.Operation {
 		return tests
 	}
 	return append(tests, servingupgrade.ServingPreUpgradeTests()...)
-}
-
-func postUpgradeTests() []pkgupgrade.Operation {
-	tests := servingupgrade.ServingPostUpgradeTests()
-	return append(tests, eventingupgrade.PostUpgradeTest())
 }
 
 func newUpgradeConfig(t *testing.T) pkgupgrade.Configuration {


### PR DESCRIPTION
The PR https://github.com/openshift-knative/serverless-operator/pull/803 showed 4 runs in a row where Autoscaling tests were passing. All these checks ran after the increase of cpu/mem request for the pod running the tests. The autoscaling tests are more resource-intensive since the previous release as they are using more threads. The assumption is that the client's are not able to send enough load to the autoscaler and the tests fail because of insufficient scaling. Let's run all the tests together (with Eventing tests) in this PR to confirm that.