### PR TITLE
Drop deprecated injectors in controller-runtime

### DIFF
--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -107,27 +107,13 @@ func main() {
 	}
 
 	// Serving Webhooks
-	hookServer.Register("/mutate-knativeservings", &webhook.Admission{Handler: &knativeserving.Configurator{
-		Client:  mgr.GetClient(),
-		Decoder: decoder,
-	}})
-	hookServer.Register("/validate-knativeservings", &webhook.Admission{Handler: &knativeserving.Validator{
-		Client:  mgr.GetClient(),
-		Decoder: decoder,
-	}})
+	hookServer.Register("/mutate-knativeservings", &webhook.Admission{Handler: knativeserving.NewConfigurator(mgr.GetClient(), decoder)})
+	hookServer.Register("/validate-knativeservings", &webhook.Admission{Handler: knativeserving.NewValidator(mgr.GetClient(), decoder)})
 	// Eventing Webhooks
-	hookServer.Register("/mutate-knativeeventings", &webhook.Admission{Handler: &knativeeventing.Configurator{
-		Decoder: decoder,
-	}})
-	hookServer.Register("/validate-knativeeventings", &webhook.Admission{Handler: &knativeeventing.Validator{
-		Client:  mgr.GetClient(),
-		Decoder: decoder,
-	}})
+	hookServer.Register("/mutate-knativeeventings", &webhook.Admission{Handler: knativeeventing.NewConfigurator(decoder)})
+	hookServer.Register("/validate-knativeeventings", &webhook.Admission{Handler: knativeeventing.NewValidator(mgr.GetClient(), decoder)})
 	// Kafka Webhooks
