### PR TITLE
[SRVKE-873] Update eventing dashboards

### DIFF
--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml
@@ -48,7 +48,7 @@ data:
           "id": 2,
           "panels": [],
           "repeat": null,
-          "title": "Broker (broker-ingress)",
+          "title": "Broker (broker-ingress) Aggregated Metrics (per namespace)",
           "type": "row"
         },
         {
@@ -118,7 +118,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(mt_broker_ingress_event_count{namespace_name=~\"$namespace\"}[1m]))",
+              "expr": "sum(rate(mt_broker_ingress_event_count{namespace_name=~\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -206,7 +206,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(mt_broker_ingress_event_count{response_code_class=\"2xx\", namespace_name=~\"$namespace\"}[1m])) / sum(rate(mt_broker_ingress_event_count{namespace_name=~\"$namespace\"}[1m]))",
+              "expr": "sum(rate(mt_broker_ingress_event_count{response_code_class=\"2xx\", namespace_name=~\"$eventNamespace\"}[1m])) / sum(rate(mt_broker_ingress_event_count{namespace_name=~\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -271,7 +271,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(mt_broker_ingress_event_count{namespace_name=~\"$namespace\"}[1m])) by (event_type)",
+              "expr": "sum(rate(mt_broker_ingress_event_count{namespace_name=~\"$eventNamespace\"}[1m])) by (event_type)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -307,6 +307,102 @@ data:
               "show": true
             },
             {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 33,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(mt_broker_ingress_event_count{namespace_name=~\"$eventNamespace\"}[1m])) by (response_code_class)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{response_code_class}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Broker (broker-ingress): Event Count by Response Code Class (rate per minute)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 3,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": 3,
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -387,7 +483,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(mt_broker_ingress_event_count{response_code_class!=\"2xx\", namespace_name=~\"$namespace\"}[1m])) / sum(rate(mt_broker_ingress_event_count{namespace_name=~\"$namespace\"}[1m]))",
+              "expr": "sum(rate(mt_broker_ingress_event_count{response_code_class!=\"2xx\", namespace_name=~\"$eventNamespace\"}[1m])) / sum(rate(mt_broker_ingress_event_count{namespace_name=~\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -407,102 +503,6 @@ data:
             }
           ],
           "valueName": "current"
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "decimals": 3,
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 9
-          },
-          "id": 33,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(rate(mt_broker_ingress_event_count{namespace_name=~\"$namespace\"}[1m])) by (response_code_class)",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{response_code_class}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Broker (broker-ingress): Event Count by Response Code Class (rate per minute)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 3,
-              "format": "ops",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "decimals": 3,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
         },
         {
           "aliasColors": {},
@@ -550,26 +550,26 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.50, sum(rate(mt_broker_ingress_event_dispatch_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(mt_broker_ingress_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "instant": false,
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.90, sum(rate(mt_broker_ingress_event_dispatch_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.90, sum(rate(mt_broker_ingress_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "legendFormat": "p90",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(mt_broker_ingress_event_dispatch_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(mt_broker_ingress_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "legendFormat": "p95",
               "refId": "C"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(mt_broker_ingress_event_dispatch_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(mt_broker_ingress_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "legendFormat": "p99",
               "refId": "D"
@@ -627,7 +627,7 @@ data:
           },
           "id": 14,
           "panels": [],
-          "title": "Trigger (broker-filter)",
+          "title": "Trigger (broker-filter) Aggregated Metrics (per namespace)",
           "type": "row"
         },
         {
@@ -697,7 +697,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(mt_broker_filter_event_count{namespace_name=~\"$namespace\"}[1m]))",
+              "expr": "sum(rate(mt_broker_filter_event_count{namespace_name=~\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -785,7 +785,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(mt_broker_filter_event_count{response_code_class=\"2xx\", namespace_name=~\"$namespace\"}[1m])) / sum(rate(mt_broker_filter_event_count{namespace_name=~\"$namespace\"}[1m]))",
+              "expr": "sum(rate(mt_broker_filter_event_count{response_code_class=\"2xx\", namespace_name=~\"$eventNamespace\"}[1m])) / sum(rate(mt_broker_filter_event_count{namespace_name=~\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -805,6 +805,99 @@ data:
             }
           ],
           "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "id": 31,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(mt_broker_filter_event_count{namespace_name=~\"$eventNamespace\"}[1m])) by (event_type)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{event_type}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Broker (broker-filter): Event Count by Event Type (rate per minute)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -851,7 +944,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(mt_broker_filter_event_count{namespace_name=~\"$namespace\"}[1m])) by (response_code_class)",
+              "expr": "sum(rate(mt_broker_filter_event_count{namespace_name=~\"$eventNamespace\"}[1m])) by (response_code_class)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -969,7 +1062,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(mt_broker_filter_event_count{response_code_class!=\"2xx\", namespace_name=~\"$namespace\"}[1m])) / sum(rate(mt_broker_filter_event_count{namespace_name=~\"$namespace\"}[1m]))",
+              "expr": "sum(rate(mt_broker_filter_event_count{response_code_class!=\"2xx\", namespace_name=~\"$eventNamespace\"}[1m])) / sum(rate(mt_broker_filter_event_count{namespace_name=~\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -1036,26 +1129,26 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.50, sum(rate(mt_broker_filter_event_dispatch_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(mt_broker_filter_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "instant": false,
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.90, sum(rate(mt_broker_filter_event_dispatch_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.90, sum(rate(mt_broker_filter_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "legendFormat": "p90",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(mt_broker_filter_event_dispatch_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(mt_broker_filter_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "legendFormat": "p95",
               "refId": "C"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(mt_broker_filter_event_dispatch_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(mt_broker_filter_event_dispatch_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "legendFormat": "p99",
               "refId": "D"
@@ -1149,26 +1242,26 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.50, sum(rate(mt_broker_filter_event_processing_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(mt_broker_filter_event_processing_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "instant": false,
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.90, sum(rate(mt_broker_filter_event_processing_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.90, sum(rate(mt_broker_filter_event_processing_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "legendFormat": "p90",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(mt_broker_filter_event_processing_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(mt_broker_filter_event_processing_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "legendFormat": "p95",
               "refId": "C"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(mt_broker_filter_event_processing_latencies_bucket{namespace_name=~\"$namespace\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(mt_broker_filter_event_processing_latencies_bucket{namespace_name=~\"$eventNamespace\"}[1m])) by (le))",
               "format": "time_series",
               "legendFormat": "p99",
               "refId": "D"
@@ -1237,7 +1330,7 @@ data:
             "includeAll": true,
             "label": "namespace",
             "multi": true,
-            "name": "namespace",
+            "name": "eventNamespace",
             "options": [],
             "query": "label_values(mt_broker_ingress_event_count{namespace_name!=\"unknown\"}, namespace_name)",
             "refresh": 1,

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-broker.yaml
@@ -127,7 +127,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Broker (broker-ingress): Event Count (rate per minute)",
+          "title": "Broker (broker-ingress): Event Count (avg/sec, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -215,7 +215,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Broker (broker-ingress): Success Rate  (2xx Event, rate per minute)",
+          "title": "Broker (broker-ingress): Success Rate  (2xx Event, fraction rate, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -283,7 +283,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Broker (broker-ingress): Event Count by Event Type (rate per minute)",
+          "title": "Broker (broker-ingress): Event Count by Event Type (avg/sec, over 1m window)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -377,7 +377,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Broker (broker-ingress): Event Count by Response Code Class (rate per minute)",
+          "title": "Broker (broker-ingress): Event Count by Response Code Class (avg/sec, over 1m window)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -492,7 +492,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Broker (broker-ingress): Failure Rate (non-2xx Event, fraction of rate per minute)",
+          "title": "Broker (broker-ingress): Failure Rate (non-2xx Event, fraction rate, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -706,7 +706,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Trigger (broker-filter): Event Count (rate per minute)",
+          "title": "Trigger (broker-filter): Event Count (avg/sec, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -794,7 +794,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Trigger (broker-filter): Success Rate  (2xx Event, fraction rate per minute)",
+          "title": "Trigger (broker-filter): Success Rate  (2xx Event, fraction rate, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -862,7 +862,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Broker (broker-filter): Event Count by Event Type (rate per minute)",
+          "title": "Broker (broker-filter): Event Count by Event Type (avg/sec, over 1m window)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -956,7 +956,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Trigger (broker-filter): Event Count by Response Code Class (rate per minute)",
+          "title": "Trigger (broker-filter): Event Count by Response Code Class (avg/sec, over 1m window)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1071,7 +1071,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Trigger (broker-filter): Failure Rate (non-2xx Event, fraction rate per minute)",
+          "title": "Trigger (broker-filter): Failure Rate (non-2xx Event, fraction rate, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
@@ -21,7 +21,7 @@ data:
       "annotations": {
         "list": []
       },
-      "description": "Knative Eventing - Revision CPU and Memory Usage",
+      "description": "Knative Eventing - Source CPU and Memory Usage",
       "editable": false,
       "gnetId": null,
       "graphTooltip": 0,

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
@@ -88,7 +88,7 @@ data:
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total CPU Usage (rate per minute)",
+          "title": "Total CPU Usage (avg/sec, over 1m window)",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -259,7 +259,7 @@ data:
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Total Network I/O (rate per minute)",
+            "title": "Total Network I/O (avg/sec, over 1m window)",
             "tooltip": {
               "shared": true,
               "sort": 2,
@@ -302,7 +302,7 @@ data:
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
-            "description": "Network I/O errors (rate per minute)",
+            "description": "Network I/O errors (avg/sec, over 1m window)",
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
@@ -356,7 +356,7 @@ data:
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Total Network Errors (rate per minute)",
+            "title": "Total Network Errors (avg/sec, over 1m window)",
             "tooltip": {
               "shared": true,
               "sort": 2,

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-source.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-source.yaml
@@ -127,7 +127,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "ApiServerSource: Event Count (rate per minute)",
+          "title": "ApiServerSource: Event Count (avg/sec, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -215,7 +215,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "ApiServerSource: Success Rate (2xx Event, fraction rate per minute)",
+          "title": "ApiServerSource: Success Rate (2xx Event, fraction rate, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -284,7 +284,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "ApiServerSource: Event Count by Response Code Class (rate per minute)",
+          "title": "ApiServerSource: Event Count by Response Code Class (avg/sec, over 1m window)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -399,7 +399,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "ApiServerSource: Failure Rate (non-2xx Event, fraction rate per minute)",
+          "title": "ApiServerSource: Failure Rate (non-2xx Event, fraction rate, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -501,7 +501,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "MT PingSource: Event Count (rate per minute)",
+          "title": "MT PingSource: Event Count (avg/sec, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -589,7 +589,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "MT PingSource: Success Rate  (2xx Event, fraction rate per minute)",
+          "title": "MT PingSource: Success Rate  (2xx Event, fraction rate, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -658,7 +658,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "MT PingSource: Event Count by Response Code Class (rate per minute)",
+          "title": "MT PingSource: Event Count by Response Code Class (avg/sec, over 1m window)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -773,7 +773,7 @@ data:
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "MT PingSource: Failure Rate (non-2xx Event, fraction rate per minute)",
+          "title": "MT PingSource: Failure Rate (non-2xx Event, fraction rate, over 1m window)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -875,7 +875,7 @@ data:
              "thresholds": "",
              "timeFrom": null,
              "timeShift": null,
-             "title": "Kafka: Event Count (rate per minute)",
+             "title": "Kafka: Event Count (avg/sec, over 1m window)",
              "type": "singlestat",
              "valueFontSize": "80%",
              "valueMaps": [
@@ -963,7 +963,7 @@ data:
              "thresholds": "",
              "timeFrom": null,
              "timeShift": null,
-             "title": "KafkaSource: Success Rate (2xx Event, fraction rate per minute)",
+             "title": "KafkaSource: Success Rate (2xx Event, fraction rate, over 1m window)",
              "type": "singlestat",
              "valueFontSize": "80%",
              "valueMaps": [
@@ -1032,7 +1032,7 @@ data:
              "timeFrom": null,
              "timeRegions": [],
              "timeShift": null,
-             "title": "KafkaSource: Event Count by Response Code Class (rate per minute)",
+             "title": "KafkaSource: Event Count by Response Code Class (avg/sec, over 1m window)",
              "tooltip": {
                "shared": true,
                "sort": 0,
@@ -1147,7 +1147,7 @@ data:
              "thresholds": "",
              "timeFrom": null,
              "timeShift": null,
-             "title": "KafkaSource: Failure Rate (non-2xx Event, fraction rate per minute)",
+             "title": "KafkaSource: Failure Rate (non-2xx Event, fraction rate, over 1m window)",
              "type": "singlestat",
              "valueFontSize": "80%",
              "valueMaps": [

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-source.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-source.yaml
@@ -48,7 +48,7 @@ data:
           "id": 2,
           "panels": [],
           "repeat": null,
-          "title": "ApiServerSource",
+          "title": "ApiServer Source Aggregated Metrics (per namespace)",
           "type": "row"
         },
         {
@@ -118,7 +118,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(apiserversource_event_count{namespace=\"$namespace\"}[1m]))",
+              "expr": "sum(rate(apiserversource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -206,7 +206,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(apiserversource_event_count{namespace=\"$namespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(apiserversource_event_count{namespace=\"$namespace\"}[1m]))",
+              "expr": "sum(rate(apiserversource_event_count{namespace_name=\"$eventNamespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(apiserversource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -272,7 +272,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(apiserversource_event_count{namespace=\"$namespace\"}[1m])) by (response_code_class)",
+              "expr": "sum(rate(apiserversource_event_count{namespace_name=\"$eventNamespace\"}[1m])) by (response_code_class)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -390,7 +390,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(apiserversource_event_count{namespace=\"$namespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(apiserversource_event_count{namespace=\"$namespace\"}[1m]))",
+              "expr": "sum(rate(apiserversource_event_count{namespace_name=\"$eventNamespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(apiserversource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -422,7 +422,7 @@ data:
           "id": 42,
           "panels": [],
           "repeat": null,
-          "title": "MT PingSource",
+          "title": "MT Ping Source Aggregated Metrics (per namespace)",
           "type": "row"
         },
         {
@@ -492,7 +492,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(pingsource_event_count{namespace=\"$namespace\"}[1m]))",
+              "expr": "sum(rate(pingsource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -580,7 +580,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(pingsource_event_count{namespace=\"$namespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(pingsource_event_count{namespace=\"$namespace\"}[1m]))",
+              "expr": "sum(rate(pingsource_event_count{namespace_name=\"$eventNamespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(pingsource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -646,7 +646,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(pingsource_event_count{namespace=\"$namespace\"}[1m])) by (response_code_class)",
+              "expr": "sum(rate(pingsource_event_count{namespace_name=\"$eventNamespace\"}[1m])) by (response_code_class)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -764,7 +764,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(pingsource_event_count{namespace=\"$namespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(pingsource_event_count{namespace=\"$namespace\"}[1m]))",
+              "expr": "sum(rate(pingsource_event_count{namespace_name=\"$eventNamespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(pingsource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
               "format": "time_series",
               "instant": false,
               "refId": "A"
@@ -796,7 +796,7 @@ data:
             "id": 42,
             "panels": [],
             "repeat": null,
-            "title": "KafkaSource",
+            "title": "Kafka Source Aggregated Metrics (per namespace)",
             "type": "row"
           },
           {
@@ -866,7 +866,7 @@ data:
              "tableColumn": "",
              "targets": [
                {
-                 "expr": "sum(rate(kafkasource_event_count{namespace=\"$namespace\"}[1m]))",
+                 "expr": "sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
                  "format": "time_series",
                  "instant": false,
                  "refId": "A"
@@ -954,7 +954,7 @@ data:
              "tableColumn": "",
              "targets": [
                {
-                 "expr": "sum(rate(kafkasource_event_count{namespace=\"$namespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(kafkasource_event_count{namespace=\"$namespace\"}[1m]))",
+                 "expr": "sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
                  "format": "time_series",
                  "instant": false,
                  "refId": "A"
@@ -1020,7 +1020,7 @@ data:
              "steppedLine": false,
              "targets": [
                {
-                 "expr": "sum(rate(kafkasource_event_count{namespace=\"$namespace\"}[1m])) by (response_code_class)",
+                 "expr": "sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\"}[1m])) by (response_code_class)",
                  "format": "time_series",
                  "hide": false,
                  "instant": false,
@@ -1138,7 +1138,7 @@ data:
              "tableColumn": "",
              "targets": [
                {
-                 "expr": "sum(rate(kafkasource_event_count{namespace=\"$namespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(kafkasource_event_count{namespace=\"$namespace\"}[1m]))",
+                 "expr": "sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
                  "format": "time_series",
                  "instant": false,
                  "refId": "A"
@@ -1170,9 +1170,9 @@ data:
             "includeAll": false,
             "label": "Namespace",
             "multi": false,
-            "name": "namespace",
+            "name": "eventNamespace",
             "options": [],
-            "query": "label_values(kube_pod_labels{label_eventing_knative_dev_source=~\".+\"}, namespace)",
+            "query": "label_values((pingsource_event_count{} OR kafkasource_event_count{} OR apiserversource_event_count{}), namespace_name)",
             "refresh": 2,
             "regex": "",
             "sort": 1,

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-serving-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-serving-resources.yaml
@@ -102,7 +102,7 @@ data:
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total CPU Usage (rate per minute)",
+          "title": "Total CPU Usage (avg/sec, over 1m window)",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -221,7 +221,7 @@ data:
             "dashLength": 10,
             "dashes": false,
             "datasource": "prometheus",
-            "description": "Network I/O at the pod level (rate per minute)",
+            "description": "Network I/O at the pod level (avg/sec, over 1m window)",
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
@@ -273,7 +273,7 @@ data:
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Total Network I/O (rate per minute)",
+            "title": "Total Network I/O (avg/sec, over 1m window)",
             "tooltip": {
               "shared": true,
               "sort": 2,
@@ -370,7 +370,7 @@ data:
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Total Network Errors (rate per minute)",
+            "title": "Total Network Errors (avg/sec, over 1m window)",
             "tooltip": {
               "shared": true,
               "sort": 2,


### PR DESCRIPTION
a) add Event Count by Event Type (rate per minute) panel to broker-filter (triggers)
b) make panel order consistent for broker filter and ingress.
For example Event Count by Response Code Class (rate per minute) appears after failure rate for brokers.
c) source dashboard has a namespace variable that maps to a dropdown list which needs to be based on a different query. Current query is: https://github.com/openshift-knative/serverless-operator/blob/5d6160bc1d97a9a34cbef9b337bf48657241d37b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-source.yaml#L1175.
As not all sources have pods we should base this on the namespace query that matches the source namespace. This makes correlation much easier.
The right query is: "query": "label_values((pingsource_event_count{} OR kafkasource_event_count{} OR apiserversource_event_count{}), namespace_name)"
Also change namespace to EventNamespace to make the distinction clear.

Screenshots of the new dashboards:
![image](https://user-images.githubusercontent.com/7945591/122911267-cb3c1b80-d35f-11eb-9313-013aea67ebbb.png)
![image](https://user-images.githubusercontent.com/7945591/122911302-d42ced00-d35f-11eb-9a02-52f1cf150061.png)
![image](https://user-images.githubusercontent.com/7945591/122911341-e018af00-d35f-11eb-86f7-b26fec62facb.png)
