### PR TITLE
Remove kafka dispatcher deployment image reference

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -70,7 +70,6 @@ kafka_image "kafka-controller-manager__manager"    "${eventing_kafka}-source-con
 kafka_image "KAFKA_RA_IMAGE"                       "${eventing_kafka}-receive-adapter"
 kafka_image "kafka-ch-controller__controller"      "${eventing_kafka}-consolidated-controller"
 kafka_image "DISPATCHER_IMAGE"                     "${eventing_kafka}-consolidated-dispatcher"
-kafka_image "kafka-ch-dispatcher__dispatcher"      "${eventing_kafka}-consolidated-dispatcher"
 kafka_image "kafka-webhook__kafka-webhook"         "${eventing_kafka}-webhook"
 
 image "KUBE_RBAC_PROXY"   "${rbac_proxy}"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -620,8 +620,6 @@ spec:
                         value: "registry.ci.openshift.org/openshift/knative-v0.23.5:knative-eventing-kafka-consolidated-controller"
                       - name: "KAFKA_IMAGE_DISPATCHER_IMAGE"
                         value: "registry.ci.openshift.org/openshift/knative-v0.23.5:knative-eventing-kafka-consolidated-dispatcher"
-                      - name: "KAFKA_IMAGE_kafka-ch-dispatcher__dispatcher"
-                        value: "registry.ci.openshift.org/openshift/knative-v0.23.5:knative-eventing-kafka-consolidated-dispatcher"
                       - name: "KAFKA_IMAGE_kafka-webhook__kafka-webhook"
                         value: "registry.ci.openshift.org/openshift/knative-v0.23.5:knative-eventing-kafka-webhook"
                     securityContext:
@@ -861,8 +859,6 @@ spec:
     - name: "KAFKA_IMAGE_kafka-ch-controller__controller"
       image: "registry.ci.openshift.org/openshift/knative-v0.23.5:knative-eventing-kafka-consolidated-controller"
     - name: "KAFKA_IMAGE_DISPATCHER_IMAGE"
-      image: "registry.ci.openshift.org/openshift/knative-v0.23.5:knative-eventing-kafka-consolidated-dispatcher"
-    - name: "KAFKA_IMAGE_kafka-ch-dispatcher__dispatcher"
       image: "registry.ci.openshift.org/openshift/knative-v0.23.5:knative-eventing-kafka-consolidated-dispatcher"
     - name: "KAFKA_IMAGE_kafka-webhook__kafka-webhook"
       image: "registry.ci.openshift.org/openshift/knative-v0.23.5:knative-eventing-kafka-webhook"


### PR DESCRIPTION
With the 1.17 branch we no longer ship the manifest for the `kafka-ch-dispatcher`, therefore we do no longer need to replace its' image.

The controller is creating/owning the deployment, and thae dispatcher image is listed there:
 https://github.com/openshift-knative/serverless-operator/blob/main/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml#L881-L882

This image we still replace via: https://github.com/matzew/serverless-operator/blob/ac1e9134ebd07febfd768e8037b4fe328d7eb540/hack/generate/csv.sh#L72

/kind clean-up