### PR TITLE
Upgrade tests - re-enable -race and increase log level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24
 	knative.dev/networking v0.0.0-20210107024535-ecb89ced52d9
 	knative.dev/operator v0.20.1
-	knative.dev/pkg v0.0.0-20210107022335-51c72e24c179
+	knative.dev/pkg v0.0.0-20210217160502-b7d7ff183788
 	knative.dev/serving v0.20.0
 	sigs.k8s.io/controller-runtime v0.8.1
 	sigs.k8s.io/yaml v1.2.0
@@ -54,5 +54,5 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
 	knative.dev/eventing => github.com/openshift/knative-eventing v0.99.1-0.20210212083459-1f8c3e444cf5
 	knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20210202142951-dd8077f58870
-	knative.dev/serving => github.com/openshift/knative-serving v0.10.1-0.20210127081219-6330eae520d2
+	knative.dev/serving => github.com/openshift/knative-serving v0.10.1-0.20210301102056-4e0f782522f1
 )

--- a/go.sum
+++ b/go.sum
@@ -874,8 +874,8 @@ github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47 h1:+TEY29DK0Xh
 github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47/go.mod h1:u7NRAjtYVAKokiI9LouzTv4mhds8P4S1TwdVAfbjKSk=
 github.com/openshift/knative-eventing v0.99.1-0.20210212083459-1f8c3e444cf5 h1:Zwuj4m0QWbWwgLzIjTXnT+kikkhjOHL8cTFZ7MRIMhY=
 github.com/openshift/knative-eventing v0.99.1-0.20210212083459-1f8c3e444cf5/go.mod h1:7KjOHRQTPqsH0y1NbQLnboZeWJWVTztQVd/0lFCmz7A=
-github.com/openshift/knative-serving v0.10.1-0.20210127081219-6330eae520d2 h1:73MxYyGe1wQJro6nNDXa0oH989GxCvm8vk+RVVDc3TQ=
-github.com/openshift/knative-serving v0.10.1-0.20210127081219-6330eae520d2/go.mod h1:357cOGGPTY1aNqbDeyr35/LvYn1yc0WCe0EQLTNN8Mc=
+github.com/openshift/knative-serving v0.10.1-0.20210301102056-4e0f782522f1 h1:IwdTDL+7L9Wi+I2lwIXmaOhGIuMCifglZQ5/Q3n8miU=
+github.com/openshift/knative-serving v0.10.1-0.20210301102056-4e0f782522f1/go.mod h1:CjfTUUhh2KCQaUV3epHFu3SHPCMRRYh6VBn+C3QbSmk=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -1723,6 +1723,8 @@ knative.dev/operator v0.20.1/go.mod h1:84arZGjkCDZzOY6oumgAPI/ffaOmJoNma9HptEKMI
 knative.dev/pkg v0.0.0-20201224024804-27db5ac24cfb/go.mod h1:hckgW978SdzPA2H5EDvRPY8xsnPuDZLJLbPf8Jte7Q0=
 knative.dev/pkg v0.0.0-20210107022335-51c72e24c179 h1:lkrgrv69iUk2qhOG9symy15kJUaJZmMybSloi7C3gIw=
 knative.dev/pkg v0.0.0-20210107022335-51c72e24c179/go.mod h1:hckgW978SdzPA2H5EDvRPY8xsnPuDZLJLbPf8Jte7Q0=
