### PR TITLE
Create the custom route with edge termination as per docs

### DIFF
--- a/test/servinge2e/kourier/custom_route_test.go
+++ b/test/servinge2e/kourier/custom_route_test.go
@@ -68,6 +68,10 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 				Kind: "Service",
 				Name: "kourier",
 			},
+			TLS: &routev1.TLSConfig{
+				Termination:                   routev1.TLSTerminationEdge,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
+			},
 		},
 	}
 	route, err = caCtx.Clients.Route.Routes("knative-serving-ingress").Create(context.Background(), route, meta.CreateOptions{})


### PR DESCRIPTION
This is required to allow HTTP and HTTPS based services to be served by this route, as is the default for us currently. Docs already state, that one should use edge termination.