### PR TITLE
Dispacther is at replicas: 0, initially

### DIFF
--- a/test/e2ekafka/knative_kafka_test.go
+++ b/test/e2ekafka/knative_kafka_test.go
@@ -22,7 +22,6 @@ const (
 var knativeKafkaChannelControlPlaneDeploymentNames = []string{
 	"kafka-ch-controller",
 	"kafka-webhook",
-	"kafka-ch-dispatcher",
 }
 
 var knativeKafkaSourceControlPlaneDeploymentNames = []string{


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

The dispatcher is at `0` replicas, hence removing from the smoke test.

We will need to add a more sophisticated smoke test here.  Will create a JIRA for that, once _this_ is in.