### PR TITLE
[RELEASE-1.17] Revert "Keep kafkas at one replica (#1132)"

### DIFF
--- a/knative-operator/pkg/common/kafka.go
+++ b/knative-operator/pkg/common/kafka.go
@@ -12,7 +12,7 @@ func MutateKafka(ke *operatorv1alpha1.KnativeKafka) {
 func defaultToKafkaHa(ke *operatorv1alpha1.KnativeKafka) {
 	if ke.Spec.HighAvailability == nil {
 		ke.Spec.HighAvailability = &commonv1alpha1.HighAvailability{
-			Replicas: 1,
+			Replicas: 2,
 		}
 	}
 }

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -437,7 +437,7 @@ func makeCr(mods ...func(*v1alpha1.KnativeKafka)) *v1alpha1.KnativeKafka {
 				BootstrapServers: "foo.bar.com",
 			},
 			HighAvailability: &operatorv1alpha1.HighAvailability{
-				Replicas: 1,
+				Replicas: 2,
 			},
 		},
 	}


### PR DESCRIPTION
This reverts commit e64724db951b4946911ce9a517f91f9e0e7e5074.

Original thought was, we should be going with just one instead. However, looks like the PDBs might cause some regression here.:

> having it at 1 might actually be a regression and cause a problem, because the kafka-webhook PodDisruptionBudget created in serverless 1.16 will still exist after upgrading to 1.17 , so if KnativeKafka is reinstalled after serverless 1.17 upgrade, it might hit the PDB's allowedDisruptions limit (by having a single replica, with the PDB not allowing a single disruption)

Which is sad.... Not sure if we could control that better.

For sanity, we stick w/ the same value we had on the 1.16 release....