### PR TITLE
Destroy all image references to guarantee overrides to work

### DIFF
--- a/hack/lib/common.bash
+++ b/hack/lib/common.bash
@@ -78,3 +78,9 @@ function versions.major_minor {
   # Ref: https://regex101.com/r/Po1HA3/1
   echo "${version}" | sed 's/^v\?\([[:digit:]]\+\)\.\([[:digit:]]\+\).*/\1.\2/'
 }
+
+# Breaks all image references in the passed YAML file.
+function yaml.break_image_references {
+  sed -i "s,image: .*,image: TO_BE_REPLACED," "$1"
+  sed -i "s,queueSidecarImage: .*,queueSidecarImage: TO_BE_REPLACED," "$1"
+}

--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
@@ -674,7 +674,7 @@ spec:
       serviceAccountName: kafka-ch-controller
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka/cmd/channel/consolidated/controller@sha256:9a5a69b557e1513cc91dd7f69c0d0b54091820ae0b65561916418e76c11e33e2
+          image: TO_BE_REPLACED
           env:
             - name: CONFIG_LOGGING_NAME
               value: config-logging
@@ -744,7 +744,7 @@ spec:
     spec:
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka/cmd/channel/consolidated/dispatcher@sha256:329f0efd4c266467bcd669218beb7bde8020d6e5316a90375de113e38f833f13
+          image: TO_BE_REPLACED
           env:
             - name: SYSTEM_NAMESPACE
               value: ''
@@ -887,7 +887,7 @@ spec:
       containers:
         - name: kafka-webhook
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka/cmd/webhook@sha256:44225c21dff1fb38ad343b80a212e8a3541fa5952fa8c087f9ce59c3973841bc
+          image: TO_BE_REPLACED
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:

--- a/knative-operator/deploy/resources/knativekafka/2-source.yaml
+++ b/knative-operator/deploy/resources/knativekafka/2-source.yaml
@@ -466,7 +466,7 @@ spec:
       serviceAccountName: kafka-controller-manager
       containers:
         - name: manager
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka/cmd/source/controller@sha256:6a00b749fce9efd721bf5c1c834cd0129594d0edf3fdaf25e10f6566ffe4577e
+          image: TO_BE_REPLACED
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -29,6 +29,9 @@ function download_kafka {
     url="https://github.com/knative-sandbox/eventing-kafka/releases/download/$version/$file"
 
     wget --no-check-certificate "$url" -O "$target_file"
+
+    # Break all image references so we know our overrides work correctly.
+    yaml.break_image_references "$target_file"
   done
 }
 

--- a/openshift-knative-operator/cmd/operator/kodata/ingress/0.22/5-controller.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/0.22/5-controller.yaml
@@ -41,7 +41,7 @@ spec:
       - name: networking-istio
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: ko://knative.dev/net-istio/cmd/controller
+        image: TO_BE_REPLACED
 
         resources:
           requests:

--- a/openshift-knative-operator/cmd/operator/kodata/ingress/0.22/6-webhook-deployment.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/0.22/6-webhook-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: ko://knative.dev/net-istio/cmd/webhook
+        image: TO_BE_REPLACED
 
         resources:
           requests:

--- a/openshift-knative-operator/cmd/operator/kodata/ingress/0.22/kourier.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/0.22/kourier.yaml
@@ -222,7 +222,7 @@ spec:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: gcr.io/knative-releases/knative.dev/net-kourier/cmd/kourier@sha256:7f10e56399b567a59bac93e8c59912acd073d9a1e3b3c0f763284083d0707e47
+        - image: TO_BE_REPLACED
           name: kourier-control
           env:
             - name: CERTS_SECRET_NAMESPACE
@@ -308,7 +308,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/envoyproxy/envoy:v1.16-latest
+          image: TO_BE_REPLACED
           name: kourier-gateway
           ports:
             - name: http2-external

