### PR TITLE
Serve CLI artifacts from operator

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -137,7 +137,7 @@ for name in "${kafka_images[@]}"; do
 done
 
 # Override the image for the CLI artifact deployment
-yq write --inplace "$target" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.containers(name==cli-downloads).image" "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
+yq write --inplace "$target" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.initContainers(name==cli-artifacts).image" "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
 
 for name in "${!yaml_keys[@]}"; do
   echo "Value: ${name} -> ${yaml_keys[$name]}"

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -194,19 +194,19 @@ func populateKnConsoleCLIDownload(baseURL string, instance *servingv1alpha1.Knat
 			Description: "The OpenShift Serverless client `kn` is a CLI tool that allows you to fully manage OpenShift Serverless Serving and Eventing resources without writing a single line of YAML.",
 			Links: []consolev1.CLIDownloadLink{{
 				Text: "Download kn for Linux for x86_64",
-				Href: baseURL + "/amd64/linux/kn-linux-amd64.tar.gz",
+				Href: baseURL + "/kn-linux-amd64.tar.gz",
 			}, {
 				Text: "Download kn for Linux for IBM Power little endian",
-				Href: baseURL + "/ppc64le/linux/kn-linux-ppc64le.tar.gz",
+				Href: baseURL + "/kn-linux-ppc64le.tar.gz",
 			}, {
 				Text: "Download kn for Linux for IBM Z",
-				Href: baseURL + "/s390x/linux/kn-linux-s390x.tar.gz",
+				Href: baseURL + "/kn-linux-s390x.tar.gz",
 			}, {
 				Text: "Download kn for macOS",
-				Href: baseURL + "/amd64/macos/kn-macos-amd64.tar.gz",
+				Href: baseURL + "/kn-macos-amd64.tar.gz",
 			}, {
 				Text: "Download kn for Windows",
-				Href: baseURL + "/amd64/windows/kn-windows-amd64.zip",
+				Href: baseURL + "/kn-windows-amd64.zip",
 			}},
 		},
 	}

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -382,13 +382,15 @@ spec:
                   app: openshift-admission-server
               spec:
                 serviceAccountName: knative-operator
-                containers:
-                  - name: cli-downloads
+                initContainers:
+                  - name: cli-artifacts
                     image: registry.ci.openshift.org/openshift/knative-v0.22.0:kn-cli-artifacts
                     imagePullPolicy: Always
-                    ports:
-                      - name: http-cli
-                        containerPort: 8080
+                    command: ['sh', '-c', 'cp /usr/share/kn/**/* /cli-artifacts']
+                    volumeMounts:
+                      - mountPath: /cli-artifacts
+                        name: cli-artifacts
+                containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
@@ -401,6 +403,12 @@ spec:
                       httpGet:
                         path: /healthz
                         port: 8687
+                    ports:
+                      - name: http-cli
+                        containerPort: 8080
+                    volumeMounts:
+                      - mountPath: /cli-artifacts
+                        name: cli-artifacts
                     env:
                       - name: WATCH_NAMESPACE
                         value: ""
@@ -494,6 +502,9 @@ spec:
                         value: "registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-consolidated-dispatcher"
                       - name: "KAFKA_IMAGE_kafka-webhook__kafka-webhook"
                         value: "registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-webhook"
+                volumes:
+                  - name: cli-artifacts
+                    emptyDir: {}
         - name: knative-openshift-ingress
           spec:
             replicas: 1

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -330,13 +330,15 @@ spec:
                 app: openshift-admission-server
             spec:
               serviceAccountName: knative-operator
-              containers:
-                - name: cli-downloads
+              initContainers:
+                - name: cli-artifacts
                   image: TO_BE_REPLACED
                   imagePullPolicy: Always
-                  ports:
-                    - name: http-cli
-                      containerPort: 8080
+                  command: ['sh', '-c', 'cp /usr/share/kn/**/* /cli-artifacts']
+                  volumeMounts:
+                    - mountPath: /cli-artifacts
+                      name: cli-artifacts
+              containers:
                 - name: knative-openshift
                   # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                   image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
@@ -349,6 +351,12 @@ spec:
                     httpGet:
                       path: /healthz
                       port: 8687
+                  ports:
+                    - name: http-cli
+                      containerPort: 8080
+                  volumeMounts:
+                    - mountPath: /cli-artifacts
+                      name: cli-artifacts
                   env:
                     - name: WATCH_NAMESPACE
                       value: ""
@@ -378,6 +386,9 @@ spec:
                       value: "deploy/resources/quickstart/serverless-application-quickstart.yaml"
                     - name: DASHBOARDS_ROOT_MANIFEST_PATH
                       value: "deploy/resources/dashboards"
+              volumes:
+                - name: cli-artifacts
+                  emptyDir: {}
       - name: knative-openshift-ingress
         spec:
           replicas: 1


### PR DESCRIPTION
Gets rid of the "unnecessary" (very very very seldomly used) CLI artifact container in favor of serving the respective artifacts from a server launched by the operator itself. The artifacts are copied in via using the existing artifact image as an init container so no new images or builds necessary.

**Note:** Please doublecheck this for security. We don't want an attacker stealing files from the operator's filesystem (i.e. serviceaccount tokens) through a path based attack. We might decide that the additional safety is actually worth the extra container, maybe. Sending this anyway, as I wanted to know how much work it is.

/assign @rhuss @dsimansk 