### PR TITLE
[SRVKS-590] Don't reconcile KS/KE if placed in the wrong namespace.

### DIFF
--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -28,7 +28,7 @@ const (
 	// This needs to remain "knative-eventing-openshift" to be compatible with earlier versions.
 	finalizerName = "knative-eventing-openshift"
 
-	requiredNsKey = "REQUIRED_EVENTING_NAMESPACE"
+	requiredNsEnvName = "REQUIRED_EVENTING_NAMESPACE"
 )
 
 var log = common.Log.WithName("controller")
@@ -44,7 +44,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	client := mgr.GetClient()
 
 	// Create required namespace first.
-	if ns, required := os.LookupEnv(requiredNsKey); required {
+	if ns, required := os.LookupEnv(requiredNsEnvName); required {
 		client.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 			Name: ns,
 		}})
@@ -65,8 +65,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource KnativeEventing
+	requiredNs := os.Getenv(requiredNsEnvName)
 	return c.Watch(&source.Kind{Type: &eventingv1alpha1.KnativeEventing{}}, &handler.EnqueueRequestForObject{}, predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		requiredNs := os.Getenv(requiredNsKey)
 		if requiredNs == "" {
 			return true
 		}

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -88,13 +88,6 @@ type ReconcileKnativeEventing struct {
 // Reconcile reads that state of the cluster for a KnativeEventing
 func (r *ReconcileKnativeEventing) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-
-	// Immediately abort reconcilation if not in the correct namespace.
-	requiredNs := os.Getenv(requiredNsKey)
-	if requiredNs != "" && request.Namespace != requiredNs {
-		return reconcile.Result{}, nil
-	}
-
 	reqLogger.Info("Reconciling KnativeEventing")
 
 	// Fetch the KnativeEventing instance

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -45,6 +46,8 @@ const (
 	// certVersionKey is an annotation key used by the Serverless operator to annotate the Knative Serving
 	// controller's PodTemplate to make it redeploy on certificate changes.
 	certVersionKey = "serving.knative.openshift.io/mounted-cert-version"
+
+	requiredNsKey = "REQUIRED_SERVING_NAMESPACE"
 )
 
 var log = common.Log.WithName("controller")
@@ -60,7 +63,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	client := mgr.GetClient()
 
 	// Create required namespace first.
-	if ns, required := os.LookupEnv("REQUIRED_SERVING_NAMESPACE"); required {
+	if ns, required := os.LookupEnv(requiredNsKey); required {
 		client.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 			Name: ns,
 		}})
@@ -80,8 +83,14 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for changes to primary resource KnativeServing
-	err = c.Watch(&source.Kind{Type: &servingv1alpha1.KnativeServing{}}, &handler.EnqueueRequestForObject{})
+	// Watch for changes to primary resource KnativeServing, only in the expected namespace.
+	err = c.Watch(&source.Kind{Type: &servingv1alpha1.KnativeServing{}}, &handler.EnqueueRequestForObject{}, predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		requiredNs := os.Getenv(requiredNsKey)
+		if requiredNs == "" {
+			return true
+		}
+		return obj.GetNamespace() == requiredNs
+	}))
 	if err != nil {
 		return err
 	}

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -300,6 +300,10 @@ spec:
                             fieldPath: metadata.namespace
                       - name: METRICS_DOMAIN
                         value: knative.dev/serving-operator
+                      - name: REQUIRED_SERVING_NAMESPACE
+                        value: "knative-serving"
+                      - name: REQUIRED_EVENTING_NAMESPACE
+                        value: "knative-eventing"
                       - name: "IMAGE_queue-proxy"
                         value: "registry.ci.openshift.org/openshift/knative-v0.20.0:knative-serving-queue"
                       - name: "IMAGE_activator"

--- a/openshift-knative-operator/pkg/eventing/extension.go
+++ b/openshift-knative-operator/pkg/eventing/extension.go
@@ -13,7 +13,7 @@ import (
 	"knative.dev/pkg/controller"
 )
 
