### PR TITLE
[SRVKS-712] Add sidecar.istio.io/rewriteAppHTTPProbers annotation for TestKsvcWithServiceMeshJWTDefaultPolicy

### DIFF
--- a/test/servinge2e/servicemesh_test.go
+++ b/test/servinge2e/servicemesh_test.go
@@ -601,7 +601,8 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 
 		// Create a test ksvc, should be accessible only via proper JWT token
 		testKsvc := test.Service("jwt-test", testNamespace, image, map[string]string{
-			"sidecar.istio.io/inject": "true",
+			"sidecar.istio.io/inject":                "true",
+			"sidecar.istio.io/rewriteAppHTTPProbers": "true",
 		})
 		testKsvc = withServiceReadyOrFail(ctx, testKsvc)
 


### PR DESCRIPTION
This patch adds `sidecar.istio.io/rewriteAppHTTPProbers` annotation to
the Ksvc in TestKsvcWithServiceMeshJWTDefaultPolicy.

When JWT is enabled, HTTP requests is blocked by auth policy. So
rewriteAppHTTPProbers option lets sidecar redirect the request to
application.

/cc @markusthoemmes @maschmid @mgencur 