### PR TITLE
Don't recompute image-from-env map twice

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -84,7 +84,7 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	// Override images.
 	// TODO(SRVCOM-1069): Rethink overriding behavior and/or error surfacing.
 	images := common.ImageMapFromEnvironment(os.Environ())
-	ks.Spec.Registry.Override = common.ImageMapFromEnvironment(os.Environ())
+	ks.Spec.Registry.Override = images
 	ks.Spec.Registry.Default = images["default"]
 	common.Configure(&ks.Spec.CommonSpec, "deployment", "queueSidecarImage", images["queue-proxy"])
 


### PR DESCRIPTION
A small nit found while hunting down the most recent upgrade test bug. Let's see if the upgrade test passes here.