### PR TITLE
Replace golint with revive

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Go Lint - knative-operator
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.30
+          version: v1.40
           working-directory: ./src/github.com/${{ github.repository }}
 
       # This is mostly copied from https://github.com/get-woke/woke-action-reviewdog/blob/main/entrypoint.sh

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,10 +12,10 @@ linters:
     - asciicheck
     - gofmt
     - goimports
-    - golint
     - gosec
     - misspell
     - prealloc
+    - revive
     - stylecheck
     - unconvert
     - unparam
@@ -28,3 +28,7 @@ issues:
       linters:
         - gosec
         - unparam
+
+    - text: "should have comment"
+      linters:
+        - revive

--- a/knative-operator/pkg/common/service_monitor.go
+++ b/knative-operator/pkg/common/service_monitor.go
@@ -60,10 +60,7 @@ func SetupSourceServiceMonitor(client client.Client, instance *appsv1.Deployment
 	if manifest, err = manifest.Transform(transforms...); err != nil {
 		return fmt.Errorf("unable to transform source service monitor manifest: %w", err)
 	}
-	if err := manifest.Apply(); err != nil {
-		return err
-	}
-	return nil
+	return manifest.Apply()
 }
 
 func getMonitorPath(envVar string, defaultVal string) string {

--- a/knative-operator/pkg/common/serving.go
+++ b/knative-operator/pkg/common/serving.go
@@ -16,7 +16,7 @@ import (
 var log = Log
 
 const (
-	// defaultDomainTemplate is a value for domainTemplate in config-network.
+	// DefaultDomainTemplate is a value for domainTemplate in config-network.
 	// As Knative on OpenShift uses OpenShift's wildcard cert the domain level must have "<sub>.domain", not "<sub1>.<sub2>.domain".
 	DefaultDomainTemplate = "{{.Name}}-{{.Namespace}}.{{.Domain}}"
 )

--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -108,7 +108,7 @@ func EnsureContainerMemoryLimit(s *operatorv1alpha1.CommonSpec, containerName st
 	})
 }
 
-// common function to enqueue reconcile requests for resources
+// EnqueueRequestByOwnerAnnotations is a common function to enqueue reconcile requests for resources.
 func EnqueueRequestByOwnerAnnotations(ownerNameAnnotationKey, ownerNamespaceAnnotationKey string) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
 		annotations := obj.GetAnnotations()

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -172,10 +172,7 @@ func (r *ReconcileKnativeEventing) installDashboards(instance *eventingv1alpha1.
 	if err := dashboard.Apply(os.Getenv(dashboard.EventingBrokerDashboardPathEnvVar), instance, r.client); err != nil {
 		return err
 	}
-	if err := dashboard.Apply(os.Getenv(dashboard.EventingSourceDashboardPathEnvVar), instance, r.client); err != nil {
-		return err
-	}
-	return nil
+	return dashboard.Apply(os.Getenv(dashboard.EventingSourceDashboardPathEnvVar), instance, r.client)
 }
 
 // general clean-up, mostly resources in different namespaces from eventingv1alpha1.KnativeEventing.

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -170,10 +170,7 @@ func (r *ReconcileKnativeKafka) reconcileKnativeKafka(instance *operatorv1alpha1
 		return err
 	}
 	// delete the components that are disabled
