### PR TITLE
Fix update-deps script to properly handle forks

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -27,13 +27,16 @@ FLOATING_DEPS=(
   "github.com/openshift/client-go@${OCP_VERSION}"
   "github.com/operator-framework/operator-lifecycle-manager@${OCP_VERSION}"
 
-  "knative.dev/eventing-kafka@${EVENTING_KAFKA_VERSION}"
-  "knative.dev/eventing@${EVENTING_VERSION}"
   "knative.dev/hack@${KN_VERSION}"
   "knative.dev/networking@${KN_VERSION}"
   "knative.dev/operator@${KN_VERSION}"
   "knative.dev/pkg@${KN_VERSION}"
-  "knative.dev/serving@${SERVING_VERSION}"
+)
+
+FLOATING_FORK_DEPS=(
+  "knative.dev/eventing-kafka=github.com/openshift-knative/eventing-kafka@${EVENTING_KAFKA_VERSION}"
+  "knative.dev/eventing=github.com/openshift/knative-eventing@${EVENTING_VERSION}"
+  "knative.dev/serving=github.com/openshift/knative-serving@${SERVING_VERSION}"
 )
 
 # Parse flags to determine if we need to update our floating deps.
@@ -49,6 +52,13 @@ done
 readonly GO_GET
 
 if (( GO_GET )); then
+  # Treat forks specifically due to https://github.com/golang/go/issues/32721
+  for dep in "${FLOATING_FORK_DEPS[@]}"; do
+    go mod edit -replace "${dep}"
+    # Let the dependency update the magic SHA otherwise the
+    # following "go mod edit" will fail.
+    go mod vendor
+  done
   go get -d "${FLOATING_DEPS[@]}"
 fi
 


### PR DESCRIPTION
This PR fixes the problem from https://github.com/openshift-knative/serverless-operator/pull/802#issuecomment-815694940

Even with this PR the update-deps.sh scripts fails with the following error:
```
go: github.com/operator-framework/operator-lifecycle-manager imports
	helm.sh/helm/v3/cmd/helm imports
	github.com/docker/docker/pkg/term imports
	github.com/docker/docker/pkg/term/windows imports
	github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.8.1: parsing go.mod:
	module declares its path as: github.com/sirupsen/logrus
	        but was required as: github.com/Sirupsen/logrus

```
But it's unrelated and can be fixed separately. 