+knative.dev/pkg v0.0.0-20210217160502-b7d7ff183788 h1:cAJhicFIoAcL/oMR2HpNz9rOXBJjPPCRS+h5oVe07Ak=
+knative.dev/pkg v0.0.0-20210217160502-b7d7ff183788/go.mod h1:hckgW978SdzPA2H5EDvRPY8xsnPuDZLJLbPf8Jte7Q0=
 knative.dev/reconciler-test v0.0.0-20210108100436-db4d65735605/go.mod h1:rmQpZseeqDpg6/ToFzIeV5hTRkOJujaXBCK7iYL7M4E=
 pgregory.net/rapid v0.3.3 h1:jCjBsY4ln4Atz78QoBWxUEvAHaFyNDQg9+WU62aCn1U=
 pgregory.net/rapid v0.3.3/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -47,7 +47,7 @@ function go_test_e2e {
     [[ -n "$arg" ]] && go_test_args+=("$arg")
   done
   set +Eeuo pipefail
-  report_go_test -count=1 "${go_test_args[@]}"
+  report_go_test -race -count=1 "${go_test_args[@]}"
   retcode=$?
   set -Eeuo pipefail
 
@@ -77,7 +77,7 @@ function serverless_operator_e2e_tests {
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
-  go_test_e2e -race -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2e \
+  go_test_e2e -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2e \
     --channel "$OLM_CHANNEL" \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@"
@@ -96,7 +96,7 @@ function serverless_operator_kafka_e2e_tests {
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
-  go_test_e2e -race -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2ekafka \
+  go_test_e2e -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2ekafka \
     --channel "$OLM_CHANNEL" \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@"
@@ -116,7 +116,7 @@ function downstream_serving_e2e_tests {
   # Add system-namespace labels for TestNetworkPolicy and ServiceMesh tests.
   add_systemnamespace_label
 
-  go_test_e2e -race -failfast -timeout=60m -parallel=1 ./test/servinge2e \
+  go_test_e2e -failfast -timeout=60m -parallel=1 ./test/servinge2e \
     --kubeconfig "${kubeconfigs[0]}" \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@"
@@ -133,7 +133,7 @@ function downstream_eventing_e2e_tests {
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
-  go_test_e2e -race -failfast -timeout=30m -parallel=1 ./test/eventinge2e \
+  go_test_e2e -failfast -timeout=30m -parallel=1 ./test/eventinge2e \
     --kubeconfig "${kubeconfigs[0]}" \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@"
@@ -150,7 +150,7 @@ function downstream_knative_kafka_e2e_tests {
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
-  go_test_e2e -race -failfast -timeout=30m -parallel=1 ./test/extensione2e/kafka \
+  go_test_e2e -failfast -timeout=30m -parallel=1 ./test/extensione2e/kafka \
     --kubeconfig "${kubeconfigs[0]}" \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@"
@@ -167,7 +167,7 @@ function downstream_monitoring_e2e_tests {
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
-  go_test_e2e -race -failfast -timeout=30m -parallel=1 ./test/monitoringe2e \
+  go_test_e2e -failfast -timeout=30m -parallel=1 ./test/monitoringe2e \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@"
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -204,6 +204,7 @@ function run_rolling_upgrade_tests {
   E2E_UPGRADE_TESTS_SERVING_USE=true \
   E2E_UPGRADE_TESTS_CONFIGMOUNTPOINT=/.config/wathola \
   E2E_UPGRADE_TESTS_INTERVAL="50ms" \
+  GO_TEST_VERBOSITY=standard-verbose \
   SYSTEM_NAMESPACE=knative-serving \
   go_test_e2e -tags=upgrade -timeout=30m \
     ./test/upgrade \

--- a/vendor/knative.dev/pkg/metrics/resource_view.go
+++ b/vendor/knative.dev/pkg/metrics/resource_view.go
@@ -82,10 +82,16 @@ func cleanup() {
 	expiryCutoff := allMeters.clock.Now().Add(-1 * maxMeterExporterAge)
 	allMeters.lock.Lock()
 	defer allMeters.lock.Unlock()
+	resourceViews.lock.Lock()
+	defer resourceViews.lock.Unlock()
 	for key, meter := range allMeters.meters {
 		if key != "" && meter.t.Before(expiryCutoff) {
 			flushGivenExporter(meter.e)
+			// Make a copy of views to avoid data races
+			viewsCopy := copyViews(resourceViews.views)
+			meter.m.Unregister(viewsCopy...)
 			delete(allMeters.meters, key)
+			meter.m.Stop()
 		}
 	}
 }
@@ -139,7 +145,7 @@ func RegisterResourceView(views ...*view.View) error {
 	return nil
 }
 
-// UnregisterResourceView is similar to view.Unregiste(), except that it will
+// UnregisterResourceView is similar to view.Unregister(), except that it will
 // unregister the view across all Resources tracked byt he system, rather than
 // simply the default view.
 func UnregisterResourceView(views ...*view.View) {

--- a/vendor/knative.dev/serving/test/upgrade/probe.go
+++ b/vendor/knative.dev/serving/test/upgrade/probe.go
@@ -51,7 +51,7 @@ func ProbeTest() pkgupgrade.BackgroundOperation {
 			// This polls until we get a 200 with the right body.
 			assertServiceResourcesUpdated(c.T, clients, *names, url, test.PizzaPlanetText1)
 
-			prober = test.RunRouteProber(c.T.Logf, clients, url, test.AddRootCAtoTransport(context.Background(), c.T.Logf, clients, test.ServingFlags.HTTPS))
+			prober = test.RunRouteProber(c.Log.Infof, clients, url, test.AddRootCAtoTransport(context.Background(), c.T.Logf, clients, test.ServingFlags.HTTPS))
 		},
 		func(c pkgupgrade.Context) {
 			// Verify

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1158,7 +1158,7 @@ knative.dev/operator/pkg/reconciler/knativeeventing
 knative.dev/operator/pkg/reconciler/knativeeventing/common
 knative.dev/operator/pkg/reconciler/knativeserving
 knative.dev/operator/pkg/reconciler/knativeserving/common
-# knative.dev/pkg v0.0.0-20210107022335-51c72e24c179
+# knative.dev/pkg v0.0.0-20210217160502-b7d7ff183788
 ## explicit
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck
@@ -1231,7 +1231,7 @@ knative.dev/pkg/version
 knative.dev/pkg/webhook
 knative.dev/pkg/webhook/certificates/resources
 knative.dev/pkg/webhook/resourcesemantics
-# knative.dev/serving v0.20.0 => github.com/openshift/knative-serving v0.10.1-0.20210127081219-6330eae520d2
+# knative.dev/serving v0.20.0 => github.com/openshift/knative-serving v0.10.1-0.20210301102056-4e0f782522f1
 ## explicit
 knative.dev/serving/pkg/apis/autoscaling
 knative.dev/serving/pkg/apis/autoscaling/v1alpha1
@@ -1313,4 +1313,4 @@ sigs.k8s.io/yaml
 # k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
 # knative.dev/eventing => github.com/openshift/knative-eventing v0.99.1-0.20210212083459-1f8c3e444cf5
 # knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20210202142951-dd8077f58870
-# knative.dev/serving => github.com/openshift/knative-serving v0.10.1-0.20210127081219-6330eae520d2
+# knative.dev/serving => github.com/openshift/knative-serving v0.10.1-0.20210301102056-4e0f782522f1


### PR DESCRIPTION
Updated deps to get the midstream fix for the Prober test which was causing race conditions and re-enabled -race because now it should work without problems.