### PR TITLE
[main] Configuring non trivial KafkaChannel options

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -218,20 +218,27 @@ EOF
 
 function ensure_kafka_channel_default {
   logger.info 'Set KafkaChannel as default'
-
-  oc patch knativeeventing knative-eventing -n "${EVENTING_NAMESPACE}" --type merge \
-    --patch '{
+  local defaultChConfig channelTemplateSpec yamls patchfile
+  yamls="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/yamls"
+  defaultChConfig="$(cat "${yamls}/kafka-default-ch-config.yaml")"
+  channelTemplateSpec="$(cat "${yamls}/kafka-channel-templatespec.yaml")"
+  patchfile="$(mktemp -t kafka-dafault-XXXXX.json)"
+  echo '{
   "spec": {
     "config": {
       "default-ch-webhook": {
-        "default-ch-config": "clusterDefault: \n  apiVersion: messaging.knative.dev/v1beta1\n  kind: KafkaChannel\n"
+        "default-ch-config": "'"${defaultChConfig//$'\n'/'\n'}"'"
       },
       "config-br-default-channel": {
-        "channelTemplateSpec": "apiVersion: messaging.knative.dev/v1beta1\nkind: KafkaChannel\n"
+        "channelTemplateSpec": "'"${channelTemplateSpec//$'\n'/'\n'}"'"
       }
     }
   }
-}'
+}' > "${patchfile}"
+  oc patch knativeeventing knative-eventing \
+    -n "${EVENTING_NAMESPACE}" \
+    --type merge --patch "$(cat "${patchfile}")"
+  rm -f "${patchfile}"
 
   logger.success 'KafkaChannel is set as default.'
 }

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -227,10 +227,10 @@ function ensure_kafka_channel_default {
   "spec": {
     "config": {
       "default-ch-webhook": {
-        "default-ch-config": "'"${defaultChConfig//$'\n'/'\n'}"'"
+        "default-ch-config": "'"${defaultChConfig//$'\n'/\\n}"'"
       },
       "config-br-default-channel": {
-        "channelTemplateSpec": "'"${channelTemplateSpec//$'\n'/'\n'}"'"
+        "channelTemplateSpec": "'"${channelTemplateSpec//$'\n'/\\n}"'"
       }
     }
   }

--- a/hack/lib/yamls/kafka-channel-templatespec.yaml
+++ b/hack/lib/yamls/kafka-channel-templatespec.yaml
@@ -1,0 +1,9 @@
+apiVersion: messaging.knative.dev/v1beta1
+kind: KafkaChannel
+spec:
+  numPartitions: 6
+  replicationFactor: 3
+  delivery:
+    retry: 12
+    backoffPolicy: exponential
+    backoffDelay: PT1S

--- a/hack/lib/yamls/kafka-default-ch-config.yaml
+++ b/hack/lib/yamls/kafka-default-ch-config.yaml
@@ -1,0 +1,10 @@
+clusterDefault:
+  apiVersion: messaging.knative.dev/v1beta1
+  kind: KafkaChannel
+  spec:
+    numPartitions: 6
+    replicationFactor: 3
+    delivery:
+      retry: 12
+      backoffPolicy: exponential
+      backoffDelay: PT1S


### PR DESCRIPTION
The same as #895, but targets `main`.

This PR should address knative-sandbox/eventing-kafka#533 for serverless-operator and productized builds on main branch.