### PR TITLE
Use of ocp range feature

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -84,7 +84,7 @@ yaml_keys[spec.minKubeVersion]="$(metadata.get requirements.kube.minVersion)"
 yaml_keys[spec.replaces]="$(metadata.get project.name).v$(metadata.get olm.replaces)"
 
 declare -A vars
-vars[OCP_TARGET]="$(metadata.get 'requirements.ocp.[0]')"
+vars[OCP_TARGET]="$(metadata.get 'requirements.ocpVersion.min')"
 
 function add_related_image {
   cat << EOF | yq write --inplace --script - "$1"

--- a/hack/generate/dockerfile.sh
+++ b/hack/generate/dockerfile.sh
@@ -18,7 +18,7 @@ values[EVENTING_VERSION]="$(metadata.get dependencies.eventing)"
 values[EVENTING_KAFKA_VERSION]="$(metadata.get dependencies.eventing_kafka)"
 values[GOLANG_VERSION]="$(metadata.get requirements.golang)"
 values[NODEJS_VERSION]="$(metadata.get requirements.nodejs)"
-values[OCP_TARGET_VLIST]="$(metadata.get 'requirements.ocp.*' | sed 's/^/v/' | paste -sd ',' -)"
+values[OCP_TARGET_VLIST]="$(metadata.get 'requirements.ocpVersion.label')"
 
 # Start fresh
 cp "$template" "$target"

--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -18,6 +18,6 @@ LABEL \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \
       io.k8s.display-name="Red Hat OpenShift Serverless Bundle" \
-      com.redhat.openshift.versions="v4.6,v4.7,v4.8" \
+      com.redhat.openshift.versions="v4.6-v4.8" \
       com.redhat.delivery.operator.bundle=true \
       com.redhat.delivery.backport=false

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -16,10 +16,9 @@ requirements:
     minVersion: 1.19.0
   golang: '1.15'
   nodejs: 14.x
-  ocp:
-    - '4.6'
-    - '4.7'
-    - '4.8'
+  ocpVersion:
+    min: '4.6'
+    label: 'v4.6-v4.8'
 
 dependencies:
   serving: 0.23.1

--- a/olm-catalog/serverless-operator/stopbundle.Dockerfile
+++ b/olm-catalog/serverless-operator/stopbundle.Dockerfile
@@ -18,7 +18,7 @@ LABEL \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \
       io.k8s.display-name="Red Hat OpenShift Serverless Bundle" \
-      com.redhat.openshift.versions="v4.6,v4.7,v4.8" \
+      com.redhat.openshift.versions="v4.6-v4.8" \
       com.redhat.delivery.operator.bundle=true \
       com.redhat.delivery.backport=false
 


### PR DESCRIPTION
- Replaced the OCP key from the project.yaml and used ocpVersion with min and label sub-keys. One can be used for the csv.sh file for the document link and another can help in the generation of a range of ocp versions.
- I have not run the make release-files command, because its changing the Dockerfile present in olm-catalog.
- But tried in local setup, the values are now coming in range, but the "LABELoperators.operatorframework.io.bundle.channels.v1="- stable" , value is being changing to "- stable" , not able to get why the '-' is being added in the beginning.
