### PR TITLE
UI tests OCP version-aware

### DIFF
--- a/test/ui-e2e-tests.sh
+++ b/test/ui-e2e-tests.sh
@@ -29,6 +29,7 @@ function archive_cypress_artifacts {
   popd >/dev/null
 }
 
+OCP_VERSION="$(oc get clusterversion version -o jsonpath='{.status.desired.version}')"
 OCP_USERNAME="${OCP_USERNAME:-uitesting}"
 OCP_PASSWORD="${OCP_PASSWORD:-$(echo "$OCP_USERNAME" | sha1sum - | awk '{print $1}')}"
 OCP_LOGIN_PROVIDER="${OCP_LOGIN_PROVIDER:-my_htpasswd_provider}"
@@ -36,7 +37,7 @@ CYPRESS_BASE_URL="https://$(oc get route console -n openshift-console -o jsonpat
 INSTALL_SERVERLESS="${INSTALL_SERVERLESS:-true}"
 # use cypress:open to run test development UI
 NPM_TARGET="${NPM_TARGET:-test}"
-export OCP_USERNAME OCP_PASSWORD OCP_LOGIN_PROVIDER CYPRESS_BASE_URL
+export OCP_VERSION OCP_USERNAME OCP_PASSWORD OCP_LOGIN_PROVIDER CYPRESS_BASE_URL
 
 scale_up_workers
 create_namespaces

--- a/test/ui/cypress/integration/serving.spec.js
+++ b/test/ui/cypress/integration/serving.spec.js
@@ -187,6 +187,13 @@ describe('OCP UI for Serverless', () => {
   })
 
   it('can deploy a cluster-local service', () => {
+    const ocpVersion = Cypress.env('OCP_VERSION')
+    cy.semver(ocpVersion).then((semver) => {
+      // TODO: provide 4.6.x version when https://bugzilla.redhat.com/show_bug.cgi?id=1978159
+      //       gets targeted in advisory.
+      const range = '>= 4.8 || >= 4.7.18'
+      cy.onlyOn(semver.satisfies(range))
+    })
     describe('with authenticated via Web Console', cy.login)
     describe('deploy kservice from image', () => {
       showcaseKsvc.deployImage({clusterLocal: true})

--- a/test/ui/cypress/integration/serving.spec.js
+++ b/test/ui/cypress/integration/serving.spec.js
@@ -189,9 +189,9 @@ describe('OCP UI for Serverless', () => {
   it('can deploy a cluster-local service', () => {
     const ocpVersion = Cypress.env('OCP_VERSION')
     cy.semver(ocpVersion).then((semver) => {
-      // TODO: provide 4.6.x version when https://bugzilla.redhat.com/show_bug.cgi?id=1978159
-      //       gets targeted in advisory.
-      const range = '>= 4.8 || >= 4.7.18'
+      // TODO: set proper 4.6.x version when BZ gets targeted in advisory:
+      //       https://bugzilla.redhat.com/show_bug.cgi?id=1978159
+      const range = '>=4.8 || ~4.7.18 || ~4.6.39'
       cy.onlyOn(semver.satisfies(range))
     })
     describe('with authenticated via Web Console', cy.login)

--- a/test/ui/cypress/plugins/index.js
+++ b/test/ui/cypress/plugins/index.js
@@ -20,6 +20,7 @@ module.exports = (on, config) => {
   // `config` is the resolved Cypress config
   config.env.TEST_NAMESPACE = process.env.TEST_NAMESPACE || 'default'
   config.env.OCP_LOGIN_PROVIDER = process.env.OCP_LOGIN_PROVIDER || 'kube:admin'
+  config.env.OCP_VERSION = process.env.OCP_VERSION || '0.0.0'
   config.env.OCP_USERNAME = process.env.OCP_USERNAME || 'kube:admin'
   config.env.OCP_PASSWORD = process.env.OCP_PASSWORD
 

--- a/test/ui/cypress/support/index.js
+++ b/test/ui/cypress/support/index.js
@@ -9,3 +9,5 @@
 import './commands'
 import './login'
 import './semver'
+
+require('@cypress/skip-test/support')

--- a/test/ui/cypress/support/semver.js
+++ b/test/ui/cypress/support/semver.js
@@ -2,12 +2,14 @@ const semver = require('semver')
 
 class SemverResolver {
   constructor(version) {
-    this.version = version
+    this.version = semver.coerce(version)
   }
 
   satisfies(range) {
     const r = new semver.Range(range)
-    return r.test(this.version)
+    const result = r.test(this.version)
+    console.log(`Version '${this.version}' matches range '${range}': ${result}`)
+    return result
   }
 }
 

--- a/test/ui/cypress/support/semver.js
+++ b/test/ui/cypress/support/semver.js
@@ -1,5 +1,18 @@
-Cypress.Commands.add('semver', () => {
+const semver = require('semver')
+
+class SemverResolver {
+  constructor(version) {
+    this.version = version
+  }
+
+  satisfies(range) {
+    const r = new semver.Range(range)
+    return r.test(this.version)
+  }
+}
+
+Cypress.Commands.add('semver', (version) => {
   return new Cypress.Promise((resolve, _) => {
-    resolve(require('semver'))
+    resolve(new SemverResolver(version))
   })
 })

--- a/test/ui/package-lock.json
+++ b/test/ui/package-lock.json
@@ -65,6 +65,12 @@
         "uuid": "^3.3.2"
       }
     },
+    "@cypress/skip-test": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@cypress/skip-test/-/skip-test-2.6.1.tgz",
+      "integrity": "sha512-X+ibefBiuOmC5gKG91wRIT0/OqXeETYvu7zXktjZ3yLeO186Y8ia0K7/gQUpAwuUi28DuqMd1+7tBQVtPkzbPA==",
+      "dev": true
+    },
     "@cypress/xvfb": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",

--- a/test/ui/package.json
+++ b/test/ui/package.json
@@ -11,6 +11,7 @@
     "semver": "^7.3.5"
   },
   "devDependencies": {
+    "@cypress/skip-test": "^2.6.1",
     "cypress": "^7.5.0",
     "cypress-multi-reporters": "^1.5.0",
     "mocha": "^8.4.0",


### PR DESCRIPTION
This adds a gating to cluster.local test to execute it only on OCP versions that contain the openshift/console#9197 patch. We don't know the 4.6.x version for sure - the number there is just a guess.

/cc @mgencur 
/cc @markusthoemmes 