### PR TITLE
Update `test/serving.bash` to use oc apply instead of ytt

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -8,8 +8,7 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 RUN yum install -y kubectl ansible httpd-tools
 
 RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
-  knative.dev/test-infra/kntest/cmd/kntest \
-  github.com/k14s/ytt/cmd/ytt
+  knative.dev/test-infra/kntest/cmd/kntest
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd

--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -8,8 +8,7 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 RUN yum install -y kubectl ansible httpd-tools
 
 RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
-  knative.dev/test-infra/kntest/cmd/kntest \
-  github.com/k14s/ytt/cmd/ytt
+  knative.dev/test-infra/kntest/cmd/kntest
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -20,10 +20,8 @@ function prepare_knative_serving_tests {
   rm -fv test/config/config-deployment.yaml
 
   # Create test resources (namespaces, configMaps, secrets)
-  ytt \
-    -f "test/config/ytt/lib" \
-    -f "test/config/ytt/values.yaml" \
-    -f test/config/ytt/core/resources.yaml | oc apply -f -
+  oc apply -f test/config/cluster-resources.yaml
+  oc apply -f test/config/test-resources.yaml
   # Adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
   oc adm policy add-scc-to-user anyuid -z default -n serving-tests
   # Add networkpolicy to test namespace and label to serving namespaces for testing under the strict networkpolicy.


### PR DESCRIPTION
This patch updates `test/serving.bash` to use oc apply instead of ytt.

Upstream conformance allows conformance test without ytt as https://github.com/knative/serving/commit/69caf075172546ab075a3b63ab7a23aced1eb9d0.
And downstream backport it as https://github.com/openshift/knative-serving/commit/c9430691c62581d82d867be2306b90baf6d33581.

So we should not need `ytt` command anymore.