### PR TITLE
Using Apache Kafka 2.8.0 and latest of Strimzi

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -23,7 +23,7 @@ function install_strimzi_cluster {
       namespace: kafka
     spec:
       kafka:
-        version: 2.7.0
+        version: 2.8.0
         replicas: 3
         listeners:
           - name: plain
@@ -46,8 +46,8 @@ function install_strimzi_cluster {
           offsets.topic.replication.factor: 3
           transaction.state.log.replication.factor: 3
           transaction.state.log.min.isr: 2
-          inter.broker.protocol.version: "2.7"
-          log.message.format.version: "2.7"
+          inter.broker.protocol.version: "2.8"
+          log.message.format.version: "2.8"
           auto.create.topics.enable: "false"
         storage:
           type: jbod

--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 function install_strimzi_operator {
-#  strimzi_version=$(curl https://github.com/strimzi/strimzi-kafka-operator/releases/latest |  awk -F 'tag/' '{print $2}' | awk -F '"' '{print $1}' 2>/dev/null)
-  strimzi_version=0.22.1
+  strimzi_version=$(curl https://github.com/strimzi/strimzi-kafka-operator/releases/latest |  awk -F 'tag/' '{print $2}' | awk -F '"' '{print $1}' 2>/dev/null)
   header "Installing Strimzi Kafka operator"
   oc create namespace kafka
   curl -L "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml" \

--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -4,9 +4,10 @@ function install_strimzi_operator {
   strimzi_version=$(curl https://github.com/strimzi/strimzi-kafka-operator/releases/latest |  awk -F 'tag/' '{print $2}' | awk -F '"' '{print $1}' 2>/dev/null)
   header "Installing Strimzi Kafka operator"
   oc create namespace kafka
+  oc -n kafka apply --selector strimzi.io/crd-install=true -f "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml"
   curl -L "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml" \
   | sed 's/namespace: .*/namespace: kafka/' \
-  | oc -n kafka create -f -
+  | oc -n kafka apply -f -
 
   # Wait for the CRD we need to actually be active
   oc wait crd --timeout=-1s kafkas.kafka.strimzi.io --for=condition=Established


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Reverting some PRs that had been needed temporary, due to changes on Strimzi:
* https://github.com/openshift-knative/serverless-operator/pull/853
* https://github.com/openshift-knative/serverless-operator/pull/942

We now can use the latest again and no longer need to do `oc create`.

Bonus: Using the latest (0.23) of Strimzi gives us the option to test against 2.8.0 of Apache Kafka :tada: 
