### PR TITLE
Wait for objects to be deleted in user permission tests

### DIFF
--- a/test/eventinge2e/user_permissions_test.go
+++ b/test/eventinge2e/user_permissions_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	eventingflowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
@@ -142,10 +143,10 @@ func TestEventingUserPermissions(t *testing.T) {
 		},
 	}}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			for gvr, allowed := range test.allowed {
-				client := test.userContext.Clients.Dynamic.Resource(gvr).Namespace(testNamespace)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for gvr, allowed := range tt.allowed {
+				client := tt.userContext.Clients.Dynamic.Resource(gvr).Namespace(testNamespace)
 
 				obj := objects[gvr].DeepCopy()
 				obj.SetName("test-" + gvr.Resource)
@@ -158,6 +159,20 @@ func TestEventingUserPermissions(t *testing.T) {
 				err = client.Delete(context.Background(), obj.GetName(), metav1.DeleteOptions{})
 				if (allowed.delete && err != nil) || (!allowed.delete && !apierrs.IsForbidden(err)) {
 					t.Errorf("Unexpected error deleting %s, allowed = %v, err = %v", gvr.String(), allowed.delete, err)
+				}
+
+				if err != nil {
+					// If we've been able to delete the object we can assume we're able to get it as well.
+					// Some objects take a while to be deleted, so we retry a few times.
+					if err := wait.PollImmediate(test.Interval, test.Timeout, func() (bool, error) {
+						_, err = client.Get(context.Background(), obj.GetName(), metav1.GetOptions{})
+						if apierrs.IsNotFound(err) {
+							return true, nil
+						}
+						return false, err
+					}); err != nil {
+						t.Fatalf("Unexpected error waiting for %s to be deleted, err = %v", gvr.String(), err)
+					}
 				}
 
 				_, err = client.Get(context.Background(), obj.GetName(), metav1.GetOptions{})

--- a/test/servinge2e/user_permissions_test.go
+++ b/test/servinge2e/user_permissions_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	networkingv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
@@ -123,10 +124,10 @@ func TestServingUserPermissions(t *testing.T) {
 		},
 	}}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			for gvr, allowed := range test.allowed {
-				client := test.userContext.Clients.Dynamic.Resource(gvr).Namespace(testNamespace)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for gvr, allowed := range tt.allowed {
+				client := tt.userContext.Clients.Dynamic.Resource(gvr).Namespace(testNamespace)
 
 				obj := objects[gvr].DeepCopy()
 				obj.SetName("test-" + gvr.Resource)
@@ -139,6 +140,20 @@ func TestServingUserPermissions(t *testing.T) {
 				err = client.Delete(context.Background(), obj.GetName(), metav1.DeleteOptions{})
 				if (allowed.delete && err != nil) || (!allowed.delete && !apierrs.IsForbidden(err)) {
 					t.Errorf("Unexpected error deleting %s, allowed = %v, err = %v", gvr.String(), allowed.delete, err)
+				}
+
+				if err != nil {
+					// If we've been able to delete the object we can assume we're able to get it as well.
+					// Some objects take a while to be deleted, so we retry a few times.
+					if err := wait.PollImmediate(test.Interval, test.Timeout, func() (bool, error) {
+						_, err = client.Get(context.Background(), obj.GetName(), metav1.GetOptions{})
+						if apierrs.IsNotFound(err) {
+							return true, nil
+						}
+						return false, err
+					}); err != nil {
+						t.Fatalf("Unexpected error waiting for %s to be deleted, err = %v", gvr.String(), err)
+					}
 				}
 
 				_, err = client.Get(context.Background(), obj.GetName(), metav1.GetOptions{})


### PR DESCRIPTION
This is supposed to fix errors like https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.7-e2e-aws-ocp-47-continuous/1419628633156227072.

/assign @skonto @mgencur 