### PR TITLE
Lengthen timeout of namespace deletion assert

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -82,7 +82,7 @@ function serverless_operator_e2e_tests {
     "$@"
 
   # make sure knative-serving-ingress namespace is deleted.
-  timeout 180 "[[ \$(oc get ns ${SERVING_NAMESPACE}-ingress --no-headers | wc -l) == 1 ]]"
+  timeout 600 "[[ \$(oc get ns ${SERVING_NAMESPACE}-ingress --no-headers | wc -l) == 1 ]]"
 }
 
 function serverless_operator_kafka_e2e_tests {


### PR DESCRIPTION
There was at least one occurrence (see https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.8-e2e-aws-ocp-48-continuous/1429594442234335232) where this failed due to the timeout just being to short. We don't really care about how long it takes as soon as it's being done at all.