### PR TITLE
[SRVCOM-1331] Secure metric endpoints for Kafka control plane pods

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/rbacproxytransforms.go
+++ b/knative-operator/pkg/controller/knativekafka/rbacproxytransforms.go
@@ -1,0 +1,50 @@
+package knativekafka
+
+import (
+	"context"
+	"errors"
+
+	mf "github.com/manifestival/manifestival"
+	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
+	"k8s.io/apimachinery/pkg/util/sets"
+	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	kafkaChannelComponents = []string{"kafka-ch-controller", "kafka-ch-dispatcher", "kafka-webhook"}
+	kafkaSourceComponents  = []string{"kafka-controller-manager"}
+)
+
+func addRBACProxySupportToManifest(instance *operatorv1alpha1.KnativeKafka, components []string) (*mf.Manifest, error) {
+	proxyManifest := mf.Manifest{}
+	// Only create the roles needed for the deployment service accounts as Prometheus has already
+	// the rights needed due to eventing that is assumed to be installed.
+	for _, c := range components {
+		crbM, err := monitoring.CreateClusterRoleBindingManifest(c, instance.GetNamespace())
+		if err != nil {
+			return nil, err
+		}
+		proxyManifest = proxyManifest.Append(*crbM)
+		if err = monitoring.AppendManifestsForComponent(c, instance.GetNamespace(), &proxyManifest); err != nil {
+			return nil, err
+		}
+	}
+	return &proxyManifest, nil
+}
+
+func getRBACProxyInjectTransformer(apiClient client.Client) (mf.Transformer, error) {
+	eventingList := &eventingv1alpha1.KnativeEventingList{}
+	err := apiClient.List(context.Background(), eventingList)
+	if err != nil {
+		return nil, err
+	}
+	if len(eventingList.Items) == 0 {
+		return nil, errors.New("eventing instance not found")
+	}
+	if monitoring.ShouldEnableMonitoring(eventingList.Items[0].GetSpec().GetConfig()) {
+		return monitoring.InjectRbacProxyContainerToDeployments(sets.NewString(append(kafkaChannelComponents, kafkaSourceComponents...)...)), nil
+	}
+	return nil, nil
+}

--- a/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection.go
+++ b/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection.go
@@ -19,7 +19,7 @@ const (
 	rbacProxyImageEnvVar = "IMAGE_KUBE_RBAC_PROXY"
 )
 
-func injectRbacProxyContainerToDeployments(deployments sets.String) mf.Transformer {
+func InjectRbacProxyContainerToDeployments(deployments sets.String) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		kind := strings.ToLower(u.GetKind())
 		// Only touch the related deployments

--- a/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection_test.go
+++ b/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection_test.go
@@ -19,7 +19,7 @@ func TestInjectRbacProxyContainerToDeployments(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to load test manifest: %w", err)
 	}
-	transforms := []mf.Transformer{injectRbacProxyContainerToDeployments(servingDeployments)}
+	transforms := []mf.Transformer{InjectRbacProxyContainerToDeployments(servingDeployments)}
 	if manifest, err = manifest.Transform(transforms...); err != nil {
 		t.Errorf("Unable to transform test manifest: %w", err)
 	}

--- a/test/monitoringe2e/helpers.go
+++ b/test/monitoringe2e/helpers.go
@@ -42,6 +42,13 @@ var (
 		"sugar_controller_go_mallocs",
 	}
 
+	KafkaQueries = []string{
+		"kafkachannel_controller_go_mallocs",
+		"kafka_controller_go_mallocs",
+		"kafkachannel_webhook_go_mallocs",
+		"kafkachannel_dispatcher_go_mallocs",
+	}
+
 	serverlessComponentQueries = []string{
 		// Checks if openshift-knative-operator metrics are served
 		"knative_operator_go_mallocs",


### PR DESCRIPTION
- Adds rbac proxy to the right deployments
- Adds tests for the metrics exposed

Note: Kafka sources will be secured in another PR along with the rest of the sources.
