### PR TITLE
[SRVCOM-1148] Automatically use stop-image from previous version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ release-files:
 		templates/main.Dockerfile \
 		olm-catalog/serverless-operator/Dockerfile
 	./hack/generate/dockerfile.sh \
+		templates/stopbundle.Dockerfile \
+		olm-catalog/serverless-operator/stopbundle.Dockerfile
+	./hack/generate/dockerfile.sh \
 		templates/test-source-image.Dockerfile \
 		openshift/ci-operator/source-image/Dockerfile
 	./hack/generate/dockerfile.sh \

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -119,7 +119,7 @@ spec:
         - -c
         - |-
           podman login -u $pull_user -p $token image-registry.openshift-image-registry.svc:5000 && \
-          /bin/opm registry add -d index.db --container-tool=podman --mode=replaces -b quay.io/openshift-knative/serverless-bundle:1.7.2,quay.io/openshift-knative/serverless-bundle:1.8.0,quay.io/openshift-knative/serverless-bundle:1.9.0,quay.io/openshift-knative/serverless-bundle:1.10.0,quay.io/openshift-knative/serverless-bundle:1.10.1,quay.io/openshift-knative/serverless-bundle:1.11.0,registry.ci.openshift.org/openshift/openshift-serverless-v1.12.0:serverless-bundle,registry.ci.openshift.org/openshift/openshift-serverless-v1.13.0:serverless-bundle,quay.io/openshift-knative/serverless-bundle:1.14.0,registry.ci.openshift.org/openshift/openshift-serverless-v1.15.0:serverless-bundle,image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle && \
+          /bin/opm registry add -d index.db --container-tool=podman --mode=replaces -b registry.ci.openshift.org/openshift/openshift-serverless-v$PREVIOUS_VERSION:serverless-stop-bundle,image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle && \
           /bin/opm registry serve -d index.db -p 50051
 ---
 apiVersion: v1

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -16,9 +16,11 @@ export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v$(metadata.get depen
 export KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v$(metadata.get dependencies.eventing)}"
 export KNATIVE_EVENTING_KAFKA_VERSION="${KNATIVE_EVENTING_KAFKA_VERSION:-v$(metadata.get dependencies.eventing_kafka)}"
 
-CURRENT_CSV="$(metadata.get project.name).v$(metadata.get project.version)"
-PREVIOUS_CSV="$(metadata.get project.name).v$(metadata.get olm.replaces)"
-export CURRENT_CSV PREVIOUS_CSV
+CURRENT_VERSION="$(metadata.get project.version)"
+PREVIOUS_VERSION="$(metadata.get olm.replaces)"
+CURRENT_CSV="$(metadata.get project.name).v$CURRENT_VERSION"
+PREVIOUS_CSV="$(metadata.get project.name).v$PREVIOUS_VERSION"
+export CURRENT_VERSION PREVIOUS_VERSION CURRENT_CSV PREVIOUS_CSV
 
 # Directories below are filled with source code by ci-operator
 export KNATIVE_SERVING_HOME="${GOPATH}/src/knative.dev/serving"

--- a/olm-catalog/serverless-operator/stopbundle.Dockerfile
+++ b/olm-catalog/serverless-operator/stopbundle.Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine
+
+COPY manifests /manifests
+COPY metadata/annotations.yaml /metadata/annotations.yaml
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=serverless-operator
+LABEL operators.operatorframework.io.bundle.channel.default.v1="stable"
+LABEL operators.operatorframework.io.bundle.channels.v1="stable"
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
+      name="openshift-serverless-1/serverless-operator-bundle" \
+      version="1.16.0" \
+      summary="Red Hat OpenShift Serverless Bundle" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless Bundle" \
+      io.k8s.display-name="Red Hat OpenShift Serverless Bundle" \
+      com.redhat.openshift.versions="v4.6,v4.7,v4.8" \
+      com.redhat.delivery.operator.bundle=true \
+      com.redhat.delivery.backport=false
+
+# Remove the "replaces" line to make this bundle be able to be "the last".
+RUN sed -i '/replaces:/d' /manifests/serverless-operator.clusterserviceversion.yaml

--- a/templates/stopbundle.Dockerfile
+++ b/templates/stopbundle.Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine
+
+COPY manifests /manifests
+COPY metadata/annotations.yaml /metadata/annotations.yaml
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=__NAME__
+LABEL operators.operatorframework.io.bundle.channel.default.v1="__DEFAULT_CHANNEL__"
+LABEL operators.operatorframework.io.bundle.channels.v1="__CHANNEL_LIST__"
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
+      name="openshift-serverless-1/serverless-operator-bundle" \
+      version="__VERSION__" \
+      summary="Red Hat OpenShift Serverless Bundle" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless Bundle" \
+      io.k8s.display-name="Red Hat OpenShift Serverless Bundle" \
+      com.redhat.openshift.versions="__OCP_TARGET_VLIST__" \
+      com.redhat.delivery.operator.bundle=true \
+      com.redhat.delivery.backport=false
+
+# Remove the "replaces" line to make this bundle be able to be "the last".
+RUN sed -i '/replaces:/d' /manifests/serverless-operator.clusterserviceversion.yaml


### PR DESCRIPTION
This approach is being adopted for now. The 1.15 image has already been produced, so this just puts the pieces together. "Automated" fetching the "last" image via a suggestion by @skonto.