### PR TITLE
Use golang-1.14 from CI as based image for build_root

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM docker.io/openshift/origin-release:golang-1.14
+FROM registry.ci.openshift.org/openshift/release:golang-1.14
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/

--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM docker.io/openshift/origin-release:golang-__GOLANG_VERSION__
+FROM registry.ci.openshift.org/openshift/release:golang-__GOLANG_VERSION__
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/


### PR DESCRIPTION
Fix error such as
```
Error reading manifest golang-1.14 in docker.io/openshift/origin-release: toomanyrequests: You have reached your pull rate limit. 
```
from https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.6-e2e-aws-ocp-46-continuous/1387013902545457152