### PR TITLE
[SRVKS-786] Custom certificates for custom domains without ServiceMesh

### DIFF
--- a/serving/ingress/pkg/reconciler/ingress/resources/route.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route.go
@@ -136,8 +136,10 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 		},
 	}
 
-	// If the passthrough annotation is set, target the HTTPS port and configure passthrough.
-	if _, ok := annotations[EnablePassthroughRouteAnnotation]; ok {
+	// Target the HTTPS port and configure passthrough when:
+	// * the passthrough annotation is set.
+	// * the ingress.spec.tls is set. (DomainMapping with BYP cert.)
+	if _, ok := annotations[EnablePassthroughRouteAnnotation]; ok || len(ci.Spec.TLS) > 0 {
 		route.Spec.Port.TargetPort = intstr.FromString(HTTPSPort)
 		route.Spec.TLS.Termination = routev1.TLSTerminationPassthrough
 		route.Spec.TLS.InsecureEdgeTerminationPolicy = routev1.InsecureEdgeTerminationPolicyRedirect

--- a/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
@@ -256,7 +256,7 @@ func TestMakeRoute(t *testing.T) {
 		{
 			name: "valid, passthrough by BYO cert",
 			ingress: ingress(
-				withTLS(networkingv1alpha1.IngressTLS{[]string{"custom.example.com"}, "someSecretName", "someSecretNamespace"}),
+				withTLS(networkingv1alpha1.IngressTLS{Hosts: []string{"custom.example.com"}, SecretName: "someSecretName"}),
 				withRules(rule(withHosts([]string{localDomain, externalDomain}))),
 			),
 			want: []*routev1.Route{{

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -77,6 +77,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
 
   SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e emptydir" -timeout=30m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
+    ./test/e2e/domainmapping \
     ${OPENSHIFT_TEST_OPTIONS} \
     --imagetemplate "$image_template"
 

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -75,17 +75,9 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     parallel=2
   fi
 
-  sed -ie "s/pkgTest.EventuallyMatchesBody(test.PizzaPlanetText1)/v1test.RetryingRouteInconsistency(spoof.MatchesAllOf(spoof.IsStatusOK, pkgTest.EventuallyMatchesBody(test.PizzaPlanetText1)))/g" ./test/e2e/domainmapping/domain_mapping_test.go
-
-  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e" -timeout=30m -parallel=$parallel \
-    ./test/e2e/domainmapping \
-    ${OPENSHIFT_TEST_OPTIONS} \
-    --imagetemplate "$image_template"
-
-  exit 1
-
   SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e emptydir" -timeout=30m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
+    ./test/e2e/domainmapping \
     ${OPENSHIFT_TEST_OPTIONS} \
     --imagetemplate "$image_template"
 

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -75,9 +75,17 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     parallel=2
   fi
 
+  sed -ie "s/pkgTest.EventuallyMatchesBody(test.PizzaPlanetText1)/v1test.RetryingRouteInconsistency(spoof.MatchesAllOf(spoof.IsStatusOK, pkgTest.EventuallyMatchesBody(test.PizzaPlanetText1)))/g" ./test/e2e/domainmapping/domain_mapping_test.go
+
+  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e" -timeout=30m -parallel=$parallel \
+    ./test/e2e/domainmapping \
+    ${OPENSHIFT_TEST_OPTIONS} \
+    --imagetemplate "$image_template"
+
+  exit 1
+
   SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e emptydir" -timeout=30m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
-    ./test/e2e/domainmapping \
     ${OPENSHIFT_TEST_OPTIONS} \
     --imagetemplate "$image_template"
 


### PR DESCRIPTION
This patch changes to create OpenShift Route with passthrough tls mode
when KIngress has `spec.tls`.

KIngress's `spec.tls` was not used on OpenShift as we don't support
autoTLS. But since v0.24, [DomainMapping with BYO cert](https://github.com/knative/serving/commit/f2cb8e542d8a681232b3d9f689b4032b650ad4b3) uses the field
without autoTLS.

No big change is necessary but we create OpenShift Route with
passthrough tls mode for better UX when users use DomainMapping with TLS.

For e2e test, Downstream also can use upstream's `TestBYOCertificate`. 

Fix https://issues.redhat.com/browse/SRVKS-786