### PR TITLE
[SRVKS-545] Default the external URL scheme to HTTPS

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -105,6 +105,9 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	// Override the default domainTemplate to use $name-$ns rather than $name.$ns.
 	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "domainTemplate", defaultDomainTemplate)
 
+	// Default the URL scheme to HTTPS if nothing else is defined.
+	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "defaultExternalScheme", "https")
+
 	// Ensure webhook has 1G of memory.
 	common.EnsureContainerMemoryLimit(&ks.Spec.CommonSpec, "webhook", resource.MustParse("1024Mi"))
 

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -210,6 +210,22 @@ func TestReconcile(t *testing.T) {
 			}
 		}),
 	}, {
+		name: "override default url scheme",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Config: v1alpha1.ConfigMapData{
+						"network": map[string]string{
+							"defaultExternalScheme": "http",
+						},
+					},
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			common.Configure(&ks.Spec.CommonSpec, "network", "defaultExternalScheme", "http")
+		}),
+	}, {
 		name: "override autocreateClusterDomainClaims config",
 		in: &v1alpha1.KnativeServing{
 			Spec: v1alpha1.KnativeServingSpec{
@@ -434,6 +450,7 @@ func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
 						"domainTemplate":                defaultDomainTemplate,
 						"ingress.class":                 kourierIngressClassName,
 						"autocreateClusterDomainClaims": "true",
+						"defaultExternalScheme":         "https",
 					},
 				},
 				Registry: v1alpha1.Registry{

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -34,6 +34,7 @@ if [[ $FULL_MESH == "true" ]]; then
   enable_net_istio
 else
   ensure_serverless_installed
+  trust_router_ca
 fi
 
 [ -n "$OPENSHIFT_CI" ] && setup_quick_api_deprecation_alerts

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -50,11 +50,9 @@ function upstream_knative_serving_e2e_and_conformance_tests {
 
   image_template="registry.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-{{.Name}}"
   subdomain=$(oc get ingresses.config.openshift.io cluster  -o jsonpath="{.spec.domain}")
-  OPENSHIFT_TEST_OPTIONS="--kubeconfig $KUBECONFIG --enable-beta --enable-alpha --resolvabledomain --customdomain=$subdomain"
+  OPENSHIFT_TEST_OPTIONS="--kubeconfig $KUBECONFIG --enable-beta --enable-alpha --resolvabledomain --customdomain=$subdomain --https"
 
   if [[ $FULL_MESH == "true" ]]; then
-    OPENSHIFT_TEST_OPTIONS+=" --https"
-
     # Use x509ignoreCN=0.
     # This should not be necesssary if we could ceate certs with SAN. However, openssl command in the CI
     # seems old version and so it does not have "-addext" option to add SAN.

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -20,6 +20,8 @@ logger.success '🚀 Cluster prepared for testing.'
 # Install ServiceMesh and enable mTLS.
 if [[ $FULL_MESH == true ]]; then
   UNINSTALL_MESH="false" install_mesh
+else
+  trust_router_ca
 fi
 
 # Run upgrade tests


### PR DESCRIPTION
As per title, as Openshift supports HTTPS by default and it's the more secure option.