### PR TITLE
Retry common infra-related issues when checking CLI binaries

### DIFF
--- a/test/servinge2e/verify_deploy_resources_test.go
+++ b/test/servinge2e/verify_deploy_resources_test.go
@@ -6,9 +6,12 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openshift-knative/serverless-operator/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/test/spoof"
 )
 
 func TestKnConsoleCLIDownload(t *testing.T) {
@@ -28,12 +31,14 @@ func TestKnConsoleCLIDownload(t *testing.T) {
 		if !strings.HasPrefix(link.Href, "https://") {
 			t.Fatalf("incorrect href found for kn CCD, expecting prefix %q, found link %q", "https://", link.Href)
 		}
-		client := &http.Client{Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, // OCP clusters have self-signed certs by default.
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true, // OCP clusters have self-signed certs by default.
+				},
 			},
-		}}
-		h, err := client.Head(link.Href)
+		}
+		h, err := retryingHead(t, client, link.Href)
 		if err != nil {
 			t.Fatalf("Failed to perform a HEAD request for URL %q, error: %v", link.Href, err)
 		}
@@ -41,4 +46,25 @@ func TestKnConsoleCLIDownload(t *testing.T) {
 			t.Errorf("Failed to verify kn CCD, kn artifact %q size %d less than 10MB", link.Href, h.ContentLength)
 		}
 	}
+}
+
+func retryingHead(t *testing.T, client *http.Client, url string) (*http.Response, error) {
+	var h *http.Response
+	if err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+		var err error
+		h, err = client.Head(url)
+		if err != nil {
+			retry, newErr := spoof.DefaultErrorRetryChecker(err)
+			if retry {
+				t.Logf("Retrying %s: %v", url, newErr)
+				return false, nil
+			}
+			t.Logf("NOT Retrying %s: %v", url, err)
+			return true, err
+		}
+		return true, nil
+	}); err != nil {
+		return nil, err
+	}
+	return h, nil
 }


### PR DESCRIPTION
As per title, this avoids unnecessary failures like https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.6-e2e-aws-ocp-46-continuous/1442459020324507648