### PR TITLE
[SRVKS-676] Remove bridging code for label migration

### DIFF
--- a/serving/ingress/pkg/reconciler/ingress/controller.go
+++ b/serving/ingress/pkg/reconciler/ingress/controller.go
@@ -11,7 +11,6 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
-	"knative.dev/serving/pkg/apis/serving"
 
 	routeclient "github.com/openshift-knative/serverless-operator/pkg/client/injection/client"
 	routeinformer "github.com/openshift-knative/serverless-operator/pkg/client/injection/informers/route/v1/route"
@@ -47,15 +46,6 @@ func NewController(
 	ingressInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, kourierIngressClassName, false),
 		Handler:    controller.HandleAll(impl.Enqueue),
-	})
-
-	// We started using OpenShiftIngressLabelKey labels below but still handle resources with this labels for safety.
-	routeInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: reconciler.LabelExistsFilterFunc(networking.IngressLabelKey),
-		Handler: controller.HandleAll(impl.EnqueueLabelOfNamespaceScopedResource(
-			serving.RouteNamespaceLabelKey,
-			networking.IngressLabelKey,
-		)),
 	})
 
 	routeInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/serving/ingress/pkg/reconciler/ingress/ingress.go
+++ b/serving/ingress/pkg/reconciler/ingress/ingress.go
@@ -8,12 +8,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	ingressreconciler "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/ingress"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
-	"knative.dev/serving/pkg/apis/serving"
 
 	routev1client "github.com/openshift-knative/serverless-operator/pkg/client/clientset/versioned/typed/route/v1"
 	routev1lister "github.com/openshift-knative/serverless-operator/pkg/client/listers/route/v1"
@@ -117,23 +115,8 @@ func (r *Reconciler) reconcileRoute(ctx context.Context, desired *routev1.Route)
 func (r *Reconciler) routeList(ing *v1alpha1.Ingress) (map[string]*routev1.Route, error) {
 	routes := make(map[string]*routev1.Route)
 
-	ingressLabels := ing.GetLabels()
-	// List routes by upstream label. We started using OpenShiftIngressLabelKey labels but
-	// still use the labels for safety.
-	rs, err := r.routeLister.List(labels.SelectorFromSet(map[string]string{
-		networking.IngressLabelKey:     ing.GetName(),
-		serving.RouteLabelKey:          ingressLabels[serving.RouteLabelKey],
-		serving.RouteNamespaceLabelKey: ingressLabels[serving.RouteNamespaceLabelKey],
-	}))
-	if err != nil {
-		return nil, err
-	}
-	for _, r := range rs {
-		routes[r.Name] = r
-	}
-
 	// List routes by the downstream label.
-	rs, err = r.routeLister.List(labels.SelectorFromSet(map[string]string{
+	rs, err := r.routeLister.List(labels.SelectorFromSet(map[string]string{
 		resources.OpenShiftIngressLabelKey:          ing.GetName(),
 		resources.OpenShiftIngressNamespaceLabelKey: ing.GetNamespace(),
 	}))

--- a/serving/ingress/pkg/reconciler/ingress/ingress_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/ingress_test.go
@@ -182,21 +182,6 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", ingName),
 		},
-	}, {
-		// The new downstream label (OpenShiftIngressLabelKey) was introduced but Routes with old labels still should be reconciled.
-		Name:                    "reconcile only old labels",
-		SkipNamespaceValidation: true,
-		Key:                     key,
-		Objects: []runtime.Object{
-			ing(ingNamespace, ingName),
-			route(ingressNamespace, routeName, func(r *routev1.Route) {
-				delete(r.Labels, resources.OpenShiftIngressLabelKey)
-				delete(r.Labels, resources.OpenShiftIngressNamespaceLabelKey)
-			}), // Test without downstream labels.
-		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: route(ingressNamespace, routeName),
-		}},
 	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {


### PR DESCRIPTION
https://github.com/openshift-knative/serverless-operator/pull/763 started using `serving.knative.openshift.io/ingressName` label instead of `serving.knative.dev/routes`.
We kept old event handler for `serving.knative.dev/routes` label for safety but it should be alright to remove it now.