--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/2-eventing-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/2-eventing-core.yaml
@@ -671,7 +671,7 @@ spec:
       containers:
         - name: eventing-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:b02cfc6d0858de1ae6d5d5acbe1ac2ed1c5411f2adcec417c2b113b3b3274e4a
+          image: TO_BE_REPLACED
           resources:
             requests:
               cpu: 100m
@@ -751,7 +751,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:ac30b62fa390b01c24a9bb891c4b8aa7a8c6c747a5182592d81af58d65eaa65c
+          image: TO_BE_REPLACED
           env:
             - name: SYSTEM_NAMESPACE
               value: ''
@@ -887,7 +887,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:5f037fe6755fb85fb0a155f9892c8519a058dbf395d2d04b2c6769ffd2d68950
+          image: TO_BE_REPLACED
           resources:
             requests:
               # taken from serving.

--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/3-in-memory-channel.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/3-in-memory-channel.yaml
@@ -690,7 +690,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:4f035b5037826141b04ffb5a3341c8382a749f8d1f4cc08d6fe7b840490a3f57
+          image: TO_BE_REPLACED
           env:
             - name: CONFIG_LOGGING_NAME
               value: config-logging
@@ -760,7 +760,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:6d6fe3f22de31580147b3b58b31dc27ddbd53a7cbb214dfea3a9542c605fc759
+          image: TO_BE_REPLACED
           readinessProbe: &probe
             failureThreshold: 3
             httpGet:

--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/4-mt-channel-broker.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/4-mt-channel-broker.yaml
@@ -286,7 +286,7 @@ spec:
       containers:
         - name: filter
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:3b629041b97f8eb5edb699ab23b30c686de70e71573e94d1510e6ec560f8f852
+          image: TO_BE_REPLACED
           readinessProbe: &probe
             failureThreshold: 3
             httpGet:
@@ -397,7 +397,7 @@ spec:
       containers:
         - name: ingress
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:d2d1eb861676848afd28079f6e27d422ba8833b257eb8cb1f68949ece3233d9b
+          image: TO_BE_REPLACED
           readinessProbe: &probe
             failureThreshold: 3
             httpGet:
@@ -518,7 +518,7 @@ spec:
       containers:
         - name: mt-broker-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:ef99bdd22bd3d05f05f2347e92f3470e5f3f95c54618b11578fa68beb86e24ba
+          image: TO_BE_REPLACED
           resources:
             requests:
               cpu: 100m

--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/5-eventing-sugar-controller.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/5-eventing-sugar-controller.yaml
@@ -31,7 +31,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:8ae0e243a1d31c0c57f8152fe83ddff1d1f62f9e38f4f13a75806023c200fb8b
+          image: TO_BE_REPLACED
           env:
             - name: CONFIG_LOGGING_NAME
               value: config-logging

--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
@@ -947,7 +947,7 @@ metadata:
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:6cd0c234bfbf88ac75df5243c2f9213dcc9def610414c506d418f9388187b771
+  image: TO_BE_REPLACED
 
 ---
 # Copyright 2018 The Knative Authors
@@ -1315,7 +1315,7 @@ metadata:
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:6cd0c234bfbf88ac75df5243c2f9213dcc9def610414c506d418f9388187b771
+  queueSidecarImage: TO_BE_REPLACED
   _example: |
     ################################
     #                              #
@@ -2212,7 +2212,7 @@ spec:
         - name: activator
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:91e67a579378fa39d7c941e379db183464c3add3d53b4617f65d9cbc2f0c770a
+          image: TO_BE_REPLACED
           # The numbers are based on performance test results from
           # https://github.com/knative/serving/issues/1625#issuecomment-511930023
           resources:
@@ -2362,7 +2362,7 @@ spec:
         - name: autoscaler
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:761dc36210e69ebef3a64ce72ad9f54f8172e4aed6b97e8a706e3128956ec54d
+          image: TO_BE_REPLACED
           resources:
             requests:
               cpu: 100m
