### PR TITLE
[SRVKS-744] Only configure domain template if not otherwise set

### DIFF
--- a/knative-operator/pkg/common/serving.go
+++ b/knative-operator/pkg/common/serving.go
@@ -15,19 +15,12 @@ import (
 
 var log = Log
 
-const (
-	// DefaultDomainTemplate is a value for domainTemplate in config-network.
-	// As Knative on OpenShift uses OpenShift's wildcard cert the domain level must have "<sub>.domain", not "<sub1>.<sub2>.domain".
-	DefaultDomainTemplate = "{{.Name}}-{{.Namespace}}.{{.Domain}}"
-)
-
 func Mutate(ks *servingv1alpha1.KnativeServing, c client.Client) error {
 	if err := ingress(ks, c); err != nil {
 		return fmt.Errorf("failed to configure ingress: %w", err)
 	}
 
 	configureLogURLTemplate(ks, c)
-	domainTemplate(ks)
 	ensureCustomCerts(ks)
 	imagesFromEnviron(ks)
 	ensureServingWebhookMemoryLimit(ks)
@@ -45,10 +38,6 @@ func defaultToHa(ks *servingv1alpha1.KnativeServing) {
 
 func ensureServingWebhookMemoryLimit(ks *servingv1alpha1.KnativeServing) {
 	EnsureContainerMemoryLimit(&ks.Spec.CommonSpec, "webhook", resource.MustParse("1024Mi"))
-}
-
-func domainTemplate(ks *servingv1alpha1.KnativeServing) {
-	Configure(ks, "network", "domainTemplate", DefaultDomainTemplate)
 }
 
 // configure ingress

--- a/knative-operator/pkg/common/serving_test.go
+++ b/knative-operator/pkg/common/serving_test.go
@@ -78,7 +78,6 @@ func TestMutate(t *testing.T) {
 			t.Error(err)
 		}
 
-		verifyNetworkConfig(t, ks)
 		verifyIngress(t, ks, domain)
 		verifyImageOverride(t, &ks.Spec.Registry, "queue-proxy", image)
 		verifyQueueProxySidecarImageOverride(t, ks, image)
@@ -91,7 +90,6 @@ func TestMutate(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		verifyNetworkConfig(t, ks)
 		verifyIngress(t, ks, domain)
 		verifyImageOverride(t, &ks.Spec.Registry, "queue-proxy", image)
 		verifyQueueProxySidecarImageOverride(t, ks, image)
@@ -100,13 +98,14 @@ func TestMutate(t *testing.T) {
 		tc.ha(t, ks)
 
 		// Force a change and rerun
-		ks.Spec.Config["network"]["ingress.class"] = "foo"
-		ks.Spec.Config["network"]["domainTemplate"] = "{{.Name}}.{{.Namespace}}.{{Domain}}"
+		ks.Spec.Config["network"] = map[string]string{
+			"ingress.class":  "foo",
+			"domainTemplate": "{{.Name}}.{{.Namespace}}.{{Domain}}",
+		}
 		err = common.Mutate(ks, client)
 		if err != nil {
 			t.Error(err)
 		}
-		verifyNetworkConfig(t, ks)
 		verifyIngress(t, ks, domain)
 		verifyImageOverride(t, &ks.Spec.Registry, "queue-proxy", image)
 		verifyQueueProxySidecarImageOverride(t, ks, image)
@@ -216,14 +215,6 @@ func verifyIngress(t *testing.T, ks *servingv1alpha1.KnativeServing, expected st
 	domain := ks.Spec.Config["domain"]
 	if actual, ok := domain[expected]; !ok || actual != "" {
 		t.Errorf("Missing %v, domain=%v", expected, domain)
-	}
-}
-
-func verifyNetworkConfig(t *testing.T, ks *servingv1alpha1.KnativeServing) {
-	network := ks.Spec.Config["network"]
-
-	if actual := network["domainTemplate"]; actual != common.DefaultDomainTemplate {
-		t.Errorf("got %q, want %q", actual, common.DefaultDomainTemplate)
 	}
 }
 

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -103,8 +103,7 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "ingress.class", defaultIngressClass(ks))
 
 	// Override the default domainTemplate to use $name-$ns rather than $name.$ns.
-	// TODO(SRVCOM-1069): Rethink overriding behavior and/or error surfacing.
-	common.Configure(&ks.Spec.CommonSpec, "network", "domainTemplate", defaultDomainTemplate)
+	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "domainTemplate", defaultDomainTemplate)
 
 	// Ensure webhook has 1G of memory.
 	common.EnsureContainerMemoryLimit(&ks.Spec.CommonSpec, "webhook", resource.MustParse("1024Mi"))


### PR DESCRIPTION
Users may have a legitimate reason to override this, so there is no point in us forcing a specific template on them.