### PR TITLE
Remove all docker references (except zipkin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ the CI environment), use these commands:
 
 ```
 $ crc start --cpus=6 --memory 16384
-$ export DOCKER_REPO_OVERRIDE=docker.io/username
+$ export DOCKER_REPO_OVERRIDE=quay.io/username
 $ make images test-operator
 ```
 
@@ -53,7 +53,7 @@ crc start --cpus=6 --memory 16384
 To test the Serverless Operator against your private Openshift cluster you first
 need to push the necessary images to a publicly available location. To do that,
 make sure the `DOCKER_REPO_OVERRIDE` environment variable is set to a docker
-repository you can push to, for example `docker.io/markusthoemmes`. You might
+repository you can push to, for example `quay.io/markusthoemmes`. You might
 need to run `docker login` to be able to push images. Now run
 `make images` and all images in this repository will now be built and
 pushed to your docker repository.

--- a/knative-operator/pkg/common/eventing_test.go
+++ b/knative-operator/pkg/common/eventing_test.go
@@ -15,8 +15,8 @@ import (
 
 func TestMutateEventing(t *testing.T) {
 	const (
-		image1 = "docker.io/foo:tag"
-		image2 = "docker.io/baz:tag"
+		image1 = "quay.io/foo:tag"
+		image2 = "quay.io/baz:tag"
 	)
 	ke := &operatorv1alpha1.KnativeEventing{
 		ObjectMeta: metav1.ObjectMeta{

--- a/knative-operator/pkg/common/serving_test.go
+++ b/knative-operator/pkg/common/serving_test.go
@@ -35,7 +35,7 @@ func TestMutate(t *testing.T) {
 	const (
 		networks = "foo,bar,baz"
 		domain   = "fubar"
-		image    = "docker.io/queue:tag"
+		image    = "quay.io/queue:tag"
 	)
 	os.Setenv("IMAGE_queue-proxy", image)
 	type check func(*testing.T, *servingv1alpha1.KnativeServing)

--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -47,15 +47,15 @@ func BuildImageOverrideMapFromEnviron(environ []string, prefix string) map[strin
 		pair := strings.SplitN(e, "=", 2)
 		if strings.HasPrefix(pair[0], prefix) {
 			// convert
-			// "IMAGE_container=docker.io/foo"
-			// "IMAGE_deployment__container=docker.io/foo2"
-			// "IMAGE_env_var=docker.io/foo3"
-			// "IMAGE_deployment__env_var=docker.io/foo4"
+			// "IMAGE_container=quay.io/foo"
+			// "IMAGE_deployment__container=quay.io/foo2"
+			// "IMAGE_env_var=quay.io/foo3"
+			// "IMAGE_deployment__env_var=quay.io/foo4"
 			// to
-			// container: docker.io/foo
-			// deployment/container: docker.io/foo2
-			// env_var: docker.io/foo3
-			// deployment/env_var: docker.io/foo4
+			// container: quay.io/foo
+			// deployment/container: quay.io/foo2
+			// env_var: quay.io/foo3
+			// deployment/env_var: quay.io/foo4
 			name := strings.TrimPrefix(pair[0], prefix)
 			name = strings.Replace(name, "__", "/", 1)
 			if pair[1] != "" {

--- a/knative-operator/pkg/controller/knativekafka/images_test.go
+++ b/knative-operator/pkg/controller/knativekafka/images_test.go
@@ -67,14 +67,14 @@ var updateImageTests = []updateImageTest{
 		name: "NoChangeOverrideWithDifferentName",
 		containers: []corev1.Container{{
 			Name:  "image",
-			Image: "docker.io/name/image:tag2"},
+			Image: "quay.io/name/image:tag2"},
 		},
 		overrideMap: map[string]string{
 			"Unused": "new-registry.io/test/path",
 		},
 		expected: []corev1.Container{{
 			Name:  "image",
-			Image: "docker.io/name/image:tag2"},
+			Image: "quay.io/name/image:tag2"},
 		},
 	},
 	{
@@ -95,10 +95,10 @@ var updateImageTests = []updateImageTest{
 			Env: []corev1.EnvVar{{Name: "SOME_IMAGE", Value: "gcr.io/foo/bar"}},
 		}},
 		overrideMap: map[string]string{
-			"SOME_IMAGE": "docker.io/my/overridden-image",
+			"SOME_IMAGE": "quay.io/my/overridden-image",
 		},
 		expected: []corev1.Container{{
-			Env: []corev1.EnvVar{{Name: "SOME_IMAGE", Value: "docker.io/my/overridden-image"}},
+			Env: []corev1.EnvVar{{Name: "SOME_IMAGE", Value: "quay.io/my/overridden-image"}},
 		}},
 	},
 	{
@@ -107,7 +107,7 @@ var updateImageTests = []updateImageTest{
 			Env: []corev1.EnvVar{{Name: "SOME_IMAGE", Value: "gcr.io/foo/bar"}},
 		}},
 		overrideMap: map[string]string{
-			"OTHER_IMAGE": "docker.io/my/overridden-image",
+			"OTHER_IMAGE": "quay.io/my/overridden-image",
 		},
 		expected: []corev1.Container{{
 			Env: []corev1.EnvVar{{Name: "SOME_IMAGE", Value: "gcr.io/foo/bar"}},
@@ -122,12 +122,12 @@ var updateImageTests = []updateImageTest{
 		}},
 		overrideMap: map[string]string{
 			"queue":      "new-registry.io/test/path/new-value:new-override-tag",
-			"SOME_IMAGE": "docker.io/my/overridden-image",
+			"SOME_IMAGE": "quay.io/my/overridden-image",
 		},
 		expected: []corev1.Container{{
 			Name:  "queue",
 			Image: "new-registry.io/test/path/new-value:new-override-tag",
-			Env:   []corev1.EnvVar{{Name: "SOME_IMAGE", Value: "docker.io/my/overridden-image"}},
+			Env:   []corev1.EnvVar{{Name: "SOME_IMAGE", Value: "quay.io/my/overridden-image"}},
 		}},
 	},
 	{

--- a/test/servinge2e/service_to_service_test.go
+++ b/test/servinge2e/service_to_service_test.go
@@ -63,7 +63,7 @@ func TestServiceToServiceCalls(t *testing.T) {
 
 func testServiceToService(t *testing.T, ctx *test.Context, namespace string, tc testCase) {
 	// Create a ksvc with the specified annotations and labels
-	service := test.Service(tc.name, namespace, helloworldImage, tc.annotations)
+	service := test.Service(tc.name, namespace, image, tc.annotations)
 	service.ObjectMeta.Labels = tc.labels
 
 	service = withServiceReadyOrFail(ctx, service)

--- a/test/servinge2e/servicemesh_test.go
+++ b/test/servinge2e/servicemesh_test.go
@@ -47,7 +47,6 @@ type testCase struct {
 
 const (
 	serviceMeshTestNamespaceName = "serverless-tests-mesh"
-	helloworldImage              = "gcr.io/knative-samples/helloworld-go"
 	httpProxyImage               = "registry.ci.openshift.org/openshift/knative-v0.17.3:knative-serving-test-httpproxy"
 	istioInjectKey               = "sidecar.istio.io/inject"
 )
@@ -446,7 +445,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 		// istio-pilot caches the JWKS content if a new Policy has the same jwksUri as some old policy.
 		// Rerunning this test would fail if we kept the jwksUri constant across invocations then,
 		// hence the random suffix for the jwks ksvc.
-		jwksKsvc := test.Service(helpers.AppendRandomString("jwks"), testNamespace, "openshift/hello-openshift", nil)
+		jwksKsvc := test.Service(helpers.AppendRandomString("jwks"), testNamespace, "registry.ci.openshift.org/openshift/hello-openshift", nil)
 		jwksKsvc.Spec.Template.Spec.Containers[0].Env = append(jwksKsvc.Spec.Template.Spec.Containers[0].Env, core.EnvVar{
 			Name:  "RESPONSE",
 			Value: jwks,
@@ -745,7 +744,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 
 func lookupOpenShiftRouterIP(ctx *test.Context) net.IP {
 	// Deploy an auxiliary ksvc accessible via an OpenShift route, so that we have a route hostname that we can resolve
-	aux := test.Service("aux", testNamespace, "openshift/hello-openshift", nil)
+	aux := test.Service("aux", testNamespace, image, nil)
 	aux = withServiceReadyOrFail(ctx, aux)
 
 	ips, err := net.LookupIP(aux.Status.URL.Host)
@@ -767,7 +766,7 @@ func TestKsvcWithServiceMeshCustomDomain(t *testing.T) {
 		t := ctx.T
 
 		// Deploy a cluster-local ksvc "hello"
-		ksvc := test.Service("hello", testNamespace, "openshift/hello-openshift", nil)
+		ksvc := test.Service("hello", testNamespace, image, nil)
 		ksvc.ObjectMeta.Labels = map[string]string{
 			network.VisibilityLabelKey: serving.VisibilityClusterLocal,
 		}
@@ -832,7 +831,7 @@ func TestKsvcWithServiceMeshCustomDomain(t *testing.T) {
 			t.Fatalf("Error polling custom domain: %v", err)
 		}
 
-		const expectedResponse = "Hello OpenShift!"
+		const expectedResponse = "Hello World!"
 		if resp.StatusCode != 200 || strings.TrimSpace(string(resp.Body)) != expectedResponse {
 			t.Fatalf("Expecting a HTTP 200 response with %q, got %d: %s", expectedResponse, resp.StatusCode, string(resp.Body))
 		}
@@ -896,7 +895,7 @@ func TestKsvcWithServiceMeshCustomTlsDomain(t *testing.T) {
 		t := ctx.T
 
 		// Deploy a cluster-local ksvc "hello"
-		ksvc := test.Service("hello", testNamespace, "openshift/hello-openshift", nil)
+		ksvc := test.Service("hello", testNamespace, image, nil)
 		ksvc.ObjectMeta.Labels = map[string]string{
 			network.VisibilityLabelKey: serving.VisibilityClusterLocal,
 		}
@@ -991,7 +990,7 @@ func TestKsvcWithServiceMeshCustomTlsDomain(t *testing.T) {
 			t.Fatalf("Error polling custom domain: %v", err)
 		}
 
-		const expectedResponse = "Hello OpenShift!"
+		const expectedResponse = "Hello World!"
 		if resp.StatusCode != 200 || strings.TrimSpace(string(resp.Body)) != expectedResponse {
 			t.Fatalf("Expecting an HTTP 200 response with %q, got %d: %s", expectedResponse, resp.StatusCode, string(resp.Body))
 		}


### PR DESCRIPTION
As per title, this removes all docker references (however benign they are :joy:) to avoid hitting rate-limiting issues. The only left over image is a zipkin image, which thus far hasn't caused us any trouble. I haven't found an alternative for that, the quay.io based org seems to be abandoned.

/assign @nak3 