### PR TITLE
Filter out the pingsource alert

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -275,9 +275,10 @@ function check_serverless_alerts {
   local alerts_file monitoring_route num_alerts
   alerts_file="${ARTIFACTS:-/tmp}/alerts.json"
   monitoring_route=$(oc -n openshift-monitoring get routes alertmanager-main -oyaml -ojsonpath='{.spec.host}')
+  # TODO(SRVKE-669) remove the filter for the pingsource-mt-adapter service once issue is fixed.
   curl -k -H "Authorization: Bearer $(oc -n openshift-monitoring sa get-token prometheus-k8s)" \
     "https://${monitoring_route}/api/v1/alerts" | \
-    jq -c '.data | map(select(.labels.namespace == "'"${OPERATORS_NAMESPACE}"'" or .labels.namespace == "'"${EVENTING_NAMESPACE}"'" or .labels.namespace == "'"${SERVING_NAMESPACE}"'" or .labels.namespace == "'"${INGRESS_NAMESPACE}"'"))' > "${alerts_file}"
+    jq -c '.data | map(select((.labels.service != "pingsource-mt-adapter") and (.labels.namespace == "'"${OPERATORS_NAMESPACE}"'" or .labels.namespace == "'"${EVENTING_NAMESPACE}"'" or .labels.namespace == "'"${SERVING_NAMESPACE}"'" or .labels.namespace == "'"${INGRESS_NAMESPACE}"'")))' > "${alerts_file}"
 
   num_alerts=$(jq 'length' "${alerts_file}")
   if [ ! "${num_alerts}" = "0" ]; then


### PR DESCRIPTION
Right now we get an alert that fails the CI jobs.

>[{"labels":{"alertname":"TargetDown","job":"pingsource-mt-adapter","namespace":"knative-eventing","prometheus":"openshift-monitoring/k8s","service":"pingsource-mt-adapter","severity":"warning"},"annotations":{"message":"100% of the pingsource-mt-adapter/pingsource-mt-adapter targets in knative-eventing namespace are down."},"startsAt":"2021-06-30T13:21:00.163Z","endsAt":"2021-06-30T13:25:30.163Z","generatorURL":"https://prometheus-k8s-openshift-monitoring.apps.ci-op-5pw4fi4b-1351c.origin-ci-int-aws.dev.rhcloud.com/graph?g0.expr=100+%2A+%28count+by%28job%2C+namespace%2C+service%29+%28up+%3D%3D+0%29+%2F+count+by%28job%2C+namespace%2C+service%29+%28up%29%29+%3E+10&g0.tab=1","status":{"state":"active","silencedBy":[],"inhibitedBy":[]},"receivers":["Default"],"fingerprint":"beb45909056a9b50"}]

Temporarily filter out the alert until the bug is fixed.