### PR TITLE
[RELEASE-1.15][SRVKE-841] Fix source resources dashboard for long source names

### DIFF
--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
@@ -64,7 +64,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod\", container != \"POD\", container != \"\"}[1m])) by (container)",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod|k8s_POD_pingsource-mt-adapter-.+\", container != \"POD\", container != \"\"}[1m])) by (container)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{container}}",
@@ -144,7 +144,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$pod\", container != \"POD\", container != \"\"}) by (container)",
+              "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$pod|k8s_POD_pingsource-mt-adapter-.+\", container != \"POD\", container != \"\"}) by (container)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{container}}",
@@ -229,14 +229,14 @@ data:
             "steppedLine": false,
             "targets": [
              {
-                "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+\"}[1m]))",
+                "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "received bytes",
                 "refId": "A"
               },
               {
-                "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+\"}[1m]))",
+                "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
                 "legendFormat": "transmitted bytes",
                 "refId": "B"
               }
@@ -324,14 +324,14 @@ data:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+\"}[1m]))",
+                "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat":  "receive errors",
                 "refId": "A"
               },
               {
-                "expr": "sum(rate(container_network_transmit_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+\"}[1m]))",
+                "expr": "sum(rate(container_network_transmit_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
                 "format": "time_series",
                 "instant": false,
                 "legendFormat": "transmit errors",
@@ -490,7 +490,7 @@ data:
             "allValue": null,
             "current": {},
             "datasource": "prometheus",
-            "hide": 0,
+            "hide": 1,
             "includeAll": false,
             "label": "SourcePodName",
             "multi": false,

--- a/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/grafana-dash-knative-eventing-resources.yaml
@@ -64,7 +64,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$sprefix-$source-.+|pingsource-mt-adapter-.+\", container != \"POD\", container != \"\"}[1m])) by (container)",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod\", container != \"POD\", container != \"\"}[1m])) by (container)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{container}}",
@@ -144,7 +144,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$sprefix-$source-.+|pingsource-mt-adapter-.+\", container != \"POD\", container != \"\"}) by (container)",
+              "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$pod\", container != \"POD\", container != \"\"}) by (container)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{container}}",
@@ -229,14 +229,14 @@ data:
             "steppedLine": false,
             "targets": [
              {
-                "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
+                "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+\"}[1m]))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "received bytes",
                 "refId": "A"
               },
               {
-                "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
+                "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+\"}[1m]))",
                 "legendFormat": "transmitted bytes",
                 "refId": "B"
               }
@@ -324,14 +324,14 @@ data:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
+                "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+\"}[1m]))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat":  "receive errors",
                 "refId": "A"
               },
               {
-                "expr": "sum(rate(container_network_transmit_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$sprefix-$source-.+|k8s_POD_pingsource-mt-adapter-.+\"}[1m]))",
+                "expr": "sum(rate(container_network_transmit_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$pod.+\"}[1m]))",
                 "format": "time_series",
                 "instant": false,
                 "legendFormat": "transmit errors",
@@ -436,7 +436,7 @@ data:
             "multi": false,
             "name": "Source Type",
             "options": [],
-            "query": "label_values(label_replace(kube_pod_labels{namespace=\"$namespace\", label_eventing_knative_dev_source=~\".+\"}, \"label_eventing_knative_dev_source\", \"$1$2\", \"label_eventing_knative_dev_source\", \"(.+)-(.+)-(controller)\"), label_eventing_knative_dev_source)",
+            "query": "label_values(label_replace(kube_pod_labels{namespace=\"$namespace\", label_eventing_knative_dev_source=\"$scontroller\"}, \"label_eventing_knative_dev_source\", \"$1$2\", \"label_eventing_knative_dev_source\", \"(.+)-(.+)-(controller)\"), label_eventing_knative_dev_source)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -456,7 +456,7 @@ data:
             "multi": false,
             "name": "sprefix",
             "options": [],
-            "query": "label_values(label_replace(kube_pod_labels{namespace=\"$namespace\", label_eventing_knative_dev_source=~\".+\"}, \"label_eventing_knative_dev_source\", \"$1$2\", \"label_eventing_knative_dev_source\", \"(.+)-(.+)-(controller)\"), label_eventing_knative_dev_source)",
+            "query": "label_values(label_replace(kube_pod_labels{namespace=\"$namespace\", label_eventing_knative_dev_source=\"$scontroller\"}, \"label_eventing_knative_dev_source\", \"$1$2\", \"label_eventing_knative_dev_source\", \"(.+)-(.+)-(controller)\"), label_eventing_knative_dev_source)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -476,7 +476,27 @@ data:
             "multi": false,
             "name": "source",
             "options": [],
-            "query": "label_values(kube_pod_labels{label_eventing_knative_dev_source=~\".+\", label_eventing_knative_dev_sourceName=~\".+\", namespace=\"$namespace\", label_eventing_knative_dev_source=\"$scontroller\"}, label_eventing_knative_dev_sourceName)",
+            "query": "label_values(kube_pod_labels{label_eventing_knative_dev_sourceName=~\".+\", namespace=\"$namespace\", label_eventing_knative_dev_source=\"$scontroller\"}, label_eventing_knative_dev_sourceName)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 2,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {},
+            "datasource": "prometheus",
+            "hide": 0,
+            "includeAll": false,
+            "label": "SourcePodName",
+            "multi": false,
+            "name": "pod",
+            "options": [],
+            "query": "label_values(kube_pod_labels{label_eventing_knative_dev_sourceName=\"$source\", namespace=\"$namespace\", label_eventing_knative_dev_source=\"$scontroller\"}, pod)",
             "refresh": 2,
             "regex": "",
             "sort": 2,


### PR DESCRIPTION
Right now long names are truncated by Eventing and dashboards dont work as expected. More details in SRVKE-841.
Apiserversource:
![image](https://user-images.githubusercontent.com/7945591/123116217-62c96900-d449-11eb-8c91-0903247453eb.png)
![image](https://user-images.githubusercontent.com/7945591/123116254-6957e080-d449-11eb-9e59-98445c393034.png)

Ping source:
![image](https://user-images.githubusercontent.com/7945591/123116141-534a2000-d449-11eb-844c-023cc489c8b6.png)
![image](https://user-images.githubusercontent.com/7945591/123116179-5b09c480-d449-11eb-9f8d-21e4169ec843.png)

Kafka source:
![image](https://user-images.githubusercontent.com/7945591/123117416-66112480-d44a-11eb-87d1-4e0ea8c2acd0.png)

