### PR TITLE
Use --upgradechannel for passing the right channel for upgrade tests

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -210,7 +210,7 @@ function run_rolling_upgrade_tests {
     -channels="${channels}" \
     --kubeconfigs "${KUBECONFIG}" \
     --imagetemplate "${image_template}" \
-    --channel="${OLM_UPGRADE_CHANNEL}" \
+    --upgradechannel="${OLM_UPGRADE_CHANNEL}" \
     --csv="${CURRENT_CSV}" \
     --servingversion="${KNATIVE_SERVING_VERSION}" \
     --eventingversion="${KNATIVE_EVENTING_VERSION}" \


### PR DESCRIPTION
The `--channel` is for initial installation. We should use `--upgradechannel` for upgrade tests.