### PR TITLE
Remove hpa pdb

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
@@ -1162,7 +1162,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 spec:
-  minAvailable: 1
+  minAvailable: 80%
   selector:
     matchLabels:
       app: kafka-webhook

--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
@@ -1117,57 +1117,6 @@ spec:
       terminationGracePeriodSeconds: 300
 
 ---
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: autoscaling/v2beta2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: kafka-webhook
-  namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: devel
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: kafka-webhook
-  minReplicas: 1
-  maxReplicas: 5
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 100
----
-# Webhook PDB.
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: kafka-webhook
-  namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: devel
-spec:
-  minAvailable: 80%
-  selector:
-    matchLabels:
-      app: kafka-webhook
-
----
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/knative-operator/hack/001-remove_hpa_pdb.patch
+++ b/knative-operator/hack/001-remove_hpa_pdb.patch
@@ -1,0 +1,62 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+index b193794d..2d719aec 100644
+--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
++++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+@@ -1116,57 +1116,6 @@ spec:
+       # high value that we respect whatever value it has configured for the lame duck grace period.
+       terminationGracePeriodSeconds: 300
+ 
+----
+-# Copyright 2021 The Knative Authors
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     https://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-
+-apiVersion: autoscaling/v2beta2
+-kind: HorizontalPodAutoscaler
+-metadata:
+-  name: kafka-webhook
+-  namespace: knative-eventing
+-  labels:
+-    eventing.knative.dev/release: devel
+-spec:
+-  scaleTargetRef:
+-    apiVersion: apps/v1
+-    kind: Deployment
+-    name: kafka-webhook
+-  minReplicas: 1
+-  maxReplicas: 5
+-  metrics:
+-    - type: Resource
+-      resource:
+-        name: cpu
+-        target:
+-          type: Utilization
+-          averageUtilization: 100
+----
+-# Webhook PDB.
+-apiVersion: policy/v1beta1
+-kind: PodDisruptionBudget
+-metadata:
+-  name: kafka-webhook
+-  namespace: knative-eventing
+-  labels:
+-    eventing.knative.dev/release: devel
+-spec:
+-  minAvailable: 80%
+-  selector:
+-    matchLabels:
+-      app: kafka-webhook
+-
+ ---
+ # Copyright 2020 The Knative Authors
+ #

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -38,4 +38,4 @@ function download_kafka {
 download_kafka knativekafka "$KNATIVE_EVENTING_KAFKA_VERSION" "${kafka_files[@]}"
 
 # Change the minavailable pdb for kafka-webhook to 1
-git apply "$root/knative-operator/hack/007-eventing-kafka-pdb.patch"
+#git apply "$root/knative-operator/hack/007-eventing-kafka-pdb.patch"

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -39,3 +39,6 @@ download_kafka knativekafka "$KNATIVE_EVENTING_KAFKA_VERSION" "${kafka_files[@]}
 
 # Change the minavailable pdb for kafka-webhook to 1
 #git apply "$root/knative-operator/hack/007-eventing-kafka-pdb.patch"
+
+# For 1.17 we still skip HPA/PDB
+git apply "$root/knative-operator/hack/001-remove_hpa_pdb.patch"


### PR DESCRIPTION
For 1.17 we skip the HPA/PDB

For 1.18 we might look into this: https://issues.redhat.com/browse/SRVKE-908

/assign @lberk 