@@ -2490,7 +2490,7 @@ spec:
         - name: controller
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:d772809059033e437d6e98248a334ded37b6f430c2ca23377875cc2459a3b73e
+          image: TO_BE_REPLACED
           resources:
             requests:
               cpu: 100m
@@ -2650,7 +2650,7 @@ spec:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:268bd1383b56ba7b9acf391c681f7a63780c22dcd4555c2f4a7b61ec6da81cf4
+          image: TO_BE_REPLACED
           resources:
             requests:
               cpu: 100m

--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/3-serving-hpa.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/3-serving-hpa.yaml
@@ -47,7 +47,7 @@ spec:
         - name: autoscaler-hpa
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:da6b79df4d841c6c84d58519978567b909ca4273f38dd54b2115cfcd70b7f823
+          image: TO_BE_REPLACED
           resources:
             requests:
               cpu: 30m

--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/5-serving-domainmapping.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/5-serving-domainmapping.yaml
@@ -155,7 +155,7 @@ spec:
         - name: domain-mapping
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256:2253b4d5d42853a8e5d88c5fe7ea44d9f59f42ee4e4a4144c7d68df850362cd4
+          image: TO_BE_REPLACED
           resources:
             requests:
               cpu: 30m
@@ -239,7 +239,7 @@ spec:
         - name: domainmapping-webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256:43aa1e03b450307e5fd45b5c6f1b705dc8fe13119ea79933ae81c1257e885cde
+          image: TO_BE_REPLACED
           resources:
             requests:
               cpu: 100m

--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/6-serving-post-install-jobs.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/6-serving-post-install-jobs.yaml
@@ -39,7 +39,7 @@ spec:
         - name: migrate
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:18e1c1a04c8a449f4599425d45c528d1e70734b375831c969af03f157b9749cb
+          image: TO_BE_REPLACED
           args:
             - "services.serving.knative.dev"
             - "configurations.serving.knative.dev"

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -38,6 +38,9 @@ function download {
     url="https://github.com/knative/$component/releases/download/$version/$file"
 
     wget --no-check-certificate "$url" -O "$target_file"
+
+    # Break all image references so we know our overrides work correctly.
+    yaml.break_image_references "$target_file"
   done
 }
 
@@ -59,7 +62,11 @@ function download_ingress {
     file="${files[$i]}.yaml"
     ingress_target_file="$ingress_dir/$index-$file"
     url="https://raw.githubusercontent.com/openshift-knative/${component}/${version}/config/${file}"
+
     wget --no-check-certificate "$url" -O "$ingress_target_file"
+
+    # Break all image references so we know our overrides work correctly.
+    yaml.break_image_references "$ingress_target_file"
   done
 }
 
@@ -72,6 +79,8 @@ kourier_file="$root/openshift-knative-operator/cmd/operator/kodata/ingress/$(ver
 wget --no-check-certificate "$url" -O "$kourier_file"
 # TODO: [SRVKS-610] These values should be replaced by operator instead of sed.
 sed -i -e 's/kourier-control.knative-serving/kourier-control.knative-serving-ingress/g' "$kourier_file"
+# Break all image references so we know our overrides work correctly.
+yaml.break_image_references "$kourier_file"
 
 # TODO: Remove this once upstream fixed https://github.com/knative/operator/issues/376.
 # See also https://issues.redhat.com/browse/SRVKS-670.

--- a/openshift-knative-operator/pkg/testdata/serving-core-deployment.yaml
+++ b/openshift-knative-operator/pkg/testdata/serving-core-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: activator
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:cbeb1cdcdde8b3b44bc5eb1c5a07512a36f4bd7fbee5e9677e8789ee2459b6ed
+          image: TO_BE_REPLACED
           # The numbers are based on performance test results from
           # https://github.com/knative/serving/issues/1625#issuecomment-511930023
           resources:


### PR DESCRIPTION
We've been missing a replacement one too many times now. This breaks all image references so deployments should fail completely, if we're missing a reference override somewhere.