### PR TITLE
[QE] Retry the flaky UI tests

### DIFF
--- a/test/ui/cypress.json
+++ b/test/ui/cypress.json
@@ -3,5 +3,9 @@
   "reporter": "cypress-multi-reporters",
   "reporterOptions": {
     "configFile": "reporter-config.json"
+  },
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
   }
 }


### PR DESCRIPTION
There's an option in Cypress to retry tests that fail: https://docs.cypress.io/guides/guides/test-retries

This change has pros and cons. 

It should make the UI tests more stable. On the other hand, it will effectively hide the flakes, as the tests would pass - so it would be harder to notice them.

The UI tests are running only nightly, so maybe merging this PR isn't a good idea. 

WDYT? @mgencur 