### PR TITLE
[SRVKS-763] Explicitly default domain claim creation

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -117,6 +117,10 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 		}
 	}
 
+	// Explicitly set autocreateClusterDomainClaims to true if not otherwise set to be
+	// independent from upstream default changes.
+	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "autocreateClusterDomainClaims", "true")
+
 	// Temporary fix for SRVKS-743
 	if ks.Spec.Ingress.Istio.Enabled {
 		common.ConfigureIfUnset(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -210,6 +210,22 @@ func TestReconcile(t *testing.T) {
 			}
 		}),
 	}, {
+		name: "override autocreateClusterDomainClaims config",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Config: v1alpha1.ConfigMapData{
+						"network": map[string]string{
+							"autocreateClusterDomainClaims": "false",
+						},
+					},
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			common.Configure(&ks.Spec.CommonSpec, "network", "autocreateClusterDomainClaims", "false")
+		}),
+	}, {
 		name: "respects different status",
 		in: ks(func(ks *v1alpha1.KnativeServing) {
 			ks.Status.MarkDependenciesInstalled()
@@ -415,8 +431,9 @@ func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
 						"routing.example.com": "",
 					},
 					"network": map[string]string{
-						"domainTemplate": defaultDomainTemplate,
-						"ingress.class":  kourierIngressClassName,
+						"domainTemplate":                defaultDomainTemplate,
+						"ingress.class":                 kourierIngressClassName,
+						"autocreateClusterDomainClaims": "true",
 					},
 				},
 				Registry: v1alpha1.Registry{


### PR DESCRIPTION
In order to be independent from upcoming upstream default changes, this explicitly sets the default for Openshift Serverless, if the user doesn't specify otherwise.

/assign @nak3 