### PR TITLE
[SRVKS-696] Expose config-autoscaler for every user

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
@@ -2834,3 +2834,27 @@ metadata:
 # The data is populated at install time.
 
 ---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: knative-serving
+  name: openshift-serverless-view-serving-configmaps
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["config-autoscaler"]
+    verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-serverless-view-serving-configmaps
+  namespace: knative-serving
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-serverless-view-serving-configmaps

--- a/openshift-knative-operator/hack/002-openshift-serving-role.patch
+++ b/openshift-knative-operator/hack/002-openshift-serving-role.patch
@@ -1,0 +1,33 @@
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
+index aa68ca9e..4fc83cba 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.22.0/2-serving-core.yaml
+@@ -2834,3 +2834,27 @@ metadata:
+ # The data is populated at install time.
+ 
+ ---
++kind: Role
++apiVersion: rbac.authorization.k8s.io/v1
++metadata:
++  namespace: knative-serving
++  name: openshift-serverless-view-serving-configmaps
++rules:
++  - apiGroups: [""]
++    resources: ["configmaps"]
++    resourceNames: ["config-autoscaler"]
++    verbs: ["get", "list", "watch"]
++---
++kind: RoleBinding
++apiVersion: rbac.authorization.k8s.io/v1
++metadata:
++  name: openshift-serverless-view-serving-configmaps
++  namespace: knative-serving
++subjects:
++- kind: Group
++  name: system:authenticated
++  apiGroup: rbac.authorization.k8s.io
++roleRef:
++  apiGroup: rbac.authorization.k8s.io
++  kind: Role
++  name: openshift-serverless-view-serving-configmaps
+\ No newline at end of file

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -78,6 +78,9 @@ download serving "$KNATIVE_SERVING_VERSION" "${serving_files[@]}"
 # Drop namespace from manifest.
 git apply "$root/openshift-knative-operator/hack/001-serving-namespace-deletion.patch"
 
+# Extra role for downstream, so that users can get the autoscaling CM to fetch defaults.
+git apply "$root/openshift-knative-operator/hack/002-openshift-serving-role.patch"
+
 # TODO: Remove this once upstream fixed https://github.com/knative/operator/issues/376.
 # See also https://issues.redhat.com/browse/SRVKS-670.
 git apply "$root/openshift-knative-operator/hack/003-serving-pdb.patch"


### PR DESCRIPTION
As per title. This allows the console for example to fetch this ConfigMap and determine the defaults being used in the cluster.