### PR TITLE
Fail fast in upgrades

### DIFF
--- a/test/subscription.go
+++ b/test/subscription.go
@@ -137,5 +137,5 @@ func ImageFromCSV(ctx *Context, csvName, csvNamespace, imageName string) (string
 			return img.Image, nil
 		}
 	}
-	return "", fmt.Errorf("unable to find image for %s in CSV relatedImages", imageName)
+	return "", fmt.Errorf("unable to find image for %s in CSV relatedImages: %+v", imageName, csv)
 }

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -35,7 +35,7 @@ func UpgradeServerless(ctx *test.Context) error {
 		knativeServing,
 		v1a1test.IsKnativeServingWithVersionReady(strings.TrimPrefix(test.Flags.ServingVersion, "v")),
 	); err != nil {
-		ctx.T.Error("Serving upgrade failed:", err)
+		return fmt.Errorf("serving upgrade failed: %w", err)
 	}
 
 	knativeEventing := "knative-eventing"
@@ -44,7 +44,7 @@ func UpgradeServerless(ctx *test.Context) error {
 		knativeEventing,
 		v1a1test.IsKnativeEventingWithVersionReady(strings.TrimPrefix(test.Flags.EventingVersion, "v")),
 	); err != nil {
-		ctx.T.Error("Eventing upgrade failed:", err)
+		return fmt.Errorf("eventing upgrade failed: %w", err)
 	}
 
 	// KnativeKafka doesn't provide the version to wait for. Choosing a well-known image and
@@ -54,7 +54,7 @@ func UpgradeServerless(ctx *test.Context) error {
 		test.OperatorsNamespace,
 		"kafka-webhook")
 	if err != nil {
-		ctx.T.Error(err)
+		return err
 	}
 
 	if err = WaitForPodsWithImage(ctx,
@@ -62,7 +62,7 @@ func UpgradeServerless(ctx *test.Context) error {
 		"app=kafka-webhook",
 		"kafka-webhook",
 		kafkaWebhookImage); err != nil {
-		ctx.T.Error(err)
+		return err
 	}
 
 	if _, err := v1a1test.WaitForKnativeKafkaState(ctx,
@@ -70,7 +70,7 @@ func UpgradeServerless(ctx *test.Context) error {
 		knativeEventing,
 		v1a1test.IsKnativeKafkaReady,
 	); err != nil {
-		ctx.T.Error("KnativeKafka upgrade failed:", err)
+		return fmt.Errorf("knative kafka upgrade failed: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Make the failure in https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.6-upgrade-tests-aws-ocp-46-continuous/1438835182139346944 more obvious