### PR TITLE
Fixing Strmzi Install by doing kubectl create

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -4,10 +4,9 @@ function install_strimzi_operator {
   strimzi_version=$(curl https://github.com/strimzi/strimzi-kafka-operator/releases/latest |  awk -F 'tag/' '{print $2}' | awk -F '"' '{print $1}' 2>/dev/null)
   header "Installing Strimzi Kafka operator"
   oc create namespace kafka
-  oc -n kafka apply --selector strimzi.io/crd-install=true -f "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml"
   curl -L "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml" \
   | sed 's/namespace: .*/namespace: kafka/' \
-  | oc -n kafka apply -f -
+  | oc -n kafka create -f -
 
   # Wait for the CRD we need to actually be active
   oc wait crd --timeout=-1s kafkas.kafka.strimzi.io --for=condition=Established


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


Doing `create` since apply can not handle big objects (was a change on Strimzi). 
https://github.com/openshift-knative/serverless-operator/pull/850#discussion_r596735039

