### PR TITLE
[SRVCOM-1284] Update Serving and Eventing CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ generated-files: release-files
 	./hack/update-codegen.sh
 	(cd knative-operator && ./hack/update-manifests.sh)
 	(cd openshift-knative-operator && ./hack/update-manifests.sh)
+	(cd olm-catalog/serverless-operator && ./hack/update-manifests.sh)
 	./hack/update-deps.sh
 
 # Runs the lints Github Actions do too.

--- a/olm-catalog/serverless-operator/hack/update-manifests.sh
+++ b/olm-catalog/serverless-operator/hack/update-manifests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+root="$(dirname "${BASH_SOURCE[0]}")/../../.."
+
+# Source the main vars file to get the operator version to be used.
+# shellcheck disable=SC1091,SC1090
+source "$root/hack/lib/__sources__.bash"
+
+version=${OPERATOR_VERSION:-v$(metadata.get dependencies.operator)}
+
+target_dir="$root/olm-catalog/serverless-operator/manifests/"
+target_serving_file="$target_dir/operator_v1alpha1_knativeserving_crd.yaml"
+target_eventing_file="$target_dir/operator_v1alpha1_knativeeventing_crd.yaml"
+rm -rf "$target_serving_file" "$target_eventing_file"
+
+serving_url="https://raw.githubusercontent.com/knative/operator/$version/config/300-serving.yaml"
+eventing_url="https://raw.githubusercontent.com/knative/operator/$version/config/300-eventing.yaml"
+
+wget --no-check-certificate "$serving_url" -O "$target_serving_file"
+wget --no-check-certificate "$eventing_url" -O "$target_eventing_file"

--- a/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativeeventing_crd.yaml
+++ b/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativeeventing_crd.yaml
@@ -1,173 +1,255 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: knativeeventings.operator.knative.dev
+  labels:
+    operator.knative.dev/release: devel
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .status.version
+  group: operator.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: Schema for the knativeeventings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KnativeEventing
+            properties:
+              additionalManifests:
+                description: A list of the additional eventing manifests, which will
+                  be installed by the operator
+                items:
+                  properties:
+                    URL:
+                      description: The link of the additional manifest URL
+                      type: string
+                  type: object
+                type: array
+              config:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
+                description: A means to override the corresponding entries in the
+                  upstream configmaps
+                type: object
+              defaultBrokerClass:
+                description: The default broker type to use for the brokers Knative
+                  creates. If no value is provided, MTChannelBasedBroker will be used.
+                type: string
+              high-availability:
+                description: Allows specification of HA control plane
+                properties:
+                  replicas:
+                    description: The number of replicas that HA parts of the control
+                      plane will be scaled to
+                    minimum: 1
+                    type: integer
+                type: object
+              deployments:
+                description: A mapping of deployment name to override
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      description: The name of the deployment
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels overrides labels for the deployment and its template.
+                      type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations overrides labels for the deployment and its template.
+                      type: object
+                    replicas:
+                      description: The number of replicas that HA parts of the control plane will be scaled to
+                      type: integer
+                      minimum: 1
+              manifests:
+                description: A list of eventing manifests, which will be installed
+                  by the operator
+                items:
+                  properties:
+                    URL:
+                      description: The link of the manifest URL
+                      type: string
+                  type: object
+                type: array
+              registry:
+                description: A means to override the corresponding deployment images
+                  in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+                properties:
+                  default:
+                    description: The default image reference template to use for all
+                      knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                    type: string
+                  imagePullSecrets:
+                    description: A list of secrets to be used when pulling the knative
+                      images. The secret must be created in the same namespace as
+                      the knative-eventing deployments, and not the namespace of this
+                      resource.
+                    items:
+                      properties:
+                        name:
+                          description: The name of the secret.
+                          type: string
+                      type: object
+                    type: array
+                  override:
+                    additionalProperties:
+                      type: string
+                    description: A map of a container name or image name to the full
+                      image location of the individual knative image.
+                    type: object
+                type: object
+              resources:
+                description: A mapping of deployment name to resource requirements
+                items:
+                  properties:
+                    container:
+                      description: The name of the container
+                      type: string
+                    limits:
+                      properties:
+                        cpu:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        ephemeral-storage:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        memory:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        storage:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        ephemeral-storage:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        memory:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        storage:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              sinkBindingSelectionMode:
+                description: Specifies the selection mode for the sinkbinding webhook.
+                  If the value is `inclusion`, only namespaces/objects labelled as
+                  `bindings.knative.dev/include:true` will be considered. If `exclusion`
+                  is selected, only `bindings.knative.dev/exclude:true` label is checked
+                  and these will NOT be considered. The default is `exclusion`.
+                type: string
+              version:
+                description: The version of Knative Eventing to be installed
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                description: The latest available observations of a resource's current
+                  state.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: Severity with which to treat failures of this type
+                        of condition. When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - type
+                  - status
+                  type: object
+                type: array
+              manifests:
+                description: The list of eventing manifests, which have been installed
+                  by the operator
+                items:
+                  type: string
+                type: array
+              observedGeneration:
+                description: The generation last processed by the controller
+                type: integer
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    additionalPrinterColumns:
+    - jsonPath: .status.version
       name: Version
       type: string
