### PR TITLE
[SRVCOM-1432] Drop unnecessary permissions

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -224,84 +224,28 @@ spec:
           serviceAccountName: knative-operator
         - rules:
             - apiGroups:
-                - ""
+                - ''
               resources:
-                - pods
-                - services
-                - events
                 - configmaps
               verbs:
-                - "*"
-            - apiGroups:
-                - ""
-              resources:
-                - namespaces
-              verbs:
                 - get
-            - apiGroups:
-                - apps
-              resources:
-                - deployments
-                - replicasets
-              verbs:
-                - "*"
-            - apiGroups:
-                - apiextensions.k8s.io
-              resources:
-                - customresourcedefinitions
-              verbs:
-                - "*"
-            - apiGroups:
-                - networking.k8s.io
-              resources:
-                - networkpolicies
-              verbs:
-                - "*"
-            - apiGroups:
-                - "coordination.k8s.io"
-              resources:
-                - "leases"
-              verbs:
-                - "*"
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
-                - servicemonitors
-              verbs:
-                - get
-                - create
+                - list
+                - watch
             - apiGroups:
                 - networking.internal.knative.dev
               resources:
-                - clusteringresses
-                - clusteringresses/status
-                - clusteringresses/finalizers
                 - ingresses
-                - ingresses/status
                 - ingresses/finalizers
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - patch # for the finalizer
             - apiGroups:
                 - route.openshift.io
               resources:
                 - routes
                 - routes/custom-host
-                - routes/status
-                - routes/finalizers
-              verbs:
-                - "*"
-            - apiGroups:
-                - operator.knative.dev
-              resources:
-                - knativeservings
-                - knativeservings/finalizers
-              verbs:
-                - '*'
-            - apiGroups:
-                - operator.serverless.openshift.io
-              resources:
-                - knativekafkas
-                - knativekafkas/finalizers
               verbs:
                 - '*'
           serviceAccountName: knative-openshift-ingress

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -227,84 +227,28 @@ spec:
         serviceAccountName: knative-operator
       - rules:
         - apiGroups:
-          - ""
+          - ''
           resources:
-          - pods
-          - services
-          - events
           - configmaps
           verbs:
-          - "*"
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
           - get
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          - replicasets
-          verbs:
-          - "*"
-        - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - "*"
-        - apiGroups:
-          - networking.k8s.io
-          resources:
-          - networkpolicies
-          verbs:
-          - "*"
-        - apiGroups:
-          - "coordination.k8s.io"
-          resources:
-          - "leases"
-          verbs:
-          - "*"
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - get
-          - create
+          - list
+          - watch
         - apiGroups:
           - networking.internal.knative.dev
           resources:
-          - clusteringresses
-          - clusteringresses/status
-          - clusteringresses/finalizers
           - ingresses
-          - ingresses/status
           - ingresses/finalizers
           verbs:
-          - "*"
+          - get
+          - list
+          - watch
+          - patch # for the finalizer
         - apiGroups:
           - route.openshift.io
           resources:
           - routes
           - routes/custom-host
-          - routes/status
-          - routes/finalizers
-          verbs:
-          - "*"
-        - apiGroups:
-          - operator.knative.dev
-          resources:
-          - knativeservings
-          - knativeservings/finalizers
-          verbs:
-          - '*'
-        - apiGroups:
-          - operator.serverless.openshift.io
-          resources:
-          - knativekafkas
-          - knativekafkas/finalizers
           verbs:
           - '*'
         serviceAccountName: knative-openshift-ingress


### PR DESCRIPTION
This is the "easy" part of SRVCOM-1432:

1. Drops the completely unnecessary `permissions` block. It specifies a Role (vs. a ClusterRole) and since our operators operate cluster-wide, we don't benefit from that in any way right now. We might as well just completely drop it.
2. Reduces the permissions for the ingress pod to the bare minimum. I have no clue how all of the stuff got in there in the first place (especially the KnativeServing and KnativeKafka stuff?) but :shrug:.

Next step will be actually breaking up the big `*/*/*` clusterpermission the rest of the operator deployments have.