### PR TITLE
Use 'Always' PullPolicy for all images to ease development

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -365,7 +365,7 @@ spec:
                         value: "registry.ci.openshift.org/origin/4.7:kube-rbac-proxy"
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
-                    imagePullPolicy: IfNotPresent
+                    imagePullPolicy: Always
                     name: knative-operator
                     ports:
                       - containerPort: 9090

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -311,7 +311,7 @@ spec:
                   value: "/var/run/ko/monitoring/rbac-proxy.yaml"
                 # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                 image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
-                imagePullPolicy: IfNotPresent
+                imagePullPolicy: Always
                 name: knative-operator
                 ports:
                 - containerPort: 9090


### PR DESCRIPTION
This makes development much simpler as one can simply push a new image and delete the pod in question to achieve an update. The other images are using Always anyway already, so this makes stuff consistent.

@aliok this would've prevented the issue with the stale image you had the other day.

/assign @aliok 