### PR TITLE
Update ClusterRole{Binding} APIs to v1

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.20.0/0-rbac-proxy.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.20.0/0-rbac-proxy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: rbac-proxy-metrics-prom
@@ -7,7 +7,7 @@ rules:
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: rbac-proxy-metrics-prom-rb

--- a/openshift-knative-operator/hack/004-rbac-proxy.patch
+++ b/openshift-knative-operator/hack/004-rbac-proxy.patch
@@ -5,7 +5,7 @@ index 00000000..37558cd9
 +++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.20.0/0-rbac-proxy.yaml
 @@ -0,0 +1,314 @@
 +---
-+apiVersion: rbac.authorization.k8s.io/v1beta1
++apiVersion: rbac.authorization.k8s.io/v1
 +kind: ClusterRole
 +metadata:
 +  name: rbac-proxy-metrics-prom
@@ -13,7 +13,7 @@ index 00000000..37558cd9
 +  - nonResourceURLs: ["/metrics"]
 +    verbs: ["get"]
 +---
-+apiVersion: rbac.authorization.k8s.io/v1beta1
++apiVersion: rbac.authorization.k8s.io/v1
 +kind: ClusterRoleBinding
 +metadata:
 +  name: rbac-proxy-metrics-prom-rb


### PR DESCRIPTION
This is in line with upstream usages and avoids unnecessary log lines like

```
W0215 01:07:02.962885       1 warnings.go:67] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W0215 01:07:03.862876       1 warnings.go:67] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
```

/assign @skonto 