### PR TITLE
Apply kourier defaulting a bit more diligently

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -189,6 +189,26 @@ func TestReconcile(t *testing.T) {
 			}
 		}),
 	}, {
+		name: "respect kourier settings",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				Ingress: &v1alpha1.IngressConfigs{
+					Kourier: v1alpha1.KourierIngressConfiguration{
+						// Enabled: true omitted explicitly.
+						ServiceType: corev1.ServiceTypeClusterIP,
+					},
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
+				Kourier: v1alpha1.KourierIngressConfiguration{
+					Enabled:     true,
+					ServiceType: corev1.ServiceTypeClusterIP,
+				},
+			}
+		}),
+	}, {
 		name: "respects different status",
 		in: ks(func(ks *v1alpha1.KnativeServing) {
 			ks.Status.MarkDependenciesInstalled()

--- a/openshift-knative-operator/pkg/serving/ingress.go
+++ b/openshift-knative-operator/pkg/serving/ingress.go
@@ -8,12 +8,17 @@ const istioIngressClassName = "istio.ingress.networking.knative.dev"
 // Also handles the (buggy) case, where all Ingresses are disabled.
 // See https://github.com/knative/operator/issues/568.
 func defaultToKourier(ks *v1alpha1.KnativeServing) {
-	if ks.Spec.Ingress == nil || (!ks.Spec.Ingress.Istio.Enabled && !ks.Spec.Ingress.Kourier.Enabled && !ks.Spec.Ingress.Contour.Enabled) {
+	if ks.Spec.Ingress == nil {
 		ks.Spec.Ingress = &v1alpha1.IngressConfigs{
 			Kourier: v1alpha1.KourierIngressConfiguration{
 				Enabled: true,
 			},
 		}
+		return
+	}
+
+	if !ks.Spec.Ingress.Istio.Enabled && !ks.Spec.Ingress.Kourier.Enabled && !ks.Spec.Ingress.Contour.Enabled {
+		ks.Spec.Ingress.Kourier.Enabled = true
 	}
 }
 


### PR DESCRIPTION
If the user forgets to set `enabled: true` to the Kourier ingress configuration while also configuring other fields like `service-type`, we'll currently swallow the extra config, which is a weird experience. This fixes that.

/assign @nak3 