### PR TITLE
Proclaim support for disconnected, fips and proxy-aware envs

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     operatorframework.io/suggested-namespace: "openshift-serverless"
     operatorframework.io/cluster-monitoring: "true"
+    operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     alm-examples: |-
       [
         {

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     operatorframework.io/suggested-namespace: "openshift-serverless"
     operatorframework.io/cluster-monitoring: "true"
+    operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     alm-examples: |-
       [
         {


### PR DESCRIPTION
From https://docs.openshift.com/container-platform/4.7/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-manual-annotations_osdk-generating-csvs.

AFAIK, we implemented support (and/or fixed bugs) to enable disconnected, fips and proxy-aware environments.