-const requiredNsKey = "REQUIRED_EVENTING_NAMESPACE"
+const requiredNsEnvName = "REQUIRED_EVENTING_NAMESPACE"
 
 // NewExtension creates a new extension for a Knative Eventing controller.
 func NewExtension(ctx context.Context) operator.Extension {
@@ -33,7 +33,7 @@ func (e *extension) Transformers(v1alpha1.KComponent) []mf.Transformer {
 func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) error {
 	ke := comp.(*v1alpha1.KnativeEventing)
 
-	requiredNs := os.Getenv(requiredNsKey)
+	requiredNs := os.Getenv(requiredNsEnvName)
 	if requiredNs != "" && ke.Namespace != requiredNs {
 		ke.Status.MarkInstallFailed(fmt.Sprintf("Knative Eventing must be installed into the namespace %q", requiredNs))
 		return controller.NewPermanentError(fmt.Errorf("deployed Knative Serving into unsupported namespace %q", ke.Namespace))

--- a/openshift-knative-operator/pkg/eventing/extension_test.go
+++ b/openshift-knative-operator/pkg/eventing/extension_test.go
@@ -19,7 +19,7 @@ const requiredNs = "knative-eventing"
 func TestReconcile(t *testing.T) {
 	os.Setenv("IMAGE_foo", "bar")
 	os.Setenv("IMAGE_default", "bar2")
-	os.Setenv(requiredNsKey, requiredNs)
+	os.Setenv(requiredNsEnvName, requiredNs)
 
 	cases := []struct {
 		name     string

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	loggingURLTemplate = "https://%s/app/kibana#/discover?_a=(index:.all,query:'kubernetes.labels.serving_knative_dev%%5C%%2FrevisionUID:${REVISION_UID}')"
-	requiredNsKey      = "REQUIRED_SERVING_NAMESPACE"
+	requiredNsEnvName  = "REQUIRED_SERVING_NAMESPACE"
 )
 
 // NewExtension creates a new extension for a Knative Serving controller.
@@ -49,7 +49,7 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	ks := comp.(*v1alpha1.KnativeServing)
 
 	// Make sure Knative Serving is always installed in the defined namespace.
-	requiredNs := os.Getenv(requiredNsKey)
+	requiredNs := os.Getenv(requiredNsEnvName)
 	if requiredNs != "" && ks.Namespace != requiredNs {
 		ks.Status.MarkInstallFailed(fmt.Sprintf("Knative Serving must be installed into the namespace %q", requiredNs))
 		return controller.NewPermanentError(fmt.Errorf("deployed Knative Serving into unsupported namespace %q", ks.Namespace))

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -16,9 +16,13 @@ import (
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	operator "knative.dev/operator/pkg/reconciler/common"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/controller"
 )
 
-const loggingURLTemplate = "https://%s/app/kibana#/discover?_a=(index:.all,query:'kubernetes.labels.serving_knative_dev%%5C%%2FrevisionUID:${REVISION_UID}')"
+const (
+	loggingURLTemplate = "https://%s/app/kibana#/discover?_a=(index:.all,query:'kubernetes.labels.serving_knative_dev%%5C%%2FrevisionUID:${REVISION_UID}')"
+	requiredNsKey      = "REQUIRED_SERVING_NAMESPACE"
+)
 
 // NewExtension creates a new extension for a Knative Serving controller.
 func NewExtension(ctx context.Context) operator.Extension {
@@ -43,6 +47,13 @@ func (e *extension) Transformers(ks v1alpha1.KComponent) []mf.Transformer {
 
 func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) error {
 	ks := comp.(*v1alpha1.KnativeServing)
+
+	// Make sure Knative Serving is always installed in the defined namespace.
+	requiredNs := os.Getenv(requiredNsKey)
+	if requiredNs != "" && ks.Namespace != requiredNs {
+		ks.Status.MarkInstallFailed(fmt.Sprintf("Knative Serving must be installed into the namespace %q", requiredNs))
+		return controller.NewPermanentError(fmt.Errorf("deployed Knative Serving into unsupported namespace %q", ks.Namespace))
+	}
 
 	// Mark the Kourier dependency as installing to avoid race conditions with readiness.
 	if ks.Status.GetCondition(v1alpha1.DependenciesInstalled).IsUnknown() {

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -43,7 +43,7 @@ func init() {
 	os.Setenv("IMAGE_foo", "bar")
 	os.Setenv("IMAGE_default", "bar2")
 	os.Setenv("IMAGE_queue-proxy", "baz")
-	os.Setenv(requiredNsKey, servingNamespace.Name)
+	os.Setenv(requiredNsEnvName, servingNamespace.Name)
 }
 
 func TestReconcile(t *testing.T) {

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -300,6 +300,10 @@ spec:
                       fieldPath: metadata.namespace
                 - name: METRICS_DOMAIN
                   value: knative.dev/serving-operator
+                - name: REQUIRED_SERVING_NAMESPACE
+                  value: "knative-serving"
+                - name: REQUIRED_EVENTING_NAMESPACE
+                  value: "knative-eventing"
                 # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                 image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
                 imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Apart from the checks in the webhooks, this aborts reconcilation for Knative Serving/Knative Eventing resources if they don't have been placed into the expected namespace. This can happen if the resources are placed before the webhook is up and similar cases. An error message is surfaced in the status of the resource.

/assign @skonto 