### PR TITLE
Increase timeout for WaitForUnstructuredState

### DIFF
--- a/test/unstructured.go
+++ b/test/unstructured.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,7 +62,7 @@ func WaitForUnstructuredState(ctx *Context, schema schema.GroupVersionResource, 
 		lastState *unstructured.Unstructured
 		err       error
 	)
-	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
+	waitErr := wait.PollImmediate(Interval, 10*time.Minute, func() (bool, error) {
 		lastState, err = ctx.Clients.Dynamic.Resource(schema).Namespace(namespace).Get(context.Background(), name, meta.GetOptions{})
 		return inState(lastState, err)
 	})


### PR DESCRIPTION
* we might wait for ServiceMesh control plane which might take longer on
some platforms to start

Fix for the weekly job on Azure: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.7-azure-e2e-azure-ocp-47-continuous/1378497697421463552

The Grafana pod for ServiceMesh is being started as the last one. And in my tests I got the same failure on Azure for the first time. But any further attempt on the cluster was successful.