### PR TITLE
Like on older releases, go with a dispatcher directly

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/kafkachannel-v0.20.0.yaml
+++ b/knative-operator/deploy/resources/knativekafka/kafkachannel-v0.20.0.yaml
@@ -485,7 +485,7 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: "v0.20.0"
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       messaging.knative.dev/channel: kafka-channel


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

As on 1.13 of the product, we go with the dispatcher to default to `1` replica initially 

See old behavior: https://github.com/openshift-knative/serverless-operator/blob/release-1.13/knative-operator/deploy/resources/knativekafka/kafkachannel-v0.19.1.yaml#L512  