### PR TITLE
[SRVKE-897] Improve monitoring reconciliation for sources

### DIFF
--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -119,7 +119,7 @@ func main() {
 	hookServer.Register("/mutate-knativekafkas", &webhook.Admission{Handler: knativekafka.NewConfigurator(decoder)})
 	hookServer.Register("/validate-knativekafkas", &webhook.Admission{Handler: knativekafka.NewValidator(mgr.GetClient(), decoder)})
 
-	if err := setupMonitoring(cfg); err != nil {
+	if err := setupServerlesOperatorMonitoring(cfg); err != nil {
 		log.Error(err, "Failed to start monitoring")
 	}
 
@@ -142,7 +142,7 @@ func main() {
 	}
 }
 
-func setupMonitoring(cfg *rest.Config) error {
+func setupServerlesOperatorMonitoring(cfg *rest.Config) error {
 	cl, err := client.New(cfg, client.Options{})
 	if err != nil {
 		return fmt.Errorf("failed to create a client: %w", err)
@@ -163,7 +163,7 @@ func setupMonitoring(cfg *rest.Config) error {
 		return err
 	}
 
-	if err = monitoring.SetupMonitoringRequirements(cl, operatorDeployment); err != nil {
+	if err = monitoring.SetupClusterMonitoringRequirements(cl, operatorDeployment); err != nil {
 		return fmt.Errorf("failed to setup monitoring resources: %w", err)
 	}
 

--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -163,7 +163,7 @@ func setupServerlesOperatorMonitoring(cfg *rest.Config) error {
 		return err
 	}
 
-	if err = monitoring.SetupClusterMonitoringRequirements(cl, operatorDeployment); err != nil {
+	if err = monitoring.SetupClusterMonitoringRequirements(cl, operatorDeployment, namespace); err != nil {
 		return fmt.Errorf("failed to setup monitoring resources: %w", err)
 	}
 

--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -163,7 +163,7 @@ func setupServerlesOperatorMonitoring(cfg *rest.Config) error {
 		return err
 	}
 
-	if err = monitoring.SetupClusterMonitoringRequirements(cl, operatorDeployment, namespace); err != nil {
+	if err = monitoring.SetupClusterMonitoringRequirements(cl, operatorDeployment, namespace, nil); err != nil {
 		return fmt.Errorf("failed to setup monitoring resources: %w", err)
 	}
 

--- a/knative-operator/pkg/monitoring/monitoring.go
+++ b/knative-operator/pkg/monitoring/monitoring.go
@@ -124,30 +124,6 @@ func addClusterMonitoringLabelToNamespace(namespace string, api client.Client, v
 	return nil
 }
 
-//func deleteClusterMonitoringLabelFromNamespace(namespace string, api client.Client) error {
-//	ns := &v1.Namespace{}
-//	if err := api.Get(context.TODO(), client.ObjectKey{Name: namespace}, ns); err != nil {
-//		return err
-//	}
-//	v, ok := ns.Labels[okomon.EnableMonitoringLabel]
-//	// Already not present
-//	if !ok {
-//		return nil
-//	}
-//	parsed , err := strconv.ParseBool(v)
-//	if err != nil {
-//		return nil
-//	}
-//	// Only deal with properly previously set values
-//	if parsed {
-//		delete(ns.Labels, okomon.EnableMonitoringLabel)
-//	}
-//	if err := api.Update(context.TODO(), ns); err != nil {
-//		return fmt.Errorf("could not add label %q to namespace %q: %w", okomon.EnableMonitoringLabel, namespace, err)
-//	}
-//	return nil
-//}
-
 func createPrometheusRoleAndRoleBinding(instance mf.Owner, namespace string, client client.Client) error {
 	rbacManifest, err := getManifestForPrometheusRoleAndRolebinding(instance, namespace, client)
 	if err != nil {

--- a/knative-operator/pkg/monitoring/monitoring.go
+++ b/knative-operator/pkg/monitoring/monitoring.go
@@ -44,7 +44,7 @@ func RemoveClusterMonitoringRequirements(api client.Client, instance mf.Owner) e
 	if err != nil {
 		return err
 	}
-	err = deletePromeheusRoleAndRoleBinding(instance, instance.GetNamespace(), api)
+	err = deletePrometheusRoleAndRoleBinding(instance, instance.GetNamespace(), api)
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func createPrometheusRoleAndRoleBinding(instance mf.Owner, namespace string, cli
 	return rbacManifest.Apply()
 }
 
-func deletePromeheusRoleAndRoleBinding(instance mf.Owner, namespace string, client client.Client) error {
+func deletePrometheusRoleAndRoleBinding(instance mf.Owner, namespace string, client client.Client) error {
 	rbacManifest, err := getManifestForPrometheusRoleAndRolebinding(instance, namespace, client)
 	if err != nil {
 		return err

--- a/knative-operator/pkg/monitoring/monitoring_test.go
+++ b/knative-operator/pkg/monitoring/monitoring_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	okomon "github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -36,7 +37,7 @@ func init() {
 
 func TestSetupMonitoringRequirements(t *testing.T) {
 	cl := fake.NewClientBuilder().WithObjects(&operatorNamespace, &serverlessDeployment).Build()
-	err := SetupMonitoringRequirements(cl, &serverlessDeployment)
+	err := SetupClusterMonitoringRequirements(cl, &serverlessDeployment)
 	if err != nil {
 		t.Errorf("Failed to set up monitoring requirements: %w", err)
 	}
@@ -45,7 +46,7 @@ func TestSetupMonitoringRequirements(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to get modified namespace: %w", err)
 	}
-	if actual := ns.Labels[monitoringLabel]; actual != "true" {
+	if actual := ns.Labels[okomon.EnableMonitoringLabel]; actual != "true" {
 		t.Errorf("got %q, want %q", actual, "true")
 	}
 	role := v1.Role{}

--- a/knative-operator/pkg/monitoring/monitoring_test.go
+++ b/knative-operator/pkg/monitoring/monitoring_test.go
@@ -37,7 +37,7 @@ func init() {
 
 func TestSetupMonitoringRequirements(t *testing.T) {
 	cl := fake.NewClientBuilder().WithObjects(&operatorNamespace, &serverlessDeployment).Build()
-	err := SetupClusterMonitoringRequirements(cl, &serverlessDeployment, serverlessDeployment.GetNamespace())
+	err := SetupClusterMonitoringRequirements(cl, &serverlessDeployment, serverlessDeployment.GetNamespace(), nil)
 	if err != nil {
 		t.Errorf("Failed to set up monitoring requirements: %w", err)
 	}

--- a/knative-operator/pkg/monitoring/monitoring_test.go
+++ b/knative-operator/pkg/monitoring/monitoring_test.go
@@ -37,7 +37,7 @@ func init() {
 
 func TestSetupMonitoringRequirements(t *testing.T) {
 	cl := fake.NewClientBuilder().WithObjects(&operatorNamespace, &serverlessDeployment).Build()
-	err := SetupClusterMonitoringRequirements(cl, &serverlessDeployment)
+	err := SetupClusterMonitoringRequirements(cl, &serverlessDeployment, serverlessDeployment.GetNamespace())
 	if err != nil {
 		t.Errorf("Failed to set up monitoring requirements: %w", err)
 	}
@@ -50,7 +50,7 @@ func TestSetupMonitoringRequirements(t *testing.T) {
 		t.Errorf("got %q, want %q", actual, "true")
 	}
 	role := v1.Role{}
-	err = cl.Get(context.TODO(), client.ObjectKey{Name: "knative-serving-prometheus-k8s", Namespace: installedNS}, &role)
+	err = cl.Get(context.TODO(), client.ObjectKey{Name: rbacName, Namespace: installedNS}, &role)
 	if err != nil {
 		t.Errorf("Failed to get created role: %w", err)
 	}
@@ -58,7 +58,7 @@ func TestSetupMonitoringRequirements(t *testing.T) {
 		t.Error("Rules should be non empty")
 	}
 	rb := v1.RoleBinding{}
-	err = cl.Get(context.TODO(), client.ObjectKey{Name: "knative-serving-prometheus-k8s", Namespace: installedNS}, &rb)
+	err = cl.Get(context.TODO(), client.ObjectKey{Name: rbacName, Namespace: installedNS}, &rb)
 	if err != nil {
 		t.Errorf("Failed to get created rolebinding: %w", err)
 	}

--- a/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
+++ b/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
@@ -3,8 +3,6 @@ package sources
 import (
 	"context"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"strconv"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
@@ -17,8 +15,10 @@ import (
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )

--- a/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
+++ b/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	generateSourceServiceMonitorsEnvVar = "GENERATE_SERVICE_MONITORS_FOR_SOURCES_BY_DEFAULT"
-	useClusterMonitoringEnvVar          = "USE_CLUSTER_MONITORING_FOR_SOURCES_BY_DEFAULT"
+	generateSourceServiceMonitorsEnvVar = "SOURCES_GENERATE_SERVICE_MONITORS"
+	useClusterMonitoringEnvVar          = "SOURCES_USE_CLUSTER_MONITORING"
 
 	log = common.Log.WithName("source-deployment-discovery-controller")
 )

--- a/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
+++ b/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
@@ -69,7 +69,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	enqueueRequestsRBAC := handler.MapFunc(func(obj client.Object) []reconcile.Request {
 		oLabels := obj.GetLabels()
 		if _, ok := oLabels[rbacLabelKey]; ok {
-			// Use a special request to trigger ns level reconcilation related to sources
+			// Use a special request to trigger ns level reconciliation related to sources
 			return []reconcile.Request{{
 				NamespacedName: types.NamespacedName{Namespace: obj.GetNamespace(), Name: ""},
 			}}

--- a/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
+++ b/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
@@ -2,23 +2,31 @@ package sources
 
 import (
 	"context"
+	"os"
+	"strconv"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring"
+	okomon "github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 	v1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = common.Log.WithName("source-deployment-discovery-controller")
+var (
+	generateSourceServiceMonitorsEnvVar = "GENERATE_SERVICE_MONITORS_FOR_SOURCES_BY_DEFAULT"
+	useClusterMonitoringEnvVar          = "USE_CLUSTER_MONITORING_FOR_SOURCES_BY_DEFAULT"
+
+	log = common.Log.WithName("source-deployment-discovery-controller")
+)
 
 // Add creates a new Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -53,7 +61,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		}
 		return nil
 	})
-	err = c.Watch(&source.Kind{Type: &v1.Deployment{}}, handler.EnqueueRequestsFromMapFunc(enqueueRequests), skipDeletePredicate{}, skipUpdatePredicate{})
+	err = c.Watch(&source.Kind{Type: &v1.Deployment{}}, handler.EnqueueRequestsFromMapFunc(enqueueRequests))
 	if err != nil {
 		return err
 	}
@@ -69,6 +77,9 @@ type ReconcileSourceDeployment struct {
 	// that reads objects from the cache and writes to the apiserver
 	client client.Client
 	scheme *runtime.Scheme
+
+	testShouldUseClusterMonitoring          *bool
+	testShouldGenerateSourceServiceMonitors *bool
 }
 
 // Reconcile reads that state of the cluster for an eventing source deployment
@@ -76,31 +87,92 @@ func (r *ReconcileSourceDeployment) Reconcile(ctx context.Context, request recon
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling the source deployment, setting up a service/service monitor if required")
 	dep := &v1.Deployment{}
-	if err := r.client.Get(context.TODO(), request.NamespacedName, dep); err != nil {
-		// the deployment does not exist anymore do nothing
+	err := r.client.Get(context.TODO(), request.NamespacedName, dep)
+	inDeletion := false
+	if apierrors.IsNotFound(err) {
+		// The deployment does not exist anymore, deletions are shown as failing reads
+		log.Info("Source in deletion phase")
+		inDeletion = true
+	} else if err != nil {
+		// Do nothing if can't get the source for some other error
 		return reconcile.Result{}, nil
 	}
-	if err := monitoring.SetupMonitoringRequirements(r.client, dep); err != nil {
+	eventing := &v1alpha1.KnativeEventing{}
+	if err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: "knative-eventing", Name: "knative-eventing"}, eventing); err != nil {
 		return reconcile.Result{}, err
 	}
-	if err := SetupSourceServiceMonitorResources(r.client, dep); err != nil {
-		return reconcile.Result{}, err
+	shouldEnableMonitoring := okomon.ShouldEnableMonitoring(eventing.Spec.GetConfig())
+	return reconcile.Result{}, r.reconcileSourceMonitoring(r.client, dep, shouldEnableMonitoring, inDeletion)
+}
+
+func (r *ReconcileSourceDeployment) reconcileSourceMonitoring(rclient client.Client, dep *v1.Deployment, shouldEnableMonitoring bool, inDeletion bool) error {
+	// Setup monitoring resources only if monitoring should be on and source deployment is not being deleted
+	if shouldEnableMonitoring && !inDeletion {
+		// Setup cluster monitoring Prometheus monitoring requirements
+		if r.shouldUseClusterMonitoringForSourcesByDefault() {
+			if err := monitoring.SetupClusterMonitoringRequirements(rclient, dep); err != nil {
+				return err
+			}
+		} else {
+			// Make sure we disable cluster monitoring if we have to eg. we move from a state of enabled to disabled and
+			// resources are left without cleanup. This brings us to the right state.
+			if dep.Namespace != "knative-eventing" {
+				if err := monitoring.RemoveClusterMonitoringRequirements(rclient, dep); err != nil {
+					return err
+				}
+			}
+		}
+		if r.shouldGenerateSourceServiceMonitorsByDefault() {
+			if err := SetupSourceServiceMonitorResources(rclient, dep); err != nil {
+				return err
+			}
+		}
+	} else {
+		// Start fresh in any source adapter namespace. Try remove any service monitor resources if monitoring is off or we are in
+		// deletion phase
+		if dep.Namespace != "knative-eventing" {
+			if err := monitoring.RemoveClusterMonitoringRequirements(rclient, dep); err != nil {
+				return err
+			}
+			// No need to do anything if in deletion phase as owner references will do the reaping
+			if !inDeletion {
+				if err := RemoveSourceServiceMonitorResources(rclient, dep); err != nil {
+					return err
+				}
+			}
+		}
 	}
-	return reconcile.Result{}, nil
+	return nil
 }
 
-type skipDeletePredicate struct {
-	predicate.Funcs
+func (r *ReconcileSourceDeployment) shouldUseClusterMonitoringForSourcesByDefault() bool {
+	if r.testShouldUseClusterMonitoring != nil {
+		return *r.testShouldUseClusterMonitoring
+	}
+	enable := os.Getenv(useClusterMonitoringEnvVar)
+	if enable != "" {
+		parsed, err := strconv.ParseBool(enable)
+		if err != nil {
+			// ignore value if garbage
+			return true
+		}
+		return parsed
+	}
+	return true
 }
 
-func (skipDeletePredicate) Delete(e event.DeleteEvent) bool {
-	return false
-}
-
-type skipUpdatePredicate struct {
-	predicate.Funcs
-}
-
-func (skipUpdatePredicate) Update(e event.UpdateEvent) bool {
-	return false
+func (r *ReconcileSourceDeployment) shouldGenerateSourceServiceMonitorsByDefault() bool {
+	if r.testShouldGenerateSourceServiceMonitors != nil {
+		return *r.testShouldGenerateSourceServiceMonitors
+	}
+	enable := os.Getenv(generateSourceServiceMonitorsEnvVar)
+	if enable != "" {
+		parsed, err := strconv.ParseBool(enable)
+		if err != nil {
+			// ignore value if garbage
+			return true
+		}
+		return parsed
+	}
+	return true
 }

--- a/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller_test.go
+++ b/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller_test.go
@@ -208,11 +208,11 @@ func TestSourceMonitoringReconcile(t *testing.T) {
 
 func checkPrometheusResources(cl client.Client, shouldExist bool, t *testing.T) {
 	role := &rbacv1.Role{}
-	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "knative-serving-prometheus-k8s", Namespace: apiserverRequest.Namespace}, role); checkError(err, shouldExist, t) {
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "knative-prometheus-k8s", Namespace: apiserverRequest.Namespace}, role); checkError(err, shouldExist, t) {
 		t.Fatalf("get: (%v)", err)
 	}
 	roleBinding := &rbacv1.RoleBinding{}
-	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "knative-serving-prometheus-k8s", Namespace: apiserverRequest.Namespace}, roleBinding); checkError(err, shouldExist, t) {
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "knative-prometheus-k8s", Namespace: apiserverRequest.Namespace}, roleBinding); checkError(err, shouldExist, t) {
 		t.Fatalf("get: (%v)", err)
 	}
 }

--- a/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller_test.go
+++ b/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
-	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -92,8 +91,10 @@ func TestSourceReconcile(t *testing.T) {
 		WithObjects(&apiserversourceDeployment, &pingsourceDeployment, &defaultNamespace, &eventingNamespace, eventingInstance).
 		Build()
 	r := &ReconcileSourceDeployment{client: cl, scheme: scheme.Scheme}
-	r.testShouldGenerateSourceServiceMonitors = ptr.Bool(true)
-	r.testShouldUseClusterMonitoring = ptr.Bool(true)
+	_ = os.Setenv(generateSourceServiceMonitorsEnvVar, "true")
+	defer os.Unsetenv(generateSourceServiceMonitorsEnvVar)
+	_ = os.Setenv(useClusterMonitoringEnvVar, "true")
+	defer os.Unsetenv(useClusterMonitoringEnvVar)
 	// Reconcile for an api server source
 	if _, err := r.Reconcile(context.Background(), apiserverRequest); err != nil {
 		t.Fatalf("reconcile: (%v)", err)
@@ -153,8 +154,10 @@ func TestSourceMonitoringReconcile(t *testing.T) {
 
 	// No cluster monitoring only generate service monitors.
 	r := &ReconcileSourceDeployment{client: cl, scheme: scheme.Scheme}
-	r.testShouldGenerateSourceServiceMonitors = ptr.Bool(true)
-	r.testShouldUseClusterMonitoring = ptr.Bool(false)
+	_ = os.Setenv(generateSourceServiceMonitorsEnvVar, "true")
+	defer os.Unsetenv(generateSourceServiceMonitorsEnvVar)
+	_ = os.Setenv(useClusterMonitoringEnvVar, "false")
+	defer os.Unsetenv(useClusterMonitoringEnvVar)
 	// Reconcile for an api server source
 	if _, err := r.Reconcile(context.Background(), apiserverRequest); err != nil {
 		t.Fatalf("reconcile: (%v)", err)
@@ -186,8 +189,8 @@ func TestSourceMonitoringReconcile(t *testing.T) {
 	}
 	checkPrometheusResources(cl, false, t)
 	r = &ReconcileSourceDeployment{client: cl, scheme: scheme.Scheme}
-	r.testShouldGenerateSourceServiceMonitors = ptr.Bool(false)
-	r.testShouldUseClusterMonitoring = ptr.Bool(false)
+	_ = os.Setenv(generateSourceServiceMonitorsEnvVar, "false")
+	_ = os.Setenv(useClusterMonitoringEnvVar, "false")
 	// Reconcile for an api server source
 	if _, err := r.Reconcile(context.Background(), apiserverRequest); err != nil {
 		t.Fatalf("reconcile: (%v)", err)

--- a/knative-operator/pkg/monitoring/sources/source_service_monitor.go
+++ b/knative-operator/pkg/monitoring/sources/source_service_monitor.go
@@ -49,7 +49,6 @@ func sourceServiceMonitorManifest(client client.Client, instance *appsv1.Deploym
 	if *smManifest, err = smManifest.Transform(mf.InjectOwner(instance)); err != nil {
 		return nil, fmt.Errorf("unable to transform source service monitor manifest: %w", err)
 	}
-
 	return smManifest, nil
 }
 

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -557,6 +557,8 @@ spec:
                         value: "true"
                       - name: SOURCES_GENERATE_SERVICE_MONITORS
                         value: "true"
+                      - name: GENERATE_SERVICE_MONITORS_FOR_SOURCES_BY_DEFAULT
+                        value: "true"
                       - name: "IMAGE_queue-proxy"
                         value: "registry.ci.openshift.org/openshift/knative-v0.23.1:knative-serving-queue"
                       - name: "IMAGE_activator"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -557,8 +557,6 @@ spec:
                         value: "true"
                       - name: SOURCES_GENERATE_SERVICE_MONITORS
                         value: "true"
-                      - name: GENERATE_SERVICE_MONITORS_FOR_SOURCES_BY_DEFAULT
-                        value: "true"
                       - name: "IMAGE_queue-proxy"
                         value: "registry.ci.openshift.org/openshift/knative-v0.23.1:knative-serving-queue"
                       - name: "IMAGE_activator"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -553,6 +553,10 @@ spec:
                         value: "deploy/resources/quickstart/serverless-application-quickstart.yaml"
                       - name: DASHBOARDS_ROOT_MANIFEST_PATH
                         value: "deploy/resources/dashboards"
+                      - name: SOURCES_USE_CLUSTER_MONITORING
+                        value: "true"
+                      - name: SOURCES_GENERATE_SERVICE_MONITORS
+                        value: "true"
                       - name: "IMAGE_queue-proxy"
                         value: "registry.ci.openshift.org/openshift/knative-v0.23.1:knative-serving-queue"
                       - name: "IMAGE_activator"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -515,6 +515,10 @@ spec:
                         value: "deploy/resources/quickstart/serverless-application-quickstart.yaml"
                       - name: DASHBOARDS_ROOT_MANIFEST_PATH
                         value: "deploy/resources/dashboards"
+                      - name: SOURCES_USE_CLUSTER_MONITORING
+                        value: "true"
+                      - name: SOURCES_GENERATE_SERVICE_MONITORS
+                        value: "true"
                     securityContext:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: true


### PR DESCRIPTION
- Fixes SRVKE-897
- Makes monitoring setup for sources easier to configure. Right now by default we setup cluster monitoring for sources per namespace they reside in, for better get started UX. We do this by marking the corresponding ns with a special flag: `openshift.io/cluster-monitoring=true`. This causes any services running side by side with a source (same namespace) being scraped by the cluster monitoring Prometheus instance. This should be avoided in general because user services should have a different metrics budget and not impose load to the cluster instance. As a general rule of thumb though we should not restrict operations options.
Since OCP Monitoring (discussed with the team there) allows only to use either cluster monitoring or user-workload monitoring per ns (no mixed cases) we should allow users to setup things according to their needs. By default cluster monitoring is enabled to ship all Source metrics to the cluster Prometheus instance and feed admin dashboards with data (for better UX). 
With this PR there is more control by introducing two vars that affect how much automation we offer:
If `SOURCES_USE_CLUSTER_MONITORING` is set to true cluster monitoring is setup automatically.
If `SOURCES_GENERATE_SERVICE_MONITORS` is set to true service monitors are created for each source.
If user sets cluster monitoring to false and allows the generation of service monitors then automatically the sources are ready to be scraped by the user-workload monitoring Prometheus instance without effort. Enabling user-workload monitoring is a [one step process](https://docs.openshift.com/container-platform/4.7/monitoring/enabling-monitoring-for-user-defined-projects.html).
The user-workload monitoring Prometheus instance will not scrape ns targeted by the cluster one and vice versa, for more check [here](https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/user-workload-monitoring.md) and [here](https://www.openshift.com/blog/thanos-querier-versus-thanos-querier).
These env vars provide the maximum flexibility for the end-user.
- Each time an env update is done at the S-O side, the S-O deployment is restarted and a full resync of source deployments is being done (ctr runtime cache is synched). The same happens if the config for metrics backend is changed at the Eventing CR level. This guarantees that we dont have some sources being updated and some others not. Should be equivalent to the global resync in knative controllers.