### PR TITLE
Stop forcing garbage collection at the end of upgrade tests

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -399,30 +399,6 @@ spec:
 EOF
 }
 
-function trigger_gc_and_print_knative {
-  echo ">>> Knative Servings"
-  oc get knativeserving.operator.knative.dev --all-namespaces -o yaml
-
-  echo ">>> Knative Services"
-  oc get ksvc --all-namespaces
-
-  echo ">>> Triggering GC"
-  for pod in $(oc get pod -n openshift-kube-controller-manager -l kube-controller-manager=true -o custom-columns=name:metadata.name --no-headers); do
-    echo "killing pod $pod"
-    oc rsh -n openshift-kube-controller-manager "$pod" /bin/sh -c "kill 1"
-    sleep 30
-  done
-
-  echo "Sleeping so GC can run"
-  sleep 120
-
-  echo ">>> Knative Servings"
-  oc get knativeserving.operator.knative.dev --all-namespaces -o yaml
-
-  echo ">>> Knative Services"
-  oc get ksvc --all-namespaces
-}
-
 function wait_for_leader_controller() {
   local leader
   echo -n "Waiting for a leader Controller"

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -21,7 +21,7 @@ scale_up_workers
 
 # Install ServiceMesh and enable mTLS.
 if [[ $FULL_MESH == true ]]; then
-   UNINSTALL_MESH="false" install_mesh
+  UNINSTALL_MESH="false" install_mesh
 fi
 
 # Run upgrade tests
@@ -32,7 +32,6 @@ if [[ $TEST_KNATIVE_UPGRADE == true ]]; then
     ensure_kafka_channel_default
   fi
   run_rolling_upgrade_tests
-  trigger_gc_and_print_knative
   teardown_serverless
 fi
 


### PR DESCRIPTION
This is unlikely to catch anything useful as we don't have any OwnerRefs on the resources this is checking against anymore. It has however caused at least [one failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.7-upgrade-tests-aws-ocp-47-continuous/1423614841347641344) already.