### PR TITLE
Add yq to local bin

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -29,6 +29,7 @@ jobs:
         run: |
           sudo wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/bin/yq
           sudo chmod +x /usr/bin/yq
+          sudo mv /usr/bin/yq /usr/local/bin/yq
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Since a few days ago (6), yq is being installed by default on [ubuntu latest vm](https://github.com/actions/virtual-environments/blob/main/images/linux/ubuntu2004.json). Discussion [here](https://github.com/actions/virtual-environments/pull/3646/files#r673836709). This causes S-O actions to [fail](https://github.com/openshift-knative/serverless-operator/pull/1098/checks?check_run_id=3121938547). Reason is yq is installed under `/usr/local/bin` in vm and under `/usr/bin` in our setup. The former takes precedence in PATH, thus the error.