-    - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
-    - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
       name: Reason
       type: string
-  group: operator.knative.dev
   names:
     kind: KnativeEventing
     listKind: KnativeEventingList
     plural: knativeeventings
     singular: knativeeventing
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      description: Schema for the knativeeventings API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Spec defines the desired state of KnativeEventing
-          properties:
-            config:
-              additionalProperties:
-                additionalProperties:
-                  type: string
-                type: object
-              description: A means to override the corresponding entries in the upstream
-                configmaps
-              type: object
-            registry:
-              description: A means to override the corresponding deployment images in the upstream.
-                This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
-              type: object
-              properties:
-                default:
-                  description: The default image reference template to use for all knative images.
-                    Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
-                  type: string
-                override:
-                  description: A map of a container name or image name to the full image location of the individual knative image.
-                  type: object
-                  additionalProperties:
-                    type: string
-                imagePullSecrets:
-                  description: A list of secrets to be used when pulling the knative images. The secret must be created in the
-                    same namespace as the knative-eventing deployments, and not the namespace of this resource.
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      name:
-                        description: The name of the secret.
-                        type: string
-            defaultBrokerClass:
-              description: The default broker type to use for the brokers Knative creates.
-                If no value is provided, ChannelBasedBroker will be used.
-              type: string
-            sinkBindingSelectionMode:
-              description: Specifies the NamespaceSelector and ObjectSelector for the sinkbinding webhook.
-                If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
-                will be considered by the sinkbinding webhook;
-                If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
-                will NOT be considered by the sinkbinding webhook.
-                The default is `exclusion`.
-              type: string
-            resources:
-              description: A mapping of deployment name to resource requirements
-              type: array
-              items:
-                type: object
-                properties:
-                  container:
-                    description: The name of the container
-                    type: string
-                  requests:
-                    type: object
-                    properties:
-                      memory:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      cpu:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      storage:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      ephemeral-storage:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                  limits:
-                    type: object
-                    properties:
-                      memory:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      cpu:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      storage:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      ephemeral-storage:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-          type: object
-        status:
-          properties:
-            conditions:
-              description: The latest available observations of a resource's current
-                state.
-              items:
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition
-                      transitioned from one status to another. We use VolatileTime
-                      in place of metav1.Time to exclude this from creating equality.Semantic
-                      differences (all other things held constant).
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  severity:
-                    description: Severity with which to treat failures of this type
-                      of condition. When this is not specified, it defaults to Error.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - type
-                - status
-                type: object
-              type: array
-            version:
-              description: The version of the installed release
-              type: string
-          type: object
-  version: v1alpha1
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  conversion:
+    strategy: None

--- a/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativeserving_crd.yaml
+++ b/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativeserving_crd.yaml
@@ -1,202 +1,322 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: knativeservings.operator.knative.dev
+  labels:
+    operator.knative.dev/release: devel
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.version
-    name: Version
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
-    name: Ready
-    type: string
-  - JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    name: Reason
-    type: string
   group: operator.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: Schema for the knativeservings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KnativeServing
