### PR TITLE
Port kafkas pdb removal to main

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
@@ -962,21 +962,6 @@ spec:
           type: Utilization
           averageUtilization: 100
 ---
-# Webhook PDB.
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: kafka-webhook
-  namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: devel
-spec:
-  minAvailable: 80%
-  selector:
-    matchLabels:
-      app: kafka-webhook
-
----
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/knative-operator/hack/007-eventing-kafka-pdb.patch
+++ b/knative-operator/hack/007-eventing-kafka-pdb.patch
@@ -1,0 +1,26 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+index 0008eb6f..3244db66 100644
+--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
++++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+@@ -962,21 +962,6 @@ spec:
+           type: Utilization
+           averageUtilization: 100
+ ---
+-# Webhook PDB.
+-apiVersion: policy/v1beta1
+-kind: PodDisruptionBudget
+-metadata:
+-  name: kafka-webhook
+-  namespace: knative-eventing
+-  labels:
+-    eventing.knative.dev/release: devel
+-spec:
+-  minAvailable: 80%
+-  selector:
+-    matchLabels:
+-      app: kafka-webhook
+-
+----
+ # Copyright 2020 The Knative Authors
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -33,3 +33,6 @@ function download_kafka {
 }
 
 download_kafka knativekafka "$KNATIVE_EVENTING_KAFKA_VERSION" "${kafka_files[@]}"
+
+# This is for  SRVKE-807.
+git apply "$root/knative-operator/hack/007-eventing-kafka-pdb.patch"


### PR DESCRIPTION
Porting the `Knattive Kafka` related parts of SRVKE-807 to `main`  (which was only addressed on 1.15 so far)