### PR TITLE
[SRVCOM-1285] Drop unsupported fields from the Serving CRD

### DIFF
--- a/olm-catalog/serverless-operator/hack/002-serving-drop-unsupported-fields.patch
+++ b/olm-catalog/serverless-operator/hack/002-serving-drop-unsupported-fields.patch
@@ -1,0 +1,112 @@
+diff --git a/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativeserving_crd.yaml b/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativeserving_crd.yaml
+index 141b7e33..8ce6f448 100644
+--- a/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativeserving_crd.yaml
++++ b/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativeserving_crd.yaml
+@@ -44,27 +44,8 @@ spec:
+             type: object
+           spec:
+             description: Spec defines the desired state of KnativeServing
++            x-kubernetes-preserve-unknown-fields: true # To allow for some fields we've deleted.
+             properties:
+-              additionalManifests:
+-                description: A list of the additional serving manifests, which will
+-                  be installed by the operator
+-                items:
+-                  properties:
+-                    URL:
+-                      description: The link of the additional manifest URL
+-                      type: string
+-                  type: object
+-                type: array
+-              cluster-local-gateway:
+-                description: A means to override the cluster-local-gateway. This field
+-                  is deprecated. Use `spec.ingres.istio.knative-local-gateway`
+-                properties:
+-                  selector:
+-                    additionalProperties:
+-                      type: string
+-                    description: The selector for the ingress-gateway.
+-                    type: object
+-                type: object
+               config:
+                 additionalProperties:
+                   additionalProperties:
+@@ -122,13 +103,8 @@ spec:
+                       minimum: 1
+               ingress:
+                 description: The ingress configuration for Knative Serving
++                x-kubernetes-preserve-unknown-fields: true # To allow for some fields we've deleted.
+                 properties:
+-                  contour:
+-                    description: Contour settings
+-                    properties:
+-                      enabled:
+-                        type: boolean
+-                    type: object
+                   istio:
+                     description: Istio settings
+                     properties:
+@@ -162,53 +138,6 @@ spec:
+                         type: string
+                     type: object
+                 type: object
+-              knative-ingress-gateway:
+-                description: A means to override the knative-ingress-gateway. This
+-                  field is deprecated. Use `spec.ingres.istio.knative-ingress-gateway`
+-                properties:
+-                  selector:
+-                    additionalProperties:
+-                      type: string
+-                    description: The selector for the ingress-gateway.
+-                    type: object
+-                type: object
+-              manifests:
+-                description: A list of serving manifests, which will be installed
+-                  by the operator
+-                items:
+-                  properties:
+-                    URL:
+-                      description: The link of the manifest URL
+-                      type: string
+-                  type: object
+-                type: array
+-              registry:
+-                description: A means to override the corresponding deployment images
+-                  in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+-                properties:
+-                  default:
+-                    description: The default image reference template to use for all
+-                      knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+-                    type: string
+-                  imagePullSecrets:
+-                    description: A list of secrets to be used when pulling the knative
+-                      images. The secret must be created in the same namespace as
+-                      the knative-serving deployments, and not the namespace of this
+-                      resource.
+-                    items:
+-                      properties:
+-                        name:
+-                          description: The name of the secret.
+-                          type: string
+-                      type: object
+-                    type: array
+-                  override:
+-                    additionalProperties:
+-                      type: string
+-                    description: A map of a container name or image name to the full
+-                      image location of the individual knative image.
+-                    type: object
+-                type: object
+               resources:
+                 description: A mapping of deployment name to resource requirements
+                 items:
+@@ -248,9 +177,6 @@ spec:
+                       type: object
+                   type: object
+                 type: array
+-              version:
+-                description: The version of Knative Serving to be installed
+-                type: string
+             type: object
+           status:
+             description: Status defines the observed state of KnativeServing

--- a/olm-catalog/serverless-operator/hack/update-manifests.sh
+++ b/olm-catalog/serverless-operator/hack/update-manifests.sh
@@ -23,3 +23,6 @@ wget --no-check-certificate "$eventing_url" -O "$target_eventing_file"
 
 # For SRVKE-755 state the actual default for Openshift Serverless disable HPA:
 git apply "$root/olm-catalog/serverless-operator/hack/001-eventing-sinkbinding-default-override"
+
+# Drop unsupported fields from the Serving CRD.
+git apply "$root/olm-catalog/serverless-operator/hack/002-serving-drop-unsupported-fields.patch"

--- a/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativeserving_crd.yaml
+++ b/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativeserving_crd.yaml
@@ -44,27 +44,8 @@ spec:
             type: object
           spec:
             description: Spec defines the desired state of KnativeServing
+            x-kubernetes-preserve-unknown-fields: true # To allow for some fields we've deleted.
             properties:
-              additionalManifests:
-                description: A list of the additional serving manifests, which will
-                  be installed by the operator
-                items:
-                  properties:
-                    URL:
-                      description: The link of the additional manifest URL
-                      type: string
-                  type: object
-                type: array
-              cluster-local-gateway:
-                description: A means to override the cluster-local-gateway. This field
-                  is deprecated. Use `spec.ingres.istio.knative-local-gateway`
-                properties:
-                  selector:
-                    additionalProperties:
-                      type: string
-                    description: The selector for the ingress-gateway.
-                    type: object
-                type: object
               config:
                 additionalProperties:
                   additionalProperties:
@@ -122,13 +103,8 @@ spec:
                       minimum: 1
               ingress:
                 description: The ingress configuration for Knative Serving
+                x-kubernetes-preserve-unknown-fields: true # To allow for some fields we've deleted.
                 properties:
-                  contour:
-                    description: Contour settings
-                    properties:
-                      enabled:
-                        type: boolean
-                    type: object
                   istio:
                     description: Istio settings
                     properties:
@@ -160,53 +136,6 @@ spec:
                         type: boolean
                       service-type:
                         type: string
-                    type: object
-                type: object
-              knative-ingress-gateway:
-                description: A means to override the knative-ingress-gateway. This
-                  field is deprecated. Use `spec.ingres.istio.knative-ingress-gateway`
-                properties:
-                  selector:
-                    additionalProperties:
-                      type: string
-                    description: The selector for the ingress-gateway.
-                    type: object
-                type: object
-              manifests:
-                description: A list of serving manifests, which will be installed
-                  by the operator
-                items:
-                  properties:
-                    URL:
-                      description: The link of the manifest URL
-                      type: string
-                  type: object
-                type: array
-              registry:
-                description: A means to override the corresponding deployment images
-                  in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
-                properties:
-                  default:
-                    description: The default image reference template to use for all
-                      knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
-                    type: string
-                  imagePullSecrets:
-                    description: A list of secrets to be used when pulling the knative
-                      images. The secret must be created in the same namespace as
-                      the knative-serving deployments, and not the namespace of this
-                      resource.
-                    items:
-                      properties:
-                        name:
-                          description: The name of the secret.
-                          type: string
-                      type: object
-                    type: array
-                  override:
-                    additionalProperties:
-                      type: string
-                    description: A map of a container name or image name to the full
-                      image location of the individual knative image.
                     type: object
                 type: object
               resources:
@@ -248,9 +177,6 @@ spec:
                       type: object
                   type: object
                 type: array
-              version:
-                description: The version of Knative Serving to be installed
-                type: string
             type: object
           status:
             description: Status defines the observed state of KnativeServing


### PR DESCRIPTION
This improves our UX by dropping all the fields we don't expect users to set from the `explain` output of the Serving CRD. We'll still allow users to make use of those fields generally (by adding the `preserve-unknown-fields` clause) but we'll no longer actively advertise them.

/hold

For feedback.