### PR TITLE
Keep kafkas at one replica

### DIFF
--- a/knative-operator/pkg/common/kafka.go
+++ b/knative-operator/pkg/common/kafka.go
@@ -12,7 +12,7 @@ func MutateKafka(ke *operatorv1alpha1.KnativeKafka) {
 func defaultToKafkaHa(ke *operatorv1alpha1.KnativeKafka) {
 	if ke.Spec.HighAvailability == nil {
 		ke.Spec.HighAvailability = &commonv1alpha1.HighAvailability{
-			Replicas: 2,
+			Replicas: 1,
 		}
 	}
 }

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -437,7 +437,7 @@ func makeCr(mods ...func(*v1alpha1.KnativeKafka)) *v1alpha1.KnativeKafka {
 				BootstrapServers: "foo.bar.com",
 			},
 			HighAvailability: &operatorv1alpha1.HighAvailability{
-				Replicas: 2,
+				Replicas: 1,
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Continue to keep kafka at one replica