### PR TITLE
manually Adding post-install for eventing

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/3-eventing-kafka-post-install.yaml
+++ b/knative-operator/deploy/resources/knativekafka/3-eventing-kafka-post-install.yaml
@@ -1,0 +1,133 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-kafka-eventing-post-install-job-role
+  labels:
+    kafka.eventing.knative.dev/release: devel
+rules:
+  # Storage version upgrader needs to be able to patch CRDs.
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+      - "customresourcedefinitions/status"
+    verbs:
+      - "get"
+      - "list"
+      - "update"
+      - "patch"
+      - "watch"
+  # Our own resources we care about.
+  - apiGroups:
+      - "messaging.knative.dev"
+    resources:
+      - "kafkachannels"
+      - "subscriptions"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knative-kafka-eventing-post-install-job
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-kafka-eventing-post-install-job-role-binding
+  labels:
+    kafka.eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: knative-kafka-eventing-post-install-job
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-kafka-eventing-post-install-job-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Adding a prefix to avoid naming conflict with previous version's post-install jobs,
+  # we cannot use `generateName` here as it's not supported by `kubectl apply -f`
+  #
+  # If `ttlSecondsAfterFinished` feature gate becomes generally available in the future,
+  # we can rely on that and keep using the same Job name.
+  name: v0.21-kafka-storage-version-migration
+  namespace: knative-eventing
+  labels:
+    app: "storage-version-migration"
+    kafka.eventing.knative.dev/release: devel
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: "storage-version-migration"
+        eventing.knative.dev/release: devel
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: knative-kafka-eventing-post-install-job
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: registry.ci.openshift.org/openshift/knative-v0.21.1:knative-eventing-kafka-storage-version-migration
+          args:
+            - "kafkachannels.messaging.knative.dev"
+            - "subscriptions.messaging.knative.dev"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -443,6 +443,8 @@ spec:
                         value: deploy/resources/kourier/kourier-latest.yaml
                       - name: KAFKACHANNEL_MANIFEST_PATH
                         value: deploy/resources/knativekafka/1-channel-consolidated.yaml
+                      - name: KAFKACHANNEL_POST_INSTALL_MANIFEST_PATH
+                        value: deploy/resources/knativekafka/3-eventing-kafka-post-install.yaml
                       - name: KAFKASOURCE_MANIFEST_PATH
                         value: deploy/resources/knativekafka/2-source.yaml
                       - name: QUICKSTART_MANIFEST_PATH

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -377,6 +377,8 @@ spec:
                       value: deploy/resources/kourier/kourier-latest.yaml
                     - name: KAFKACHANNEL_MANIFEST_PATH
                       value: deploy/resources/knativekafka/1-channel-consolidated.yaml
+                    - name: KAFKACHANNEL_POST_INSTALL_MANIFEST_PATH
+                      value: deploy/resources/knativekafka/3-eventing-kafka-post-install.yaml
                     - name: KAFKASOURCE_MANIFEST_PATH
                       value: deploy/resources/knativekafka/2-source.yaml
                     - name: QUICKSTART_MANIFEST_PATH


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

In _midstream_ (mainly for product, _downstream_), we backported the "post-install" job from 0.22 release to 0.21, for a smoother upgrade of our customers, in case they are using `v1alpha1` version of the `KafkaChannel` (we release note to *NOT* do that).

The backport PR to our `0.21` branch: https://github.com/openshift-knative/eventing-kafka/pull/160
and the upstream, which did land there _only_ on 0.22: https://github.com/knative-sandbox/eventing-kafka/pull/446

## Proposed changes

This adds the (manually) generated "post job" yaml, with our own image (`registry.ci.openshift.org/openshift/knative-v0.21.1:knative-eventing-kafka-storage-version-migration`). 

/cc @lberk 
/cc @warrenvw 
/cc @aliok 
/cc @mgencur 
/cc @cardil 

The PR is currently in **WIP** state, since the new `3-...post install` YAML file needs to be installed _only_ when the channel is installed... 