### PR TITLE
Deduplicate test kernel for permission tests

### DIFF
--- a/test/extensione2e/kafka/user_permissions_test.go
+++ b/test/extensione2e/kafka/user_permissions_test.go
@@ -1,28 +1,18 @@
 package knativekafkae2e
 
 import (
-	"context"
 	"testing"
 
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	"knative.dev/pkg/tracker"
 
 	"github.com/openshift-knative/serverless-operator/test"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	kafkabindingsv1beta1 "knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
 )
-
-type allowedOperations struct {
-	get    bool
-	list   bool
-	create bool
-	delete bool
-}
 
 func init() {
 	kafkabindingsv1beta1.AddToScheme(scheme.Scheme)
@@ -63,84 +53,25 @@ func TestKafkaUserPermissions(t *testing.T) {
 		t.Fatalf("Failed to convert KafkaBinding: %v", err)
 	}
 
-	allowAll := allowedOperations{
-		get:    true,
-		list:   true,
-		create: true,
-		delete: true,
-	}
-	allowViewOnly := allowedOperations{
-		get:  true,
-		list: true,
-	}
-
-	tests := []struct {
-		name        string
-		userContext *test.Context
-		allowed     map[schema.GroupVersionResource]allowedOperations
-	}{{
-		name:        "project admin user",
-		userContext: paCtx,
-		allowed: map[schema.GroupVersionResource]allowedOperations{
-			kafkaBindingsGVR: allowAll,
+	tests := []test.UserPermissionTest{{
+		Name:        "project admin user",
+		UserContext: paCtx,
+		AllowedOperations: map[schema.GroupVersionResource]test.AllowedOperations{
+			kafkaBindingsGVR: test.AllowAll,
 		},
 	}, {
-		name:        "edit user",
-		userContext: editCtx,
-		allowed: map[schema.GroupVersionResource]allowedOperations{
-			kafkaBindingsGVR: allowAll,
+		Name:        "edit user",
+		UserContext: editCtx,
+		AllowedOperations: map[schema.GroupVersionResource]test.AllowedOperations{
+			kafkaBindingsGVR: test.AllowAll,
 		},
 	}, {
-		name:        "view user",
-		userContext: viewCtx,
-		allowed: map[schema.GroupVersionResource]allowedOperations{
-			kafkaBindingsGVR: allowViewOnly,
+		Name:        "view user",
+		UserContext: viewCtx,
+		AllowedOperations: map[schema.GroupVersionResource]test.AllowedOperations{
+			kafkaBindingsGVR: test.AllowViewOnly,
 		},
 	}}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			for gvr, allowed := range tt.allowed {
-				client := tt.userContext.Clients.Dynamic.Resource(gvr).Namespace(testNamespace)
-
-				obj := objects[gvr].DeepCopy()
-				obj.SetName("test-" + gvr.Resource)
-
-				_, err := client.Create(context.Background(), obj, metav1.CreateOptions{})
-				if (allowed.create && err != nil) || (!allowed.create && !apierrs.IsForbidden(err)) {
-					t.Errorf("Unexpected error creating %s, allowed = %v, err = %v", gvr.String(), allowed.create, err)
-				}
-
-				err = client.Delete(context.Background(), obj.GetName(), metav1.DeleteOptions{})
-				if (allowed.delete && err != nil) || (!allowed.delete && !apierrs.IsForbidden(err)) {
-					t.Errorf("Unexpected error deleting %s, allowed = %v, err = %v", gvr.String(), allowed.delete, err)
-				}
-
-				if err != nil {
-					// If we've been able to delete the object we can assume we're able to get it as well.
-					// Some objects take a while to be deleted, so we retry a few times.
-					if err := wait.PollImmediate(test.Interval, test.Timeout, func() (bool, error) {
-						_, err = client.Get(context.Background(), obj.GetName(), metav1.GetOptions{})
-						if apierrs.IsNotFound(err) {
-							return true, nil
-						}
-						return false, err
-					}); err != nil {
-						t.Fatalf("Unexpected error waiting for %s to be deleted, err = %v", gvr.String(), err)
-					}
-				}
-
-				_, err = client.Get(context.Background(), obj.GetName(), metav1.GetOptions{})
-				// Ignore IsNotFound errors as "Forbidden" would overrule it anyway.
-				if (allowed.get && err != nil && !apierrs.IsNotFound(err)) || (!allowed.get && !apierrs.IsForbidden(err)) {
-					t.Errorf("Unexpected error getting %s, allowed = %v, err = %v", gvr.String(), allowed.get, err)
-				}
-
-				_, err = client.List(context.Background(), metav1.ListOptions{})
-				if (allowed.list && err != nil) || (!allowed.list && !apierrs.IsForbidden(err)) {
-					t.Errorf("Unexpected error listing %s, allowed = %v, err = %v", gvr.String(), allowed.list, err)
-				}
-			}
-		})
-	}
+	test.RunUserPermissionTests(t, objects, tests...)
 }

--- a/test/servinge2e/user_permissions_test.go
+++ b/test/servinge2e/user_permissions_test.go
@@ -1,16 +1,12 @@
 package servinge2e
 
 import (
-	"context"
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
 	corev1 "k8s.io/api/core/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	networkingv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
@@ -26,13 +22,6 @@ const (
 	kubeHelloworldService = "kube-helloworld-go"
 	helloworldText        = "Hello World!"
 )
-
-type allowedOperations struct {
-	get    bool
-	list   bool
-	create bool
-	delete bool
-}
 
 func init() {
 	servingv1.AddToScheme(scheme.Scheme)
@@ -83,90 +72,31 @@ func TestServingUserPermissions(t *testing.T) {
 		t.Fatalf("Failed to convert PodAutoscaler: %v", err)
 	}
 
-	allowAll := allowedOperations{
-		get:    true,
-		list:   true,
-		create: true,
-		delete: true,
-	}
-	allowViewOnly := allowedOperations{
-		get:  true,
-		list: true,
-	}
-
-	tests := []struct {
-		name        string
-		userContext *test.Context
-		allowed     map[schema.GroupVersionResource]allowedOperations
-	}{{
-		name:        "project admin user",
-		userContext: paCtx,
-		allowed: map[schema.GroupVersionResource]allowedOperations{
-			serviceGVR: allowAll,
-			ingressGVR: allowViewOnly,
-			paGVR:      allowViewOnly,
+	tests := []test.UserPermissionTest{{
+		Name:        "project admin user",
+		UserContext: paCtx,
+		AllowedOperations: map[schema.GroupVersionResource]test.AllowedOperations{
+			serviceGVR: test.AllowAll,
+			ingressGVR: test.AllowViewOnly,
+			paGVR:      test.AllowViewOnly,
 		},
 	}, {
-		name:        "edit user",
-		userContext: editCtx,
-		allowed: map[schema.GroupVersionResource]allowedOperations{
-			serviceGVR: allowAll,
-			ingressGVR: allowViewOnly,
-			paGVR:      allowViewOnly,
+		Name:        "edit user",
+		UserContext: editCtx,
+		AllowedOperations: map[schema.GroupVersionResource]test.AllowedOperations{
+			serviceGVR: test.AllowAll,
+			ingressGVR: test.AllowViewOnly,
+			paGVR:      test.AllowViewOnly,
 		},
 	}, {
-		name:        "view user",
-		userContext: viewCtx,
-		allowed: map[schema.GroupVersionResource]allowedOperations{
-			serviceGVR: allowViewOnly,
-			ingressGVR: allowViewOnly,
-			paGVR:      allowViewOnly,
+		Name:        "view user",
+		UserContext: viewCtx,
+		AllowedOperations: map[schema.GroupVersionResource]test.AllowedOperations{
+			serviceGVR: test.AllowViewOnly,
+			ingressGVR: test.AllowViewOnly,
+			paGVR:      test.AllowViewOnly,
 		},
 	}}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			for gvr, allowed := range tt.allowed {
-				client := tt.userContext.Clients.Dynamic.Resource(gvr).Namespace(testNamespace)
-
-				obj := objects[gvr].DeepCopy()
-				obj.SetName("test-" + gvr.Resource)
-
-				_, err := client.Create(context.Background(), obj, metav1.CreateOptions{})
-				if (allowed.create && err != nil) || (!allowed.create && !apierrs.IsForbidden(err)) {
-					t.Errorf("Unexpected error creating %s, allowed = %v, err = %v", gvr.String(), allowed.create, err)
-				}
-
-				err = client.Delete(context.Background(), obj.GetName(), metav1.DeleteOptions{})
-				if (allowed.delete && err != nil) || (!allowed.delete && !apierrs.IsForbidden(err)) {
-					t.Errorf("Unexpected error deleting %s, allowed = %v, err = %v", gvr.String(), allowed.delete, err)
-				}
-
-				if err != nil {
-					// If we've been able to delete the object we can assume we're able to get it as well.
-					// Some objects take a while to be deleted, so we retry a few times.
-					if err := wait.PollImmediate(test.Interval, test.Timeout, func() (bool, error) {
-						_, err = client.Get(context.Background(), obj.GetName(), metav1.GetOptions{})
-						if apierrs.IsNotFound(err) {
-							return true, nil
-						}
-						return false, err
-					}); err != nil {
-						t.Fatalf("Unexpected error waiting for %s to be deleted, err = %v", gvr.String(), err)
-					}
-				}
-
-				_, err = client.Get(context.Background(), obj.GetName(), metav1.GetOptions{})
-				// Ignore IsNotFound errors as "Forbidden" would overrule it anyway.
-				if (allowed.get && err != nil && !apierrs.IsNotFound(err)) || (!allowed.get && !apierrs.IsForbidden(err)) {
-					t.Errorf("Unexpected error getting %s, allowed = %v, err = %v", gvr.String(), allowed.get, err)
-				}
-
-				_, err = client.List(context.Background(), metav1.ListOptions{})
-				if (allowed.list && err != nil) || (!allowed.list && !apierrs.IsForbidden(err)) {
-					t.Errorf("Unexpected error listing %s, allowed = %v, err = %v", gvr.String(), allowed.list, err)
-				}
-			}
-		})
-	}
+	test.RunUserPermissionTests(t, objects, tests...)
 }

--- a/test/user_permissions.go
+++ b/test/user_permissions.go
@@ -1,0 +1,86 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type AllowedOperations struct {
+	Get    bool
+	List   bool
+	Create bool
+	Delete bool
+}
+
+var (
+	AllowAll = AllowedOperations{
+		Get:    true,
+		List:   true,
+		Create: true,
+		Delete: true,
+	}
+	AllowViewOnly = AllowedOperations{
+		Get:  true,
+		List: true,
+	}
+)
+
+type UserPermissionTest struct {
+	Name              string
+	UserContext       *Context
+	AllowedOperations map[schema.GroupVersionResource]AllowedOperations
+}
+
+func RunUserPermissionTests(t *testing.T, objects map[schema.GroupVersionResource]*unstructured.Unstructured, tests ...UserPermissionTest) {
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for gvr, allowed := range test.AllowedOperations {
+				client := test.UserContext.Clients.Dynamic.Resource(gvr).Namespace("serverless-tests")
+
+				obj := objects[gvr].DeepCopy()
+				obj.SetName("test-" + gvr.Resource)
+
+				_, err := client.Create(context.Background(), obj, metav1.CreateOptions{})
+				if (allowed.Create && err != nil) || (!allowed.Create && !apierrs.IsForbidden(err)) {
+					t.Errorf("Unexpected error creating %s, allowed = %v, err = %v", gvr.String(), allowed.Create, err)
+				}
+
+				err = client.Delete(context.Background(), obj.GetName(), metav1.DeleteOptions{})
+				if (allowed.Delete && err != nil) || (!allowed.Delete && !apierrs.IsForbidden(err)) {
+					t.Errorf("Unexpected error deleting %s, allowed = %v, err = %v", gvr.String(), allowed.Delete, err)
+				}
+
+				if err != nil {
+					// If we've been able to delete the object we can assume we're able to get it as well.
+					// Some objects take a while to be deleted, so we retry a few times.
+					if err := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
+						_, err = client.Get(context.Background(), obj.GetName(), metav1.GetOptions{})
+						if apierrs.IsNotFound(err) {
+							return true, nil
+						}
+						return false, err
+					}); err != nil {
+						t.Fatalf("Unexpected error waiting for %s to be deleted, err = %v", gvr.String(), err)
+					}
+				}
+
+				_, err = client.Get(context.Background(), obj.GetName(), metav1.GetOptions{})
+				// Ignore IsNotFound errors as "Forbidden" would overrule it anyway.
+				if (allowed.Get && err != nil && !apierrs.IsNotFound(err)) || (!allowed.Get && !apierrs.IsForbidden(err)) {
+					t.Errorf("Unexpected error getting %s, allowed = %v, err = %v", gvr.String(), allowed.Get, err)
+				}
+
+				_, err = client.List(context.Background(), metav1.ListOptions{})
+				if (allowed.List && err != nil) || (!allowed.List && !apierrs.IsForbidden(err)) {
+					t.Errorf("Unexpected error listing %s, allowed = %v, err = %v", gvr.String(), allowed.List, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
These tests have a lot in common, so it might come in handy to deduplicate their kernels and types to avoid divergence.