### PR TITLE
OCP 4.6 was listed, which is kube 1.19

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -89,7 +89,7 @@ spec:
         kind: KnativeKafka
         name: knativekafkas.operator.serverless.openshift.io
         version: v1alpha1
-  minKubeVersion: 1.15.0
+  minKubeVersion: 1.19.0
   description: |-
     The Red Hat OpenShift Serverless operator provides a collection of APIs that
     enables containers, microservices and functions to run "serverless".

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -13,7 +13,7 @@ olm:
 
 requirements:
   kube:
-    minVersion: 1.15.0
+    minVersion: 1.19.0
   golang: '1.15'
   nodejs: 14.x
   ocp:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

As per title, aligning the min version w/ the listed lowest OCP version

/assign @markusthoemmes 