### PR TITLE
Fix memory usage unit

### DIFF
--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
@@ -154,7 +154,7 @@ data:
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total Memory Usage (rate per minute)",
+          "title": "Total Memory Usage (bytes)",
           "tooltip": {
             "shared": true,
             "sort": 2,

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-serving-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-serving-resources.yaml
@@ -168,7 +168,7 @@ data:
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total Memory Usage (rate per minute)",
+          "title": "Total Memory Usage (bytes)",
           "tooltip": {
             "shared": true,
             "sort": 2,


### PR DESCRIPTION
We don't use rate() for memory usage. [Memory usage (container_memory_usage_bytes)](https://github.com/google/cadvisor/blob/master/docs/storage/prometheus.md#prometheus-container-metrics) is measured via a gauge which cant be used with [rate()](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate) otherwise it would cause wrong results when gauge decreases. Thus the unit is wrong.
