### PR TITLE
Enable multi-arch support in operator

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -223,8 +223,20 @@ func populateKnConsoleCLIDownload(baseURL string, instance *servingv1alpha1.Knat
 			Description: "The OpenShift Serverless client `kn` is a CLI tool that allows you to fully manage OpenShift Serverless Serving and Eventing resources without writing a single line of YAML.",
 			Links: []consolev1.CLIDownloadLink{
 				{
-					Text: "Download kn for Linux",
+					Text: "Download kn for Linux for x86_64",
 					Href: baseURL + "/amd64/linux/kn-linux-amd64.tar.gz",
+				},
+				{
+					Text: "Download kn for Linux for IBM Power little endian",
+					Href: baseURL + "/ppc64le/linux/kn-linux-ppc64le.tar.gz",
+				},
+				{
+					Text: "Download kn for Linux for IBM Z",
+					Href: baseURL + "/s390x/linux/kn-linux-s390x.tar.gz",
+				},
+				{
+					Text: "Download kn for Linux for ARM 64 (unsupported)",
+					Href: baseURL + "/arm64/linux/kn-linux-arm64.tar.gz",
 				},
 				{
 					Text: "Download kn for macOS",

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -51,6 +51,10 @@ metadata:
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
     olm.skipRange: '>=1.13.0 <1.14.0'
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: serverless-operator.v1.14.0
   namespace: placeholder
 spec:

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -51,6 +51,10 @@ metadata:
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
     olm.skipRange:
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name:
   namespace: placeholder
 spec:

--- a/test/servinge2e/verify_deploy_resources_test.go
+++ b/test/servinge2e/verify_deploy_resources_test.go
@@ -59,7 +59,7 @@ func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
 			t.Fatalf("failed to HEAD request for URL %s, error: %v", link.Href, err)
 		}
 		if h.ContentLength < 1024*1024*10 {
-			t.Fatalf("failed to verify kn CCD, kn artifact %s size less than 10MB", link.Href)
+			t.Errorf("failed to verify kn CCD, kn artifact %s size %d less than 10MB", link.Href, h.ContentLength)
 		}
 	}
 }

--- a/test/servinge2e/verify_deploy_resources_test.go
+++ b/test/servinge2e/verify_deploy_resources_test.go
@@ -37,8 +37,8 @@ func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
 		t.Fatalf("unable to GET kn ConsoleCLIDownload CO 'kn': %v", err)
 	}
 	// Verify the links in kn CCD CO
-	if len(ccd.Spec.Links) != 3 {
-		t.Fatalf("expecting 3 links for artifacts for kn ConsoleCLIDownload, found %d", len(ccd.Spec.Links))
+	if len(ccd.Spec.Links) != 6 {
+		t.Fatalf("expecting 6 links for artifacts for kn ConsoleCLIDownload, found %d", len(ccd.Spec.Links))
 	}
 	// Verify if individual link starts with correct route
 	protocol := "https://"

--- a/test/servinge2e/verify_deploy_resources_test.go
+++ b/test/servinge2e/verify_deploy_resources_test.go
@@ -65,13 +65,13 @@ func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
 				g, err := client.Get(link.Href)
 				if err != nil {
 					t.Errorf("http get: %s", err)
-					defer g.Body.Close()
-					bytes, err := ioutil.ReadAll(g.Body)
-					if err != nil {
-						t.Errorf("%s", err.Error())
-					}
-					t.Errorf("%s", string(bytes))
 				}
+				defer g.Body.Close()
+				bytes, err := ioutil.ReadAll(g.Body)
+				if err != nil {
+					t.Errorf("%s", err.Error())
+				}
+				t.Errorf("%s", string(bytes))
 			}
 		}
 	}

--- a/test/servinge2e/verify_deploy_resources_test.go
+++ b/test/servinge2e/verify_deploy_resources_test.go
@@ -68,9 +68,9 @@ func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
 					defer g.Body.Close()
 					bytes, err := ioutil.ReadAll(g.Body)
 					if err != nil {
-						t.Errorf(err)
+						t.Errorf("%s", err.Error())
 					}
-					t.Errorf("%s", string(g.Body))
+					t.Errorf("%s", string(bytes))
 				}
 			}
 		}

--- a/test/servinge2e/verify_deploy_resources_test.go
+++ b/test/servinge2e/verify_deploy_resources_test.go
@@ -3,6 +3,7 @@ package servinge2e
 import (
 	"context"
 	"crypto/tls"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -60,6 +61,18 @@ func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
 		}
 		if h.ContentLength < 1024*1024*10 {
 			t.Errorf("failed to verify kn CCD, kn artifact %s size %d less than 10MB", link.Href, h.ContentLength)
+			if h.ContentLength < 5000 {
+				g, err := client.Get(link.Href)
+				if err != nil {
+					t.Errorf("http get: %s", err)
+					defer g.Body.Close()
+					bytes, err := ioutil.ReadAll(g.Body)
+					if err != nil {
+						t.Errorf(err)
+					}
+					t.Errorf("%s", string(g.Body))
+				}
+			}
 		}
 	}
 }

--- a/test/servinge2e/verify_deploy_resources_test.go
+++ b/test/servinge2e/verify_deploy_resources_test.go
@@ -3,7 +3,6 @@ package servinge2e
 import (
 	"context"
 	"crypto/tls"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -61,18 +60,6 @@ func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
 		}
 		if h.ContentLength < 1024*1024*10 {
 			t.Errorf("failed to verify kn CCD, kn artifact %s size %d less than 10MB", link.Href, h.ContentLength)
-			if h.ContentLength < 5000 {
-				g, err := client.Get(link.Href)
-				if err != nil {
-					t.Errorf("http get: %s", err)
-				}
-				defer g.Body.Close()
-				bytes, err := ioutil.ReadAll(g.Body)
-				if err != nil {
-					t.Errorf("%s", err.Error())
-				}
-				t.Errorf("%s", string(bytes))
-			}
 		}
 	}
 }


### PR DESCRIPTION
- Add links for Linux clients on other architectures
- Enable ppc64le and s390x in CSV

Replaces #840