### PR TITLE
Use versioned image references in CSV

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -373,7 +373,7 @@ spec:
                       - name: "IMAGE_KN_CLI_ARTIFACTS"
                         value: "registry.ci.openshift.org/openshift/knative-v0.20.0:kn-cli-artifacts"
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:openshift-knative-operator
                     imagePullPolicy: IfNotPresent
                     name: knative-operator
                     ports:
@@ -396,7 +396,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -532,7 +532,7 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:knative-openshift-ingress
                     imagePullPolicy: Always
                     env:
                       - name: WATCH_NAMESPACE
@@ -727,13 +727,13 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:knative-openshift-ingress
     - name: "IMAGE_queue-proxy"
       image: "registry.ci.openshift.org/openshift/knative-v0.20.0:knative-serving-queue"
     - name: "IMAGE_activator"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -311,7 +311,7 @@ spec:
                 - name: SERVING_SERVICE_MONITOR_RBAC_MANIFEST_PATH
                   value: "/var/run/ko/monitoring/rbac-proxy.yaml"
                 # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+                image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:openshift-knative-operator
                 imagePullPolicy: IfNotPresent
                 name: knative-operator
                 ports:
@@ -334,7 +334,7 @@ spec:
               containers:
                 - name: knative-openshift
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                  image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                  image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:knative-operator
                   imagePullPolicy: Always
                   readinessProbe:
                     httpGet:
@@ -396,7 +396,7 @@ spec:
               containers:
                 - name: knative-openshift-ingress
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                  image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                  image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:knative-openshift-ingress
                   imagePullPolicy: Always
                   env:
                     - name: WATCH_NAMESPACE
@@ -591,12 +591,12 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:knative-openshift-ingress
   replaces:
   version:


### PR DESCRIPTION
As per title. We publish the bundle image from this build, expecting that `registry.ci.openshift.org/openshift/openshift-serverless-v1.14.0:serverless-bundle` would install v1.14.0. It doesn't currently as this points to the nightly images which are advanced by main. This also breaks trying to install v1.14.0 from the branch.