### PR TITLE
Remove workaround in `wait_for_knative_serving_ingress_ns_deleted`

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -82,7 +82,7 @@ function serverless_operator_e2e_tests {
     "$@"
 
   # make sure knative-serving-ingress namespace is deleted.
-  oc wait --for=delete namespace "${SERVING_NAMESPACE}-ingress" --timeout=300s
+  timeout 180 "[[ \$(oc get ns "${SERVING_NAMESPACE}"-ingress --no-headers | wc -l) == 1 ]]"
 }
 
 function serverless_operator_kafka_e2e_tests {

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -81,7 +81,8 @@ function serverless_operator_e2e_tests {
     --kubeconfigs "${kubeconfigs_str}" \
     "$@"
 
-  wait_for_knative_serving_ingress_ns_deleted
+  # make sure knative-serving-ingress namespace is deleted.
+  oc wait --for=delete namespace "${SERVING_NAMESPACE}-ingress" --timeout=300s
 }
 
 function serverless_operator_kafka_e2e_tests {

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -3,17 +3,6 @@
 # For SC2164
 set -e
 
-function wait_for_knative_serving_ingress_ns_deleted {
-  local NS="${SERVING_NAMESPACE}-ingress"
-  timeout 180 "[[ \$(oc get ns $NS --no-headers | wc -l) == 1 ]]" || true
-  # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1798282 on Azure - if loadbalancer status is empty
-  # it's safe to remove the finalizer.
-  if oc -n "$NS" get svc kourier >/dev/null 2>&1 && [ "$(oc -n "$NS" get svc kourier -ojsonpath="{.status.loadBalancer.*}")" = "" ]; then
-    oc -n "$NS" patch services/kourier --type=json --patch='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
-  fi
-  timeout 180 "[[ \$(oc get ns $NS --no-headers | wc -l) == 1 ]]"
-}
-
 function prepare_knative_serving_tests {
   logger.debug 'Preparing Serving tests'
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1798282 was fixed on OCP
4.5 and the main branch was not tested with 4.5 anymore.

So this patch removes the workaround.

/cc @mgencur @maschmid @markusthoemmes 
