### PR TITLE
Make sure the demoapp is running before running UI tests

### DIFF
--- a/test/ui/cypress/integration/serving.spec.js
+++ b/test/ui/cypress/integration/serving.spec.js
@@ -79,7 +79,10 @@ describe('OCP UI for Serverless', () => {
         .type(showcaseKsvc.name())
       cy.get('button[type=submit]').click()
       cy.url().should('include', `/topology/ns/${showcaseKsvc.namespace}`)
-      cy.contains(showcaseKsvc.app())
+      cy.visit(`/topology/ns/${showcaseKsvc.namespace}/list`)
+      cy.get('div.pf-topology-content').contains(showcaseKsvc.name()).click()
+      // Make sure the app is running before proceeding.
+      cy.contains('Running')
     }
 
     removeApp() {


### PR DESCRIPTION
Fix errors such as this one: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.7-e2e-aws-ocp-47-continuous/1386651336493240320
The error screen is [this](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.7-e2e-aws-ocp-47-continuous/1386651336493240320/artifacts/e2e-aws-ocp-47-continuous/serverless-e2e/artifacts/build-lz+Sp52c/ui/screenshots/serving.spec.js/OCP%20UI%20for%20Serverless%20--%20can%20deploy%20kservice%20and%20scale%20it%20(failed).png)
I was not able to reproduce locally, but it seems some wait time should be there at the beginning before calling the service's URL. It takes a little while to start the service, including puling the image.
We already use `retryOnStatusCodeFailure` flag but according to https://github.com/cypress-io/cypress/pull/4015 there are only 5 attempts and only 5 seconds between the first and last attempt. So waiting for the Pod to be Running should help fix the problem.