### PR TITLE
Increase timeout to login user to 10 minutes

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -209,5 +209,5 @@ function add_user {
   logger.debug "Context: $ctx, Cluster: $cluster, Server: $server"
 
   occmd="bash -c '! oc login --kubeconfig=${name}.kubeconfig --insecure-skip-tls-verify=true --username=${name} --password=${pass} ${server} > /dev/null'"
-  timeout 180 "${occmd}"
+  timeout 600 "${occmd}"
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -326,7 +326,7 @@ function create_htpasswd_users {
 
   for i in $(seq 1 "$num_users"); do
     occmd="bash -c '! oc login --insecure-skip-tls-verify=true --kubeconfig=user${i}.kubeconfig --username=user${i} --password=password${i} ${server} > /dev/null'"
-    timeout 180 "${occmd}"
+    timeout 600 "${occmd}"
   done
 
   logger.success "${num_users} htpasswd users created"


### PR DESCRIPTION
Debugged one occurrence of the issues on 4.8 and talked to the authentication team about it. There's a known issue about user creation taking quite the while to be reconciled, see https://bugzilla.redhat.com/show_bug.cgi?id=1958198. We don't really care, so bumping this to 10min should be just fine.

/assign @mgencur 