### PR TITLE
Bump operator version to 0.22.0

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -30,4 +30,4 @@ dependencies:
   eventing: 0.22.0
   eventing_kafka: 0.22.3
   cli: 0.22.0
-  operator: 0.21.2
+  operator: 0.22.0


### PR DESCRIPTION
For good measure. Doesn't actually induce any change (it's used to download the correct CRDs).