+            properties:
+              additionalManifests:
+                description: A list of the additional serving manifests, which will
+                  be installed by the operator
+                items:
+                  properties:
+                    URL:
+                      description: The link of the additional manifest URL
+                      type: string
+                  type: object
+                type: array
+              cluster-local-gateway:
+                description: A means to override the cluster-local-gateway. This field
+                  is deprecated. Use `spec.ingres.istio.knative-local-gateway`
+                properties:
+                  selector:
+                    additionalProperties:
+                      type: string
+                    description: The selector for the ingress-gateway.
+                    type: object
+                type: object
+              config:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
+                description: A means to override the corresponding entries in the
+                  upstream configmaps
+                type: object
+              controller-custom-certs:
+                description: Enabling the controller to trust registries with self-signed
+                  certificates
+                properties:
+                  name:
+                    description: The name of the ConfigMap or Secret
+                    type: string
+                  type:
+                    description: One of ConfigMap or Secret
+                    enum:
+                    - ConfigMap
+                    - Secret
+                    - ""
+                    type: string
+                type: object
+              high-availability:
+                description: Allows specification of HA control plane
+                properties:
+                  replicas:
+                    description: The number of replicas that HA parts of the control
+                      plane will be scaled to
+                    minimum: 1
+                    type: integer
+                type: object
+              deployments:
+                description: A mapping of deployment name to override
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      description: The name of the deployment
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels overrides labels for the deployment and its template.
+                      type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations overrides labels for the deployment and its template.
+                      type: object
+                    replicas:
+                      description: The number of replicas that HA parts of the control plane will be scaled to
+                      type: integer
+                      minimum: 1
+              ingress:
+                description: The ingress configuration for Knative Serving
+                properties:
+                  contour:
+                    description: Contour settings
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                  istio:
+                    description: Istio settings
+                    properties:
+                      enabled:
+                        type: boolean
+                      knative-ingress-gateway:
+                        description: A means to override the knative-ingress-gateway
+                        properties:
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: The selector for the ingress-gateway.
+                            type: object
+                        type: object
+                      knative-local-gateway:
+                        description: A means to override the knative-local-gateway
+                        properties:
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: The selector for the ingress-gateway.
+                            type: object
+                        type: object
+                    type: object
+                  kourier:
+                    description: Kourier settings
+                    properties:
+                      enabled:
+                        type: boolean
+                      service-type:
+                        type: string
+                    type: object
+                type: object
+              knative-ingress-gateway:
+                description: A means to override the knative-ingress-gateway. This
+                  field is deprecated. Use `spec.ingres.istio.knative-ingress-gateway`
+                properties:
+                  selector:
+                    additionalProperties:
+                      type: string
+                    description: The selector for the ingress-gateway.
+                    type: object
+                type: object
+              manifests:
+                description: A list of serving manifests, which will be installed
+                  by the operator
+                items:
+                  properties:
+                    URL:
+                      description: The link of the manifest URL
+                      type: string
+                  type: object
+                type: array
+              registry:
+                description: A means to override the corresponding deployment images
+                  in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+                properties:
+                  default:
+                    description: The default image reference template to use for all
+                      knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                    type: string
+                  imagePullSecrets:
+                    description: A list of secrets to be used when pulling the knative
+                      images. The secret must be created in the same namespace as
+                      the knative-serving deployments, and not the namespace of this
+                      resource.
+                    items:
+                      properties:
+                        name:
+                          description: The name of the secret.
+                          type: string
+                      type: object
+                    type: array
+                  override:
+                    additionalProperties:
+                      type: string
+                    description: A map of a container name or image name to the full
+                      image location of the individual knative image.
+                    type: object
+                type: object
+              resources:
+                description: A mapping of deployment name to resource requirements
+                items:
+                  properties:
+                    container:
+                      description: The name of the container
+                      type: string
+                    limits:
+                      properties:
+                        cpu:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        ephemeral-storage:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        memory:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        storage:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        ephemeral-storage:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        memory:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                        storage:
+                          pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              version:
+                description: The version of Knative Serving to be installed
+                type: string
+            type: object
+          status:
+            description: Status defines the observed state of KnativeServing
+            properties:
+              conditions:
+                description: The latest available observations of a resource's current
+                  state.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: Severity with which to treat failures of this type
+                        of condition. When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - type
+                  - status
+                  type: object
+                type: array
+              manifests:
+                description: The list of serving manifests, which have been installed
+                  by the operator
+                items:
+                  type: string
+                type: array
+              observedGeneration:
+                description: The generation last processed by the controller
+                type: integer
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
   names:
     kind: KnativeServing
     listKind: KnativeServingList
     plural: knativeservings
     singular: knativeserving
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      description: Schema for the knativeservings API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Spec defines the desired state of KnativeServing
-          properties:
-            config:
-              additionalProperties:
-                additionalProperties:
-                  type: string
-                type: object
-              description: A means to override the corresponding entries in the upstream
-                configmaps
-              type: object
-            knative-ingress-gateway:
-              description: A means to override the knative-ingress-gateway
-              type: object
-              properties:
-                selector:
-                  description: The selector for the ingress-gateway.
-                  type: object
-                  additionalProperties:
-                    type: string
-            cluster-local-gateway:
-              description: A means to override the cluster-local-gateway
-              type: object
-              properties:
-                selector:
-                  description: The selector for the ingress-gateway.
-                  type: object
-                  additionalProperties:
-                    type: string
-            registry:
-              description: A means to override the corresponding deployment images in the upstream.
-                This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
-              type: object
-              properties:
-                default:
-                  description: The default image reference template to use for all knative images.
-                    Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
-                  type: string
-                override:
-                  description: A map of a container name or image name to the full image location of the individual knative image.
-                  type: object
-                  additionalProperties:
-                    type: string
-                imagePullSecrets:
-                  description: A list of secrets to be used when pulling the knative images. The secret must be created in the
-                    same namespace as the knative-serving deployments, and not the namespace of this resource.
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      name:
-                        description: The name of the secret.
-                        type: string
-            controller-custom-certs:
-              description: Enabling the controller to trust registries with self-signed certificates
-              type: object
-              properties:
-                type:
-                  description: One of ConfigMap or Secret
-                  type: string
-                  enum:
-                  - ConfigMap
-                  - Secret
-                  - ""
-                name:
-                  description: The name of the ConfigMap or Secret
-                  type: string
-            high-availability:
-              description: Allows specification of HA control plane
-              type: object
-              properties:
-                replicas:
-                  description: The number of replicas that HA parts of the control plane will be scaled to
-                  type: integer
-                  minimum: 1
-            resources:
-              description: A mapping of deployment name to resource requirements
-              type: array
-              items:
-                type: object
-                properties:
-                  container:
-                    description: The name of the container
-                    type: string
-                  requests:
-                    type: object
-                    properties:
-                      memory:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      cpu:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      storage:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      ephemeral-storage:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                  limits:
-                    type: object
-                    properties:
-                      memory:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      cpu:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      storage:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                      ephemeral-storage:
-                        type: string
-                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-          type: object
-        status:
-          description: Status defines the observed state of KnativeServing
-          properties:
-            conditions:
-              description: The latest available observations of a resource's current
-                state.
-              items:
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition
-                      transitioned from one status to another. We use VolatileTime
-                      in place of metav1.Time to exclude this from creating equality.Semantic
-                      differences (all other things held constant).
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  severity:
-                    description: Severity with which to treat failures of this type
-                      of condition. When this is not specified, it defaults to Error.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - type
-                - status
-                type: object
-              type: array
-            version:
-              description: The version of the installed release
-              type: string
-          type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+  conversion:
+    strategy: None

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -27,3 +27,4 @@ dependencies:
   kourier: 0.21.0
   cli: 0.20.0
   maistra: 2.0.0
+  operator: 0.21.2


### PR DESCRIPTION
This patch updates `operator_v1alpha1_knativeeventing_crd.yaml` and `operator_v1alpha1_knativeserving_crd.yaml` that are very old.