### PR TITLE
[SRVCOM-1432] Drop namespace local permissions

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -214,15 +214,16 @@ spec:
     strategy: deployment
     spec:
       clusterPermissions:
-        - rules:
+        - serviceAccountName: knative-operator
+          rules:
             - apiGroups:
                 - '*'
               resources:
                 - '*'
               verbs:
                 - '*'
-          serviceAccountName: knative-operator
-        - rules:
+        - serviceAccountName: knative-openshift-ingress
+          rules:
             - apiGroups:
                 - ''
               resources:
@@ -248,58 +249,6 @@ spec:
                 - routes/custom-host
               verbs:
                 - '*'
-          serviceAccountName: knative-openshift-ingress
-      permissions:
-        - rules:
-            - apiGroups:
-                - ""
-              resources:
-                - pods
-                - services
-                - endpoints
-                - persistentvolumeclaims
-                - events
-                - configmaps
-                - secrets
-              verbs:
-                - '*'
-            - apiGroups:
-                - ""
-              resources:
-                - namespaces
-              verbs:
-                - get
-            - apiGroups:
-                - apps
-              resources:
-                - deployments
-                - daemonsets
-                - replicasets
-                - statefulsets
-              verbs:
-                - '*'
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
-                - servicemonitors
-              verbs:
-                - get
-                - create
-            - apiGroups:
-                - apps
-              resourceNames:
-                - knative-operator
-              resources:
-                - deployments/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - operator.knative.dev
-              resources:
-                - '*'
-              verbs:
-                - '*'
-          serviceAccountName: knative-operator
       deployments:
         # Our version of the upstream operator. This is responsible for installing Knative
         # itself.

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -217,15 +217,16 @@ spec:
     strategy: deployment
     spec:
       clusterPermissions:
-      - rules:
+      - serviceAccountName: knative-operator
+        rules:
         - apiGroups:
           - '*'
           resources:
           - '*'
           verbs:
           - '*'
-        serviceAccountName: knative-operator
-      - rules:
+      - serviceAccountName: knative-openshift-ingress
+        rules:
         - apiGroups:
           - ''
           resources:
@@ -251,58 +252,6 @@ spec:
           - routes/custom-host
           verbs:
           - '*'
-        serviceAccountName: knative-openshift-ingress
-      permissions:
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          - services
-          - endpoints
-          - persistentvolumeclaims
-          - events
-          - configmaps
-          - secrets
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - get
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
-          verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - get
-          - create
-        - apiGroups:
-          - apps
-          resourceNames:
-          - knative-operator
-          resources:
-          - deployments/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - operator.knative.dev
-          resources:
-          - '*'
-          verbs:
-          - '*'
-        serviceAccountName: knative-operator
 
       deployments:
       # Our version of the upstream operator. This is responsible for installing Knative


### PR DESCRIPTION
Drops the completely unnecessary permissions block. It specifies a Role (vs. a ClusterRole) and since our operators operate cluster-wide, we don't benefit from that in any way right now. We might as well just completely drop it.

(I fumbled somewhere as I thought I had this in #1111 already)