### PR TITLE
Cypress UI tests dependencies

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -14,4 +14,15 @@ RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
 RUN chmod g+rw /etc/passwd
 
 RUN yum install -y https://rpm.nodesource.com/pub_14.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
-RUN yum install -y gcc-c++ make nodejs
+RUN yum install -y \
+  gcc-c++ \
+  make \
+  nodejs \
+  xorg-x11-server-Xvfb \
+  gtk2-devel \
+  gtk3-devel \
+  libnotify-devel \
+  GConf2 \
+  nss \
+  libXScrnSaver \
+  alsa-lib

--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -14,4 +14,15 @@ RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
 RUN chmod g+rw /etc/passwd
 
 RUN yum install -y https://rpm.nodesource.com/pub___NODEJS_VERSION__/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
-RUN yum install -y gcc-c++ make nodejs
+RUN yum install -y \
+  gcc-c++ \
+  make \
+  nodejs \
+  xorg-x11-server-Xvfb \
+  gtk2-devel \
+  gtk3-devel \
+  libnotify-devel \
+  GConf2 \
+  nss \
+  libXScrnSaver \
+  alsa-lib


### PR DESCRIPTION
To be able to run Cypress UI tests we need to install required dependencies on the test runner.

Ref.: https://docs.cypress.io/guides/continuous-integration/introduction.html#Dependencies