### PR TITLE
Add `--enable-alpha` option to ha test

### DIFF
--- a/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
+++ b/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
@@ -3,6 +3,9 @@ kind: KnativeServing
 metadata:
   name: knative-serving
 spec:
+  deployments:
+  - name: domain-mapping
+    replicas: 2
   config:
     autoscaler:
       container-concurrency-target-default: "100"


### PR DESCRIPTION
This patch adds `--enable-alpha` to e2e tests and run TestDomainMappingHA.

/cc @markusthoemmes @mgencur 