### PR TITLE
Make ServiceToService test consistent with the others

### DIFF
--- a/test/servinge2e/kourier/service_to_service_test.go
+++ b/test/servinge2e/kourier/service_to_service_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
+	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	network "knative.dev/networking/pkg"
-	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
 )
@@ -77,16 +77,7 @@ func testServiceToService(t *testing.T, ctx *test.Context, namespace string, tc 
 	}
 
 	// Verify the service is actually accessible from the outside
-	if _, err := pkgTest.WaitForEndpointState(
-		context.Background(),
-		ctx.Clients.Kube,
-		t.Logf,
-		serviceURL,
-		pkgTest.EventuallyMatchesBody(helloworldText),
-		"WaitForRouteToServeText",
-		true); err != nil {
-		t.Errorf("the Route at domain %s didn't serve the expected text %q: %v", service.Status.URL.URL(), helloworldText, err)
-	}
+	servinge2e.WaitForRouteServingText(t, ctx, serviceURL, helloworldText)
 
 	// Verify the expected istio-proxy is really there
 	podList, err := ctx.Clients.Kube.CoreV1().Pods(namespace).List(context.Background(), meta.ListOptions{LabelSelector: "serving.knative.dev/service=" + service.Name})


### PR DESCRIPTION
Like my last PR, this removes one more manual call to `WaitForEndpointState` to use the generic helper, which allows centralized TLS config.

/assign @nak3 