### PR TITLE
Allow the operator to show up on OCP 4.9

### DIFF
--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -18,6 +18,6 @@ LABEL \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \
       io.k8s.display-name="Red Hat OpenShift Serverless Bundle" \
-      com.redhat.openshift.versions="v4.6-v4.8" \
+      com.redhat.openshift.versions="v4.6-v4.9" \
       com.redhat.delivery.operator.bundle=true \
       com.redhat.delivery.backport=false

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -18,7 +18,7 @@ requirements:
   nodejs: 14.x
   ocpVersion:
     min: '4.6'
-    label: 'v4.6-v4.8'
+    label: 'v4.6-v4.9'
 
 dependencies:
   serving: 0.24.0

--- a/olm-catalog/serverless-operator/stopbundle.Dockerfile
+++ b/olm-catalog/serverless-operator/stopbundle.Dockerfile
@@ -18,7 +18,7 @@ LABEL \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \
       io.k8s.display-name="Red Hat OpenShift Serverless Bundle" \
-      com.redhat.openshift.versions="v4.6-v4.8" \
+      com.redhat.openshift.versions="v4.6-v4.9" \
       com.redhat.delivery.operator.bundle=true \
       com.redhat.delivery.backport=false
 


### PR DESCRIPTION
As per title (and per thread on serverless-dev), this is required for the operator to be installable on 4.9.