### PR TITLE
Run custom domain test with coformance test

### DIFF
--- a/test/serving.bash
+++ b/test/serving.bash
@@ -61,15 +61,9 @@ function upstream_knative_serving_e2e_and_conformance_tests {
   fi
 
   SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel \
-    ./test/e2e ./test/conformance/api/v1/... ./test/conformance/runtime/... \
+    ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     --resolvabledomain --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$image_template"
-
-  # Test new features especially DomainMapping without resolvabledomain.
-  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel \
-    ./test/conformance/api/v1alpha1/... \
-    --kubeconfig "$KUBECONFIG" \
-    --imagetemplate "$image_template" \
     --enable-beta \
     --enable-alpha
 

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -63,7 +63,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
   SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     --resolvabledomain --kubeconfig "$KUBECONFIG" \
-    --imagetemplate "$image_template"
+    --imagetemplate "$image_template" \
     --enable-beta \
     --enable-alpha
 


### PR DESCRIPTION
Since serving v0.20+, `ResolvableDomain` flag is separated from custom domain.
Please refer to https://github.com/knative/serving/commit/82b59914fb9727f040b4d58073b2e6049b2d4583.

Hence the conformance test should be able to run with customdomain and
other tests.