### PR TITLE
Use DomainMapping test with `--customdomain` option

### DIFF
--- a/test/serving.bash
+++ b/test/serving.bash
@@ -63,7 +63,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     --resolvabledomain --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$image_template" \
-    --customdomain="$subdomain"
+    --customdomain="$subdomain" \
     --enable-beta \
     --enable-alpha
 

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -49,6 +49,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     --patch='{"spec": {"config": { "autoscaler": {"allow-zero-initial-scale": "true"}}}}'
 
   image_template="registry.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-{{.Name}}"
+  subdomain=$(oc get ingresses.config.openshift.io cluster  -o jsonpath="{.spec.domain}")
 
   local parallel=3
 
@@ -62,6 +63,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     --resolvabledomain --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$image_template" \
+    --customdomain="$subdomain"
     --enable-beta \
     --enable-alpha
 


### PR DESCRIPTION
DomainMapping test needs two domain like:

- `original-ksvc.serverless.devcluster.openshift.com`
- `mydomain.example.com`

We have a wildcard DNS for `*.serverless.devcluster.openshift.com` but cannot prepare for DNS the second domain `mydomain.example.com` so we used spoof client for the `mydomain.example.com`.
But if we changed the second domain to `mydomain.serverless.devcluster.openshift.com`, it should work.

Hence this patch changes to use `--customdomain` option.