### PR TITLE
[SRVCOM-1416] Login test users without using a precreated KUBECONFIG

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -202,7 +202,12 @@ function add_user {
   fi
 
   logger.debug 'Generate kubeconfig'
-  cp "${KUBECONFIG}" "$name.kubeconfig"
-  occmd="bash -c '! oc login --kubeconfig=${name}.kubeconfig --username=${name} --password=${pass} > /dev/null'"
+  
+  ctx=$(oc config current-context)
+  cluster=$(oc config view -ojsonpath="{.contexts[?(@.name == \"$ctx\")].context.cluster}")
+  server=$(oc config view -ojsonpath="{.clusters[?(@.name == \"$cluster\")].cluster.server}")
+  logger.debug "Context: $ctx, Cluster: $cluster, Server: $server"
+
+  occmd="bash -c '! oc login --kubeconfig=${name}.kubeconfig --insecure-skip-tls-verify=true --username=${name} --password=${pass} ${server} > /dev/null'"
   timeout 180 "${occmd}"
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -318,9 +318,14 @@ function create_htpasswd_users {
   fi
 
   logger.info 'Generate kubeconfig for each user'
+
+  ctx=$(oc config current-context)
+  cluster=$(oc config view -ojsonpath="{.contexts[?(@.name == \"$ctx\")].context.cluster}")
+  server=$(oc config view -ojsonpath="{.clusters[?(@.name == \"$cluster\")].cluster.server}")
+  logger.debug "Context: $ctx, Cluster: $cluster, Server: $server"
+
   for i in $(seq 1 "$num_users"); do
-    cp "${KUBECONFIG}" "user${i}.kubeconfig"
-    occmd="bash -c '! oc login --kubeconfig=user${i}.kubeconfig --username=user${i} --password=password${i} > /dev/null'"
+    occmd="bash -c '! oc login --insecure-skip-tls-verify=true --kubeconfig=user${i}.kubeconfig --username=user${i} --password=password${i} ${server} > /dev/null'"
     timeout 180 "${occmd}"
   done
 


### PR DESCRIPTION
The current way of doing the logins is causing trouble on hive clusters, so this is a different approach without requiring the precreated KUBECONFIG as a base.
It uses the cluster that's used by `current-context` to login to support local use-cases as well. Tested just fine with CRC.