### PR TITLE
Disable leader election between ingress classes

### DIFF
--- a/serving/ingress/cmd/controller/main.go
+++ b/serving/ingress/cmd/controller/main.go
@@ -4,6 +4,7 @@ import (
 	// This defines the shared main for injected controllers.
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
 
 	"github.com/openshift-knative/serverless-operator/serving/ingress/pkg/reconciler/ingress"
 )
@@ -14,5 +15,11 @@ var ctors = []injection.ControllerConstructor{
 }
 
 func main() {
-	sharedmain.Main("openshift-ingress-controller", ctors...)
+	ctx := signals.NewContext()
+
+	// Disable leader election to allow both ingress controllers to do their job.
+	// TODO: Fix the respective clash in Knative's reconciler framework.
+	ctx = sharedmain.WithHADisabled(ctx)
+
+	sharedmain.MainWithContext(ctx, "openshift-ingress-controller", ctors...)
 }


### PR DESCRIPTION
We're now running two ingress reconcilers (one for Kourier and one for Istio) in the same component, which makes their respective leader election clash

```
I0429 08:25:42.686755       1 leaderelection.go:243] attempting to acquire leader lease  openshift-serverless/openshift-ingress-controller.github.com.openshift-knative.serverless-operator.serving.ingress.pkg.reconciler.ingress.reconciler.00-of-01...
I0429 08:25:42.686761       1 leaderelection.go:243] attempting to acquire leader lease  openshift-serverless/openshift-ingress-controller.github.com.openshift-knative.serverless-operator.serving.ingress.pkg.reconciler.ingress.reconciler.00-of-01...
```

As a result, only one of the reconcilers will run in practice, which breaks things horribly. We don't actually run multiple instances of these today anyway, so disabling the HA code fixes that situation.