### PR TITLE
Serve CLI artifacts from the operator deployment rather than a ksvc

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -65,7 +65,6 @@ image "pingsource-mt-adapter__dispatcher"           "${eventing}-mtping"
 
 image "APISERVER_RA_IMAGE"   "${eventing}-apiserver-receive-adapter"
 image "DISPATCHER_IMAGE"     "${eventing}-channel-dispatcher"
-image "KN_CLI_ARTIFACTS"     "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
 
 kafka_image "kafka-controller-manager__manager"    "${eventing_kafka}-source-controller"
 kafka_image "KAFKA_RA_IMAGE"                       "${eventing_kafka}-receive-adapter"
@@ -136,6 +135,9 @@ for name in "${kafka_images[@]}"; do
   add_related_image "$target" "KAFKA_IMAGE_${name}" "${kafka_images_addresses[$name]}"
   add_downstream_operator_deployment_image "$target" "KAFKA_IMAGE_${name}" "${kafka_images_addresses[$name]}"
 done
+
+# Override the image for the CLI artifact deployment
+yq write --inplace "$target" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.containers(name==cli-downloads).image" "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
 
 for name in "${!yaml_keys[@]}"; do
   echo "Value: ${name} -> ${yaml_keys[$name]}"

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -6,91 +6,83 @@ import (
 	"os"
 	"strings"
 
-	v1 "github.com/openshift/api/route/v1"
-	appsv1 "k8s.io/api/apps/v1"
-
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-
 	consolev1 "github.com/openshift/api/console/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	knCLIDownload               = "kn"
-	knConsoleCLIDownloadService = "kn-cli"
-	deprecatedResourceName      = "kn-cli-downloads"
+	knCLIDownload          = "kn"
+	deprecatedResourceName = "kn-cli-downloads"
 )
