### PR TITLE
Add install-operator target to only install the serverless-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ images:
 install:
 	./hack/install.sh
 
+install-operator:
+	INSTALL_SERVING="false" INSTALL_EVENTING="false" ./hack/install.sh
+
 install-all: install-strimzi
 	INSTALL_KAFKA="true" ./hack/install.sh
 


### PR DESCRIPTION
This is quite useful if you want to test specific Knative Serving settings for example, without having the default applied first. This basically does the equivalent of installing the Serverless Operator through Operatorhub, but with the current codebase.

/assign @rhuss 