### PR TITLE
Stop auto-upgrading Openshift related golang deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.19.7
 	k8s.io/code-generator => k8s.io/code-generator v0.19.7
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
-	knative.dev/eventing => github.com/openshift/knative-eventing v0.99.1-0.20210615095610-6ba6287e0d43
-	knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20210622064103-4b37bbac41a7
-	knative.dev/serving => github.com/openshift/knative-serving v0.10.1-0.20210622082206-e5d94ec4da95
+	knative.dev/eventing => github.com/openshift/knative-eventing v0.99.1-0.20210628141718-a84d0554b961
+	knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20210628142118-4a62c9cd9173
+	knative.dev/serving => github.com/openshift/knative-serving v0.10.1-0.20210701102323-75ffe62956f2
 )

--- a/go.sum
+++ b/go.sum
@@ -934,8 +934,8 @@ github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5X
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
-github.com/openshift-knative/eventing-kafka v0.19.1-0.20210622064103-4b37bbac41a7 h1:6CNPzbq/alcTUUSXgsrenXYVPIcj43896ydvIWvdZYA=
-github.com/openshift-knative/eventing-kafka v0.19.1-0.20210622064103-4b37bbac41a7/go.mod h1:jvgupXSyJtbnebTPkAbBnal7xxLtGs8uXg2UfoWT2Ts=
+github.com/openshift-knative/eventing-kafka v0.19.1-0.20210628142118-4a62c9cd9173 h1:ZbQYX9ZKXAEHjDOmMhHQai63JKOYlPYOdI1Pn/QHVkA=
+github.com/openshift-knative/eventing-kafka v0.19.1-0.20210628142118-4a62c9cd9173/go.mod h1:jvgupXSyJtbnebTPkAbBnal7xxLtGs8uXg2UfoWT2Ts=
 github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
 github.com/openshift/api v0.0.0-20200331152225-585af27e34fd/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
 github.com/openshift/api v0.0.0-20210105115604-44119421ec6b/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
@@ -946,10 +946,10 @@ github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mo
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
 github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47 h1:+TEY29DK0XhqB7HFC9OfV8qf3wffSyi7MWv3AP28DGQ=
 github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47/go.mod h1:u7NRAjtYVAKokiI9LouzTv4mhds8P4S1TwdVAfbjKSk=
-github.com/openshift/knative-eventing v0.99.1-0.20210615095610-6ba6287e0d43 h1:YU2wOBSF6xG09YfhDG5FrV+Qg/dHisBGXNcDQw4p3Wg=
-github.com/openshift/knative-eventing v0.99.1-0.20210615095610-6ba6287e0d43/go.mod h1:EmyNMt16keS1pusIL5GxxueP06nxRtl+fiZIy1Il5Ws=
-github.com/openshift/knative-serving v0.10.1-0.20210622082206-e5d94ec4da95 h1:MWaeumDCn9tOPnEkvuON1UrIbYj2MMdb6/Zi4u9F0zQ=
-github.com/openshift/knative-serving v0.10.1-0.20210622082206-e5d94ec4da95/go.mod h1:1j9Kv89CFB671mXbVRsbbyhlBh7d3BfksOtSy9j8jQ4=
+github.com/openshift/knative-eventing v0.99.1-0.20210628141718-a84d0554b961 h1:U4ClHRyWSC4+iqI1TIj31jvb2izZJnqSqQgQ+1rNT14=
+github.com/openshift/knative-eventing v0.99.1-0.20210628141718-a84d0554b961/go.mod h1:EmyNMt16keS1pusIL5GxxueP06nxRtl+fiZIy1Il5Ws=
+github.com/openshift/knative-serving v0.10.1-0.20210701102323-75ffe62956f2 h1:D6bT6huKoBEX0QyrnVXEBJep5YeBSu34ilrjR8tUKTU=
+github.com/openshift/knative-serving v0.10.1-0.20210701102323-75ffe62956f2/go.mod h1:1j9Kv89CFB671mXbVRsbbyhlBh7d3BfksOtSy9j8jQ4=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -18,16 +18,9 @@ EVENTING_VERSION="release-v0.22.0"
 EVENTING_KAFKA_VERSION="release-v0.22.0"
 SERVING_VERSION="release-v0.23.1"
 
