### PR TITLE
[UI] Remove skip version TODO

### DIFF
--- a/test/ui/cypress/integration/serving.spec.js
+++ b/test/ui/cypress/integration/serving.spec.js
@@ -189,8 +189,6 @@ describe('OCP UI for Serverless', () => {
   it('can deploy a cluster-local service', () => {
     const ocpVersion = Cypress.env('OCP_VERSION')
     cy.semver(ocpVersion).then((semver) => {
-      // TODO: set proper 4.6.x version when BZ gets targeted in advisory:
-      //       https://bugzilla.redhat.com/show_bug.cgi?id=1978159
       const range = '>=4.8 || ~4.7.18 || ~4.6.39'
       cy.onlyOn(semver.satisfies(range))
     })


### PR DESCRIPTION
According to _BZ_ description https://bugzilla.redhat.com/show_bug.cgi?id=1978159 and https://access.redhat.com/errata/RHBA-2021:2684 fix is going to be releases as 4.6.39.

That means I properly guess the OCP version here, so that removal of _TODO_ is enough to make it correct.

/cc @mgencur 