### PR TITLE
Skip 0 replica optimization

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
@@ -726,9 +726,7 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: "v0.22.3"
 spec:
-  # this deployment is going to be scaled up by the
-  # controller when the very first KafkaChannel is created
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       messaging.knative.dev/channel: kafka-channel

--- a/knative-operator/hack/001-eventing-kafkachannel_replicas1.patch
+++ b/knative-operator/hack/001-eventing-kafkachannel_replicas1.patch
@@ -1,0 +1,15 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+index 393457ce..23da885d 100644
+--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
++++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+@@ -726,9 +726,7 @@ metadata:
+   labels:
+     kafka.eventing.knative.dev/release: "v0.22.3"
+ spec:
+-  # this deployment is going to be scaled up by the
+-  # controller when the very first KafkaChannel is created
+-  replicas: 0
++  replicas: 1
+   selector:
+     matchLabels:
+       messaging.knative.dev/channel: kafka-channel

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -37,5 +37,8 @@ function download_kafka {
 
 download_kafka knativekafka "$KNATIVE_EVENTING_KAFKA_VERSION" "${kafka_files[@]}"
 
+# We set the replica to 1, for now, while upstream has it 0.
+git apply "$root/knative-operator/hack/001-eventing-kafkachannel_replicas1.patch"
+
 # This is for  SRVKE-807.
 git apply "$root/knative-operator/hack/007-eventing-kafka-pdb.patch"


### PR DESCRIPTION
see if we are still better w/ default to `replicas: 1` for the kafka channel deployment 