-# Controls the version of OCP related dependencies.
-OCP_VERSION="release-4.7"
-
 # The list of dependencies that we track at HEAD and periodically
 # float forward in this repository.
 FLOATING_DEPS=(
-  "github.com/openshift/api@${OCP_VERSION}"
-  "github.com/openshift/client-go@${OCP_VERSION}"
-  "github.com/operator-framework/operator-lifecycle-manager@${OCP_VERSION}"
-
   "knative.dev/hack@${KN_VERSION}"
   "knative.dev/networking@${KN_VERSION}"
   "knative.dev/operator@${KN_VERSION}"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1052,7 +1052,7 @@ k8s.io/utils/trace
 # knative.dev/caching v0.0.0-20210512050647-922782660f7c
 knative.dev/caching/pkg/apis/caching
 knative.dev/caching/pkg/apis/caching/v1alpha1
-# knative.dev/eventing v0.23.2 => github.com/openshift/knative-eventing v0.99.1-0.20210615095610-6ba6287e0d43
+# knative.dev/eventing v0.23.2 => github.com/openshift/knative-eventing v0.99.1-0.20210628141718-a84d0554b961
 ## explicit
 knative.dev/eventing/pkg/apis/config
 knative.dev/eventing/pkg/apis/duck
@@ -1162,7 +1162,7 @@ knative.dev/eventing/test/upgrade/prober/wathola/event
 knative.dev/eventing/test/upgrade/prober/wathola/fetcher
 knative.dev/eventing/test/upgrade/prober/wathola/receiver
 knative.dev/eventing/test/upgrade/prober/wathola/sender
-# knative.dev/eventing-kafka v0.0.0-00010101000000-000000000000 => github.com/openshift-knative/eventing-kafka v0.19.1-0.20210622064103-4b37bbac41a7
+# knative.dev/eventing-kafka v0.0.0-00010101000000-000000000000 => github.com/openshift-knative/eventing-kafka v0.19.1-0.20210628142118-4a62c9cd9173
 ## explicit
 knative.dev/eventing-kafka/pkg/apis/bindings
 knative.dev/eventing-kafka/pkg/apis/bindings/v1alpha1
@@ -1324,7 +1324,7 @@ knative.dev/pkg/version
 knative.dev/pkg/webhook
 knative.dev/pkg/webhook/certificates/resources
 knative.dev/pkg/webhook/resourcesemantics
-# knative.dev/serving v0.23.1 => github.com/openshift/knative-serving v0.10.1-0.20210622082206-e5d94ec4da95
+# knative.dev/serving v0.23.1 => github.com/openshift/knative-serving v0.10.1-0.20210701102323-75ffe62956f2
 ## explicit
 knative.dev/serving/pkg/apis/autoscaling
 knative.dev/serving/pkg/apis/autoscaling/v1alpha1
@@ -1403,6 +1403,6 @@ sigs.k8s.io/yaml
 # k8s.io/client-go => k8s.io/client-go v0.19.7
 # k8s.io/code-generator => k8s.io/code-generator v0.19.7
 # k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
-# knative.dev/eventing => github.com/openshift/knative-eventing v0.99.1-0.20210615095610-6ba6287e0d43
-# knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20210622064103-4b37bbac41a7
-# knative.dev/serving => github.com/openshift/knative-serving v0.10.1-0.20210622082206-e5d94ec4da95
+# knative.dev/eventing => github.com/openshift/knative-eventing v0.99.1-0.20210628141718-a84d0554b961
+# knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20210628142118-4a62c9cd9173
+# knative.dev/serving => github.com/openshift/knative-serving v0.10.1-0.20210701102323-75ffe62956f2


### PR DESCRIPTION
These are just causing trouble we didn't quite ask for and it's ultra rarely needed anyway --> more trouble than it's worth.

This also includes a run of `./hack/update-deps.sh --upgrade` for consistency.