### PR TITLE
[main] Going with hard coded 0.22.1 version for 1.15

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 function install_strimzi_operator {
-  strimzi_version=$(curl https://github.com/strimzi/strimzi-kafka-operator/releases/latest |  awk -F 'tag/' '{print $2}' | awk -F '"' '{print $1}' 2>/dev/null)
+#  strimzi_version=$(curl https://github.com/strimzi/strimzi-kafka-operator/releases/latest |  awk -F 'tag/' '{print $2}' | awk -F '"' '{print $1}' 2>/dev/null)
+  strimzi_version=0.22.1
   header "Installing Strimzi Kafka operator"
   oc create namespace kafka
   curl -L "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml" \


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

For now, we go with the latest 0.22.1 release of Strimzi

With 0.23, they remove their `v1beta1` APIs, and we need to prepare for that differently.

With this we stay with beta1 for a bit longer... after 1.15 has sailed, I am updating this to latest of strimzi 