### PR TITLE
Set INGRESS_NAMESPACE to knative-serving when net-istio is used

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -27,6 +27,8 @@ if [[ $TEST_KNATIVE_KAFKA == true ]]; then
 fi
 
 if [[ $FULL_MESH == "true" ]]; then
+  # net-istio does not use knative-serving-ingress namespace.
+  export INGRESS_NAMESPACE="knative-serving"
   UNINSTALL_MESH="false" install_mesh
   ensure_serverless_installed
   enable_net_istio

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -307,7 +307,11 @@ function setup_quick_api_deprecation_alerts {
     return
   fi
   logger.info "Setup quick API deprecation alerts"
-  for ns in "${OPERATORS_NAMESPACE}" "${EVENTING_NAMESPACE}" "${SERVING_NAMESPACE}" "${INGRESS_NAMESPACE}"; do
+  local namespaces="${OPERATORS_NAMESPACE}" "${EVENTING_NAMESPACE}" "${SERVING_NAMESPACE}""
+  if [[ "${SERVING_NAMESPACE}" != "${INGRESS_NAMESPACE}" ]]; then
+    namespaces=""${namespaces}" "{INGRESS_NAMESPACE}""
+  fi
+  for ns in "${namespaces}"; do
     # Reuse the existing api-usage Prometheus rule and only make it react more quickly.
     oc get prometheusrule api-usage -n openshift-kube-apiserver -oyaml | \
       sed -e "s/\(.*name:.*\)/\1-quick/g" \

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -307,9 +307,9 @@ function setup_quick_api_deprecation_alerts {
     return
   fi
   logger.info "Setup quick API deprecation alerts"
-  local namespaces="${OPERATORS_NAMESPACE} ${EVENTING_NAMESPACE} ${SERVING_NAMESPACE}"
+  local namespaces=("${OPERATORS_NAMESPACE}" "${EVENTING_NAMESPACE}" "${SERVING_NAMESPACE}")
   if [[ "${SERVING_NAMESPACE}" != "${INGRESS_NAMESPACE}" ]]; then
-    namespaces="${namespaces} ${INGRESS_NAMESPACE}"
+    namespaces=("${namespaces[@]}" "${INGRESS_NAMESPACE}")
   fi
   for ns in "${namespaces[@]}"; do
     # Reuse the existing api-usage Prometheus rule and only make it react more quickly.

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -307,11 +307,11 @@ function setup_quick_api_deprecation_alerts {
     return
   fi
   logger.info "Setup quick API deprecation alerts"
-  local namespaces="${OPERATORS_NAMESPACE}" "${EVENTING_NAMESPACE}" "${SERVING_NAMESPACE}""
+  local namespaces="${OPERATORS_NAMESPACE} ${EVENTING_NAMESPACE} ${SERVING_NAMESPACE}"
   if [[ "${SERVING_NAMESPACE}" != "${INGRESS_NAMESPACE}" ]]; then
-    namespaces=""${namespaces}" "{INGRESS_NAMESPACE}""
+    namespaces="${namespaces} ${INGRESS_NAMESPACE}"
   fi
-  for ns in "${namespaces}"; do
+  for ns in "${namespaces[@]}"; do
     # Reuse the existing api-usage Prometheus rule and only make it react more quickly.
     oc get prometheusrule api-usage -n openshift-kube-apiserver -oyaml | \
       sed -e "s/\(.*name:.*\)/\1-quick/g" \


### PR DESCRIPTION
This patch fixes a CI error ([log](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.8-e2e-mesh-ocp-48-continuous/1438291633555640320)):
```
Error from server (NotFound): error when creating "STDIN": namespaces "knative-serving-ingress" not found
01:13:35.713 ERROR:   🚨 Error (code: 1) occurred at ./test/lib.bash:316, with command: oc apply -f -
```

Since net-istio does not use `knative-serving-ingress`, the command fails with the default `INGRESS_NAMESPACE`.