### PR TITLE
[RELEASE-1.17] Patch vendor'ed operator to remove the PingSource from HA

### DIFF
--- a/hack/001-remove-pingsource-ha.patch
+++ b/hack/001-remove-pingsource-ha.patch
@@ -1,0 +1,12 @@
+diff --git a/vendor/knative.dev/operator/pkg/reconciler/common/ha.go b/vendor/knative.dev/operator/pkg/reconciler/common/ha.go
+index cdf0598f..49388903 100644
+--- a/vendor/knative.dev/operator/pkg/reconciler/common/ha.go
++++ b/vendor/knative.dev/operator/pkg/reconciler/common/ha.go
+@@ -46,7 +46,6 @@ func haSupport(obj v1alpha1.KComponent) sets.String {
+ 		"imc-controller",
+ 		"imc-dispatcher",
+ 		"mt-broker-controller",
+-		"pingsource-mt-adapter",
+ 	)
+ 
+ 	// HA for autoscaler is supported since v0.19+.

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -69,3 +69,6 @@ find vendor/ \( -name "OWNERS" \
   -o -name "*_test.go" \) -exec rm -fv {} +
 
 find vendor -type f -name '*.sh' -exec chmod +x {} +
+
+# SRVKE-669: Remove pingsource from HA
+git apply "$ROOT_DIR/hack/001-remove-pingsource-ha.patch"

--- a/vendor/knative.dev/operator/pkg/reconciler/common/ha.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/common/ha.go
@@ -46,7 +46,6 @@ func haSupport(obj v1alpha1.KComponent) sets.String {
 		"imc-controller",
 		"imc-dispatcher",
 		"mt-broker-controller",
-		"pingsource-mt-adapter",
 	)
 
 	// HA for autoscaler is supported since v0.19+.


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

as per title.

/assign @maschmid 