### PR TITLE
SRVKE-919: Keep PDB and patch its minAvailability to 0

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
@@ -1037,6 +1037,21 @@ spec:
       terminationGracePeriodSeconds: 300
 
 ---
+# Webhook PDB.
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kafka-webhook
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app: kafka-webhook
+
+---
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/knative-operator/hack/001-eventing-kafka-remove_hpa.patch
+++ b/knative-operator/hack/001-eventing-kafka-remove_hpa.patch
@@ -1,12 +1,11 @@
 diff --git a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
-index b193794d..2d719aec 100644
+index 8e04200d..66a6898d 100644
 --- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
 +++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
-@@ -1116,57 +1116,6 @@ spec:
-       # high value that we respect whatever value it has configured for the lame duck grace period.
+@@ -1023,42 +1023,6 @@ spec:
        terminationGracePeriodSeconds: 300
 
-----
+ ---
 -# Copyright 2021 The Knative Authors
 -#
 -# Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,20 +42,6 @@ index b193794d..2d719aec 100644
 -          type: Utilization
 -          averageUtilization: 100
 ----
--# Webhook PDB.
--apiVersion: policy/v1beta1
--kind: PodDisruptionBudget
--metadata:
--  name: kafka-webhook
--  namespace: knative-eventing
--  labels:
--    eventing.knative.dev/release: devel
--spec:
--  minAvailable: 80%
--  selector:
--    matchLabels:
--      app: kafka-webhook
--
- ---
- # Copyright 2020 The Knative Authors
- #
+ # Webhook PDB.
+ apiVersion: policy/v1beta1
+ kind: PodDisruptionBudget

--- a/knative-operator/hack/007-eventing-kafka-patch-pdb.patch
+++ b/knative-operator/hack/007-eventing-kafka-patch-pdb.patch
@@ -1,13 +1,13 @@
 diff --git a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
-index 8e88d556..d9054745 100644
+index 66a6898d..23ce5efe 100644
 --- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
 +++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
-@@ -971,7 +971,7 @@ metadata:
+@@ -1032,7 +1032,7 @@ metadata:
    labels:
      eventing.knative.dev/release: devel
  spec:
 -  minAvailable: 80%
-+  minAvailable: 1
++  minAvailable: 0
    selector:
      matchLabels:
        app: kafka-webhook

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -37,11 +37,11 @@ function download_kafka {
 
 download_kafka knativekafka "$KNATIVE_EVENTING_KAFKA_VERSION" "${kafka_files[@]}"
 
-# Change the minavailable pdb for kafka-webhook to 1
-#git apply "$root/knative-operator/hack/007-eventing-kafka-pdb.patch"
+# For 1.17 we still skip HPA
+git apply "$root/knative-operator/hack/001-eventing-kafka-remove_hpa.patch"
 
-# For 1.17 we still skip HPA/PDB
-git apply "$root/knative-operator/hack/001-remove_hpa_pdb.patch"
+# SRVKE-919: Change the minavailable pdb for kafka-webhook to 0
+git apply "$root/knative-operator/hack/007-eventing-kafka-patch-pdb.patch"
 
 # The kafka-ch-controller requires DELETE on deployment in OpenShift
 git apply "$root/knative-operator/hack/002-eventing-kafka-ctor-role.patch"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

porting https://github.com/openshift-knative/serverless-operator/pull/1180 to main

/assign @maschmid 