### PR TITLE
SRVCOM-1454 Ensure alerts about deprecated API usage are caught

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -34,6 +34,8 @@ else
   ensure_serverless_installed
 fi
 
+[ -n "$OPENSHIFT_CI" ] && setup_quick_api_deprecation_alerts
+
 # Run Knative Serving & Eventing downstream E2E tests.
 downstream_serving_e2e_tests
 downstream_eventing_e2e_tests

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -299,6 +299,18 @@ function check_serverless_alerts {
   fi
 }
 
+function setup_quick_api_deprecation_alerts {
+  logger.info "Setup quick API deprecation alerts"
+  for ns in "${OPERATORS_NAMESPACE}" "${EVENTING_NAMESPACE}" "${SERVING_NAMESPACE}" "${INGRESS_NAMESPACE}"; do
+    # Reuse the existing api-usage Prometheus rule and only make it react more quickly.
+    oc get prometheusrule api-usage -n openshift-kube-apiserver -oyaml | \
+      sed -e "s/\(.*name:.*\)/\1-quick/g" \
+          -e "s/\(.*alert:.*\)/\1-quick/g" \
+          -e "s/\(.*for:\).*/\1 1m/g" \
+          -e "s/\(.*namespace:\).*/\1 ${ns}/g" | oc apply -f -
+  done
+}
+
 # == Test users
 
 function create_htpasswd_users {


### PR DESCRIPTION
* The default alerts are fired after 60 minutes and it is too long
because our test suite runs more quickly. Setting the interval to 1
minute.

https://issues.redhat.com/browse/SRVCOM-1454