### PR TITLE
Fix stray shellcheck warnings to make everything clear

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -101,7 +101,7 @@ jobs:
             -not -path '*vendor*' | xargs -r shellcheck --format=checkstyle \
             | reviewdog -f=checkstyle \
                 -name="shellcheck" \
-                -reporter="github-pr-review" \
+                -reporter="github-pr-check" \
                 -filter-mode="added" \
                 -fail-on-error="true" \
                 -level="error"

--- a/test/eventing.bash
+++ b/test/eventing.bash
@@ -3,9 +3,6 @@
 # For SC2164
 set -e
 
-readonly EVENTING_READY_FILE="/tmp/eventing-prober-ready"
-readonly EVENTING_PROBER_FILE="/tmp/eventing-prober-signal"
-
 function upstream_knative_eventing_e2e {
   logger.info 'Running eventing tests'
 


### PR DESCRIPTION
As per title, these have been lingering. Also changed the shellcheck reporter to be pr-check based which is more robust than PR review.