### PR TITLE
[main] Set KafkaChannel as default if INSTALL_KAFKA is true

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -44,7 +44,6 @@ function install_serverless_previous {
   fi
   if [[ $INSTALL_KAFKA == "true" ]]; then
     deploy_knativekafka_cr
-    ensure_kafka_channel_default
   fi
 
   logger.success "Previous version of Serverless is installed: $PREVIOUS_CSV"
@@ -62,7 +61,6 @@ function install_serverless_latest {
   fi
   if [[ $INSTALL_KAFKA == "true" ]]; then
     deploy_knativekafka_cr
-    ensure_kafka_channel_default
   fi
 
   logger.success "Latest version of Serverless is installed: $CURRENT_CSV"

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -26,6 +26,10 @@ fi
 # Run upgrade tests
 if [[ $TEST_KNATIVE_UPGRADE == true ]]; then
   install_serverless_previous
+  # Set KafkaChannel as default for upgrade tests.
+  if [[ $INSTALL_KAFKA == "true" ]]; then
+    ensure_kafka_channel_default
+  fi
   run_rolling_upgrade_tests
   trigger_gc_and_print_knative
   # Call teardown only if E2E tests follow.


### PR DESCRIPTION
This is required for upgrade tests so that Eventing Brokers use the KafkaChannel.