### PR TITLE
Stop deleting installplans explicitly

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -352,10 +352,6 @@ function teardown_serverless {
   oc delete subscriptions.operators.coreos.com \
     -n "${OPERATORS_NAMESPACE}" "${OPERATOR}" \
     --ignore-not-found
-  for ip in $(set +o pipefail && oc get installplan -n "${OPERATORS_NAMESPACE}" --no-headers 2>/dev/null \
-      | grep serverless-operator | cut -f1 -d' '); do
-    oc delete installplan -n "${OPERATORS_NAMESPACE}" "$ip"
-  done
   for csv in $(set +o pipefail && oc get csv -n "${OPERATORS_NAMESPACE}" --no-headers 2>/dev/null \
       | grep serverless-operator | cut -f1 -d' '); do
     oc delete csv -n "${OPERATORS_NAMESPACE}" "${csv}"


### PR DESCRIPTION
Install plans have an OwnerReference to the subscription which we delete before, so this deletion races and sometimes fails, as in https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.6-e2e-aws-ocp-46-continuous/1408032296992247808.

/assign @mgencur 