### PR TITLE
[SRVCOM-1329] Add metrics for openshift knative operator and ingress

### DIFF
--- a/olm-catalog/serverless-operator/manifests/config-observability.yaml
+++ b/olm-catalog/serverless-operator/manifests/config-observability.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: openshift-serverless
+data:
+  metrics.backend-destination: prometheus

--- a/olm-catalog/serverless-operator/manifests/config-observability.yaml
+++ b/olm-catalog/serverless-operator/manifests/config-observability.yaml
@@ -2,6 +2,5 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-observability
-  namespace: openshift-serverless
 data:
   metrics.backend-destination: prometheus

--- a/olm-catalog/serverless-operator/manifests/knative-openshift-ingress.service.yaml
+++ b/olm-catalog/serverless-operator/manifests/knative-openshift-ingress.service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: knative-openshift-ingress
+  name: knative-openshift-ingress-metrics
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    name: knative-openshift-ingress
+  type: ClusterIP

--- a/olm-catalog/serverless-operator/manifests/knative-openshift-ingress.servicemonitor.yaml
+++ b/olm-catalog/serverless-operator/manifests/knative-openshift-ingress.servicemonitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    name: knative-openshift-ingress
+  name: knative-openshift-ingress-metrics
+spec:
+  endpoints:
+    - port: metrics
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      name: knative-openshift-ingress

--- a/olm-catalog/serverless-operator/manifests/openshift-knative-operator.service.yaml
+++ b/olm-catalog/serverless-operator/manifests/openshift-knative-operator.service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: knative-operator
+  name: knative-operator-metrics
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    name: knative-operator
+  type: ClusterIP

--- a/olm-catalog/serverless-operator/manifests/openshift-knative-operator.servicemonitor.yaml
+++ b/olm-catalog/serverless-operator/manifests/openshift-knative-operator.servicemonitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    name: knative-operator
+  name: knative-operator-metrics
+spec:
+  endpoints:
+    - port: metrics
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      name: knative-operator

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -547,7 +547,7 @@ spec:
                         name: metrics
                     env:
                       - name: METRICS_DOMAIN
-                        value: knative.dev/serving-ingress
+                        value: knative.dev/serving
                       - name: WATCH_NAMESPACE
                         value: "" # watch all namespaces for ClusterIngress
                       - name: POD_NAME

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -377,7 +377,7 @@ spec:
                       - name: "IMAGE_KN_CLI_ARTIFACTS"
                         value: "registry.ci.openshift.org/openshift/knative-v0.21.0:kn-cli-artifacts"
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+                    image: docker.io/skonto/openshift-knative-operator
                     imagePullPolicy: IfNotPresent
                     name: knative-operator
                     ports:
@@ -400,7 +400,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                    image: docker.io/skonto/knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -540,9 +540,14 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                    image: docker.io/skonto/knative-openshift-ingress
                     imagePullPolicy: Always
+                    ports:
+                      - containerPort: 9090
+                        name: metrics
                     env:
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-ingress
                       - name: WATCH_NAMESPACE
                         value: "" # watch all namespaces for ClusterIngress
                       - name: POD_NAME
@@ -735,13 +740,13 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+      image: docker.io/skonto/openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+      image: docker.io/skonto/knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+      image: docker.io/skonto/knative-openshift-ingress
     - name: "IMAGE_queue-proxy"
       image: "registry.ci.openshift.org/openshift/knative-v0.22.0:knative-serving-queue"
     - name: "IMAGE_activator"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -377,7 +377,7 @@ spec:
                       - name: "IMAGE_KN_CLI_ARTIFACTS"
                         value: "registry.ci.openshift.org/openshift/knative-v0.21.0:kn-cli-artifacts"
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: docker.io/skonto/openshift-knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
                     imagePullPolicy: IfNotPresent
                     name: knative-operator
                     ports:
@@ -400,7 +400,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: docker.io/skonto/knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -540,7 +540,7 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: docker.io/skonto/knative-openshift-ingress
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -740,13 +740,13 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: docker.io/skonto/openshift-knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: docker.io/skonto/knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: docker.io/skonto/knative-openshift-ingress
+      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
     - name: "IMAGE_queue-proxy"
       image: "registry.ci.openshift.org/openshift/knative-v0.22.0:knative-serving-queue"
     - name: "IMAGE_activator"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -398,7 +398,12 @@ spec:
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                   image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
                   imagePullPolicy: Always
+                  ports:
+                    - containerPort: 9090
+                      name: metrics
                   env:
+                    - name: METRICS_DOMAIN
+                      value: knative.dev/serving-ingress
                     - name: WATCH_NAMESPACE
                       value: "" # watch all namespaces for ClusterIngress
                     - name: POD_NAME

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -403,7 +403,7 @@ spec:
                       name: metrics
                   env:
                     - name: METRICS_DOMAIN
