### PR TITLE
[SRVKS-733] Add an annotation to make routes use passthrough

### DIFF
--- a/serving/ingress/pkg/reconciler/ingress/ingress_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/ingress_test.go
@@ -446,7 +446,7 @@ func route(ns, name string, opts ...routeOption) *routev1.Route {
 		Spec: routev1.RouteSpec{
 			Host: domainName,
 			Port: &routev1.RoutePort{
-				TargetPort: intstr.FromString(resources.KourierHTTPPort),
+				TargetPort: intstr.FromString(resources.HTTPPort),
 			},
 			To: routev1.RouteTargetReference{
 				Kind:   "Service",
@@ -486,7 +486,7 @@ func routeIstio(ns, name string, opts ...routeOption) *routev1.Route {
 		Spec: routev1.RouteSpec{
 			Host: domainName,
 			Port: &routev1.RoutePort{
-				TargetPort: intstr.FromString(resources.KourierHTTPPort),
+				TargetPort: intstr.FromString(resources.HTTPPort),
 			},
 			To: routev1.RouteTargetReference{
 				Kind:   "Service",

--- a/serving/ingress/pkg/reconciler/ingress/resources/route.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route.go
@@ -140,7 +140,7 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 	if _, ok := annotations[EnablePassthroughRouteAnnotation]; ok {
 		route.Spec.Port.TargetPort = intstr.FromString(HTTPSPort)
 		route.Spec.TLS.Termination = routev1.TLSTerminationPassthrough
-		route.Spec.TLS.InsecureEdgeTerminationPolicy = routev1.InsecureEdgeTerminationPolicyNone
+		route.Spec.TLS.InsecureEdgeTerminationPolicy = routev1.InsecureEdgeTerminationPolicyRedirect
 	}
 
 	return route, nil

--- a/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
@@ -247,7 +247,7 @@ func TestMakeRoute(t *testing.T) {
 					},
 					TLS: &routev1.TLSConfig{
 						Termination:                   routev1.TLSTerminationPassthrough,
-						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 					},
 					WildcardPolicy: routev1.WildcardPolicyNone,
 				},

--- a/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
@@ -74,7 +74,7 @@ func TestMakeRoute(t *testing.T) {
 						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
-						TargetPort: intstr.FromString(KourierHTTPPort),
+						TargetPort: intstr.FromString(HTTPPort),
 					},
 					TLS: &routev1.TLSConfig{
 						Termination:                   routev1.TLSTerminationEdge,
@@ -125,7 +125,7 @@ func TestMakeRoute(t *testing.T) {
 						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
-						TargetPort: intstr.FromString(KourierHTTPPort),
+						TargetPort: intstr.FromString(HTTPPort),
 					},
 					TLS: &routev1.TLSConfig{
 						Termination:                   routev1.TLSTerminationEdge,
@@ -156,7 +156,7 @@ func TestMakeRoute(t *testing.T) {
 						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
-						TargetPort: intstr.FromString(KourierHTTPPort),
+						TargetPort: intstr.FromString(HTTPPort),
 					},
 
 					TLS: &routev1.TLSConfig{
@@ -196,7 +196,7 @@ func TestMakeRoute(t *testing.T) {
 						Weight: ptr.Int32(100),
 					},
 					Port: &routev1.RoutePort{
-						TargetPort: intstr.FromString(KourierHTTPPort),
+						TargetPort: intstr.FromString(HTTPPort),
 					},
 
 					TLS: &routev1.TLSConfig{
@@ -213,6 +213,45 @@ func TestMakeRoute(t *testing.T) {
 				rule(withHosts([]string{localDomain, externalDomain}))),
 			),
 			wantErr: ErrNoValidLoadbalancerDomain,
+		},
+		{
+			name: "valid, passthrough",
+			ingress: ingress(withPassthroughAnnotation, withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						networking.IngressLabelKey:        "ingress",
+						serving.RouteLabelKey:             "route1",
+						serving.RouteNamespaceLabelKey:    "default",
+						OpenShiftIngressLabelKey:          "ingress",
+						OpenShiftIngressNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation:                DefaultTimeout,
+						EnablePassthroughRouteAnnotation: "true",
+					},
+					Namespace: lbNamespace,
+					Name:      routeName0,
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain,
+					To: routev1.RouteTargetReference{
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString(HTTPSPort),
+					},
+					TLS: &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationPassthrough,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
+				},
+			}},
 		},
 	}
 
@@ -284,6 +323,15 @@ func withDisabledAnnotation(ing *networkingv1alpha1.Ingress) {
 		annos = map[string]string{}
 	}
 	annos[DisableRouteAnnotation] = ""
+	ing.SetAnnotations(annos)
+}
+
+func withPassthroughAnnotation(ing *networkingv1alpha1.Ingress) {
+	annos := ing.GetAnnotations()
+	if annos == nil {
+		annos = map[string]string{}
+	}
+	annos[EnablePassthroughRouteAnnotation] = "true"
 	ing.SetAnnotations(annos)
 }
 

--- a/test/servinge2e/custom_route_test.go
+++ b/test/servinge2e/custom_route_test.go
@@ -62,7 +62,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 		Spec: routev1.RouteSpec{
 			Host: ksvc.Status.URL.Host,
 			Port: &routev1.RoutePort{
-				TargetPort: intstr.FromString(resources.KourierHTTPPort),
+				TargetPort: intstr.FromString(resources.HTTPPort),
 			},
 			To: routev1.RouteTargetReference{
 				Kind: "Service",
@@ -135,7 +135,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 		Spec: routev1.RouteSpec{
 			Host: dm.Status.URL.Host,
 			Port: &routev1.RoutePort{
-				TargetPort: intstr.FromString(resources.KourierHTTPPort),
+				TargetPort: intstr.FromString(resources.HTTPPort),
 			},
 			To: routev1.RouteTargetReference{
 				Kind: "Service",


### PR DESCRIPTION
As per title, this adds an annotation to be added to a Knative Service (or a Route) to make us generate a route that has passthrough encryption enabled on it.

/assign @nak3 