### PR TITLE
Add KnativeKafka version to it's status and assert after upgrade

### DIFF
--- a/knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
+++ b/knative-operator/deploy/crds/operator_v1alpha1_knativekafka_crd.yaml
@@ -117,7 +117,13 @@ spec:
                   that was last processed by the controller.
                 format: int64
                 type: integer
+              version:
+                description: The version of the installed release
+                type: string
     additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
     - name: Ready
       type: string
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"

--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
@@ -26,6 +26,10 @@ type KnativeKafkaSpec struct {
 // +k8s:openapi-gen=true
 type KnativeKafkaStatus struct {
 	duckv1.Status `json:",inline"`
+
+	// The version of the installed release
+	// +optional
+	Version string `json:"version,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -273,6 +273,7 @@ func (r *ReconcileKnativeKafka) apply(manifest *mf.Manifest, instance *operatorv
 		return fmt.Errorf("failed to apply non rbac manifest: %w", err)
 	}
 	instance.Status.MarkInstallSucceeded()
+	instance.Status.Version = os.Getenv("KNATIVE_EVENTING_KAFKA_VERSION")
 	return nil
 }
 

--- a/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
+++ b/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
@@ -126,7 +126,13 @@ spec:
                   that was last processed by the controller.
                 format: int64
                 type: integer
+              version:
+                description: The version of the installed release
+                type: string
     additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
     - name: Ready
       type: string
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -624,6 +624,8 @@ spec:
                         value: "registry.ci.openshift.org/openshift/knative-v0.25.3:knative-eventing-kafka-consolidated-dispatcher"
                       - name: "KAFKA_IMAGE_kafka-webhook__kafka-webhook"
                         value: "registry.ci.openshift.org/openshift/knative-v0.25.3:knative-eventing-kafka-webhook"
+                      - name: "KNATIVE_EVENTING_KAFKA_VERSION"
+                        value: "0.25.3"
                     securityContext:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: true

--- a/test/flags.go
+++ b/test/flags.go
@@ -21,6 +21,7 @@ type FlagsStruct struct {
 	CSV                   string // Target CSV for upgrades
 	ServingVersion        string // Target Serving version for upgrades
 	EventingVersion       string // Target Eventing version for upgrades
+	KafkaVersion          string // Target Kafka version for upgrades
 	OpenShiftImage        string // Target OpenShift image for upgrades
 	UpgradeOpenShift      bool   // Whether to upgrade the OpenShift cluster
 	SkipServingPreUpgrade bool   // Whether to skip Serving pre-upgrade tests
@@ -49,6 +50,8 @@ func initializeFlags() *FlagsStruct {
 		"Target Serving version for upgrade tests, empty by default.")
 	flag.StringVar(&f.EventingVersion, "eventingversion", "",
 		"Target Eventing version for upgrade tests, empty by default.")
+	flag.StringVar(&f.KafkaVersion, "kafkaversion", "",
+		"Target Kafka version for upgrade tests, empty by default.")
 	flag.StringVar(&f.OpenShiftImage, "openshiftimage", "",
 		"Target OpenShift image for cluster upgrades, empty by default.")
 	flag.BoolVar(&f.UpgradeOpenShift, "upgradeopenshift", false,

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -221,6 +221,7 @@ function run_rolling_upgrade_tests {
     --csv="${CURRENT_CSV}" \
     --servingversion="${KNATIVE_SERVING_VERSION}" \
     --eventingversion="${KNATIVE_EVENTING_VERSION}" \
+    --kafkaversion="${KNATIVE_EVENTING_KAFKA_VERSION}" \
     --openshiftimage="${UPGRADE_OCP_IMAGE}" \
     --resolvabledomain
 

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -47,28 +47,10 @@ func UpgradeServerless(ctx *test.Context) error {
 		return fmt.Errorf("eventing upgrade failed: %w", err)
 	}
 
-	// KnativeKafka doesn't provide the version to wait for. Choosing a well-known image and
-	// waiting for all pods to be updated to this image before proceeding.
-	kafkaWebhookImage, err := test.ImageFromCSV(ctx,
-		test.Flags.CSV,
-		test.OperatorsNamespace,
-		"kafka-webhook")
-	if err != nil {
-		return err
-	}
-
-	if err = WaitForPodsWithImage(ctx,
-		knativeEventing,
-		"app=kafka-webhook",
-		"kafka-webhook",
-		kafkaWebhookImage); err != nil {
-		return err
-	}
-
 	if _, err := v1a1test.WaitForKnativeKafkaState(ctx,
 		"knative-kafka",
 		knativeEventing,
-		v1a1test.IsKnativeKafkaReady,
+		v1a1test.IsKnativeKafkaWithVersionReady(strings.TrimPrefix(test.Flags.KafkaVersion, "v")),
 	); err != nil {
 		return fmt.Errorf("knative kafka upgrade failed: %w", err)
 	}

--- a/test/v1alpha1/knativekafka.go
+++ b/test/v1alpha1/knativekafka.go
@@ -90,7 +90,7 @@ func WaitForKnativeKafkaState(ctx *test.Context, name, namespace string, inState
 		err       error
 	)
 	waitErr := wait.PollImmediate(test.Interval, test.Timeout, func() (bool, error) {
-		lastState := &kafkav1alpha1.KnativeKafka{}
+		lastState = &kafkav1alpha1.KnativeKafka{}
 		var u *unstructured.Unstructured
 		u, err = ctx.Clients.Dynamic.Resource(kafkav1alpha1.SchemeGroupVersion.WithResource("knativekafkas")).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {

--- a/test/v1alpha1/knativekafka.go
+++ b/test/v1alpha1/knativekafka.go
@@ -84,7 +84,7 @@ func DeleteKnativeKafka(ctx *test.Context, name, namespace string) error {
 	return err
 }
 
-func WaitForKnativeKafkaState(ctx *test.Context, name, namespace string, inState func(s *kafkav1alpha1.KnativeKafka, err error) (bool, error)) (*kafkav1alpha1.KnativeKafka, error) {
+func WaitForKnativeKafkaState(ctx *test.Context, name, namespace string, inState KafkaInStateFunc) (*kafkav1alpha1.KnativeKafka, error) {
 	var (
 		lastState *kafkav1alpha1.KnativeKafka
 		err       error
@@ -108,4 +108,12 @@ func WaitForKnativeKafkaState(ctx *test.Context, name, namespace string, inState
 
 func IsKnativeKafkaReady(s *kafkav1alpha1.KnativeKafka, err error) (bool, error) {
 	return s.Status.IsReady(), err
+}
+
+type KafkaInStateFunc func(k *kafkav1alpha1.KnativeKafka, err error) (bool, error)
+
+func IsKnativeKafkaWithVersionReady(version string) KafkaInStateFunc {
+	return func(k *kafkav1alpha1.KnativeKafka, err error) (bool, error) {
+		return k.Status.Version == version && k.Status.IsReady(), err
+	}
 }


### PR DESCRIPTION
As per title, we've been having trouble figuring out when Knative Kafka would be upgraded and worked around it not surfacing a version by deep-checking the cluster's state.
This makes KnativeKafka be on-par with serving and eventing by surfacing its version itself so we can wait for that signal.