### PR TITLE
[SRVKS-725] Guarantee order of env vars when injecting them

### DIFF
--- a/openshift-knative-operator/pkg/common/deployment.go
+++ b/openshift-knative-operator/pkg/common/deployment.go
@@ -12,7 +12,7 @@ import (
 // specified deployment/container.
 // Note: We're not deleting empty environment variables and instead set them to empty
 // string. Three-way-merging of the deployment drops the update otherwise.
-func InjectEnvironmentIntoDeployment(deploymentName, containerName string, env map[string]string) mf.Transformer {
+func InjectEnvironmentIntoDeployment(deploymentName, containerName string, envs ...corev1.EnvVar) mf.Transformer {
 	return transformDeployment(deploymentName, func(deploy *appsv1.Deployment) error {
 		containers := deploy.Spec.Template.Spec.Containers
 		for i := range containers {
@@ -21,8 +21,8 @@ func InjectEnvironmentIntoDeployment(deploymentName, containerName string, env m
 				continue
 			}
 
-			for key, value := range env {
-				c.Env = upsert(c.Env, key, value)
+			for _, val := range envs {
+				c.Env = upsert(c.Env, val)
 			}
 		}
 
@@ -32,19 +32,16 @@ func InjectEnvironmentIntoDeployment(deploymentName, containerName string, env m
 
 // upsert updates the env var if the key already exists or inserts it if it didn't
 // exist.
-func upsert(orgEnv []corev1.EnvVar, key, value string) []corev1.EnvVar {
+func upsert(orgEnv []corev1.EnvVar, val corev1.EnvVar) []corev1.EnvVar {
 	// Set the value if the key is already present.
 	for i := range orgEnv {
-		if orgEnv[i].Name == key {
-			orgEnv[i].Value = value
+		if orgEnv[i].Name == val.Name {
+			orgEnv[i].Value = val.Value
 			return orgEnv
 		}
 	}
 	// If not, append a key-value pair.
-	return append(orgEnv, corev1.EnvVar{
-		Name:  key,
-		Value: value,
-	})
+	return append(orgEnv, val)
 }
 
 // transformDeployment returns a transformer that transforms a deployment with the given

--- a/openshift-knative-operator/pkg/common/deployment_test.go
+++ b/openshift-knative-operator/pkg/common/deployment_test.go
@@ -27,13 +27,13 @@ func TestInjectEnvironmentIntoDeployment(t *testing.T) {
 		in         *appsv1.Deployment
 		deployment string
 		container  string
-		env        map[string]string
+		envs       []corev1.EnvVar
 		want       *appsv1.Deployment
 	}{{
 		name:       "ignore",
 		deployment: "foo",
 		container:  "container1",
-		env:        map[string]string{"foo": "bar"},
+		envs:       []corev1.EnvVar{envVar("foo", "bar")},
 		in: &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
@@ -56,7 +56,7 @@ func TestInjectEnvironmentIntoDeployment(t *testing.T) {
 		name:       "append",
 		deployment: "test",
 		container:  "container1",
-		env:        map[string]string{"foo": "bar"},
+		envs:       []corev1.EnvVar{envVar("foo", "bar")},
 		in: &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
@@ -85,7 +85,7 @@ func TestInjectEnvironmentIntoDeployment(t *testing.T) {
 		name:       "update",
 		deployment: "test",
 		container:  "container2",
-		env:        map[string]string{"2": "bar"},
+		envs:       []corev1.EnvVar{envVar("2", "bar")},
 		in: &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
@@ -119,7 +119,7 @@ func TestInjectEnvironmentIntoDeployment(t *testing.T) {
 				t.Fatal("Failed to convert deployment to unstructured", err)
 			}
 
-			if err := InjectEnvironmentIntoDeployment(test.deployment, test.container, test.env)(u); err != nil {
+			if err := InjectEnvironmentIntoDeployment(test.deployment, test.container, test.envs...)(u); err != nil {
 				t.Fatal("Unexpected error from transformer", err)
 			}
 
@@ -165,7 +165,7 @@ func TestUpsert(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := upsert(test.in, test.add.Name, test.add.Value)
+			got := upsert(test.in, test.add)
 			if !cmp.Equal(got, test.want) {
 				t.Errorf("Got = %v, want: %v, diff:\n%s", got, test.want, cmp.Diff(got, test.want))
 			}

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 	"github.com/openshift-knative/serverless-operator/pkg/client/clientset/versioned"
 	ocpclient "github.com/openshift-knative/serverless-operator/pkg/client/injection/client"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -43,11 +44,11 @@ func (e *extension) Manifests(ks v1alpha1.KComponent) ([]mf.Manifest, error) {
 
 func (e *extension) Transformers(ks v1alpha1.KComponent) []mf.Transformer {
 	return append([]mf.Transformer{
-		common.InjectEnvironmentIntoDeployment("controller", "controller", map[string]string{
-			"HTTP_PROXY":  os.Getenv("HTTP_PROXY"),
-			"HTTPS_PROXY": os.Getenv("HTTPS_PROXY"),
-			"NO_PROXY":    os.Getenv("NO_PROXY"),
-		}),
+		common.InjectEnvironmentIntoDeployment("controller", "controller",
+			corev1.EnvVar{Name: "HTTP_PROXY", Value: os.Getenv("HTTP_PROXY")},
+			corev1.EnvVar{Name: "HTTPS_PROXY", Value: os.Getenv("HTTPS_PROXY")},
+			corev1.EnvVar{Name: "NO_PROXY", Value: os.Getenv("NO_PROXY")},
+		),
 	}, monitoring.GetServingTransformers(ks)...)
 }
 


### PR DESCRIPTION
Passing the environment vars to inject as a map then iterating that map
causes them to be added in a random order which causes unnecessary
restarts of the controller. Passing them as a list guarantees the same
order everytime.