### PR TITLE
Serve CLI artifacts from operator

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -137,7 +137,7 @@ for name in "${kafka_images[@]}"; do
 done
 
 # Override the image for the CLI artifact deployment
-yq write --inplace "$target" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.containers(name==cli-downloads).image" "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
+yq write --inplace "$target" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.initContainers(name==cli-artifacts).image" "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
 
 for name in "${!yaml_keys[@]}"; do
   echo "Value: ${name} -> ${yaml_keys[$name]}"

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -194,19 +194,19 @@ func populateKnConsoleCLIDownload(baseURL string, instance *servingv1alpha1.Knat
 			Description: "The OpenShift Serverless client `kn` is a CLI tool that allows you to fully manage OpenShift Serverless Serving and Eventing resources without writing a single line of YAML.",
 			Links: []consolev1.CLIDownloadLink{{
 				Text: "Download kn for Linux for x86_64",
-				Href: baseURL + "/amd64/linux/kn-linux-amd64.tar.gz",
+				Href: baseURL + "/kn-linux-amd64.tar.gz",
 			}, {
 				Text: "Download kn for Linux for IBM Power little endian",
-				Href: baseURL + "/ppc64le/linux/kn-linux-ppc64le.tar.gz",
+				Href: baseURL + "/kn-linux-ppc64le.tar.gz",
 			}, {
 				Text: "Download kn for Linux for IBM Z",
-				Href: baseURL + "/s390x/linux/kn-linux-s390x.tar.gz",
+				Href: baseURL + "/kn-linux-s390x.tar.gz",
 			}, {
 				Text: "Download kn for macOS",
-				Href: baseURL + "/amd64/macos/kn-macos-amd64.tar.gz",
+				Href: baseURL + "/kn-macos-amd64.tar.gz",
 			}, {
 				Text: "Download kn for Windows",
-				Href: baseURL + "/amd64/windows/kn-windows-amd64.zip",
+				Href: baseURL + "/kn-windows-amd64.zip",
 			}},
 		},
 	}

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -490,13 +490,15 @@ spec:
                   name: knative-openshift
               spec:
                 serviceAccountName: knative-operator
-                containers:
-                  - name: cli-downloads
+                initContainers:
+                  - name: cli-artifacts
                     image: registry.ci.openshift.org/openshift/knative-v0.22.0:kn-cli-artifacts
                     imagePullPolicy: Always
-                    ports:
-                      - name: http-cli
-                        containerPort: 8080
+                    command: ["sh", "-c", "cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*"]
+                    volumeMounts:
+                      - mountPath: /cli-artifacts
+                        name: cli-artifacts
+                containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
@@ -509,6 +511,12 @@ spec:
                       httpGet:
                         path: /healthz
                         port: 8687
+                    ports:
+                      - name: http-cli
+                        containerPort: 8080
+                    volumeMounts:
+                      - mountPath: /cli-artifacts
+                        name: cli-artifacts
                     env:
                       - name: WATCH_NAMESPACE
                         value: ""
@@ -602,6 +610,9 @@ spec:
                         value: "registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-consolidated-dispatcher"
                       - name: "KAFKA_IMAGE_kafka-webhook__kafka-webhook"
                         value: "registry.ci.openshift.org/openshift/knative-v0.22.3:knative-eventing-kafka-webhook"
+                volumes:
+                  - name: cli-artifacts
+                    emptyDir: {}
         # Openshift Ingress adapter for Knative's Ingress implementation.
         - name: knative-openshift-ingress
           spec:

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -447,13 +447,20 @@ spec:
                   name: knative-openshift
               spec:
                 serviceAccountName: knative-operator
-                containers:
-                  - name: cli-downloads
+                initContainers:
+                  - name: cli-artifacts
                     image: TO_BE_REPLACED
                     imagePullPolicy: Always
-                    ports:
-                      - name: http-cli
-                        containerPort: 8080
+                    command:
+                      [
+                        "sh",
+                        "-c",
+                        "cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*",
+                      ]
+                    volumeMounts:
+                      - mountPath: /cli-artifacts
+                        name: cli-artifacts
+                containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
@@ -466,6 +473,12 @@ spec:
                       httpGet:
                         path: /healthz
                         port: 8687
+                    ports:
+                      - name: http-cli
+                        containerPort: 8080
+                    volumeMounts:
+                      - mountPath: /cli-artifacts
+                        name: cli-artifacts
                     env:
                       - name: WATCH_NAMESPACE
                         value: ""
@@ -495,6 +508,9 @@ spec:
                         value: "deploy/resources/quickstart/serverless-application-quickstart.yaml"
                       - name: DASHBOARDS_ROOT_MANIFEST_PATH
                         value: "deploy/resources/dashboards"
+                volumes:
+                  - name: cli-artifacts
+                    emptyDir: {}
 
         # Openshift Ingress adapter for Knative's Ingress implementation.
         - name: knative-openshift-ingress


### PR DESCRIPTION
Reviving this as it turns out that the python based server in the "other" way of doing this currently unnecessarily requires read access to the file system, which I'd like to ditch from all of our deployments.

We've discussed the security implications of this in Slack quite a bit and @rhuss and @skonto made good points regarding this actually being "more secure" (or rather less surface) in that we use the same technology (Golang) to serve the CLI and to develop all of our other components. That means, that we wouldn't have to watch for potential python CVEs to get fixed too, which is nice!

/assign @rhuss 