### PR TITLE
[RELEASE-1.15] [SRVCOM-1148] Add a 'stop' bundle image that can act as the first in the chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ release-files:
 		templates/main.Dockerfile \
 		olm-catalog/serverless-operator/Dockerfile
 	./hack/generate/dockerfile.sh \
+		templates/stopbundle.Dockerfile \
+		olm-catalog/serverless-operator/stopbundle.Dockerfile
+	./hack/generate/dockerfile.sh \
 		templates/test-source-image.Dockerfile \
 		openshift/ci-operator/source-image/Dockerfile
 	./hack/generate/dockerfile.sh \

--- a/olm-catalog/serverless-operator/stopbundle.Dockerfile
+++ b/olm-catalog/serverless-operator/stopbundle.Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine
+
+COPY manifests /manifests
+COPY metadata/annotations.yaml /metadata/annotations.yaml
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=serverless-operator
+LABEL operators.operatorframework.io.bundle.channel.default.v1="stable"
+LABEL operators.operatorframework.io.bundle.channels.v1="stable"
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
+      name="openshift-serverless-1/serverless-operator-bundle" \
+      version="1.15.0" \
+      summary="Red Hat OpenShift Serverless Bundle" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless Bundle" \
+      io.k8s.display-name="Red Hat OpenShift Serverless Bundle" \
+      com.redhat.openshift.versions="v4.6,v4.7" \
+      com.redhat.delivery.operator.bundle=true \
+      com.redhat.delivery.backport=false
+
+# Remove the "replaces" line to make this bundle be able to be "the last".
+RUN sed -i '/replaces:/d' /manifests/serverless-operator.clusterserviceversion.yaml

--- a/templates/stopbundle.Dockerfile
+++ b/templates/stopbundle.Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine
+
+COPY manifests /manifests
+COPY metadata/annotations.yaml /metadata/annotations.yaml
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=__NAME__
+LABEL operators.operatorframework.io.bundle.channel.default.v1="__DEFAULT_CHANNEL__"
+LABEL operators.operatorframework.io.bundle.channels.v1="__CHANNEL_LIST__"
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
+      name="openshift-serverless-1/serverless-operator-bundle" \
+      version="__VERSION__" \
+      summary="Red Hat OpenShift Serverless Bundle" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless Bundle" \
+      io.k8s.display-name="Red Hat OpenShift Serverless Bundle" \
+      com.redhat.openshift.versions="__OCP_TARGET_VLIST__" \
+      com.redhat.delivery.operator.bundle=true \
+      com.redhat.delivery.backport=false
+
+# Remove the "replaces" line to make this bundle be able to be "the last".
+RUN sed -i '/replaces:/d' /manifests/serverless-operator.clusterserviceversion.yaml


### PR DESCRIPTION
As per title, this adds a new bundle image which drops the `replaces` stanza so it can act as the beginning of the graph for OLM. This allows us to start an index image from 1.15 (and every version from now on) to limit the amount of stuff that has to be downloaded.

/assign @mgencur 