-                      value: knative.dev/serving-ingress
+                      value: knative.dev/serving
                     - name: WATCH_NAMESPACE
                       value: "" # watch all namespaces for ClusterIngress
                     - name: POD_NAME

--- a/test/monitoringe2e/helpers.go
+++ b/test/monitoringe2e/helpers.go
@@ -45,7 +45,7 @@ var (
 	serverlessComponentQueries = []string{
 		// Checks if openshift-knative-operator metrics are served
 		"knative_operator_go_mallocs",
-		// Checks if knative-opeshift metrics are served
+		// Checks if knative-openshift metrics are served
 		"controller_runtime_active_workers{controller=\"knativeserving-controller\"}",
 		// Checks if knative-openshift-ingress metrics are served
 		"openshift_ingress_controller_go_mallocs",

--- a/test/monitoringe2e/helpers.go
+++ b/test/monitoringe2e/helpers.go
@@ -41,6 +41,15 @@ var (
 		"mt_broker_ingress_go_mallocs",
 		"sugar_controller_go_mallocs",
 	}
+
+	serverlessComponentQueries = []string{
+		// Checks if openshift-knative-operator metrics are served
+		"knative_operator_go_mallocs",
+		// Checks if knative-opeshift metrics are served
+		"controller_runtime_active_workers{controller=\"knativeserving-controller\"}",
+		// Checks if knative-openshift-ingress metrics are served
+		"openshift_ingress_controller_go_mallocs",
+	}
 )
 
 type authRoundtripper struct {
@@ -116,7 +125,7 @@ func VerifyHealthStatusMetric(caCtx *test.Context, label string, expectedValue s
 	return nil
 }
 
-func VerifyControlPlaneMetrics(caCtx *test.Context, metricQueries []string) error {
+func VerifyMetrics(caCtx *test.Context, metricQueries []string) error {
 	pc, err := newPrometheusClient(caCtx)
 	if err != nil {
 		return err

--- a/test/monitoringe2e/monitoring_test.go
+++ b/test/monitoringe2e/monitoring_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test"
 )
 
-func TestKnativeControlPlaneMetrics(t *testing.T) {
+func TestKnativeMetrics(t *testing.T) {
 	caCtx := test.SetupClusterAdmin(t)
 	cleanup := func() {
 		test.CleanupAll(t, caCtx)
@@ -15,15 +15,23 @@ func TestKnativeControlPlaneMetrics(t *testing.T) {
 	defer cleanup()
 	t.Run("verify Serving control plane metrics work correctly", func(t *testing.T) {
 		// Serving control plane metrics should work
-		if err := VerifyControlPlaneMetrics(caCtx, servingMetricQueries); err != nil {
+		if err := VerifyMetrics(caCtx, servingMetricQueries); err != nil {
 			t.Fatal("Failed to verify that Serving control plane metrics work correctly", err)
 		}
 	})
 
 	t.Run("verify Eventing control plane metrics work correctly", func(t *testing.T) {
 		// Eventing control plane metrics should work
-		if err := VerifyControlPlaneMetrics(caCtx, eventingMetricQueries); err != nil {
+		if err := VerifyMetrics(caCtx, eventingMetricQueries); err != nil {
 			t.Fatal("Failed to verify that Eventing control plane metrics work correctly", err)
 		}
 	})
+
+	t.Run("verify Knative operators and Openshift ingress metrics work correctly", func(t *testing.T) {
+		// Eventing control plane metrics should work
+		if err := VerifyMetrics(caCtx, serverlessComponentQueries); err != nil {
+			t.Fatal("Failed to verify that Knative operators and Openshift ingress metrics work correctly", err)
+		}
+	})
 }
+

--- a/test/monitoringe2e/monitoring_test.go
+++ b/test/monitoringe2e/monitoring_test.go
@@ -28,7 +28,7 @@ func TestKnativeMetrics(t *testing.T) {
 	})
 
 	t.Run("verify Knative operators and Openshift ingress metrics work correctly", func(t *testing.T) {
-		// Eventing control plane metrics should work
+		// Knative operators and Openshift ingress metrics should work
 		if err := VerifyMetrics(caCtx, serverlessComponentQueries); err != nil {
 			t.Fatal("Failed to verify that Knative operators and Openshift ingress metrics work correctly", err)
 		}

--- a/test/monitoringe2e/monitoring_test.go
+++ b/test/monitoringe2e/monitoring_test.go
@@ -34,4 +34,3 @@ func TestKnativeMetrics(t *testing.T) {
 		}
 	})
 }
-


### PR DESCRIPTION
- Enables metrics for [openshift knative operator ](https://gist.github.com/skonto/b1012b47ef9818d12a7d34ffed9fb40f)and [ingress](https://gist.github.com/skonto/b6c1ef4c5d4e5ee74712ea039d06ab28). 
- Resources will be managed by olm as in the case of the serverless operator.
- Adds e2e tests for these metric endpoints.
- Endpoints are not secured as they do not disclose critical info.