### PR TITLE
[1.15] remove hpa for kafkas

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
@@ -926,42 +926,6 @@ spec:
       terminationGracePeriodSeconds: 300
 
 ---
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: autoscaling/v2beta2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: kafka-webhook
-  namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: devel
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: kafka-webhook
-  minReplicas: 1
-  maxReplicas: 5
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 100
----
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/knative-operator/hack/008-eventing-kafka-hpa.patch
+++ b/knative-operator/hack/008-eventing-kafka-hpa.patch
@@ -1,0 +1,47 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+index 0f3a867d..affa1a15 100644
+--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
++++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+@@ -926,42 +926,6 @@ spec:
+       terminationGracePeriodSeconds: 300
+ 
+ ---
+-# Copyright 2021 The Knative Authors
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     https://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-
+-apiVersion: autoscaling/v2beta2
+-kind: HorizontalPodAutoscaler
+-metadata:
+-  name: kafka-webhook
+-  namespace: knative-eventing
+-  labels:
+-    eventing.knative.dev/release: devel
+-spec:
+-  scaleTargetRef:
+-    apiVersion: apps/v1
+-    kind: Deployment
+-    name: kafka-webhook
+-  minReplicas: 1
+-  maxReplicas: 5
+-  metrics:
+-    - type: Resource
+-      resource:
+-        name: cpu
+-        target:
+-          type: Utilization
+-          averageUtilization: 100
+----
+ # Copyright 2020 The Knative Authors
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -53,3 +53,6 @@ git apply "$root/knative-operator/hack/006-kafkachannel-storage-beta1.patch"
 
 # This is for  SRVKe-807.
 git apply "$root/knative-operator/hack/007-eventing-kafka-pdb.patch"
+
+# This is for SRVKE-814
+git apply "$root/knative-operator/hack/008-eventing-kafka-hpa.patch"


### PR DESCRIPTION
For Srvke-814 we remove the HPA, for now


(similar to SRVKE-629 (which was eventing core))