### PR TITLE
Increase cluster upgrade timeout to 3 hours

### DIFF
--- a/test/upgrade/installation/openshift.go
+++ b/test/upgrade/installation/openshift.go
@@ -62,7 +62,7 @@ func UpgradeOpenShift(ctx *test.Context) error {
 func WaitForClusterVersionState(ctx *test.Context, name string, inState func(s *configv1.ClusterVersion) bool) (*configv1.ClusterVersion, error) {
 	var lastState *configv1.ClusterVersion
 	var err error
-	waitErr := wait.PollImmediate(30*time.Second, 2*time.Hour, func() (bool, error) {
+	waitErr := wait.PollImmediate(30*time.Second, 3*time.Hour, func() (bool, error) {
 		lastState, err = ctx.Clients.ConfigClient.ClusterVersions().Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			ctx.T.Log("Ignoring error while waiting for ClusterVersion state:", err)


### PR DESCRIPTION
* some OpenShift cluster upgrades might take longer than 2 hours

The last upgrade I tried from OCP 4.7.2 to 4.7.4 took 2h 12m.

Note: Increasing the timeout shouldn't have any effect on the tests because cluster upgrade tests are only executed downstream (not in this repo).