### PR TITLE
Bump operator reference to 0.25.2

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -29,4 +29,4 @@ dependencies:
   eventing: 0.24.0
   eventing_kafka: 0.24.3
   cli: 0.24.0
-  operator: 0.24.0
+  operator: 0.25.2


### PR DESCRIPTION
Just for completeness. Seems like the CRDs didn't change at all, but the reference should still be correct.

/assign @devguyio 