### PR TITLE
[SRVKE-799] Channel visualization for the admin

### DIFF
--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-channel.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-channel.yaml
@@ -1,0 +1,1065 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-definition-knative-eventing-channel
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+data:
+  eventing-source-dashboard.json: |+
+    {
+      "__inputs": [
+        {
+          "description": "",
+          "label": "prometheus",
+          "name": "prometheus",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus",
+          "type": "datasource"
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 16,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "panels": [],
+          "repeat": null,
+          "title": "In-Memory Channel Aggregated Metrics",
+          "type": "row"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "decimals": 3,
+          "description": "",
+          "format": "ops",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 0,
+            "y": 1
+          },
+          "id": 29,
+          "interval": "",
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.3.3",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+              "format": "time_series",
+              "instant": false,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "In-Memory Channel: Event Count (avg/sec, over 1m window)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "decimals": 2,
+          "description": "",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 1
+          },
+          "id": 28,
+          "interval": "",
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.3.3",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+              "format": "time_series",
+              "instant": false,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "In-Memory Channel: Success Rate (2xx Event, fraction rate, over 1m window)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 16,
+            "x": 8,
+            "y": 1
+          },
+          "id": 33,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m])) by (response_code_class)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{response_code_class}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "In-Memory Channel: Event Count by Response Code Class (avg/sec, over 1m window)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 3,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": 3,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "decimals": 2,
+          "description": "",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 5
+          },
+          "id": 27,
+          "interval": "",
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.3.3",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+              "format": "time_series",
+              "instant": false,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "In-Memory Channel: Failure Rate (non-2xx Event, fraction rate, over 1m window)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "decimals": 3,
+          "description": "50th, 90th, 95th, 99th percentile of event dispatch latency over the last 1m",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 26,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+             "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum(rate(inmemorychannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.90, sum(rate(inmemorychannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+              "format": "time_series",
+              "legendFormat": "p90",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(kinmemorychannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+              "format": "time_series",
+              "legendFormat": "p95",
+              "refId": "C"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(inmemorychannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+              "format": "time_series",
+              "legendFormat": "p99",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "In-Memory Dispatcher: Event Dispatch Latency (ms)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 2,
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 19
+          },
+            "id": 42,
+            "panels": [],
+            "repeat": null,
+            "title": "Kafka Channel Aggregated Metrics",
+            "type": "row"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "#299c46",
+              "rgba(237, 129, 40, 0.89)",
+              "#d44a3a"
+            ],
+            "datasource": "prometheus",
+             "decimals": 3,
+             "description": "",
+             "format": "ops",
+             "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+             },
+             "gridPos": {
+               "h": 8,
+               "w": 4,
+               "x": 0,
+               "y": 20
+             },
+             "id": 43,
+             "interval": "",
+             "links": [],
+             "mappingType": 1,
+             "mappingTypes": [
+               {
+                 "name": "value to text",
+                 "value": 1
+               },
+               {
+                 "name": "range to text",
+                 "value": 2
+               }
+             ],
+             "maxDataPoints": 100,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {},
+             "pluginVersion": "6.3.3",
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+               {
+                 "from": "null",
+                 "text": "N/A",
+                 "to": "null"
+               }
+             ],
+             "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": true,
+               "ymax": null,
+               "ymin": null
+             },
+             "tableColumn": "",
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+                 "format": "time_series",
+                 "instant": false,
+                 "refId": "A"
+               }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Kafka Channel: Event Count (avg/sec, over 1m window)",
+             "type": "singlestat",
+             "valueFontSize": "80%",
+             "valueMaps": [
+               {
+                 "op": "=",
+                 "text": "N/A",
+                 "value": "null"
+               }
+             ],
+             "valueName": "current"
+           },
+           {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+               "#299c46",
+               "rgba(237, 129, 40, 0.89)",
+               "#d44a3a"
+             ],
+             "datasource": "prometheus",
+             "decimals": 2,
+             "description": "",
+             "format": "none",
+             "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+             },
+             "gridPos": {
+               "h": 4,
+               "w": 4,
+               "x": 4,
+               "y": 20
+             },
+             "id": 44,
+             "interval": "",
+             "links": [],
+             "mappingType": 1,
+             "mappingTypes": [
+               {
+                 "name": "value to text",
+                 "value": 1
+               },
+               {
+                 "name": "range to text",
+                 "value": 2
+               }
+             ],
+             "maxDataPoints": 100,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {},
+             "pluginVersion": "6.3.3",
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+               {
+                 "from": "null",
+                 "text": "N/A",
+                 "to": "null"
+               }
+             ],
+             "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": true,
+               "ymax": null,
+               "ymin": null
+             },
+             "tableColumn": "",
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+                 "format": "time_series",
+                 "instant": false,
+                 "refId": "A"
+               }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Kafka Channel: Success Rate (2xx Event, fraction rate, over 1m window)",
+             "type": "singlestat",
+             "valueFontSize": "80%",
+             "valueMaps": [
+               {
+                 "op": "=",
+                 "text": "N/A",
+                 "value": "null"
+               }
+             ],
+             "valueName": "current"
+           },
+           {
+             "aliasColors": {},
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus",
+             "decimals": 3,
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+               "h": 8,
+               "w": 16,
+               "x": 8,
+               "y": 20
+             },
+             "id": 45,
+             "legend": {
+               "alignAsTable": true,
+               "avg": false,
+               "current": true,
+               "hideEmpty": false,
+               "hideZero": false,
+               "max": false,
+               "min": false,
+               "rightSide": true,
+               "show": true,
+               "total": false,
+               "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "nullPointMode": "null",
+             "options": {
+               "dataLinks": []
+             },
+             "percentage": false,
+             "pointradius": 2,
+             "points": false,
+             "renderer": "flot",
+             "seriesOverrides": [],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m])) by (response_code_class)",
+                 "format": "time_series",
+                 "hide": false,
+                 "instant": false,
+                 "legendFormat": "{{response_code_class}}",
+                 "refId": "A"
+               }
+             ],
+             "thresholds": [],
+             "timeFrom": null,
+             "timeRegions": [],
+             "timeShift": null,
+             "title": "Kafka Channel: Event Count by Response Code Class (avg/sec, over 1m window)",
+             "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": []
+             },
+             "yaxes": [
+               {
+                 "decimals": 3,
+                 "format": "ops",
+                 "label": null,
+                 "logBase": 1,
+                 "max": null,
+                 "min": null,
+                 "show": true
+               },
+               {
+                 "decimals": 3,
+                 "format": "short",
+                 "label": null,
+                 "logBase": 1,
+                 "max": null,
+                 "min": null,
+                 "show": true
+               }
+             ],
+             "yaxis": {
+               "align": false,
+               "alignLevel": null
+             }
+           },
+           {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+               "#299c46",
+               "rgba(237, 129, 40, 0.89)",
+               "#d44a3a"
+             ],
+             "datasource": "prometheus",
+             "decimals": 2,
+             "description": "",
+             "format": "none",
+             "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+             },
+             "gridPos": {
+               "h": 4,
+               "w": 4,
+               "x": 4,
+               "y": 24
+             },
+             "id": 46,
+             "interval": "",
+             "links": [],
+             "mappingType": 1,
+             "mappingTypes": [
+               {
+                 "name": "value to text",
+                 "value": 1
+               },
+               {
+                 "name": "range to text",
+                 "value": 2
+               }
+             ],
+             "maxDataPoints": 100,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {},
+             "pluginVersion": "6.3.3",
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+               {
+                 "from": "null",
+                 "text": "N/A",
+                 "to": "null"
+               }
+             ],
+             "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": true,
+               "ymax": null,
+               "ymin": null
+             },
+             "tableColumn": "",
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+                 "format": "time_series",
+                 "instant": false,
+                 "refId": "A"
+               }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Kafka Channel: Failure Rate (non-2xx Event, fraction rate, over 1m window)",
+             "type": "singlestat",
+             "valueFontSize": "80%",
+             "valueMaps": [
+               {
+                 "op": "=",
+                 "text": "N/A",
+                 "value": "null"
+               }
+             ],
+             "valueName": "current"
+           },
+           {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "decimals": 3,
+            "description": "50th, 90th, 95th, 99th percentile of event dispatch latency over the last 1m",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 9,
+              "w": 12,
+              "x": 0,
+              "y": 27
+            },
+            "id": 26,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": false,
+              "min": false,
+              "rightSide": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+              "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.50, sum(rate(kafkachannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+                "format": "time_series",
+                "instant": false,
+                "legendFormat": "p50",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.90, sum(rate(kafkachannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+                "format": "time_series",
+                "legendFormat": "p90",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.95, sum(rate(kafkachannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+                "format": "time_series",
+                "legendFormat": "p95",
+                "refId": "C"
+              },
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(kafkachannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+                "format": "time_series",
+                "legendFormat": "p99",
+                "refId": "D"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Kafka Dispatcher: Event Dispatch Latency (ms)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 2,
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {},
+            "datasource": "prometheus",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "eventNamespace",
+            "options": [],
+            "query": "label_values((kafkachannel_dispatcher_event_count{} OR inmemorychannel_dispatcher_event_count{}), namespace_name)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "refresh": false,
+      "schemaVersion": 19,
+      "style": "dark",
+      "tags": ["Knative"],
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "Knative Eventing - Channel",
+      "uid": "-Vr2tYtZk",
+      "version": 6
+    }

--- a/knative-operator/pkg/controller/dashboard/dashboard.go
+++ b/knative-operator/pkg/controller/dashboard/dashboard.go
@@ -21,6 +21,7 @@ const ConfigManagedNamespace = "openshift-config-managed"
 const EventingResourceDashboardPathEnvVar = "EVENTING_RESOURCES_DASHBOARD_MANIFEST_PATH"
 const EventingBrokerDashboardPathEnvVar = "EVENTING_BROKER_DASHBOARD_MANIFEST_PATH"
 const EventingSourceDashboardPathEnvVar = "EVENTING_SOURCE_DASHBOARD_MANIFEST_PATH"
+const EventingChannelDashboardPathEnvVar = "EVENTING_CHANNEL_DASHBOARD_MANIFEST_PATH"
 const ServingResourceDashboardPathEnvVar = "SERVING_RESOURCES_DASHBOARD_MANIFEST_PATH"
 
 // Apply applies dashboard resources.

--- a/knative-operator/pkg/controller/dashboard/testdata/grafana-dash-knative-eventing-channel.yaml
+++ b/knative-operator/pkg/controller/dashboard/testdata/grafana-dash-knative-eventing-channel.yaml
@@ -1,0 +1,1065 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-definition-knative-eventing-channel
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+data:
+  eventing-source-dashboard.json: |+
+    {
+      "__inputs": [
+        {
+          "description": "",
+          "label": "prometheus",
+          "name": "prometheus",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus",
+          "type": "datasource"
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 16,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "panels": [],
+          "repeat": null,
+          "title": "In-Memory Channel Aggregated Metrics",
+          "type": "row"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "decimals": 3,
+          "description": "",
+          "format": "ops",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 0,
+            "y": 1
+          },
+          "id": 29,
+          "interval": "",
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.3.3",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+              "format": "time_series",
+              "instant": false,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "In-Memory Channel: Event Count (rate per minute)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "decimals": 2,
+          "description": "",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 1
+          },
+          "id": 28,
+          "interval": "",
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.3.3",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+              "format": "time_series",
+              "instant": false,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "In-Memory Channel: Success Rate (2xx Event, fraction rate per minute)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 16,
+            "x": 8,
+            "y": 1
+          },
+          "id": 33,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m])) by (response_code_class)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{response_code_class}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "In-Memory Channel: Event Count by Response Code Class (rate per minute)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 3,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": 3,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "decimals": 2,
+          "description": "",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 5
+          },
+          "id": 27,
+          "interval": "",
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.3.3",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(inmemorychannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+              "format": "time_series",
+              "instant": false,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "In-Memory Channel: Failure Rate (non-2xx Event, fraction rate per minute)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "decimals": 3,
+          "description": "50th, 90th, 95th, 99th percentile of event dispatch latency over the last 1m",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 26,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+             "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum(rate(inmemorychannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.90, sum(rate(inmemorychannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+              "format": "time_series",
+              "legendFormat": "p90",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(kinmemorychannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+              "format": "time_series",
+              "legendFormat": "p95",
+              "refId": "C"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(inmemorychannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+              "format": "time_series",
+              "legendFormat": "p99",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "In-Memory Dispatcher: Event Dispatch Latency (ms)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 2,
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 19
+          },
+            "id": 42,
+            "panels": [],
+            "repeat": null,
+            "title": "Kafka Channel Aggregated Metrics",
+            "type": "row"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "#299c46",
+              "rgba(237, 129, 40, 0.89)",
+              "#d44a3a"
+            ],
+            "datasource": "prometheus",
+             "decimals": 3,
+             "description": "",
+             "format": "ops",
+             "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+             },
+             "gridPos": {
+               "h": 8,
+               "w": 4,
+               "x": 0,
+               "y": 20
+             },
+             "id": 43,
+             "interval": "",
+             "links": [],
+             "mappingType": 1,
+             "mappingTypes": [
+               {
+                 "name": "value to text",
+                 "value": 1
+               },
+               {
+                 "name": "range to text",
+                 "value": 2
+               }
+             ],
+             "maxDataPoints": 100,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {},
+             "pluginVersion": "6.3.3",
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+               {
+                 "from": "null",
+                 "text": "N/A",
+                 "to": "null"
+               }
+             ],
+             "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": true,
+               "ymax": null,
+               "ymin": null
+             },
+             "tableColumn": "",
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+                 "format": "time_series",
+                 "instant": false,
+                 "refId": "A"
+               }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Kafka Channel: Event Count (rate per minute)",
+             "type": "singlestat",
+             "valueFontSize": "80%",
+             "valueMaps": [
+               {
+                 "op": "=",
+                 "text": "N/A",
+                 "value": "null"
+               }
+             ],
+             "valueName": "current"
+           },
+           {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+               "#299c46",
+               "rgba(237, 129, 40, 0.89)",
+               "#d44a3a"
+             ],
+             "datasource": "prometheus",
+             "decimals": 2,
+             "description": "",
+             "format": "none",
+             "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+             },
+             "gridPos": {
+               "h": 4,
+               "w": 4,
+               "x": 4,
+               "y": 20
+             },
+             "id": 44,
+             "interval": "",
+             "links": [],
+             "mappingType": 1,
+             "mappingTypes": [
+               {
+                 "name": "value to text",
+                 "value": 1
+               },
+               {
+                 "name": "range to text",
+                 "value": 2
+               }
+             ],
+             "maxDataPoints": 100,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {},
+             "pluginVersion": "6.3.3",
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+               {
+                 "from": "null",
+                 "text": "N/A",
+                 "to": "null"
+               }
+             ],
+             "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": true,
+               "ymax": null,
+               "ymin": null
+             },
+             "tableColumn": "",
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+                 "format": "time_series",
+                 "instant": false,
+                 "refId": "A"
+               }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Kafka Channel: Success Rate (2xx Event, fraction rate per minute)",
+             "type": "singlestat",
+             "valueFontSize": "80%",
+             "valueMaps": [
+               {
+                 "op": "=",
+                 "text": "N/A",
+                 "value": "null"
+               }
+             ],
+             "valueName": "current"
+           },
+           {
+             "aliasColors": {},
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "prometheus",
+             "decimals": 3,
+             "fill": 1,
+             "fillGradient": 0,
+             "gridPos": {
+               "h": 8,
+               "w": 16,
+               "x": 8,
+               "y": 20
+             },
+             "id": 45,
+             "legend": {
+               "alignAsTable": true,
+               "avg": false,
+               "current": true,
+               "hideEmpty": false,
+               "hideZero": false,
+               "max": false,
+               "min": false,
+               "rightSide": true,
+               "show": true,
+               "total": false,
+               "values": true
+             },
+             "lines": true,
+             "linewidth": 1,
+             "nullPointMode": "null",
+             "options": {
+               "dataLinks": []
+             },
+             "percentage": false,
+             "pointradius": 2,
+             "points": false,
+             "renderer": "flot",
+             "seriesOverrides": [],
+             "spaceLength": 10,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m])) by (response_code_class)",
+                 "format": "time_series",
+                 "hide": false,
+                 "instant": false,
+                 "legendFormat": "{{response_code_class}}",
+                 "refId": "A"
+               }
+             ],
+             "thresholds": [],
+             "timeFrom": null,
+             "timeRegions": [],
+             "timeShift": null,
+             "title": "Kafka Channel: Event Count by Response Code Class (rate per minute)",
+             "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": []
+             },
+             "yaxes": [
+               {
+                 "decimals": 3,
+                 "format": "ops",
+                 "label": null,
+                 "logBase": 1,
+                 "max": null,
+                 "min": null,
+                 "show": true
+               },
+               {
+                 "decimals": 3,
+                 "format": "short",
+                 "label": null,
+                 "logBase": 1,
+                 "max": null,
+                 "min": null,
+                 "show": true
+               }
+             ],
+             "yaxis": {
+               "align": false,
+               "alignLevel": null
+             }
+           },
+           {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+               "#299c46",
+               "rgba(237, 129, 40, 0.89)",
+               "#d44a3a"
+             ],
+             "datasource": "prometheus",
+             "decimals": 2,
+             "description": "",
+             "format": "none",
+             "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+             },
+             "gridPos": {
+               "h": 4,
+               "w": 4,
+               "x": 4,
+               "y": 24
+             },
+             "id": 46,
+             "interval": "",
+             "links": [],
+             "mappingType": 1,
+             "mappingTypes": [
+               {
+                 "name": "value to text",
+                 "value": 1
+               },
+               {
+                 "name": "range to text",
+                 "value": 2
+               }
+             ],
+             "maxDataPoints": 100,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {},
+             "pluginVersion": "6.3.3",
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+               {
+                 "from": "null",
+                 "text": "N/A",
+                 "to": "null"
+               }
+             ],
+             "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": true,
+               "ymax": null,
+               "ymin": null
+             },
+             "tableColumn": "",
+             "targets": [
+               {
+                 "expr": "sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(kafkachannel_dispatcher_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+                 "format": "time_series",
+                 "instant": false,
+                 "refId": "A"
+               }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Kafka Channel: Failure Rate (non-2xx Event, fraction rate per minute)",
+             "type": "singlestat",
+             "valueFontSize": "80%",
+             "valueMaps": [
+               {
+                 "op": "=",
+                 "text": "N/A",
+                 "value": "null"
+               }
+             ],
+             "valueName": "current"
+           },
+           {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "decimals": 3,
+            "description": "50th, 90th, 95th, 99th percentile of event dispatch latency over the last 1m",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 9,
+              "w": 12,
+              "x": 0,
+              "y": 27
+            },
+            "id": 26,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": false,
+              "min": false,
+              "rightSide": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+              "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.50, sum(rate(kafkachannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+                "format": "time_series",
+                "instant": false,
+                "legendFormat": "p50",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.90, sum(rate(kafkachannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+                "format": "time_series",
+                "legendFormat": "p90",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.95, sum(rate(kafkachannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+                "format": "time_series",
+                "legendFormat": "p95",
+                "refId": "C"
+              },
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(kafkachannel_dispatcher_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
+                "format": "time_series",
+                "legendFormat": "p99",
+                "refId": "D"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Kafka Dispatcher: Event Dispatch Latency (ms)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 2,
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {},
+            "datasource": "prometheus",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "eventNamespace",
+            "options": [],
+            "query": "label_values((kafkachannel_dispatcher_event_count{} OR inmemorychannel_dispatcher_event_count{}), namespace_name)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "refresh": false,
+      "schemaVersion": 19,
+      "style": "dark",
+      "tags": [],
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "Knative Eventing - Channel",
+      "uid": "-Vr2tYtZk",
+      "version": 6
+    }

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -172,7 +172,12 @@ func (r *ReconcileKnativeEventing) installDashboards(instance *eventingv1alpha1.
 	if err := dashboard.Apply(os.Getenv(dashboard.EventingBrokerDashboardPathEnvVar), instance, r.client); err != nil {
 		return err
 	}
-	return dashboard.Apply(os.Getenv(dashboard.EventingSourceDashboardPathEnvVar), instance, r.client)
+
+	if err := dashboard.Apply(os.Getenv(dashboard.EventingSourceDashboardPathEnvVar), instance, r.client); err != nil {
+		return err
+	}
+
+	return dashboard.Apply(os.Getenv(dashboard.EventingChannelDashboardPathEnvVar), instance, r.client)
 }
 
 // general clean-up, mostly resources in different namespaces from eventingv1alpha1.KnativeEventing.
@@ -193,6 +198,9 @@ func (r *ReconcileKnativeEventing) delete(instance *eventingv1alpha1.KnativeEven
 		return fmt.Errorf("failed to delete broker dashboard configmap: %w", err)
 	}
 	if err := dashboard.Delete(os.Getenv(dashboard.EventingSourceDashboardPathEnvVar), instance, r.client); err != nil {
+		return fmt.Errorf("failed to delete source dashboard configmap: %w", err)
+	}
+	if err := dashboard.Delete(os.Getenv(dashboard.EventingChannelDashboardPathEnvVar), instance, r.client); err != nil {
 		return fmt.Errorf("failed to delete source dashboard configmap: %w", err)
 	}
 	// The above might take a while, so we refetch the resource again in case it has changed.

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller_test.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller_test.go
@@ -44,6 +44,7 @@ func init() {
 	os.Setenv(dashboard.EventingSourceDashboardPathEnvVar, "../dashboard/testdata/grafana-dash-knative-eventing-source.yaml")
 	os.Setenv(dashboard.EventingBrokerDashboardPathEnvVar, "../dashboard/testdata/grafana-dash-knative-eventing-broker.yaml")
 	os.Setenv(dashboard.EventingResourceDashboardPathEnvVar, "../dashboard/testdata/grafana-dash-knative-eventing-resources.yaml")
+	os.Setenv(dashboard.EventingChannelDashboardPathEnvVar, "../dashboard/testdata/grafana-dash-knative-eventing-channel.yaml")
 
 	apis.AddToScheme(scheme.Scheme)
 }
@@ -96,6 +97,11 @@ func TestEventingReconcile(t *testing.T) {
 			if err != nil {
 				t.Fatalf("get: (%v)", err)
 			}
+			channelCM := &corev1.ConfigMap{}
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-channel", Namespace: dashboardNamespace.Name}, channelCM)
+			if err != nil {
+				t.Fatalf("get: (%v)", err)
+			}
 			// Delete Dashboard configmaps.
 			err = cl.Delete(context.TODO(), resourcesCM)
 			if err != nil {
@@ -109,7 +115,10 @@ func TestEventingReconcile(t *testing.T) {
 			if err != nil {
 				t.Fatalf("delete: (%v)", err)
 			}
-
+			err = cl.Delete(context.TODO(), channelCM)
+			if err != nil {
+				t.Fatalf("delete: (%v)", err)
+			}
 			// Reconcile again with test requests.
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{Namespace: test.ownerNamespace, Name: test.ownerName},
@@ -135,6 +144,8 @@ func TestEventingReconcile(t *testing.T) {
 			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-broker", Namespace: dashboardNamespace.Name}, brokerCM)
 			checkError(t, err)
 			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-source", Namespace: dashboardNamespace.Name}, sourceCM)
+			checkError(t, err)
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-eventing-channel", Namespace: dashboardNamespace.Name}, sourceCM)
 			checkError(t, err)
 		})
 	}

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -426,6 +426,8 @@ spec:
                         value: "deploy/resources/dashboards/grafana-dash-knative-eventing-source.yaml"
                       - name: EVENTING_BROKER_DASHBOARD_MANIFEST_PATH
                         value: "deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml"
+                      - name: EVENTING_CHANNEL_DASHBOARD_MANIFEST_PATH
+                        value: "deploy/resources/dashboards/grafana-dash-knative-eventing-channel.yaml"
                       - name: KAFKACHANNEL_MANIFEST_PATH
                         value: deploy/resources/knativekafka/1-channel-consolidated.yaml
                       - name: KAFKASOURCE_MANIFEST_PATH

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -372,6 +372,8 @@ spec:
                       value: "deploy/resources/dashboards/grafana-dash-knative-eventing-source.yaml"
                     - name: EVENTING_BROKER_DASHBOARD_MANIFEST_PATH
                       value: "deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml"
+                    - name: EVENTING_CHANNEL_DASHBOARD_MANIFEST_PATH
+                      value: "deploy/resources/dashboards/grafana-dash-knative-eventing-channel.yaml"
                     - name: KAFKACHANNEL_MANIFEST_PATH
                       value: deploy/resources/knativekafka/1-channel-consolidated.yaml
                     - name: KAFKASOURCE_MANIFEST_PATH


### PR DESCRIPTION
- adds a dashboard to visualize imc and kafka channel metrics. Uses `rate` to help identify [spikes/trends](https://www.metricfire.com/blog/understanding-the-prometheus-rate-function), same as with the existing dashboards. Background info of what we can use with a counter [here](https://www.robustperception.io/how-does-a-prometheus-counter-work) and [here](https://www.robustperception.io/rate-then-sum-never-sum-then-rate).
- adds dashboard lifecycle management

![image](https://user-images.githubusercontent.com/7945591/122908520-e22d3e80-d35c-11eb-933f-81f40648c526.png)

![image](https://user-images.githubusercontent.com/7945591/122908499-da6d9a00-d35c-11eb-8b08-a3656e424684.png)

To test kafka metrics just use:
```
cat <<-EOF | kubectl apply -f -
---
apiVersion: messaging.knative.dev/v1beta1
kind: KafkaChannel
metadata:
  name: my-kafka-channel
spec:
  numPartitions: 3
  replicationFactor: 1
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: events-sa
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: event-watcher
rules:
  - apiGroups:
      - ""
    resources:
      - events
    verbs:
      - get
      - list
      - watch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: k8s-ra-event-watcher
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: event-watcher
subjects:
  - kind: ServiceAccount
    name: events-sa
    namespace: default
---
apiVersion: sources.knative.dev/v1beta1
kind: ApiServerSource
metadata:
  name: testevents
spec:
  serviceAccountName: events-sa
  mode: Resource
  resources:
    - apiVersion: v1
      kind: Event
  sink:
    ref:
      apiVersion: messaging.knative.dev/v1beta1
      kind: KafkaChannel
      name: my-kafka-channel
---
apiVersion: messaging.knative.dev/v1beta1
kind: Subscription
metadata:
  name: my-subscription
  namespace: default
spec:
  channel:
    apiVersion: messaging.knative.dev/v1beta1
    kind: KafkaChannel
    name: my-kafka-channel
  delivery:
    deadLetterSink:
      ref:
        apiVersion: serving.knative.dev/v1
        kind: Service
        name: event-display
  subscriber:
    ref:
      apiVersion: serving.knative.dev/v1
      kind: Service
      name: event-display
---
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: event-display
spec:
  template:
    spec:
      containers:
        - # This corresponds to
          # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display/main.go
          image: quay.io/openshift-knative/knative-eventing-sources-event-display

EOF
```