### PR TITLE
[SRVKS-702] Set ClusterIP service type for Kourier Gateway by default

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -102,6 +102,9 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	defaultToKourier(ks)
 	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "ingress.class", defaultIngressClass(ks))
 
+	// Apply Kourier gateway service type.
+	defaultKourierServiceType(ks)
+
 	// Override the default domainTemplate to use $name-$ns rather than $name.$ns.
 	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "domainTemplate", defaultDomainTemplate)
 

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -146,6 +146,45 @@ func TestReconcile(t *testing.T) {
 			common.Configure(&ks.Spec.CommonSpec, "network", "ingress.class", "foo")
 		}),
 	}, {
+		name: "default kourier service type",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				Ingress: &v1alpha1.IngressConfigs{
+					Kourier: v1alpha1.KourierIngressConfiguration{
+						Enabled: true,
+					},
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
+				Kourier: v1alpha1.KourierIngressConfiguration{
+					Enabled:     true,
+					ServiceType: "ClusterIP",
+				},
+			}
+		}),
+	}, {
+		name: "override kourier service type",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				Ingress: &v1alpha1.IngressConfigs{
+					Kourier: v1alpha1.KourierIngressConfiguration{
+						Enabled:     true,
+						ServiceType: "LoadBalancer",
+					},
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
+				Kourier: v1alpha1.KourierIngressConfiguration{
+					Enabled:     true,
+					ServiceType: "LoadBalancer",
+				},
+			}
+		}),
+	}, {
 		name: "override ingress config",
 		in: &v1alpha1.KnativeServing{
 			Spec: v1alpha1.KnativeServingSpec{
@@ -185,7 +224,8 @@ func TestReconcile(t *testing.T) {
 		expected: ks(func(ks *v1alpha1.KnativeServing) {
 			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
 				Kourier: v1alpha1.KourierIngressConfiguration{
-					Enabled: true,
+					Enabled:     true,
+					ServiceType: "ClusterIP",
 				},
 			}
 		}),
@@ -459,7 +499,8 @@ func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
 			},
 			Ingress: &v1alpha1.IngressConfigs{
 				Kourier: v1alpha1.KourierIngressConfiguration{
-					Enabled: true,
+					Enabled:     true,
+					ServiceType: "ClusterIP",
 				},
 			},
 		},

--- a/openshift-knative-operator/pkg/serving/ingress.go
+++ b/openshift-knative-operator/pkg/serving/ingress.go
@@ -1,6 +1,10 @@
 package serving
 
-import "knative.dev/operator/pkg/apis/operator/v1alpha1"
+import (
+	"k8s.io/api/core/v1"
+
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
 
 const istioIngressClassName = "istio.ingress.networking.knative.dev"
 
@@ -19,6 +23,15 @@ func defaultToKourier(ks *v1alpha1.KnativeServing) {
 
 	if !ks.Spec.Ingress.Istio.Enabled && !ks.Spec.Ingress.Kourier.Enabled && !ks.Spec.Ingress.Contour.Enabled {
 		ks.Spec.Ingress.Kourier.Enabled = true
+	}
+
+}
+
+func defaultKourierServiceType(ks *v1alpha1.KnativeServing) {
+	if ks.Spec.Ingress != nil && ks.Spec.Ingress.Kourier.Enabled {
+		if ks.Spec.Ingress.Kourier.ServiceType == "" {
+			ks.Spec.Ingress.Kourier.ServiceType = v1.ServiceTypeClusterIP
+		}
 	}
 }
 

--- a/openshift-knative-operator/pkg/serving/ingress.go
+++ b/openshift-knative-operator/pkg/serving/ingress.go
@@ -1,7 +1,7 @@
 package serving
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 )

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -43,6 +43,11 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     --type=merge \
     --patch='{"spec": {"config": { "autoscaler": {"allow-zero-initial-scale": "true"}}}}'
 
+  # Enable ExternalIP for Kourier.
+  oc -n "${SERVING_NAMESPACE}" patch knativeserving/knative-serving \
+    --type=merge \
+    --patch='{"spec": {"ingress": { "kourier": {"service-type": "LoadBalancer"}}}}'
+
   image_template="registry.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-{{.Name}}"
   OPENSHIFT_TEST_OPTIONS="--kubeconfig $KUBECONFIG --enable-beta --enable-alpha --resolvabledomain"
 


### PR DESCRIPTION
The service type of Kourier Gateway is currently `LoadBalancer`, even
though OpenShift Serverless uses OpenShift Route to expose the
serveerless services. Users have to take care about the extra firewall for it.

This patch changes service type of Kourier Gateway to `ClusterIP` if unset.