### PR TITLE
Remove arm64 link from consoleclidownload.go

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -235,10 +235,6 @@ func populateKnConsoleCLIDownload(baseURL string, instance *servingv1alpha1.Knat
 					Href: baseURL + "/s390x/linux/kn-linux-s390x.tar.gz",
 				},
 				{
-					Text: "Download kn for Linux for ARM 64 (unsupported)",
-					Href: baseURL + "/arm64/linux/kn-linux-arm64.tar.gz",
-				},
-				{
 					Text: "Download kn for macOS",
 					Href: baseURL + "/amd64/macos/kn-macos-amd64.tar.gz",
 				},

--- a/test/servinge2e/verify_deploy_resources_test.go
+++ b/test/servinge2e/verify_deploy_resources_test.go
@@ -37,8 +37,8 @@ func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
 		t.Fatalf("unable to GET kn ConsoleCLIDownload CO 'kn': %v", err)
 	}
 	// Verify the links in kn CCD CO
-	if len(ccd.Spec.Links) != 6 {
-		t.Fatalf("expecting 6 links for artifacts for kn ConsoleCLIDownload, found %d", len(ccd.Spec.Links))
+	if len(ccd.Spec.Links) != 5 {
+		t.Fatalf("expecting 5 links for artifacts for kn ConsoleCLIDownload, found %d", len(ccd.Spec.Links))
 	}
 	// Verify if individual link starts with correct route
 	protocol := "https://"


### PR DESCRIPTION
The arm64 client is not yet tested, and QE does not want it included in the 1.14.1 release.