### PR TITLE
Determine default ingress class based on enabled ingress

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -162,6 +162,7 @@ func TestReconcile(t *testing.T) {
 					Enabled: true,
 				},
 			}
+			common.Configure(&ks.Spec.CommonSpec, "network", "ingress.class", istioIngressClassName)
 		}),
 	}, {
 		name: "fix 'wrong' ingress config", // https://github.com/knative/operator/issues/568

--- a/openshift-knative-operator/pkg/serving/ingress.go
+++ b/openshift-knative-operator/pkg/serving/ingress.go
@@ -1,0 +1,35 @@
+package serving
+
+import "knative.dev/operator/pkg/apis/operator/v1alpha1"
+
+const istioIngressClassName = "istio.ingress.networking.knative.dev"
+
+// defaultToKourier applies an Ingress config with Kourier enabled if nothing else is defined.
+// Also handles the (buggy) case, where all Ingresses are disabled.
+// See https://github.com/knative/operator/issues/568.
+func defaultToKourier(ks *v1alpha1.KnativeServing) {
+	if ks.Spec.Ingress == nil || (!ks.Spec.Ingress.Istio.Enabled && !ks.Spec.Ingress.Kourier.Enabled && !ks.Spec.Ingress.Contour.Enabled) {
+		ks.Spec.Ingress = &v1alpha1.IngressConfigs{
+			Kourier: v1alpha1.KourierIngressConfiguration{
+				Enabled: true,
+			},
+		}
+	}
+}
+
+// defaultIngressClass tries to figure out which ingress class to default to.
+// - If nothing is defined, Kourier will be used.
+// - If Kourier is enabled, it'll always take precedence.
+// - If only Istio is enabled, it'll be used.
+func defaultIngressClass(ks *v1alpha1.KnativeServing) string {
+	if ks.Spec.Ingress == nil {
+		return kourierIngressClassName
+	}
+	if ks.Spec.Ingress.Kourier.Enabled {
+		return kourierIngressClassName
+	}
+	if ks.Spec.Ingress.Istio.Enabled {
+		return istioIngressClassName
+	}
+	return kourierIngressClassName
+}

--- a/openshift-knative-operator/pkg/serving/ingress_test.go
+++ b/openshift-knative-operator/pkg/serving/ingress_test.go
@@ -1,0 +1,64 @@
+package serving
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
+
+func TestDefaultIngressClass(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       *v1alpha1.KnativeServing
+		expected string
+	}{{
+		name:     "unset",
+		in:       &v1alpha1.KnativeServing{},
+		expected: kourierIngressClassName,
+	}, {
+		name: "all disabled",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				Ingress: &v1alpha1.IngressConfigs{},
+			},
+		},
+		expected: kourierIngressClassName,
+	}, {
+		name: "istio enabled",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				Ingress: &v1alpha1.IngressConfigs{
+					Istio: v1alpha1.IstioIngressConfiguration{
+						Enabled: true,
+					},
+				},
+			},
+		},
+		expected: istioIngressClassName,
+	}, {
+		name: "kourier and istio enabled",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				Ingress: &v1alpha1.IngressConfigs{
+					Kourier: v1alpha1.KourierIngressConfiguration{
+						Enabled: true,
+					},
+					Istio: v1alpha1.IstioIngressConfiguration{
+						Enabled: true,
+					},
+				},
+			},
+		},
+		expected: kourierIngressClassName,
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := defaultIngressClass(c.in)
+			if !cmp.Equal(got, c.expected) {
+				t.Errorf("Got = %v, want: %v, diff:\n%s", got, c.expected, cmp.Diff(got, c.expected))
+			}
+		})
+	}
+}

--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -5,7 +5,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const providerLabel = "networking.knative.dev/ingress-provider"
+const (
+	providerLabel           = "networking.knative.dev/ingress-provider"
+	kourierIngressClassName = "kourier.ingress.networking.knative.dev"
+)
 
 // overrideKourierNamespace overrides the namespace of all Kourier related resources to
 // the -ingress suffix to be backwards compatible.


### PR DESCRIPTION
Since we now support using the Ingress API (`spec.ingress`) we can actually use that to determine the ingress class so the user doesn't have to configure it "twice" (once via the ingress API and then explicitly setting the ingress class to the same value).

Essentially, a small quality-of-life improvement.

/assign @nak3 