### PR TITLE
Add upgrade build tag to golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,9 @@
 run:
   timeout: 5m
 
+  build-tags:
+    - upgrade
+
   skip-dirs:
     - pkg/client
 


### PR DESCRIPTION
Just so we also check (and compile) the upgrade tests.