### PR TITLE
[main] Set E2E_UPGRADE_TESTS_FAILONERRORS=true as we're running with Kafka

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -203,6 +203,7 @@ function run_rolling_upgrade_tests {
   E2E_UPGRADE_TESTS_SERVING_USE=true \
   E2E_UPGRADE_TESTS_CONFIGMOUNTPOINT=/.config/wathola \
   E2E_UPGRADE_TESTS_INTERVAL="50ms" \
+  E2E_UPGRADE_TESTS_FAILONERRORS=true \
   GO_TEST_VERBOSITY=standard-verbose \
   SYSTEM_NAMESPACE=knative-serving \
   go_test_e2e -tags=upgrade -timeout=30m \


### PR DESCRIPTION
* https://issues.redhat.com/browse/SRVKE-593 should be fixed now