### PR TITLE
[SRVKS-743] Disable monitoring if istio is enabled

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -119,7 +119,7 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 
 	// Temporary fix for SRVKS-743
 	if ks.Spec.Ingress.Istio.Enabled {
-		common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
+		common.ConfigureIfUnset(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 	}
 	return monitoring.ReconcileMonitoringForServing(ctx, e.kubeclient, ks)
 }

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -116,6 +116,11 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 			Type: "ConfigMap",
 		}
 	}
+
+	// Temporary fix for SRVKS-743
+	if ks.Spec.Ingress.Istio.Enabled {
+		common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
+	}
 	return monitoring.ReconcileMonitoringForServing(ctx, e.kubeclient, ks)
 }
 

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -163,6 +163,7 @@ func TestReconcile(t *testing.T) {
 				},
 			}
 			common.Configure(&ks.Spec.CommonSpec, "network", "ingress.class", istioIngressClassName)
+			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 		}),
 	}, {
 		name: "fix 'wrong' ingress config", // https://github.com/knative/operator/issues/568


### PR DESCRIPTION
This is intended for 1.16 and should be fixed in 1.17.