### PR TITLE
[SRVKS-702] Set ClusterIP service type for Kourier Gateway by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift-knative/serverless-operator
 go 1.16
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.6
 	github.com/manifestival/controller-runtime-client v0.4.0

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -102,6 +102,9 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	defaultToKourier(ks)
 	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "ingress.class", defaultIngressClass(ks))
 
+	// Apply Kourier gateway service type.
+	defaultKourierServiceType(ks)
+
 	// Override the default domainTemplate to use $name-$ns rather than $name.$ns.
 	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "domainTemplate", defaultDomainTemplate)
 

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -197,7 +197,7 @@ func checkMinimumVersion(versioner discovery.ServerVersionInterface, version str
 	// If no specific pre-release requirement is set, we default to "-0" to always allow
 	// pre-release versions of the same Major.Minor.Patch version.
 	if len(minimumVersion.Pre) == 0 {
-		minimumVersion.Pre = []semver.PRVersion{{VersionNum: 0}}
+		minimumVersion.Pre = []semver.PRVersion{{VersionNum: 0, IsNum: true}}
 	}
 
 	if currentVersion.LT(minimumVersion) {

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -146,6 +146,45 @@ func TestReconcile(t *testing.T) {
 			common.Configure(&ks.Spec.CommonSpec, "network", "ingress.class", "foo")
 		}),
 	}, {
+		name: "default kourier service type",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				Ingress: &v1alpha1.IngressConfigs{
+					Kourier: v1alpha1.KourierIngressConfiguration{
+						Enabled: true,
+					},
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
+				Kourier: v1alpha1.KourierIngressConfiguration{
+					Enabled:     true,
+					ServiceType: "ClusterIP",
+				},
+			}
+		}),
+	}, {
+		name: "override kourier service type",
+		in: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				Ingress: &v1alpha1.IngressConfigs{
+					Kourier: v1alpha1.KourierIngressConfiguration{
+						Enabled:     true,
+						ServiceType: "LoadBalancer",
+					},
+				},
+			},
+		},
+		expected: ks(func(ks *v1alpha1.KnativeServing) {
+			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
+				Kourier: v1alpha1.KourierIngressConfiguration{
+					Enabled:     true,
+					ServiceType: "LoadBalancer",
+				},
+			}
+		}),
+	}, {
 		name: "override ingress config",
 		in: &v1alpha1.KnativeServing{
 			Spec: v1alpha1.KnativeServingSpec{
@@ -185,7 +224,8 @@ func TestReconcile(t *testing.T) {
 		expected: ks(func(ks *v1alpha1.KnativeServing) {
 			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
 				Kourier: v1alpha1.KourierIngressConfiguration{
-					Enabled: true,
+					Enabled:     true,
+					ServiceType: "ClusterIP",
 				},
 			}
 		}),
@@ -459,7 +499,8 @@ func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
 			},
 			Ingress: &v1alpha1.IngressConfigs{
 				Kourier: v1alpha1.KourierIngressConfiguration{
-					Enabled: true,
+					Enabled:     true,
+					ServiceType: "ClusterIP",
 				},
 			},
 		},

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -555,13 +555,16 @@ func TestVersionCheck(t *testing.T) {
 		wantError     bool
 	}{{
 		name:          "greater version (patch)",
-		actualVersion: &testVersioner{version: "v1.20.2"},
+		actualVersion: &testVersioner{version: "v1.20.0"},
 	}, {
 		name:          "greater version (patch), no v",
-		actualVersion: &testVersioner{version: "1.20.2"},
+		actualVersion: &testVersioner{version: "1.20.0"},
 	}, {
 		name:          "greater version (patch), pre-release",
 		actualVersion: &testVersioner{version: "1.20.2-kpn-065dce"},
+	}, {
+		name:          "greater version (patch), pre-release with build",
+		actualVersion: &testVersioner{version: "1.20.0-1095+9689d22dc3121e-dirty"},
 	}, {
 		name:          "greater version (minor)",
 		actualVersion: &testVersioner{version: "v1.20.0"},

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -307,7 +307,7 @@ func TestReconcile(t *testing.T) {
 			ks := c.in.DeepCopy()
 			ctx, _ := ocpfake.With(context.Background(), objs...)
 			ctx, _ = kubefake.With(ctx, &servingNamespace)
-			ext := newFakeExtension(t, ctx)
+			ext := newFakeExtension(ctx, t)
 			ext.Reconcile(context.Background(), ks)
 			// Ignore time differences.
 			opt := cmp.Comparer(func(apis.VolatileTime, apis.VolatileTime) bool {
@@ -320,7 +320,7 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func newFakeExtension(t *testing.T, ctx context.Context) operator.Extension {
+func newFakeExtension(ctx context.Context, t *testing.T) operator.Extension {
 	kclient := kubeclient.Get(ctx)
 	fakeDiscovery, ok := kclient.Discovery().(*fakediscovery.FakeDiscovery)
 	if !ok {
@@ -453,7 +453,7 @@ func TestMonitoring(t *testing.T) {
 			c.expected.Namespace = ks.Namespace
 			ctx, _ := ocpfake.With(context.Background(), objs...)
 			ctx, kube := kubefake.With(ctx, &servingNamespace)
-			ext := newFakeExtension(t, ctx)
+			ext := newFakeExtension(ctx, t)
 			shouldEnableMonitoring, err := c.setupMonitoringToggle()
 
 			if err != nil {

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -2,6 +2,7 @@ package serving
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -10,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
+	ocpclient "github.com/openshift-knative/serverless-operator/pkg/client/injection/client"
 	ocpfake "github.com/openshift-knative/serverless-operator/pkg/client/injection/client/fake"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -17,8 +19,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operator "knative.dev/operator/pkg/reconciler/common"
 	"knative.dev/pkg/apis"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	kubefake "knative.dev/pkg/client/injection/kube/client/fake"
 )
 
@@ -39,6 +45,8 @@ var (
 	}
 )
 
+const defaultK8sVersion = "v1.20.0"
+
 func init() {
 	os.Setenv("IMAGE_foo", "bar")
 	os.Setenv("IMAGE_default", "bar2")
@@ -57,10 +65,11 @@ func TestReconcile(t *testing.T) {
 	}
 
 	cases := []struct {
-		name     string
-		in       *v1alpha1.KnativeServing
-		objs     []runtime.Object
-		expected *v1alpha1.KnativeServing
+		name       string
+		k8sVersion string
+		in         *v1alpha1.KnativeServing
+		objs       []runtime.Object
+		expected   *v1alpha1.KnativeServing
 	}{{
 		name:     "all nil",
 		in:       &v1alpha1.KnativeServing{},
@@ -298,7 +307,7 @@ func TestReconcile(t *testing.T) {
 			ks := c.in.DeepCopy()
 			ctx, _ := ocpfake.With(context.Background(), objs...)
 			ctx, _ = kubefake.With(ctx, &servingNamespace)
-			ext := NewExtension(ctx)
+			ext := newFakeExtension(t, ctx)
 			ext.Reconcile(context.Background(), ks)
 			// Ignore time differences.
 			opt := cmp.Comparer(func(apis.VolatileTime, apis.VolatileTime) bool {
@@ -308,6 +317,23 @@ func TestReconcile(t *testing.T) {
 				t.Errorf("Got = %v, want: %v, diff:\n%s", ks, c.expected, cmp.Diff(ks, c.expected, opt))
 			}
 		})
+	}
+}
+
+func newFakeExtension(t *testing.T, ctx context.Context) operator.Extension {
+	kclient := kubeclient.Get(ctx)
+	fakeDiscovery, ok := kclient.Discovery().(*fakediscovery.FakeDiscovery)
+	if !ok {
+		t.Fatalf("couldn't convert Discovery() to *FakeDiscovery")
+	}
+
+	fakeDiscovery.FakedServerVersion = &version.Info{
+		GitVersion: defaultK8sVersion,
+	}
+
+	return &extension{
+		ocpclient:  ocpclient.Get(ctx),
+		kubeclient: kclient,
 	}
 }
 
@@ -427,7 +453,7 @@ func TestMonitoring(t *testing.T) {
 			c.expected.Namespace = ks.Namespace
 			ctx, _ := ocpfake.With(context.Background(), objs...)
 			ctx, kube := kubefake.With(ctx, &servingNamespace)
-			ext := NewExtension(ctx)
+			ext := newFakeExtension(t, ctx)
 			shouldEnableMonitoring, err := c.setupMonitoringToggle()
 
 			if err != nil {
@@ -511,4 +537,69 @@ func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
 	}
 
 	return base
+}
+
+type testVersioner struct {
+	version string
+	err     error
+}
+
+func (t *testVersioner) ServerVersion() (*version.Info, error) {
+	return &version.Info{GitVersion: t.version}, t.err
+}
+
+func TestVersionCheck(t *testing.T) {
+	tests := []struct {
+		name          string
+		actualVersion *testVersioner
+		wantError     bool
+	}{{
+		name:          "greater version (patch)",
+		actualVersion: &testVersioner{version: "v1.20.2"},
+	}, {
+		name:          "greater version (patch), no v",
+		actualVersion: &testVersioner{version: "1.20.2"},
+	}, {
+		name:          "greater version (patch), pre-release",
+		actualVersion: &testVersioner{version: "1.20.2-kpn-065dce"},
+	}, {
+		name:          "greater version (minor)",
+		actualVersion: &testVersioner{version: "v1.20.0"},
+	}, {
+		name:          "same version",
+		actualVersion: &testVersioner{version: "v1.20.0"},
+	}, {
+		name:          "same version with build",
+		actualVersion: &testVersioner{version: "v1.20.0+k3s.1"},
+	}, {
+		name:          "same version with pre-release",
+		actualVersion: &testVersioner{version: "v1.20.0-k3s.1"},
+	}, {
+		name:          "smaller version",
+		actualVersion: &testVersioner{version: "v1.19.3"},
+		wantError:     true,
+	}, {
+		name:          "error while fetching",
+		actualVersion: &testVersioner{err: errors.New("random error")},
+		wantError:     true,
+	}, {
+		name:          "unparseable actual version",
+		actualVersion: &testVersioner{version: "v1.19.foo"},
+		wantError:     true,
+	}}
+
+	minVersion := "1.20.0"
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkMinimumVersion(test.actualVersion, minVersion)
+			if err == nil && test.wantError {
+				t.Errorf("Expected an error for minimum: %q, actual: %v", minVersion, test.actualVersion)
+			}
+
+			if err != nil && !test.wantError {
+				t.Errorf("Expected no error but got %v for minimum: %q, actual: %v", err, minVersion, test.actualVersion)
+			}
+		})
+	}
 }

--- a/openshift-knative-operator/pkg/serving/ingress.go
+++ b/openshift-knative-operator/pkg/serving/ingress.go
@@ -1,6 +1,10 @@
 package serving
 
-import "knative.dev/operator/pkg/apis/operator/v1alpha1"
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
 
 const istioIngressClassName = "istio.ingress.networking.knative.dev"
 
@@ -19,6 +23,15 @@ func defaultToKourier(ks *v1alpha1.KnativeServing) {
 
 	if !ks.Spec.Ingress.Istio.Enabled && !ks.Spec.Ingress.Kourier.Enabled && !ks.Spec.Ingress.Contour.Enabled {
 		ks.Spec.Ingress.Kourier.Enabled = true
+	}
+
+}
+
+func defaultKourierServiceType(ks *v1alpha1.KnativeServing) {
+	if ks.Spec.Ingress != nil && ks.Spec.Ingress.Kourier.Enabled {
+		if ks.Spec.Ingress.Kourier.ServiceType == "" {
+			ks.Spec.Ingress.Kourier.ServiceType = v1.ServiceTypeClusterIP
+		}
 	}
 }
 

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -43,6 +43,11 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     --type=merge \
     --patch='{"spec": {"config": { "autoscaler": {"allow-zero-initial-scale": "true"}}}}'
 
+  # Enable ExternalIP for Kourier.
+  oc -n "${SERVING_NAMESPACE}" patch knativeserving/knative-serving \
+    --type=merge \
+    --patch='{"spec": {"ingress": { "kourier": {"service-type": "LoadBalancer"}}}}'
+
   # Also enable emptyDir volumes for the respective tests.
   oc -n "${SERVING_NAMESPACE}" patch knativeserving/knative-serving \
     --type=merge \

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,6 +23,7 @@ github.com/Shopify/sarama
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/blang/semver/v4 v4.0.0
+## explicit
 github.com/blang/semver/v4
 # github.com/blendle/zapdriver v1.3.1
 github.com/blendle/zapdriver


### PR DESCRIPTION
This patch adds https://github.com/openshift-knative/serverless-operator/pull/1146 again.

Due to a bug in kubernetes, service type change from LoadBalancer to ClusterIP does not work before v1.20.0,
so this patch applies the default only when cluster is using k8s v1.20.0+.