### PR TITLE
SRVCOM-1282 Fix UI test failures from nightlies

### DIFF
--- a/test/extensione2e/kafka/kafka_channel_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_channel_ksvc_test.go
@@ -22,6 +22,7 @@ const (
 	channelAPIVersion = "messaging.knative.dev/v1beta1"
 	kafkaChannelKind  = "KafkaChannel"
 	subscriptionName  = "smoke-test-kafka-subscription"
+	serviceAccount    = "default"
 )
 
 var (

--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -3,8 +3,10 @@ package knativekafkae2e
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
+	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -134,6 +136,10 @@ func TestKafkaSourceToKnativeService(t *testing.T) {
 		client.Clients.Kube.BatchV1beta1().CronJobs(testNamespace).Delete(context.Background(), cronJobName+"-plain", metav1.DeleteOptions{})
 		client.Clients.Kube.BatchV1beta1().CronJobs(testNamespace).Delete(context.Background(), cronJobName+"-tls", metav1.DeleteOptions{})
 		client.Clients.Kube.BatchV1beta1().CronJobs(testNamespace).Delete(context.Background(), cronJobName+"-sasl", metav1.DeleteOptions{})
+		// Jobs and Pods are sometimes left in the namespace.
+		// Ref: https://github.com/kubernetes/kubernetes/issues/74741
+		deleteJobs(t, client, testNamespace, cronJobName)
+		deletePods(t, client, testNamespace, cronJobName)
 		client.Clients.Kube.CoreV1().Secrets(testNamespace).Delete(context.Background(), tlsSecret, metav1.DeleteOptions{})
 		client.Clients.Kube.CoreV1().Secrets(testNamespace).Delete(context.Background(), saslSecret, metav1.DeleteOptions{})
 		removePullSecretFromSA(t, client, testNamespace, serviceAccount, tlsSecret)
@@ -275,14 +281,41 @@ func removePullSecretFromSA(t *testing.T, ctx *test.Context, namespace, serviceA
 		t.Error("Unable to get ServiceAccount", serviceAccount)
 	}
 	for i, secret := range sa.ImagePullSecrets {
-		patch := []byte(fmt.Sprintf(`[{"op": "remove", "path": "/imagePullSecrets/%d"}]`, i))
 		if secret.Name == secretName {
+			patch := []byte(fmt.Sprintf(`[{"op": "remove", "path": "/imagePullSecrets/%d"}]`, i))
 			_, err = ctx.Clients.Kube.CoreV1().ServiceAccounts(namespace).
 				Patch(context.Background(), serviceAccount, types.JSONPatchType, patch, metav1.PatchOptions{})
 			if err != nil {
 				t.Errorf("Patch failed on NS/SA (%s/%s): %s", namespace, serviceAccount, err)
 			}
-			return
+		}
+	}
+}
+
+func deleteJobs(t *testing.T, ctx *test.Context, namespace, name string) {
+	t.Helper()
+	jobList, err := ctx.Clients.Kube.BatchV1().Jobs(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Error("Unable to list jobs in namespace:", namespace)
+	}
+	for _, job := range jobList.Items {
+		if strings.Contains(job.Name, name) {
+			ctx.Clients.Kube.BatchV1().Jobs(namespace).
+				Delete(context.Background(), job.Name, metav1.DeleteOptions{})
+		}
+	}
+}
+
+func deletePods(t *testing.T, ctx *test.Context, namespace, name string) {
+	t.Helper()
+	podList, err := ctx.Clients.Kube.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Error("Unable to list pods in namespace:", namespace)
+	}
+	for _, pod := range podList.Items {
+		if strings.Contains(pod.Name, name) {
+			ctx.Clients.Kube.CoreV1().Pods(namespace).
+				Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
 		}
 	}
 }

--- a/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
@@ -98,6 +98,8 @@ func TestSourceToKafkaBrokerToKnativeService(t *testing.T) {
 		client.Clients.Kube.CoreV1().ConfigMaps(testNamespace).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 		client.Clients.Kube.CoreV1().Secrets(testNamespace).Delete(context.Background(), tlsSecret, metav1.DeleteOptions{})
 		client.Clients.Kube.CoreV1().Secrets(testNamespace).Delete(context.Background(), saslSecret, metav1.DeleteOptions{})
+		removePullSecretFromSA(t, client, testNamespace, serviceAccount, tlsSecret)
+		removePullSecretFromSA(t, client, testNamespace, serviceAccount, saslSecret)
 	}
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()

--- a/test/ui/cypress/integration/serving.spec.js
+++ b/test/ui/cypress/integration/serving.spec.js
@@ -101,7 +101,10 @@ describe('OCP UI for Serverless', () => {
 
   const showcaseKsvc = new ShowcaseKservice()
 
-  it('can deploy kservice and scale it', () => {
+  it('can deploy kservice and scale it',
+    // TODO: Remove the increased timeout when https://issues.redhat.com/browse/ODC-5685 is fixed.
+    { defaultCommandTimeout: 300000 },
+    () => {
     describe('with authenticated via Web Console', () => {
       cy.login()
     })

--- a/test/ui/cypress/integration/serving.spec.js
+++ b/test/ui/cypress/integration/serving.spec.js
@@ -46,11 +46,18 @@ describe('OCP UI for Serverless', () => {
     checkScale(scale) {
       const selector = 'div.pf-topology-container__with-sidebar ' +
         'div.odc-revision-deployment-list__pod svg tspan'
-      cy.get(selector)
-        .invoke('text')
-        .should((text) => {
+      const timeout = Cypress.config().defaultCommandTimeout
+      try {
+        // TODO: Remove the increased timeout when https://issues.redhat.com/browse/ODC-5685 is fixed.
+        Cypress.config('defaultCommandTimeout', 300_000)
+        cy.get(selector)
+          .invoke('text')
+          .should((text) => {
           expect(text).to.eq(`${scale}`)
         })
+      } finally {
+        Cypress.config('defaultCommandTimeout', timeout)
+      }
     }
 
     deployImage(kind = 'regular') {
@@ -101,10 +108,7 @@ describe('OCP UI for Serverless', () => {
 
   const showcaseKsvc = new ShowcaseKservice()
 
-  it('can deploy kservice and scale it',
-    // TODO: Remove the increased timeout when https://issues.redhat.com/browse/ODC-5685 is fixed.
-    { defaultCommandTimeout: 300000 },
-    () => {
+  it('can deploy kservice and scale it', () => {
     describe('with authenticated via Web Console', () => {
       cy.login()
     })


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVCOM-1282

The problem was that the Kafka tests left a pull secret in the default serviceaccount in serverless-tests namespace. The UI tests are running after that, were trying use the pull secret but it didn't exist anymore. The Kafka tests were removing the pull secret but didn't remove it from the service account. This PR removes them from SA as well. 
There were also a few more problems with resource cleanup from previous test suites.