### PR TITLE
Revert [SRVKS-702] Set ClusterIP service type for Kourier Gateway by default

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -102,9 +102,6 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	defaultToKourier(ks)
 	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "ingress.class", defaultIngressClass(ks))
 
-	// Apply Kourier gateway service type.
-	defaultKourierServiceType(ks)
-
 	// Override the default domainTemplate to use $name-$ns rather than $name.$ns.
 	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "domainTemplate", defaultDomainTemplate)
 

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -146,45 +146,6 @@ func TestReconcile(t *testing.T) {
 			common.Configure(&ks.Spec.CommonSpec, "network", "ingress.class", "foo")
 		}),
 	}, {
-		name: "default kourier service type",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				Ingress: &v1alpha1.IngressConfigs{
-					Kourier: v1alpha1.KourierIngressConfiguration{
-						Enabled: true,
-					},
-				},
-			},
-		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
-			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
-				Kourier: v1alpha1.KourierIngressConfiguration{
-					Enabled:     true,
-					ServiceType: "ClusterIP",
-				},
-			}
-		}),
-	}, {
-		name: "override kourier service type",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				Ingress: &v1alpha1.IngressConfigs{
-					Kourier: v1alpha1.KourierIngressConfiguration{
-						Enabled:     true,
-						ServiceType: "LoadBalancer",
-					},
-				},
-			},
-		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
-			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
-				Kourier: v1alpha1.KourierIngressConfiguration{
-					Enabled:     true,
-					ServiceType: "LoadBalancer",
-				},
-			}
-		}),
-	}, {
 		name: "override ingress config",
 		in: &v1alpha1.KnativeServing{
 			Spec: v1alpha1.KnativeServingSpec{
@@ -224,8 +185,7 @@ func TestReconcile(t *testing.T) {
 		expected: ks(func(ks *v1alpha1.KnativeServing) {
 			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
 				Kourier: v1alpha1.KourierIngressConfiguration{
-					Enabled:     true,
-					ServiceType: "ClusterIP",
+					Enabled: true,
 				},
 			}
 		}),
@@ -499,8 +459,7 @@ func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
 			},
 			Ingress: &v1alpha1.IngressConfigs{
 				Kourier: v1alpha1.KourierIngressConfiguration{
-					Enabled:     true,
-					ServiceType: "ClusterIP",
+					Enabled: true,
 				},
 			},
 		},

--- a/openshift-knative-operator/pkg/serving/ingress.go
+++ b/openshift-knative-operator/pkg/serving/ingress.go
@@ -1,10 +1,6 @@
 package serving
 
-import (
-	v1 "k8s.io/api/core/v1"
-
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
-)
+import "knative.dev/operator/pkg/apis/operator/v1alpha1"
 
 const istioIngressClassName = "istio.ingress.networking.knative.dev"
 
@@ -23,15 +19,6 @@ func defaultToKourier(ks *v1alpha1.KnativeServing) {
 
 	if !ks.Spec.Ingress.Istio.Enabled && !ks.Spec.Ingress.Kourier.Enabled && !ks.Spec.Ingress.Contour.Enabled {
 		ks.Spec.Ingress.Kourier.Enabled = true
-	}
-
-}
-
-func defaultKourierServiceType(ks *v1alpha1.KnativeServing) {
-	if ks.Spec.Ingress != nil && ks.Spec.Ingress.Kourier.Enabled {
-		if ks.Spec.Ingress.Kourier.ServiceType == "" {
-			ks.Spec.Ingress.Kourier.ServiceType = v1.ServiceTypeClusterIP
-		}
 	}
 }
 

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -43,11 +43,6 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     --type=merge \
     --patch='{"spec": {"config": { "autoscaler": {"allow-zero-initial-scale": "true"}}}}'
 
-  # Enable ExternalIP for Kourier.
-  oc -n "${SERVING_NAMESPACE}" patch knativeserving/knative-serving \
-    --type=merge \
-    --patch='{"spec": {"ingress": { "kourier": {"service-type": "LoadBalancer"}}}}'
-
   # Also enable emptyDir volumes for the respective tests.
   oc -n "${SERVING_NAMESPACE}" patch knativeserving/knative-serving \
     --type=merge \


### PR DESCRIPTION
This patch reverts https://github.com/openshift-knative/serverless-operator/pull/1146 because
k8s 1.20 has a bug which fails to change the service type.

/cc @markusthoemmes 