-	hookServer.Register("/validate-knativekafkas", &webhook.Admission{Handler: &knativekafka.Validator{
-		Client:  mgr.GetClient(),
-		Decoder: decoder,
-	}})
+	hookServer.Register("/validate-knativekafkas", &webhook.Admission{Handler: knativekafka.NewValidator(mgr.GetClient(), decoder)})
 
 	if err := setupMonitoring(cfg); err != nil {
 		log.Error(err, "Failed to start monitoring")

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go
@@ -12,7 +12,7 @@ import (
 
 // Configurator annotates KEs
 type Configurator struct {
-	decoder *admission.Decoder
+	Decoder *admission.Decoder
 }
 
 // Implement admission.Handler so the controller can handle admission request.
@@ -23,7 +23,7 @@ var _ admission.Handler = (*Configurator)(nil)
 func (v *Configurator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	ke := &eventingv1alpha1.KnativeEventing{}
 
-	err := v.decoder.Decode(req, ke)
+	err := v.Decoder.Decode(req, ke)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
@@ -35,14 +35,4 @@ func (v *Configurator) Handle(ctx context.Context, req admission.Request) admiss
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	return admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshaled)
-}
-
-// Configurator implements inject.Decoder.
-// A decoder will be automatically injected.
-var _ admission.DecoderInjector = (*Configurator)(nil)
-
-// InjectDecoder injects the decoder.
-func (v *Configurator) InjectDecoder(d *admission.Decoder) error {
-	v.decoder = d
-	return nil
 }

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go
@@ -12,7 +12,14 @@ import (
 
 // Configurator annotates KEs
 type Configurator struct {
-	Decoder *admission.Decoder
+	decoder *admission.Decoder
+}
+
+// NewConfigurator creates a new Configurator instance to configure KnativeEventing CRs.
+func NewConfigurator(decoder *admission.Decoder) *Configurator {
+	return &Configurator{
+		decoder: decoder,
+	}
 }
 
 // Implement admission.Handler so the controller can handle admission request.
@@ -23,7 +30,7 @@ var _ admission.Handler = (*Configurator)(nil)
 func (v *Configurator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	ke := &eventingv1alpha1.KnativeEventing{}
 
-	err := v.Decoder.Decode(req, ke)
+	err := v.decoder.Decode(req, ke)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
@@ -9,14 +9,13 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // Validator validates KnativeEventing CR's
 type Validator struct {
-	client  client.Client
-	decoder *admission.Decoder
+	Client  client.Client
+	Decoder *admission.Decoder
 }
 
 // Implement admission.Handler so the controller can handle admission request.
@@ -26,7 +25,7 @@ var _ admission.Handler = (*Validator)(nil)
 func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	ke := &eventingv1alpha1.KnativeEventing{}
 
-	err := v.decoder.Decode(req, ke)
+	err := v.Decoder.Decode(req, ke)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
@@ -61,26 +60,6 @@ func (v *Validator) validate(ctx context.Context, ke *eventingv1alpha1.KnativeEv
 	return
 }
 
-// Validator implements inject.Client.
-// A client will be automatically injected.
-var _ inject.Client = (*Validator)(nil)
-
-// InjectClient injects the client.
-func (v *Validator) InjectClient(c client.Client) error {
-	v.client = c
-	return nil
-}
-
-// Validator implements inject.Decoder.
-// A decoder will be automatically injected.
-var _ admission.DecoderInjector = (*Validator)(nil)
-
-// InjectDecoder injects the decoder.
-func (v *Validator) InjectDecoder(d *admission.Decoder) error {
-	v.decoder = d
-	return nil
-}
-
 // validate required namespace, if any
 func (v *Validator) validateNamespace(ctx context.Context, ke *eventingv1alpha1.KnativeEventing) (bool, string, error) {
 	ns, required := os.LookupEnv("REQUIRED_EVENTING_NAMESPACE")
@@ -93,7 +72,7 @@ func (v *Validator) validateNamespace(ctx context.Context, ke *eventingv1alpha1.
 // validate this is the only KE in this namespace
 func (v *Validator) validateLoneliness(ctx context.Context, ke *eventingv1alpha1.KnativeEventing) (bool, string, error) {
 	list := &eventingv1alpha1.KnativeEventingList{}
-	if err := v.client.List(ctx, list, &client.ListOptions{Namespace: ke.Namespace}); err != nil {
+	if err := v.Client.List(ctx, list, &client.ListOptions{Namespace: ke.Namespace}); err != nil {
 		return false, "Unable to list KnativeEventings", err
 	}
 	for _, v := range list.Items {

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
@@ -38,8 +38,9 @@ func TestInvalidNamespace(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_EVENTING_NAMESPACE", "knative-eventing")
 
-	validator := Validator{}
-	validator.InjectDecoder(decoder)
+	validator := Validator{
+		Decoder: decoder,
+	}
 
 	req, err := testutil.RequestFor(ke1)
 	if err != nil {
@@ -55,9 +56,10 @@ func TestInvalidNamespace(t *testing.T) {
 func TestLoneliness(t *testing.T) {
 	os.Clearenv()
 
-	validator := Validator{}
-	validator.InjectDecoder(decoder)
-	validator.InjectClient(fake.NewClientBuilder().WithObjects(ke2).Build())
+	validator := Validator{
+		Client:  fake.NewClientBuilder().WithObjects(ke2).Build(),
+		Decoder: decoder,
+	}
 
 	req, err := testutil.RequestFor(ke1)
 	if err != nil {

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
@@ -38,9 +38,7 @@ func TestInvalidNamespace(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_EVENTING_NAMESPACE", "knative-eventing")
 
-	validator := Validator{
-		Decoder: decoder,
-	}
+	validator := NewValidator(nil, decoder)
 
 	req, err := testutil.RequestFor(ke1)
 	if err != nil {
@@ -56,10 +54,7 @@ func TestInvalidNamespace(t *testing.T) {
 func TestLoneliness(t *testing.T) {
 	os.Clearenv()
 
-	validator := Validator{
-		Client:  fake.NewClientBuilder().WithObjects(ke2).Build(),
-		Decoder: decoder,
-	}
+	validator := NewValidator(fake.NewClientBuilder().WithObjects(ke2).Build(), decoder)
 
 	req, err := testutil.RequestFor(ke1)
 	if err != nil {

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating.go
@@ -15,8 +15,16 @@ import (
 
 // Validator validates KnativeKafka CR's
 type Validator struct {
-	Client  client.Client
-	Decoder *admission.Decoder
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+// NewValidator creates a new Valicator instance to validate KnativeKafka CRs.
+func NewValidator(client client.Client, decoder *admission.Decoder) *Validator {
+	return &Validator{
+		client:  client,
+		decoder: decoder,
+	}
 }
 
 // Implement admission.Handler so the controller can handle admission request.
@@ -26,7 +34,7 @@ var _ admission.Handler = (*Validator)(nil)
 func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	ke := &operatorv1alpha1.KnativeKafka{}
 
-	err := v.Decoder.Decode(req, ke)
+	err := v.decoder.Decode(req, ke)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
@@ -75,7 +83,7 @@ func (v *Validator) validateNamespace(ctx context.Context, ke *operatorv1alpha1.
 // validate this is the only KE in this namespace
 func (v *Validator) validateLoneliness(ctx context.Context, ke *operatorv1alpha1.KnativeKafka) (bool, string, error) {
 	list := &operatorv1alpha1.KnativeKafkaList{}
-	if err := v.Client.List(ctx, list, &client.ListOptions{Namespace: ke.Namespace}); err != nil {
+	if err := v.client.List(ctx, list, &client.ListOptions{Namespace: ke.Namespace}); err != nil {
 		return false, "Unable to list KnativeKafkas", err
 	}
 	for _, v := range list.Items {
@@ -104,7 +112,7 @@ func (v *Validator) validateShape(_ context.Context, ke *operatorv1alpha1.Knativ
 func (v *Validator) validateDependencies(ctx context.Context, ke *operatorv1alpha1.KnativeKafka) (bool, string, error) {
 	// check to see if we can find KnativeEventing
 	list := &eventingv1alpha1.KnativeEventingList{}
-	if err := v.Client.List(ctx, list, &client.ListOptions{Namespace: ke.Namespace}); err != nil {
+	if err := v.client.List(ctx, list, &client.ListOptions{Namespace: ke.Namespace}); err != nil {
 		return false, "Unable to list KnativeEventing instance", err
 	}
 	if len(list.Items) == 0 {

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
@@ -128,9 +128,10 @@ func TestHappy(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_KAFKA_NAMESPACE", "knative-eventing")
 
-	validator := Validator{}
-	validator.InjectDecoder(decoder)
-	validator.InjectClient(fake.NewClientBuilder().WithObjects(validKnativeEventingCR).Build())
+	validator := Validator{
+		Decoder: decoder,
+		Client:  fake.NewClientBuilder().WithObjects(validKnativeEventingCR).Build(),
+	}
 
 	req, err := testutil.RequestFor(defaultCR)
 	if err != nil {
@@ -147,9 +148,10 @@ func TestInvalidNamespace(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_KAFKA_NAMESPACE", "knative-eventing")
 
-	validator := Validator{}
-	validator.InjectDecoder(decoder)
-	validator.InjectClient(fake.NewClientBuilder().WithObjects(validKnativeEventingCR).Build())
+	validator := Validator{
+		Decoder: decoder,
+		Client:  fake.NewClientBuilder().WithObjects(validKnativeEventingCR).Build(),
+	}
 
 	req, err := testutil.RequestFor(invalidNamespaceCR)
 	if err != nil {
@@ -166,9 +168,10 @@ func TestLoneliness(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_KAFKA_NAMESPACE", "knative-eventing")
 
-	validator := Validator{}
-	validator.InjectDecoder(decoder)
-	validator.InjectClient(fake.NewClientBuilder().WithObjects(duplicateCR, validKnativeEventingCR).Build())
+	validator := Validator{
+		Decoder: decoder,
+		Client:  fake.NewClientBuilder().WithObjects(duplicateCR, validKnativeEventingCR).Build(),
+	}
 
 	req, err := testutil.RequestFor(defaultCR)
 	if err != nil {
@@ -185,9 +188,10 @@ func TestInvalidShape(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_KAFKA_NAMESPACE", "knative-eventing")
 
-	validator := Validator{}
-	validator.InjectDecoder(decoder)
-	validator.InjectClient(fake.NewClientBuilder().WithObjects(validKnativeEventingCR).Build())
+	validator := Validator{
+		Decoder: decoder,
+		Client:  fake.NewClientBuilder().WithObjects(duplicateCR, validKnativeEventingCR).Build(),
+	}
 
 	for _, cr := range invalidShapeCRs {
 		req, err := testutil.RequestFor(&cr)
@@ -206,9 +210,10 @@ func TestValidateDeps(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_KAFKA_NAMESPACE", "knative-eventing")
 
-	validator := Validator{}
-	validator.InjectDecoder(decoder)
-	validator.InjectClient(fake.NewClientBuilder().Build())
+	validator := Validator{
+		Decoder: decoder,
+		Client:  fake.NewClientBuilder().Build(),
+	}
 
 	req, err := testutil.RequestFor(defaultCR)
 	if err != nil {

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
@@ -128,10 +128,9 @@ func TestHappy(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_KAFKA_NAMESPACE", "knative-eventing")
 
-	validator := Validator{
-		Decoder: decoder,
-		Client:  fake.NewClientBuilder().WithObjects(validKnativeEventingCR).Build(),
-	}
+	validator := NewValidator(
+		fake.NewClientBuilder().WithObjects(validKnativeEventingCR).Build(),
+		decoder)
 
 	req, err := testutil.RequestFor(defaultCR)
 	if err != nil {
@@ -148,10 +147,9 @@ func TestInvalidNamespace(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_KAFKA_NAMESPACE", "knative-eventing")
 
-	validator := Validator{
-		Decoder: decoder,
-		Client:  fake.NewClientBuilder().WithObjects(validKnativeEventingCR).Build(),
-	}
+	validator := NewValidator(
+		fake.NewClientBuilder().WithObjects(validKnativeEventingCR).Build(),
+		decoder)
 
 	req, err := testutil.RequestFor(invalidNamespaceCR)
 	if err != nil {
@@ -168,10 +166,9 @@ func TestLoneliness(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_KAFKA_NAMESPACE", "knative-eventing")
 
-	validator := Validator{
-		Decoder: decoder,
-		Client:  fake.NewClientBuilder().WithObjects(duplicateCR, validKnativeEventingCR).Build(),
-	}
+	validator := NewValidator(
+		fake.NewClientBuilder().WithObjects(duplicateCR, validKnativeEventingCR).Build(),
+		decoder)
 
 	req, err := testutil.RequestFor(defaultCR)
 	if err != nil {
@@ -188,10 +185,9 @@ func TestInvalidShape(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_KAFKA_NAMESPACE", "knative-eventing")
 
-	validator := Validator{
-		Decoder: decoder,
-		Client:  fake.NewClientBuilder().WithObjects(duplicateCR, validKnativeEventingCR).Build(),
-	}
+	validator := NewValidator(
+		fake.NewClientBuilder().WithObjects(duplicateCR, validKnativeEventingCR).Build(),
+		decoder)
 
 	for _, cr := range invalidShapeCRs {
 		req, err := testutil.RequestFor(&cr)
@@ -210,10 +206,7 @@ func TestValidateDeps(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_KAFKA_NAMESPACE", "knative-eventing")
 
-	validator := Validator{
-		Decoder: decoder,
-		Client:  fake.NewClientBuilder().Build(),
-	}
+	validator := NewValidator(fake.NewClientBuilder().Build(), decoder)
 
 	req, err := testutil.RequestFor(defaultCR)
 	if err != nil {

--- a/knative-operator/pkg/webhook/knativeserving/webhook_mutating.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_mutating.go
@@ -13,8 +13,16 @@ import (
 
 // Configurator annotates Kss
 type Configurator struct {
-	Client  client.Client
-	Decoder *admission.Decoder
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+// NewConfigurator creates a new Configurator instance to configure KnativeServing CRs.
+func NewConfigurator(client client.Client, decoder *admission.Decoder) *Configurator {
+	return &Configurator{
+		client:  client,
+		decoder: decoder,
+	}
 }
 
 // Implement admission.Handler so the controller can handle admission request.
@@ -25,12 +33,12 @@ var _ admission.Handler = (*Configurator)(nil)
 func (v *Configurator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	ks := &servingv1alpha1.KnativeServing{}
 
-	err := v.Decoder.Decode(req, ks)
+	err := v.decoder.Decode(req, ks)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	err = common.Mutate(ks, v.Client)
+	err = common.Mutate(ks, v.client)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
@@ -38,8 +38,9 @@ func TestInvalidNamespace(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_SERVING_NAMESPACE", "knative-serving")
 
-	validator := Validator{}
-	validator.InjectDecoder(decoder)
+	validator := Validator{
+		Decoder: decoder,
+	}
 
 	req, err := testutil.RequestFor(ks1)
 	if err != nil {
@@ -55,9 +56,10 @@ func TestInvalidNamespace(t *testing.T) {
 func TestLoneliness(t *testing.T) {
 	os.Clearenv()
 
-	validator := Validator{}
-	validator.InjectDecoder(decoder)
-	validator.InjectClient(fake.NewClientBuilder().WithObjects(ks2).Build())
+	validator := Validator{
+		Decoder: decoder,
+		Client:  fake.NewClientBuilder().WithObjects(ks2).Build(),
+	}
 
 	req, err := testutil.RequestFor(ks1)
 	if err != nil {

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
@@ -38,9 +38,7 @@ func TestInvalidNamespace(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("REQUIRED_SERVING_NAMESPACE", "knative-serving")
 
-	validator := Validator{
-		Decoder: decoder,
-	}
+	validator := NewValidator(nil, decoder)
 
 	req, err := testutil.RequestFor(ks1)
 	if err != nil {
@@ -56,10 +54,7 @@ func TestInvalidNamespace(t *testing.T) {
 func TestLoneliness(t *testing.T) {
 	os.Clearenv()
 
-	validator := Validator{
-		Decoder: decoder,
-		Client:  fake.NewClientBuilder().WithObjects(ks2).Build(),
-	}
+	validator := NewValidator(fake.NewClientBuilder().WithObjects(ks2).Build(), decoder)
 
 	req, err := testutil.RequestFor(ks1)
 	if err != nil {


### PR DESCRIPTION
As per title, this avoids log messages like

```
{"level":"info","ts":"2021-02-15T01:05:49.875Z","logger":"controller-runtime.injectors-warning","msg":"Injectors are deprecated, and will be removed in v0.10.x"}
```

And make us future proof :).