### PR TITLE
Add knative.openshift.io/system-namespace label in README for servicemesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ spec:
     # Add namespace you want to include mesh.
 ```
 
+and add `knative.openshift.io/system-namespace` label to system namespaces.
+
+```
+oc label namespace knative-serving knative.openshift.io/system-namespace=true
+oc label namespace knative-serving-ingress knative.openshift.io/system-namespace=true
+```
+
 and add `NetworkPolicy` in your namespace.
 
 ```
@@ -270,9 +277,6 @@ spec:
       containers:
       - image: gcr.io/knative-samples/helloworld-go
         name: user-container
-  traffic:
-  - latestRevision: true
-    percent: 100
 EOF
 ```
 


### PR DESCRIPTION
This patch adds commands to add `knative.openshift.io/system-namespace` in README.

```
oc label namespace knative-serving knative.openshift.io/system-namespace=true
oc label namespace knative-serving-ingress knative.openshift.io/system-namespace=true
```

OSSM's networkpolicy blocks traffic from other namespaces so official
doc has [the guide](https://docs.openshift.com/container-platform/4.7/serverless/networking/serverless-ossm.html) but README misses it even though it has `allow-from-serving-system-namespace` NetworkPolicy.

/cc @maschmid 