### PR TITLE
[SRKVS-732] Allow ingress.class to be overridden

### DIFF
--- a/knative-operator/pkg/common/serving.go
+++ b/knative-operator/pkg/common/serving.go
@@ -19,9 +19,6 @@ const (
 	// defaultDomainTemplate is a value for domainTemplate in config-network.
 	// As Knative on OpenShift uses OpenShift's wildcard cert the domain level must have "<sub>.domain", not "<sub1>.<sub2>.domain".
 	DefaultDomainTemplate = "{{.Name}}-{{.Namespace}}.{{.Domain}}"
-
-	// defaultIngressClass is a value for ingress.class in config-network.
-	DefaultIngressClass = "kourier.ingress.networking.knative.dev"
 )
 
 func Mutate(ks *servingv1alpha1.KnativeServing, c client.Client) error {
@@ -31,7 +28,6 @@ func Mutate(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 
 	configureLogURLTemplate(ks, c)
 	domainTemplate(ks)
-	ingressClass(ks)
 	ensureCustomCerts(ks)
 	imagesFromEnviron(ks)
 	ensureServingWebhookMemoryLimit(ks)
@@ -53,10 +49,6 @@ func ensureServingWebhookMemoryLimit(ks *servingv1alpha1.KnativeServing) {
 
 func domainTemplate(ks *servingv1alpha1.KnativeServing) {
 	Configure(ks, "network", "domainTemplate", DefaultDomainTemplate)
-}
-
-func ingressClass(ks *servingv1alpha1.KnativeServing) {
-	Configure(ks, "network", "ingress.class", DefaultIngressClass)
 }
 
 // configure ingress

--- a/knative-operator/pkg/common/serving_test.go
+++ b/knative-operator/pkg/common/serving_test.go
@@ -225,10 +225,6 @@ func verifyNetworkConfig(t *testing.T, ks *servingv1alpha1.KnativeServing) {
 	if actual := network["domainTemplate"]; actual != common.DefaultDomainTemplate {
 		t.Errorf("got %q, want %q", actual, common.DefaultDomainTemplate)
 	}
-
-	if actual := network["ingress.class"]; actual != common.DefaultIngressClass {
-		t.Errorf("got %q, want %q", actual, common.DefaultIngressClass)
-	}
 }
 
 func verifyQueueProxySidecarImageOverride(t *testing.T, ks *servingv1alpha1.KnativeServing, expected string) {

--- a/openshift-knative-operator/pkg/common/config.go
+++ b/openshift-knative-operator/pkg/common/config.go
@@ -14,3 +14,21 @@ func Configure(s *v1alpha1.CommonSpec, cm, key, value string) {
 
 	s.Config[cm][key] = value
 }
+
+// ConfigureIfUnset sets a value in the given ConfigMap under the given key if it's not
+// already set.
+func ConfigureIfUnset(s *v1alpha1.CommonSpec, cm, key, value string) {
+	if s.Config == nil {
+		s.Config = make(map[string]map[string]string, 1)
+	}
+
+	if s.Config[cm] == nil {
+		s.Config[cm] = make(map[string]string, 1)
+	}
+
+	if _, ok := s.Config[cm][key]; ok {
+		// Already set, nothing to do here.
+		return
+	}
+	s.Config[cm][key] = value
+}

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -94,9 +94,8 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 		}
 	}
 
-	// Use Kourier.
-	// TODO(SRVCOM-1069): Rethink overriding behavior and/or error surfacing.
-	common.Configure(&ks.Spec.CommonSpec, "network", "ingress.class", "kourier.ingress.networking.knative.dev")
+	// Use Kourier by default but allow a manual override.
+	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "ingress.class", "kourier.ingress.networking.knative.dev")
 
 	// Override the default domainTemplate to use $name-$ns rather than $name.$ns.
 	// TODO(SRVCOM-1069): Rethink overriding behavior and/or error surfacing.

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -130,6 +130,22 @@ func TestReconcile(t *testing.T) {
 		},
 		expected: ks(),
 	}, {
+		name: "override ingress class",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Config: v1alpha1.ConfigMapData{
+						"network": map[string]string{
+							"ingress.class": "foo",
+						},
+					},
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			common.Configure(&ks.Spec.CommonSpec, "network", "ingress.class", "foo")
+		}),
+	}, {
 		name: "respects different status",
 		in: ks(func(ks *v1alpha1.KnativeServing) {
 			ks.Status.MarkDependenciesInstalled()


### PR DESCRIPTION
1. This stops the webhook from defaulting a value into the KnativeServing's spec. This is necessary for us to be able to tell a system default apart from a user-set value.
2. Only defaults the `ingress.class` to kourier if it's not otherwise set.

/assign @nak3 