-	if err := r.executeDeleteStages(instance); err != nil {
-		return err
-	}
-	return nil
+	return r.executeDeleteStages(instance)
 }
 
 func (r *ReconcileKnativeKafka) executeInstallStages(instance *operatorv1alpha1.KnativeKafka) error {

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -48,10 +48,7 @@ func Apply(instance *servingv1alpha1.KnativeServing, apiclient client.Client, sc
 	if !service.IsReady() {
 		return fmt.Errorf("knative service %q/%q not ready yet", knConsoleCLIDownloadService, instance.GetNamespace())
 	}
-	if err := reconcileKnConsoleCLIDownload(apiclient, instance, service); err != nil {
-		return err
-	}
-	return nil
+	return reconcileKnConsoleCLIDownload(apiclient, instance, service)
 }
 
 // reconcileKnCCDResources reconciles required resources viz Knative Service

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -327,10 +327,7 @@ func (r *ReconcileKnativeServing) reconcileConfigMap(instance *servingv1alpha1.K
 }
 
 func (r *ReconcileKnativeServing) installQuickstarts(instance *servingv1alpha1.KnativeServing) error {
-	if err := quickstart.Apply(instance, r.client); err != nil {
-		return err
-	}
-	return nil
+	return quickstart.Apply(instance, r.client)
 }
 
 // installKnConsoleCLIDownload creates CR for kn CLI download link

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go
@@ -25,8 +25,7 @@ func NewConfigurator(decoder *admission.Decoder) *Configurator {
 // Implement admission.Handler so the controller can handle admission request.
 var _ admission.Handler = (*Configurator)(nil)
 
-// Configurator adds an annotation to every incoming
-// KnativeEventing CR.
+// Handle implements the Handler interface.
 func (v *Configurator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	ke := &eventingv1alpha1.KnativeEventing{}
 

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
@@ -29,7 +29,7 @@ func NewValidator(client client.Client, decoder *admission.Decoder) *Validator {
 // Implement admission.Handler so the controller can handle admission request.
 var _ admission.Handler = (*Validator)(nil)
 
-// What makes us a webhook
+// Handle implements the Handler interface.
 func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	ke := &eventingv1alpha1.KnativeEventing{}
 

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating.go
@@ -30,7 +30,7 @@ func NewValidator(client client.Client, decoder *admission.Decoder) *Validator {
 // Implement admission.Handler so the controller can handle admission request.
 var _ admission.Handler = (*Validator)(nil)
 
-// What makes us a webhook
+// Handle implements the Handler interface.
 func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	ke := &operatorv1alpha1.KnativeKafka{}
 

--- a/knative-operator/pkg/webhook/knativeserving/webhook_mutating.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_mutating.go
@@ -28,8 +28,7 @@ func NewConfigurator(client client.Client, decoder *admission.Decoder) *Configur
 // Implement admission.Handler so the controller can handle admission request.
 var _ admission.Handler = (*Configurator)(nil)
 
-// Configurator adds an annotation to every incoming
-// KnativeServing CR.
+// Handle implements the Handler interface.
 func (v *Configurator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	ks := &servingv1alpha1.KnativeServing{}
 

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating.go
@@ -29,7 +29,7 @@ func NewValidator(client client.Client, decoder *admission.Decoder) *Validator {
 // Implement admission.Handler so the controller can handle admission request.
 var _ admission.Handler = (*Validator)(nil)
 
-// What makes us a webhook
+// Handle implements the Handler interface.
 func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	ks := &servingv1alpha1.KnativeServing{}
 

--- a/openshift-knative-operator/pkg/common/deployment.go
+++ b/openshift-knative-operator/pkg/common/deployment.go
@@ -61,10 +61,6 @@ func transformDeployment(name string, f func(*appsv1.Deployment) error) mf.Trans
 			return err
 		}
 
-		if err := scheme.Scheme.Convert(deployment, u, nil); err != nil {
-			return err
-		}
-
-		return nil
+		return scheme.Scheme.Convert(deployment, u, nil)
 	}
 }

--- a/openshift-knative-operator/pkg/eventing/extension.go
+++ b/openshift-knative-operator/pkg/eventing/extension.go
@@ -60,10 +60,7 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 		ke.Spec.SinkBindingSelectionMode = "inclusion"
 	}
 
-	if err := monitoring.ReconcileMonitoringForEventing(ctx, e.kubeclient, ke); err != nil {
-		return err
-	}
-	return nil
+	return monitoring.ReconcileMonitoringForEventing(ctx, e.kubeclient, ke)
 }
 
 func (e *extension) Finalize(context.Context, v1alpha1.KComponent) error {

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -120,10 +120,7 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 			Type: "ConfigMap",
 		}
 	}
-	if err := monitoring.ReconcileMonitoringForServing(ctx, e.kubeclient, ks); err != nil {
-		return err
-	}
-	return nil
+	return monitoring.ReconcileMonitoringForServing(ctx, e.kubeclient, ks)
 }
 
 func (e *extension) Finalize(ctx context.Context, comp v1alpha1.KComponent) error {

--- a/test/clients.go
+++ b/test/clients.go
@@ -146,7 +146,7 @@ func NewClients(kubeconfig string) (*Clients, error) {
 	return clients, nil
 }
 
-// Cleanup for all contexts
+// CleanupAll cleans up all contexts
 func CleanupAll(t *testing.T, contexts ...*Context) {
 	for _, ctx := range contexts {
 		ctx.Cleanup(t)


### PR DESCRIPTION
See https://groups.google.com/g/golang-nuts/c/rCP70Aq_tBc/m/8QHp6_cqBgAJ
as towards golint's deprecation. revive is supposed to be a drop-in
replacement.