### PR TITLE
Enable DEBUG log by default for Serving and Eventing components in tests

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -214,7 +214,14 @@ metadata:
   name: knative-eventing
   namespace: ${EVENTING_NAMESPACE}
 spec:
-  {}
+  config:
+    logging:
+      loglevel.controller: "debug"
+      loglevel.webhook: "debug"
+      loglevel.kafkachannel-dispatcher: "debug"
+      loglevel.kafkachannel-controller: "debug"
+      loglevel.inmemorychannel-dispatcher: "debug"
+      loglevel.mt-broker-controller: "debug"
 EOF
 
   timeout 900 "[[ \$(oc get knativeeventing.operator.knative.dev \

--- a/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
+++ b/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
@@ -34,6 +34,9 @@ spec:
       loglevel.controller: "debug"
       loglevel.queueproxy: "debug"
       loglevel.webhook: "debug"
+      loglevel.hpaautoscaler: "debug"
+      loglevel.domainmapping: "debug"
+      loglevel.domainmapping-webhook: "debug"
     observability:
       logging.enable-var-log-collection: "false"
       metrics.backend-destination: "prometheus"


### PR DESCRIPTION
We were enabling debug logs to get extra logging in https://github.com/openshift-knative/serverless-operator/pull/1115 
However, it would be good to have the DEBUG logs enabled by default as it helps with debugging and doesn't need re-running CI. This approach is used upstream as well.