### PR TITLE
Update {Validating/Mutating}WebhookConfiguration APIs to v1

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/kafkachannel-v0.19.1.yaml
+++ b/knative-operator/deploy/resources/knativekafka/kafkachannel-v0.19.1.yaml
@@ -574,7 +574,7 @@ spec:
     messaging.knative.dev/channel: kafka-channel
     messaging.knative.dev/role: dispatcher
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.messaging.knative.dev
@@ -590,7 +590,7 @@ webhooks:
   failurePolicy: Fail
   name: defaulting.webhook.kafka.messaging.knative.dev
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.messaging.knative.dev

--- a/knative-operator/deploy/resources/knativekafka/kafkachannel-v0.19.1.yaml
+++ b/knative-operator/deploy/resources/knativekafka/kafkachannel-v0.19.1.yaml
@@ -589,6 +589,7 @@ webhooks:
       namespace: knative-eventing
   failurePolicy: Fail
   name: defaulting.webhook.kafka.messaging.knative.dev
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -605,6 +606,7 @@ webhooks:
       namespace: knative-eventing
   failurePolicy: Fail
   name: validation.webhook.kafka.messaging.knative.dev
+  sideEffects: None
 ---
 apiVersion: v1
 kind: Secret

--- a/knative-operator/deploy/resources/knativekafka/kafkasource-v0.19.1.yaml
+++ b/knative-operator/deploy/resources/knativekafka/kafkasource-v0.19.1.yaml
@@ -374,7 +374,7 @@ spec:
   selector:
     control-plane: kafka-controller-manager
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.sources.knative.dev
@@ -390,7 +390,7 @@ webhooks:
   failurePolicy: Fail
   name: defaulting.webhook.kafka.sources.knative.dev
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: kafkabindings.webhook.kafka.sources.knative.dev
@@ -406,7 +406,7 @@ webhooks:
   failurePolicy: Fail
   name: kafkabindings.webhook.kafka.sources.knative.dev
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.sources.knative.dev
@@ -422,7 +422,7 @@ webhooks:
   failurePolicy: Fail
   name: validation.webhook.kafka.sources.knative.dev
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.kafka.sources.knative.dev

--- a/knative-operator/deploy/resources/knativekafka/kafkasource-v0.19.1.yaml
+++ b/knative-operator/deploy/resources/knativekafka/kafkasource-v0.19.1.yaml
@@ -389,6 +389,7 @@ webhooks:
       namespace: knative-eventing
   failurePolicy: Fail
   name: defaulting.webhook.kafka.sources.knative.dev
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -405,6 +406,7 @@ webhooks:
       namespace: knative-eventing
   failurePolicy: Fail
   name: kafkabindings.webhook.kafka.sources.knative.dev
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -421,6 +423,7 @@ webhooks:
       namespace: knative-eventing
   failurePolicy: Fail
   name: validation.webhook.kafka.sources.knative.dev
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -437,6 +440,7 @@ webhooks:
       namespace: knative-eventing
   failurePolicy: Fail
   name: config.webhook.kafka.sources.knative.dev
+  sideEffects: None
   namespaceSelector:
     matchExpressions:
     - key: contrib.eventing.knative.dev/release


### PR DESCRIPTION
As per title. This gets rid of logs like 

```
W0215 01:13:47.481553       1 warnings.go:67] admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration
```

/assign @matzew @aliok 