### PR TITLE
Adding the rest of the eventing to be approvers for S-O repo

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,7 +2,9 @@ aliases:
   serverless-approvers:
   - alanfx
   - aliok
+  - devguyio
   - jcrossley3
+  - lberk
   - markusthoemmes
   - matzew
   - mgencur


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

as per title, to have more from the team being able to approve code