### PR TITLE
[UI][SRVCOM-1523] Display JS logs in case of failure

### DIFF
--- a/test/ui/cypress/plugins/index.js
+++ b/test/ui/cypress/plugins/index.js
@@ -24,5 +24,7 @@ module.exports = (on, config) => {
   config.env.OCP_USERNAME = process.env.OCP_USERNAME || 'kube:admin'
   config.env.OCP_PASSWORD = process.env.OCP_PASSWORD
 
+  require('cypress-terminal-report/src/installLogsPrinter')(on)
+
   return config
 }

--- a/test/ui/cypress/support/index.js
+++ b/test/ui/cypress/support/index.js
@@ -9,3 +9,4 @@
 import './commands'
 
 require('@cypress/skip-test/support')
+require('cypress-terminal-report/src/installLogsCollector')()

--- a/test/ui/package-lock.json
+++ b/test/ui/package-lock.json
@@ -539,6 +539,40 @@
         "lodash": "^4.17.15"
       }
     },
+    "cypress-terminal-report": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-3.3.2.tgz",
+      "integrity": "sha512-cEZA7fD6CesJCq1g4cKcQp92yUrDSnPA2NCeMklIWW8IyksKptt9XBZ4Nd9VvKRutABM0uFMom/IfdxAJ7gSQw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "fs-extra": "^9.0.1",
+        "methods": "^1.1.2",
+        "semver": "^7.3.5",
+        "tv4": "^1.3.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1210,6 +1244,12 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
     "mime-db": {
       "version": "1.48.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
@@ -1771,6 +1811,12 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "tv4": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM=",
+      "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/test/ui/package.json
+++ b/test/ui/package.json
@@ -13,6 +13,7 @@
     "chalk": "^4.1.1",
     "cypress": "^7.7.0",
     "cypress-multi-reporters": "^1.5.0",
+    "cypress-terminal-report": "^3.3.2",
     "diff": "^5.0.0",
     "mocha": "^9.0.2",
     "mocha-junit-reporter": "^2.0.0",


### PR DESCRIPTION
Fixes [SRVCOM-1523](https://issues.redhat.com/browse/SRVCOM-1523).

To pinpoint UI failures, especially those flaky, logs of the DevConsole application could be extremely handy.

That could be backed by analysis outcome on [BZ #2002273 comment no. 6](https://bugzilla.redhat.com/show_bug.cgi?id=2002273#c6)