### PR TITLE
[SRVKS-741] Drop namespaces from manifests to prevent reconcilation

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/2-eventing-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/2-eventing-core.yaml
@@ -11,27 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: knative-eventing
-  labels:
-    eventing.knative.dev/release: "v0.22.0"
-
----
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 apiVersion: v1
 kind: ServiceAccount

--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
@@ -1,25 +1,3 @@
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: knative-serving
-  labels:
-    serving.knative.dev/release: "v0.22.0"
-
----
 # Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/openshift-knative-operator/hack/001-eventing-namespace-deletion.patch
+++ b/openshift-knative-operator/hack/001-eventing-namespace-deletion.patch
@@ -1,0 +1,32 @@
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/2-eventing-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/2-eventing-core.yaml
+index 08010cff..8373873c 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/2-eventing-core.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/0.22.0/2-eventing-core.yaml
+@@ -11,27 +11,6 @@
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-apiVersion: v1
+-kind: Namespace
+-metadata:
+-  name: knative-eventing
+-  labels:
+-    eventing.knative.dev/release: "v0.22.0"
+-
+----
+-# Copyright 2018 The Knative Authors
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     http://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+ 
+ apiVersion: v1
+ kind: ServiceAccount

--- a/openshift-knative-operator/hack/001-serving-namespace-deletion.patch
+++ b/openshift-knative-operator/hack/001-serving-namespace-deletion.patch
@@ -1,0 +1,30 @@
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
+index e7f8e0d5..aa68ca9e 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
+@@ -1,25 +1,3 @@
+-# Copyright 2018 The Knative Authors
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     https://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-
+-apiVersion: v1
+-kind: Namespace
+-metadata:
+-  name: knative-serving
+-  labels:
+-    serving.knative.dev/release: "v0.22.0"
+-
+----
+ # Copyright 2019 The Knative Authors
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Having the namespaces in the manifests doesn't do anything useful as
we're requiring the user to create the namespace beforehand anyway. It
does however actively cause us to drop labels and annotations that users
have added via `kubectl apply` commands (versus `kubectl annotate` or
`kubectl label`), so it's actually harmful.