### PR TITLE
Get kafka-image for upgrades from CSV deployment spec

### DIFF
--- a/test/subscription.go
+++ b/test/subscription.go
@@ -141,5 +141,5 @@ func ImageFromCSV(ctx *Context, csvName, csvNamespace, imageName string) (string
 			}
 		}
 	}
-	return "", fmt.Errorf("unable to find image for %s in CSV relatedImages: %+v", imageName, csv)
+	return "", fmt.Errorf("unable to find image for %s in CSV deployment specs: %+v", imageName, csv)
 }

--- a/test/subscription.go
+++ b/test/subscription.go
@@ -135,7 +135,7 @@ func ImageFromCSV(ctx *Context, csvName, csvNamespace, imageName string) (string
 	for _, d := range csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
 		for _, c := range d.Spec.Template.Spec.Containers {
 			for _, e := range c.Env {
-				if strings.Contains(e.Name, imageName) {
+				if strings.Contains(e.Name, imageName) && strings.Contains(e.Name, "IMAGE") {
 					return e.Value, nil
 				}
 			}

--- a/test/subscription.go
+++ b/test/subscription.go
@@ -132,9 +132,13 @@ func ImageFromCSV(ctx *Context, csvName, csvNamespace, imageName string) (string
 	if err != nil {
 		return "", err
 	}
-	for _, img := range csv.Spec.RelatedImages {
-		if strings.Contains(img.Name, imageName) {
-			return img.Image, nil
+	for _, d := range csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
+		for _, c := range d.Spec.Template.Spec.Containers {
+			for _, e := range c.Env {
+				if strings.Contains(e.Name, imageName) {
+					return e.Value, nil
+				}
+			}
 		}
 	}
 	return "", fmt.Errorf("unable to find image for %s in CSV relatedImages: %+v", imageName, csv)


### PR DESCRIPTION
The relatedImages section is empty when read back by the CSV API. Need to use a different way.