### PR TITLE
[release-1.14] SRVCOM-1282 Fix UI test failures from nightlies

### DIFF
--- a/test/extensione2e/kafka/kafka_channel_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_channel_ksvc_test.go
@@ -22,6 +22,7 @@ const (
 	channelAPIVersion = "messaging.knative.dev/v1beta1"
 	kafkaChannelKind  = "KafkaChannel"
 	subscriptionName  = "smoke-test-kafka-subscription"
+	serviceAccount    = "default"
 )
 
 var (

--- a/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
@@ -98,6 +98,8 @@ func TestSourceToKafkaBrokerToKnativeService(t *testing.T) {
 		client.Clients.Kube.CoreV1().ConfigMaps(testNamespace).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 		client.Clients.Kube.CoreV1().Secrets(testNamespace).Delete(context.Background(), tlsSecret, metav1.DeleteOptions{})
 		client.Clients.Kube.CoreV1().Secrets(testNamespace).Delete(context.Background(), saslSecret, metav1.DeleteOptions{})
+		removePullSecretFromSA(t, client, testNamespace, serviceAccount, tlsSecret)
+		removePullSecretFromSA(t, client, testNamespace, serviceAccount, saslSecret)
 	}
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()

--- a/test/ui/cypress/integration/serving.spec.js
+++ b/test/ui/cypress/integration/serving.spec.js
@@ -46,11 +46,18 @@ describe('OCP UI for Serverless', () => {
     checkScale(scale) {
       const selector = 'div.pf-topology-container__with-sidebar ' +
         'div.odc-revision-deployment-list__pod svg tspan'
-      cy.get(selector)
-        .invoke('text')
-        .should((text) => {
+      const timeout = Cypress.config().defaultCommandTimeout
+      try {
+        // TODO: Remove the increased timeout when https://issues.redhat.com/browse/ODC-5685 is fixed.
+        Cypress.config('defaultCommandTimeout', 300_000)
+        cy.get(selector)
+          .invoke('text')
+          .should((text) => {
           expect(text).to.eq(`${scale}`)
         })
+      } finally {
+        Cypress.config('defaultCommandTimeout', timeout)
+      }
     }
 
     deployImage(kind = 'regular') {


### PR DESCRIPTION
This is a backport of the changes that went to "main" some time ago. We're going to support 1.14 for some time and I'm still hitting these issues which make it hard to run the test suites repeatedly.

* Remove pull secrets from SA after Kafka tests
* Increase test timeout for UI serving test
* Do not leave any successful Jobs to have the namespace clean
* Narrow scope for increased timeout in UI tests

