### PR TITLE
Setup deprecation alerts only for OCP >= 4.8

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -302,7 +302,7 @@ function check_serverless_alerts {
 function setup_quick_api_deprecation_alerts {
   local ocp_version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}')
   # Setup deprecation alerts for OCP >= 4.8
-  if $(versions.le $(versions.major_minor $ocp_version) 4.7); then
+  if $(versions.le "$(versions.major_minor "$ocp_version")" 4.7); then
     return
   fi
   logger.info "Setup quick API deprecation alerts"

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -300,9 +300,10 @@ function check_serverless_alerts {
 }
 
 function setup_quick_api_deprecation_alerts {
-  local ocp_version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}')
+  local ocp_version
+  ocp_version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}')
   # Setup deprecation alerts for OCP >= 4.8
-  if $(versions.le "$(versions.major_minor "$ocp_version")" 4.7); then
+  if versions.le "$(versions.major_minor "$ocp_version")" 4.7; then
     return
   fi
   logger.info "Setup quick API deprecation alerts"

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -300,6 +300,11 @@ function check_serverless_alerts {
 }
 
 function setup_quick_api_deprecation_alerts {
+  local ocp_version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}')
+  # Setup deprecation alerts for OCP >= 4.8
+  if $(versions.le $(versions.major_minor $ocp_version) 4.7); then
+    return
+  fi
   logger.info "Setup quick API deprecation alerts"
   for ns in "${OPERATORS_NAMESPACE}" "${EVENTING_NAMESPACE}" "${SERVING_NAMESPACE}" "${INGRESS_NAMESPACE}"; do
     # Reuse the existing api-usage Prometheus rule and only make it react more quickly.


### PR DESCRIPTION
Fixes issues like this one: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.6-e2e-aws-ocp-46-continuous/1437929380566274048