### PR TITLE
Actually use globally defined constants

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -145,7 +145,7 @@ EOF
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: serverless-operator
+  name: ${OPERATOR}
 spec:
   address: serverless-index.${OLM_NAMESPACE}.svc:50051
   displayName: "Serverless Operator"

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -401,10 +401,10 @@ function teardown_serverless {
     -n "${OPERATORS_NAMESPACE}" "${OPERATOR}" \
     --ignore-not-found
   for csv in $(set +o pipefail && oc get csv -n "${OPERATORS_NAMESPACE}" --no-headers 2>/dev/null \
-      | grep serverless-operator | cut -f1 -d' '); do
+      | grep "${OPERATOR}" | cut -f1 -d' '); do
     oc delete csv -n "${OPERATORS_NAMESPACE}" "${csv}"
   done
-  oc delete namespace openshift-serverless --ignore-not-found=true
+  oc delete namespace "${OPERATORS_NAMESPACE}" --ignore-not-found=true
 
   if [[ ! $(oc get crd -oname | grep -c 'knative.dev') -eq 0 ]]; then
     oc get crd -oname | grep 'knative.dev' | xargs oc delete --timeout=60s

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -211,7 +211,7 @@ function run_rolling_upgrade_tests {
   EVENTING_UPGRADE_TESTS_SERVING_USE=true \
   EVENTING_UPGRADE_TESTS_CONFIGMOUNTPOINT=/.config/wathola \
   GO_TEST_VERBOSITY=standard-verbose \
-  SYSTEM_NAMESPACE=knative-serving \
+  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" \
   go_test_e2e -tags=upgrade -timeout=30m \
     ./test/upgrade \
     -channels="${channels}" \
@@ -366,8 +366,8 @@ function delete_users {
 }
 
 function add_systemnamespace_label {
-  oc label namespace knative-serving knative.openshift.io/system-namespace=true --overwrite         || true
-  oc label namespace knative-serving-ingress knative.openshift.io/system-namespace=true --overwrite || true
+  oc label namespace "$SERVING_NAMESPACE" knative.openshift.io/system-namespace=true --overwrite         || true
+  oc label namespace "$INGRESS_NAMESPACE" knative.openshift.io/system-namespace=true --overwrite || true
 }
 
 function add_networkpolicy {

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -75,14 +75,14 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     parallel=2
   fi
 
-  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags="e2e emptydir" -timeout=30m -parallel=$parallel \
+  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e emptydir" -timeout=30m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     ${OPENSHIFT_TEST_OPTIONS} \
     --imagetemplate "$image_template"
 
   # Run the helloworld test with an image pulled into the internal registry.
   oc tag -n serving-tests "registry.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-helloworld" "helloworld:latest" --reference-policy=local
-  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=e2e -timeout=30m ./test/e2e -run "^(TestHelloWorld)$" \
+  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags=e2e -timeout=30m ./test/e2e -run "^(TestHelloWorld)$" \
     ${OPENSHIFT_TEST_OPTIONS} \
     --imagetemplate "image-registry.openshift-image-registry.svc:5000/serving-tests/{{.Name}}"
   
@@ -114,7 +114,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
 
   # Run HA tests separately as they're stopping core Knative Serving pods
   # Define short -spoofinterval to ensure frequent probing while stopping pods
-  SYSTEM_NAMESPACE=knative-serving go_test_e2e -tags=e2e -timeout=15m -failfast -parallel=1 ./test/ha \
+  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags=e2e -timeout=15m -failfast -parallel=1 ./test/ha \
     -replicas="${REPLICAS}" -buckets="${BUCKETS}" -spoofinterval="10ms" \
     ${OPENSHIFT_TEST_OPTIONS} \
     --imagetemplate "$image_template"


### PR DESCRIPTION
As per title, this replaces a few occurrences where global constants haven't consistently been used.