### PR TITLE
Prepair main for 1.18

### DIFF
--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.bundle.channels.v1="stable"
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
       name="openshift-serverless-1/serverless-operator-bundle" \
-      version="1.17.0" \
+      version="1.18.0" \
       summary="Red Hat OpenShift Serverless Bundle" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -50,12 +50,12 @@ metadata:
       Deploy and manage event-driven serverless applications and functions using Knative.
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
-    olm.skipRange: '>=1.16.0 <1.17.0'
+    olm.skipRange: '>=1.17.0 <1.18.0'
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: serverless-operator.v1.17.0
+  name: serverless-operator.v1.18.0
   namespace: placeholder
 spec:
   # User-facing metadata
@@ -866,5 +866,5 @@ spec:
       image: "registry.ci.openshift.org/openshift/knative-v0.23.5:knative-eventing-kafka-consolidated-dispatcher"
     - name: "KAFKA_IMAGE_kafka-webhook__kafka-webhook"
       image: "registry.ci.openshift.org/openshift/knative-v0.23.5:knative-eventing-kafka-webhook"
-  replaces: serverless-operator.v1.16.0
-  version: 1.17.0
+  replaces: serverless-operator.v1.17.0
+  version: 1.18.0

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -1,11 +1,11 @@
 ---
 project:
   name: serverless-operator
-  version: 1.17.0
+  version: 1.18.0
 
 olm:
-  replaces: 1.16.0
-  skipRange: '>=1.16.0 <1.17.0'
+  replaces: 1.17.0
+  skipRange: '>=1.17.0 <1.18.0'
   channels:
     default: 'stable'
     list:

--- a/olm-catalog/serverless-operator/stopbundle.Dockerfile
+++ b/olm-catalog/serverless-operator/stopbundle.Dockerfile
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.bundle.channels.v1="stable"
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
       name="openshift-serverless-1/serverless-operator-bundle" \
-      version="1.17.0" \
+      version="1.18.0" \
       summary="Red Hat OpenShift Serverless Bundle" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

As per title, making the main a new version, since we already have branched for 1.17 