+
+var operatorNamespace = os.Getenv(common.NamespaceEnvKey)
 
 var log = common.Log.WithName("consoleclidownload")
 
 // Apply installs kn ConsoleCLIDownload and its required resources
 func Apply(instance *servingv1alpha1.KnativeServing, apiclient client.Client, scheme *runtime.Scheme) error {
-	if !instance.Status.IsReady() {
-		// Don't return error, wait silently until Serving instance is ready
-		return nil
-	}
 	// Remove deprecated resources from previous version
 	if err := deleteDeprecatedResources(instance, apiclient); err != nil {
 		return err
 	}
-	service := &servingv1.Service{}
-	if err := reconcileKnCCDResources(instance, apiclient, service); err != nil {
+
+	route, err := reconcileKnConsoleCLIDownloadRoute(apiclient, instance)
+	if err != nil {
 		return err
 	}
-	if !service.IsReady() {
-		return fmt.Errorf("knative service %q/%q not ready yet", knConsoleCLIDownloadService, instance.GetNamespace())
-	}
-	return reconcileKnConsoleCLIDownload(apiclient, instance, service)
+
+	return reconcileKnConsoleCLIDownload(apiclient, instance, route)
 }
 
-// reconcileKnCCDResources reconciles required resources viz Knative Service
-// which will serve kn cross platform binaries within cluster
-func reconcileKnCCDResources(instance *servingv1alpha1.KnativeServing, apiclient client.Client, service *servingv1.Service) error {
-	log.Info("Installing kn ConsoleCLIDownload resources")
-	err := apiclient.Get(context.TODO(), client.ObjectKey{Namespace: instance.GetNamespace(), Name: knConsoleCLIDownloadService}, service)
-	switch {
-	case apierrors.IsNotFound(err):
-		tmpService := makeKnService(os.Getenv("IMAGE_KN_CLI_ARTIFACTS"), instance)
-		if err := apiclient.Create(context.TODO(), tmpService); err != nil {
-			return err
+func reconcileKnConsoleCLIDownloadRoute(apiclient client.Client, instance *servingv1alpha1.KnativeServing) (*routev1.Route, error) {
+	log.Info("Installing kn ConsoleCLIDownload Route")
+	ctx := context.Background()
+
+	route := &routev1.Route{}
+	err := apiclient.Get(ctx, client.ObjectKey{Namespace: operatorNamespace, Name: knCLIDownload}, route)
+	if apierrors.IsNotFound(err) {
+		route = makeRoute(instance)
+		if err := apiclient.Create(ctx, route); err != nil {
+			return nil, fmt.Errorf("failed to create route for ConsoleCLIDownload: %w", err)
 		}
-	case err == nil:
-		tmpService := makeKnService(os.Getenv("IMAGE_KN_CLI_ARTIFACTS"), instance)
-		serviceFromClusterDC := service.DeepCopy()
-		if !equality.Semantic.DeepEqual(service.Spec, tmpService.Spec) {
-			serviceFromClusterDC.Spec = tmpService.Spec
-			if err := apiclient.Update(context.TODO(), serviceFromClusterDC); err != nil {
-				return err
-			}
-		}
-	default:
-		return err
+		return route, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to fetch route for ConsoleCLIDownload: %w", err)
 	}
-	return nil
+
+	newRoute := makeRoute(instance)
+	if equality.Semantic.DeepEqual(route.Spec, newRoute.Spec) {
+		// Equal, nothing to do here.
+		return route, nil
+	}
+
+	route = route.DeepCopy()
+	route.Spec = newRoute.Spec
+	if err := apiclient.Update(ctx, route); err != nil {
+		return nil, fmt.Errorf("failed to update route for ConsoleCLIDownload: %w", err)
+	}
+	return route, nil
 }
 
 // reconcileKnConsoleCLIDownload reconciles kn ConsoleCLIDownload by finding
 // kn download resource route URL and populating spec accordingly
-func reconcileKnConsoleCLIDownload(apiclient client.Client, instance *servingv1alpha1.KnativeServing, knService *servingv1.Service) error {
-
+func reconcileKnConsoleCLIDownload(apiclient client.Client, instance *servingv1alpha1.KnativeServing, route *routev1.Route) error {
 	log.Info("Installing kn ConsoleCLIDownload")
 	ctx := context.TODO()
 
-	knRouteURL := knService.Status.URL
-	if knRouteURL == nil || knRouteURL.String() == "" {
-		return fmt.Errorf("failed to get kn ConsoleCLIDownload Knative Service URL")
-	}
-
 	knCCDGet := &consolev1.ConsoleCLIDownload{}
-	knConsoleObj := populateKnConsoleCLIDownload(https(knRouteURL.Host), instance)
+	knConsoleObj := populateKnConsoleCLIDownload(https(route.Spec.Host), instance)
 
 	// Check if kn ConsoleCLIDownload exists
 	err := apiclient.Get(ctx, client.ObjectKey{Namespace: "", Name: knCLIDownload}, knCCDGet)
@@ -131,8 +123,8 @@ func Delete(instance *servingv1alpha1.KnativeServing, apiclient client.Client, s
 		return fmt.Errorf("failed to delete kn ConsoleCLIDownload CO: %w", err)
 	}
 
-	log.Info("Deleting kn ConsoleCLIDownload Service")
-	if err := apiclient.Delete(context.TODO(), makeKnService("", instance)); err != nil && !apierrors.IsNotFound(err) {
+	log.Info("Deleting kn ConsoleCLIDownload Route")
+	if err := apiclient.Delete(context.TODO(), makeRoute(instance)); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete kn ConsoleCLIDownload Service: %w", err)
 	}
 
@@ -148,7 +140,11 @@ func deleteDeprecatedResources(instance *servingv1alpha1.KnativeServing, apiclie
 	toDelete := []client.Object{
 		&appsv1.Deployment{ObjectMeta: metaName},
 		&corev1.Service{ObjectMeta: metaName},
-		&v1.Route{ObjectMeta: metaName},
+		&routev1.Route{ObjectMeta: metaName},
+		&servingv1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name:      "kn-cli",
+			Namespace: instance.Namespace,
+		}},
 	}
 	for _, obj := range toDelete {
 		if err := apiclient.Delete(context.TODO(), obj); err != nil && !apierrors.IsNotFound(err) {
@@ -158,87 +154,62 @@ func deleteDeprecatedResources(instance *servingv1alpha1.KnativeServing, apiclie
 	return nil
 }
 
-// makeKnService makes Knative Service object and its SPEC from provided image parameter
-func makeKnService(image string, instance *servingv1alpha1.KnativeServing) *servingv1.Service {
-	if instance == nil {
-		return nil
-	}
-	// OwnerReference is not used to handle ksvc cleanup due to race condition with control-plane deletion.
-	// In such a case route's finalizer blocks clean removal of resources.
-	service := &servingv1.Service{
+func makeRoute(instance *servingv1alpha1.KnativeServing) *routev1.Route {
+	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      knConsoleCLIDownloadService,
-			Namespace: instance.Namespace,
+			Name:      knCLIDownload,
+			Namespace: os.Getenv("NAMESPACE"),
 			Annotations: map[string]string{
-				common.ServingOwnerName:      instance.Name,
-				common.ServingOwnerNamespace: instance.Namespace,
+				common.ServingOwnerName:      instance.GetName(),
+				common.ServingOwnerNamespace: instance.GetNamespace(),
 			},
 		},
-		Spec: servingv1.ServiceSpec{
-			ConfigurationSpec: servingv1.ConfigurationSpec{
-				Template: servingv1.RevisionTemplateSpec{
-					Spec: servingv1.RevisionSpec{
-						PodSpec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Image: image,
-									Resources: corev1.ResourceRequirements{
-										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("10m"),
-											corev1.ResourceMemory: resource.MustParse("50Mi"),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "knative-openshift-metrics-3",
+			},
+			TLS: &routev1.TLSConfig{
+				Termination:                   routev1.TLSTerminationEdge,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+			},
+			Port: &routev1.RoutePort{
+				TargetPort: intstr.FromString("http-cli"),
 			},
 		},
 	}
-	return service
 }
 
 // populateKnConsoleCLIDownload populates kn ConsoleCLIDownload object and its SPEC
 // using route's baseURL
 func populateKnConsoleCLIDownload(baseURL string, instance *servingv1alpha1.KnativeServing) *consolev1.ConsoleCLIDownload {
-	anno := make(map[string]string)
-	if instance != nil {
-		anno = map[string]string{
-			common.ServingOwnerName:      instance.Name,
-			common.ServingOwnerNamespace: instance.Namespace,
-		}
-	}
 	return &consolev1.ConsoleCLIDownload{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        knCLIDownload,
-			Annotations: anno,
+			Name: knCLIDownload,
+			Annotations: map[string]string{
+				common.ServingOwnerName:      instance.GetName(),
+				common.ServingOwnerNamespace: instance.GetNamespace(),
+			},
 		},
 		Spec: consolev1.ConsoleCLIDownloadSpec{
 			DisplayName: "kn - OpenShift Serverless Command Line Interface (CLI)",
 			Description: "The OpenShift Serverless client `kn` is a CLI tool that allows you to fully manage OpenShift Serverless Serving and Eventing resources without writing a single line of YAML.",
-			Links: []consolev1.CLIDownloadLink{
-				{
-					Text: "Download kn for Linux for x86_64",
-					Href: baseURL + "/amd64/linux/kn-linux-amd64.tar.gz",
-				},
-				{
-					Text: "Download kn for Linux for IBM Power little endian",
-					Href: baseURL + "/ppc64le/linux/kn-linux-ppc64le.tar.gz",
-				},
-				{
-					Text: "Download kn for Linux for IBM Z",
-					Href: baseURL + "/s390x/linux/kn-linux-s390x.tar.gz",
-				},
-				{
-					Text: "Download kn for macOS",
-					Href: baseURL + "/amd64/macos/kn-macos-amd64.tar.gz",
-				},
-				{
-					Text: "Download kn for Windows",
-					Href: baseURL + "/amd64/windows/kn-windows-amd64.zip",
-				},
-			},
+			Links: []consolev1.CLIDownloadLink{{
+				Text: "Download kn for Linux for x86_64",
+				Href: baseURL + "/amd64/linux/kn-linux-amd64.tar.gz",
+			}, {
+				Text: "Download kn for Linux for IBM Power little endian",
+				Href: baseURL + "/ppc64le/linux/kn-linux-ppc64le.tar.gz",
+			}, {
+				Text: "Download kn for Linux for IBM Z",
+				Href: baseURL + "/s390x/linux/kn-linux-s390x.tar.gz",
+			}, {
+				Text: "Download kn for macOS",
+				Href: baseURL + "/amd64/macos/kn-macos-amd64.tar.gz",
+			}, {
+				Text: "Download kn for Windows",
+				Href: baseURL + "/amd64/windows/kn-windows-amd64.zip",
+			}},
 		},
 	}
 }

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -21,14 +21,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	knCLIDownload          = "kn"
-	deprecatedResourceName = "kn-cli-downloads"
+const knCLIDownload = "kn"
+
+var (
+	operatorNamespace = os.Getenv(common.NamespaceEnvKey)
+	log               = common.Log.WithName("consoleclidownload")
 )
-
-var operatorNamespace = os.Getenv(common.NamespaceEnvKey)
-
-var log = common.Log.WithName("consoleclidownload")
 
 // Apply installs kn ConsoleCLIDownload and its required resources
 func Apply(instance *servingv1alpha1.KnativeServing, apiclient client.Client, scheme *runtime.Scheme) error {
@@ -134,7 +132,7 @@ func Delete(instance *servingv1alpha1.KnativeServing, apiclient client.Client, s
 // deleteDeprecatedResources removes deprecated resources created by previous versions
 func deleteDeprecatedResources(instance *servingv1alpha1.KnativeServing, apiclient client.Client) error {
 	metaName := metav1.ObjectMeta{
-		Name:      deprecatedResourceName,
+		Name:      "kn-cli-downloads",
 		Namespace: instance.Namespace,
 	}
 	toDelete := []client.Object{
@@ -158,7 +156,7 @@ func makeRoute(instance *servingv1alpha1.KnativeServing) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      knCLIDownload,
-			Namespace: os.Getenv("NAMESPACE"),
+			Namespace: operatorNamespace,
 			Annotations: map[string]string{
 				common.ServingOwnerName:      instance.GetName(),
 				common.ServingOwnerNamespace: instance.GetNamespace(),

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -119,7 +119,7 @@ func reconcileKnConsoleCLIDownload(apiclient client.Client, instance *servingv1a
 // Delete deletes kn ConsoleCLIDownload CO and respective deployment resources
 func Delete(instance *servingv1alpha1.KnativeServing, apiclient client.Client, scheme *runtime.Scheme) error {
 	log.Info("Deleting kn ConsoleCLIDownload CO")
-	if err := apiclient.Delete(context.TODO(), populateKnConsoleCLIDownload("", nil)); err != nil && !apierrors.IsNotFound(err) {
+	if err := apiclient.Delete(context.TODO(), populateKnConsoleCLIDownload("", instance)); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete kn ConsoleCLIDownload CO: %w", err)
 	}
 

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring/dashboards"
 	consolev1 "github.com/openshift/api/console/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -107,6 +108,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	gvkToResource := map[schema.GroupVersionKind]client.Object{
 		consolev1.GroupVersion.WithKind("ConsoleCLIDownload"): &consolev1.ConsoleCLIDownload{},
+		routev1.GroupVersion.WithKind("Route"):                &routev1.Route{},
 	}
 	for _, t := range gvkToResource {
 		err = c.Watch(&source.Kind{Type: t}, common.EnqueueRequestByOwnerAnnotations(common.ServingOwnerName, common.ServingOwnerNamespace))

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -21,7 +21,6 @@ import (
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	pkgapis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -66,46 +65,6 @@ var (
 
 	defaultRequest = reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: "knative-serving", Name: "knative-serving"},
-	}
-
-	defaultKnService = servingv1.Service{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: servingv1.SchemeGroupVersion.String(),
-			Kind:       "Service",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kn-cli",
-			Namespace: "knative-serving",
-		},
-		Spec: servingv1.ServiceSpec{
-			ConfigurationSpec: servingv1.ConfigurationSpec{
-				Template: servingv1.RevisionTemplateSpec{
-					Spec: servingv1.RevisionSpec{
-						PodSpec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name:  "kn-download-server",
-									Image: "fake.example.com/openshift/kn-cli-artifacts:latest",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		Status: servingv1.ServiceStatus{
-			Status: duckv1.Status{
-				Conditions: []pkgapis.Condition{
-					{
-						Status: "True",
-						Type:   "Ready",
-					},
-				},
-			},
-			RouteStatusFields: servingv1.RouteStatusFields{
-				URL: &pkgapis.URL{Host: "kn-cli-knative-serving.example.com"},
-			},
-		},
 	}
 
 	dashboardNamespace = corev1.Namespace{
@@ -162,9 +121,8 @@ func TestExtraResourcesReconcile(t *testing.T) {
 			ingress := &defaultIngress
 			ccd := &consolev1.ConsoleCLIDownload{}
 			ns := &dashboardNamespace
-			knService := &defaultKnService
 
-			cl := fake.NewClientBuilder().WithObjects(ks, ingress, ns, &servingNamespace, knService).Build()
+			cl := fake.NewClientBuilder().WithObjects(ks, ingress, ns, &servingNamespace).Build()
 			r := &ReconcileKnativeServing{client: cl, scheme: scheme.Scheme}
 
 			// Reconcile to initialize

--- a/olm-catalog/serverless-operator/manifests/knative-operator.service.yaml
+++ b/olm-catalog/serverless-operator/manifests/knative-operator.service.yaml
@@ -6,6 +6,10 @@ metadata:
   name: knative-openshift-metrics-3
 spec:
   ports:
+  - name: http-cli
+    port: 8080
+    protocol: TCP
+    targetPort: http-cli
   - name: http-metrics
     port: 8383
     protocol: TCP

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -359,8 +359,6 @@ spec:
                         value: "registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-apiserver-receive-adapter"
                       - name: "IMAGE_DISPATCHER_IMAGE"
                         value: "registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-channel-dispatcher"
-                      - name: "IMAGE_KN_CLI_ARTIFACTS"
-                        value: "registry.ci.openshift.org/openshift/knative-v0.22.0:kn-cli-artifacts"
                       - name: "IMAGE_KUBE_RBAC_PROXY"
                         value: "registry.ci.openshift.org/origin/4.7:kube-rbac-proxy"
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
@@ -385,6 +383,12 @@ spec:
               spec:
                 serviceAccountName: knative-operator
                 containers:
+                  - name: cli-downloads
+                    image: registry.ci.openshift.org/openshift/knative-v0.22.0:kn-cli-artifacts
+                    imagePullPolicy: Always
+                    ports:
+                      - name: http-cli
+                        containerPort: 8080
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
@@ -476,8 +480,6 @@ spec:
                         value: "registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-apiserver-receive-adapter"
                       - name: "IMAGE_DISPATCHER_IMAGE"
                         value: "registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-channel-dispatcher"
-                      - name: "IMAGE_KN_CLI_ARTIFACTS"
-                        value: "registry.ci.openshift.org/openshift/knative-v0.22.0:kn-cli-artifacts"
                       - name: "IMAGE_KUBE_RBAC_PROXY"
                         value: "registry.ci.openshift.org/origin/4.7:kube-rbac-proxy"
                       - name: "KAFKA_IMAGE_kafka-controller-manager__manager"
@@ -783,8 +785,6 @@ spec:
       image: "registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-apiserver-receive-adapter"
     - name: "IMAGE_DISPATCHER_IMAGE"
       image: "registry.ci.openshift.org/openshift/knative-v0.22.0:knative-eventing-channel-dispatcher"
-    - name: "IMAGE_KN_CLI_ARTIFACTS"
-      image: "registry.ci.openshift.org/openshift/knative-v0.22.0:kn-cli-artifacts"
     - name: "IMAGE_KUBE_RBAC_PROXY"
       image: "registry.ci.openshift.org/origin/4.7:kube-rbac-proxy"
     - name: "KAFKA_IMAGE_kafka-controller-manager__manager"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -331,6 +331,12 @@ spec:
             spec:
               serviceAccountName: knative-operator
               containers:
+                - name: cli-downloads
+                  image: TO_BE_REPLACED
+                  imagePullPolicy: Always
+                  ports:
+                    - name: http-cli
+                      containerPort: 8080
                 - name: knative-openshift
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                   image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator

--- a/test/servinge2e/verify_deploy_resources_test.go
+++ b/test/servinge2e/verify_deploy_resources_test.go
@@ -11,43 +11,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	knativeServing = "knative-serving"
-)
-
-func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
-
+func TestKnConsoleCLIDownload(t *testing.T) {
 	caCtx := test.SetupClusterAdmin(t)
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
-	defer test.CleanupAll(t, caCtx)
 
-	// Check the status of Service for kn ConsoleCLIDownload
-	service, err := test.WaitForServiceState(caCtx, "kn-cli", knativeServing, test.IsServiceReady)
-	if err != nil {
-		t.Fatalf("failed to verify kn ConcoleCLIDownload Deployment: %v", err)
-	}
-	// Verify that Service URL for kn ConsoleCLIDownload is present and has a host
-	host := service.Status.URL.Host
-	if host == "" {
-		t.Fatalf("failed to verify kn ConsoleCLIDownload Service URL is present: %v", err)
-	}
 	// Verify kn ConsoleCLIDownload CO and if download links are cluster local
 	ccd, err := caCtx.Clients.ConsoleCLIDownload.Get(context.Background(), "kn", metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("unable to GET kn ConsoleCLIDownload CO 'kn': %v", err)
+		t.Fatalf("Failed to GET kn ConsoleCLIDownload: %v", err)
 	}
 	// Verify the links in kn CCD CO
 	if len(ccd.Spec.Links) != 5 {
 		t.Fatalf("expecting 5 links for artifacts for kn ConsoleCLIDownload, found %d", len(ccd.Spec.Links))
 	}
 	// Verify if individual link starts with correct route
-	protocol := "https://"
-	if !strings.HasPrefix(host, protocol) {
-		host = protocol + host
-	}
 	for _, link := range ccd.Spec.Links {
-		if !strings.HasPrefix(link.Href, host) {
-			t.Fatalf("incorrect href found for kn CCD, expecting prefix %s, found link %s", host, link.Href)
+		if !strings.HasPrefix(link.Href, "https://") {
+			t.Fatalf("incorrect href found for kn CCD, expecting prefix %q, found link %q", "https://", link.Href)
 		}
 		client := &http.Client{Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
@@ -56,10 +35,10 @@ func TestConsoleCLIDownloadAndDeploymentResources(t *testing.T) {
 		}}
 		h, err := client.Head(link.Href)
 		if err != nil {
-			t.Fatalf("failed to HEAD request for URL %s, error: %v", link.Href, err)
+			t.Fatalf("Failed to perform a HEAD request for URL %q, error: %v", link.Href, err)
 		}
 		if h.ContentLength < 1024*1024*10 {
-			t.Errorf("failed to verify kn CCD, kn artifact %s size %d less than 10MB", link.Href, h.ContentLength)
+			t.Errorf("Failed to verify kn CCD, kn artifact %q size %d less than 10MB", link.Href, h.ContentLength)
 		}
 	}
 }


### PR DESCRIPTION
As per title, this changes the CLI artifacts to no longer be served through a Knative Service but rather launches the respective container as part of the serverless-operator deployment itself. To minimize resource consumption, the container is left without any resource requirements and/or limits, so the Openshift scheduler pretty much ignores it.

**Reasons:**
- Interdependence with Knative Serving: We can only serve the CLI binaries if Knative Serving is installed.
- Interdependence networking wise: When deploying with istio and Service Mesh support, we have to make sure that the CLI artifact service is available "generally", regardless of the implications that customers might want to put on their networking config. Having it as a "hidden" service (and thus naturally part of the mesh etc) makes this difficult to assume.
- Interdependence installation wise: When uninstalling Knative Serving, we also trigger the clean up of the artifact service. However, this is racy: Knative can be deleted before the Service finishes deleting, causing hanging resources because of unhandled finalizers etc.

**Out of scope:**
- Making the ConsoleCLIDownload available regardless of installing Knative Serving or not. This can (and should eventually) be done in a subsequent step.