### PR TITLE
[SRVKS-791] Allow emptyDir volumes

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/1-serving-crds.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/1-serving-crds.yaml
@@ -703,6 +703,7 @@ spec:
                                   secretName:
                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
+                            x-kubernetes-preserve-unknown-fields: true
                       x-kubernetes-preserve-unknown-fields: true
             status:
               description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).
@@ -1922,6 +1923,7 @@ spec:
                           secretName:
                             description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                             type: string
+                    x-kubernetes-preserve-unknown-fields: true
               x-kubernetes-preserve-unknown-fields: true
             status:
               description: RevisionStatus communicates the observed state of the Revision (from the controller).
@@ -2891,6 +2893,7 @@ spec:
                                   secretName:
                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
+                            x-kubernetes-preserve-unknown-fields: true
                       x-kubernetes-preserve-unknown-fields: true
                 traffic:
                   description: Traffic specifies how to distribute traffic over a collection of revisions and configurations.

--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/2-serving-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/2-serving-core.yaml
@@ -1018,6 +1018,7 @@ spec:
                                   secretName:
                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
+                            x-kubernetes-preserve-unknown-fields: true
                       x-kubernetes-preserve-unknown-fields: true
             status:
               description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).
@@ -2237,6 +2238,7 @@ spec:
                           secretName:
                             description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                             type: string
+                    x-kubernetes-preserve-unknown-fields: true
               x-kubernetes-preserve-unknown-fields: true
             status:
               description: RevisionStatus communicates the observed state of the Revision (from the controller).
@@ -3206,6 +3208,7 @@ spec:
                                   secretName:
                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
+                            x-kubernetes-preserve-unknown-fields: true
                       x-kubernetes-preserve-unknown-fields: true
                 traffic:
                   description: Traffic specifies how to distribute traffic over a collection of revisions and configurations.
@@ -3850,7 +3853,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.24.0"
   annotations:
-    knative.dev/example-checksum: "8c1f8302"
+    knative.dev/example-checksum: "3bac317a"
 data:
   _example: |-
     ################################
@@ -3961,6 +3964,11 @@ data:
     # 1. Enabled: http2 connection will be attempted via upgrade.
     # 2. Disabled: http2 connection will only be attempted when port name is set to "h2c".
     autodetect-http2: "disabled"
+
+    # Controls whether volume support for EmptyDir is enabled or not.
+    # 1. Enabled: enabling EmptyDir volume support
+    # 2. Disabled: disabling EmptyDir volume support
+    kubernetes.podspec-volumes-emptydir: "disabled"
 
 ---
 # Copyright 2018 The Knative Authors

--- a/openshift-knative-operator/hack/004-serving-emptydir.patch
+++ b/openshift-knative-operator/hack/004-serving-emptydir.patch
@@ -1,0 +1,77 @@
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/1-serving-crds.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/1-serving-crds.yaml
+index 20f022248..38d617211 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/1-serving-crds.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/1-serving-crds.yaml
+@@ -703,6 +703,7 @@ spec:
+                                   secretName:
+                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                     type: string
++                            x-kubernetes-preserve-unknown-fields: true
+                       x-kubernetes-preserve-unknown-fields: true
+             status:
+               description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).
+@@ -1922,6 +1923,7 @@ spec:
+                           secretName:
+                             description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                             type: string
++                    x-kubernetes-preserve-unknown-fields: true
+               x-kubernetes-preserve-unknown-fields: true
+             status:
+               description: RevisionStatus communicates the observed state of the Revision (from the controller).
+@@ -2891,6 +2893,7 @@ spec:
+                                   secretName:
+                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                     type: string
++                            x-kubernetes-preserve-unknown-fields: true
+                       x-kubernetes-preserve-unknown-fields: true
+                 traffic:
+                   description: Traffic specifies how to distribute traffic over a collection of revisions and configurations.
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/2-serving-core.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/2-serving-core.yaml
+index cdcf74368..ce9a34eb9 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/2-serving-core.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.24.0/2-serving-core.yaml
+@@ -1018,6 +1018,7 @@ spec:
+                                   secretName:
+                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                     type: string
++                            x-kubernetes-preserve-unknown-fields: true
+                       x-kubernetes-preserve-unknown-fields: true
+             status:
+               description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).
+@@ -2237,6 +2238,7 @@ spec:
+                           secretName:
+                             description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                             type: string
++                    x-kubernetes-preserve-unknown-fields: true
+               x-kubernetes-preserve-unknown-fields: true
+             status:
+               description: RevisionStatus communicates the observed state of the Revision (from the controller).
+@@ -3206,6 +3208,7 @@ spec:
+                                   secretName:
+                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                     type: string
++                            x-kubernetes-preserve-unknown-fields: true
+                       x-kubernetes-preserve-unknown-fields: true
+                 traffic:
+                   description: Traffic specifies how to distribute traffic over a collection of revisions and configurations.
+@@ -3850,7 +3853,7 @@ metadata:
+   labels:
+     serving.knative.dev/release: "v0.24.0"
+   annotations:
+-    knative.dev/example-checksum: "8c1f8302"
++    knative.dev/example-checksum: "3bac317a"
+ data:
+   _example: |-
+     ################################
+@@ -3962,6 +3965,11 @@ data:
+     # 2. Disabled: http2 connection will only be attempted when port name is set to "h2c".
+     autodetect-http2: "disabled"
+ 
++    # Controls whether volume support for EmptyDir is enabled or not.
++    # 1. Enabled: enabling EmptyDir volume support
++    # 2. Disabled: disabling EmptyDir volume support
++    kubernetes.podspec-volumes-emptydir: "disabled"
++
+ ---
+ # Copyright 2018 The Knative Authors
+ #

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -85,6 +85,9 @@ git apply "$root/openshift-knative-operator/hack/002-openshift-serving-role.patc
 # See also https://issues.redhat.com/browse/SRVKS-670.
 git apply "$root/openshift-knative-operator/hack/003-serving-pdb.patch"
 
+# Backports necessary changes for emptydir. To be removed in 1.19.
+git apply "$root/openshift-knative-operator/hack/004-serving-emptydir.patch"
+
 download_ingress net-istio "v$(metadata.get dependencies.net_istio)" "${istio_files[@]}"
 
 url="https://github.com/knative-sandbox/net-kourier/releases/download/v$(metadata.get dependencies.kourier)/kourier.yaml"

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -48,6 +48,11 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     --type=merge \
     --patch='{"spec": {"ingress": { "kourier": {"service-type": "LoadBalancer"}}}}'
 
+  # Also enable emptyDir volumes for the respective tests.
+  oc -n "${SERVING_NAMESPACE}" patch knativeserving/knative-serving \
+    --type=merge \
+    --patch='{"spec": {"config": { "features": {"kubernetes.podspec-volumes-emptydir": "enabled"}}}}'
+
   image_template="registry.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-{{.Name}}"
   OPENSHIFT_TEST_OPTIONS="--kubeconfig $KUBECONFIG --enable-beta --enable-alpha --resolvabledomain"
 
@@ -75,7 +80,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     parallel=2
   fi
 
-  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel \
+  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags="e2e emptydir" -timeout=30m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     ${OPENSHIFT_TEST_OPTIONS} \
     --imagetemplate "$image_template"


### PR DESCRIPTION
Title and JIRA have it all. This adds the necessary CRD fields to allow emptyDir volumes. Also adds the respective tests to avoid a regression.