### PR TITLE
[SRVKS-550] Set termination policy to OCP Route based on HTTPOption

### DIFF
--- a/serving/ingress/pkg/reconciler/ingress/resources/route.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route.go
@@ -111,6 +111,11 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 		return nil, ErrNoValidLoadbalancerDomain
 	}
 
+	terminationPolicy := routev1.InsecureEdgeTerminationPolicyAllow
+	if ci.Spec.HTTPOption == networkingv1alpha1.HTTPOptionRedirected {
+		terminationPolicy = routev1.InsecureEdgeTerminationPolicyRedirect
+	}
+
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -130,7 +135,7 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 			},
 			TLS: &routev1.TLSConfig{
 				Termination:                   routev1.TLSTerminationEdge,
-				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
+				InsecureEdgeTerminationPolicy: terminationPolicy,
 			},
 			WildcardPolicy: routev1.WildcardPolicyNone,
 		},

--- a/serving/ingress/pkg/reconciler/ingress/resources/route.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route.go
@@ -119,7 +119,7 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 	// TODO: Remove this annotation handling after serving 0.26+.
 	// Ingress configures the HTTPOption based on the annotation.
 	// https://github.com/knative/serving/commit/d9c1342b5761afdac88c563535885e37fae27c7e
-	if len(annotations) != 0 && annotations[networking.HTTPOptionAnnotationKey] != "" {
+	if annotations[networking.HTTPOptionAnnotationKey] != "" {
 		annotation := annotations[networking.HTTPOptionAnnotationKey]
 		switch strings.ToLower(annotation) {
 		case "enabled":
@@ -127,7 +127,7 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 		case "redirected":
 			terminationPolicy = routev1.InsecureEdgeTerminationPolicyRedirect
 		default:
-			return nil, fmt.Errorf("incorrect HTTPOption annotation:" + annotation)
+			return nil, fmt.Errorf("incorrect HTTPOption annotation: " + annotation)
 		}
 	}
 

--- a/serving/ingress/pkg/reconciler/ingress/resources/route.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route.go
@@ -116,6 +116,21 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 		terminationPolicy = routev1.InsecureEdgeTerminationPolicyRedirect
 	}
 
+	// TODO: Remove this annotation handling after serving 0.26+.
+	// Ingress configures the HTTPOption based on the annotation.
+	// https://github.com/knative/serving/commit/d9c1342b5761afdac88c563535885e37fae27c7e
+	if len(annotations) != 0 && annotations[networking.HTTPOptionAnnotationKey] != "" {
+		annotation := annotations[networking.HTTPOptionAnnotationKey]
+		switch strings.ToLower(annotation) {
+		case "enabled":
+			terminationPolicy = routev1.InsecureEdgeTerminationPolicyAllow
+		case "redirected":
+			terminationPolicy = routev1.InsecureEdgeTerminationPolicyRedirect
+		default:
+			return nil, fmt.Errorf("incorrect HTTPOption annotation:" + annotation)
+		}
+	}
+
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,

--- a/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
@@ -331,6 +331,87 @@ func TestMakeRoute(t *testing.T) {
 				},
 			}},
 		},
+		{
+			name: "valid, http redirect option by annotation",
+			ingress: ingress(
+				withRules(rule(withHosts([]string{localDomain, externalDomain}))),
+				withHTTPOptionAnnotation("redirected"),
+			),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						networking.IngressLabelKey:        "ingress",
+						serving.RouteLabelKey:             "route1",
+						serving.RouteNamespaceLabelKey:    "default",
+						OpenShiftIngressLabelKey:          "ingress",
+						OpenShiftIngressNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation:                   DefaultTimeout,
+						"networking.knative.dev/httpOption": "redirected",
+					},
+					Namespace: lbNamespace,
+					Name:      routeName0,
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain,
+					To: routev1.RouteTargetReference{
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString(HTTPPort),
+					},
+					TLS: &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationEdge,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
+				},
+			}},
+		},
+		{
+			name: "valid, http enabled option by annotation over global option",
+			ingress: ingress(
+				withRules(rule(withHosts([]string{localDomain, externalDomain}))),
+				withRedirect(),
+				withHTTPOptionAnnotation("enabled"),
+			),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						networking.IngressLabelKey:        "ingress",
+						serving.RouteLabelKey:             "route1",
+						serving.RouteNamespaceLabelKey:    "default",
+						OpenShiftIngressLabelKey:          "ingress",
+						OpenShiftIngressNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation:                   DefaultTimeout,
+						"networking.knative.dev/httpOption": "enabled",
+					},
+					Namespace: lbNamespace,
+					Name:      routeName0,
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain,
+					To: routev1.RouteTargetReference{
+						Kind:   "Service",
+						Name:   lbService,
+						Weight: ptr.Int32(100),
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString(HTTPPort),
+					},
+					TLS: &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationEdge,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
+					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
+				},
+			}},
+		},
 	}
 
 	for _, test := range tests {
@@ -404,6 +485,18 @@ func withRules(rules ...networkingv1alpha1.IngressRule) ingressOption {
 func withRedirect() ingressOption {
 	return func(ing *networkingv1alpha1.Ingress) {
 		ing.Spec.HTTPOption = networkingv1alpha1.HTTPOptionRedirected
+	}
+}
+
+func withHTTPOptionAnnotation(httpOpt string) ingressOption {
+	return func(ing *networkingv1alpha1.Ingress) {
+		ing.Spec.HTTPOption = networkingv1alpha1.HTTPOptionRedirected
+		annos := ing.GetAnnotations()
+		if annos == nil {
+			annos = map[string]string{}
+		}
+		annos[networking.HTTPOptionAnnotationKey] = httpOpt
+		ing.SetAnnotations(annos)
 	}
 }
 

--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -48,10 +48,8 @@ func TestKnativeServiceHTTPRedirect(t *testing.T) {
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
 	defer test.CleanupAll(t, caCtx)
 
-	ksvc, err := test.WithServiceReady(caCtx, "https-service", testNamespace, image)
-	if err != nil {
-		t.Fatal("Knative Service not ready", err)
-	}
+	ksvc := test.Service("redirect-service", testNamespace, image, map[string]string{"networking.knative.dev/httpOption": "redirected"})
+	ksvc = withServiceReadyOrFail(caCtx, ksvc)
 
 	// Implicitly checks that HTTPS works.
 	servinge2e.WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)

--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -2,6 +2,7 @@ package kourier
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
@@ -39,4 +40,39 @@ func TestKnativeServiceHTTPS(t *testing.T) {
 		t.Fatalf("The Route at domain %s didn't serve the expected text %q: %v", httpURL, helloworldText, err)
 	}
 
+}
+
+func TestKnativeServiceHTTPRedirect(t *testing.T) {
+
+	caCtx := test.SetupClusterAdmin(t)
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
+	defer test.CleanupAll(t, caCtx)
+
+	ksvc, err := test.WithServiceReady(caCtx, "https-service", testNamespace, image)
+	if err != nil {
+		t.Fatal("Knative Service not ready", err)
+	}
+
+	// Implicitly checks that HTTPS works.
+	servinge2e.WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
+
+	// Now check HTTP request.
+	httpURL := ksvc.Status.URL.DeepCopy()
+	httpURL.Scheme = "http"
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Do not follow redirect.
+			return http.ErrUseLastResponse
+		},
+	}
+
+	t.Log("Requesting", httpURL.String())
+	resp, err := client.Get(httpURL.String())
+	if err != nil {
+		t.Fatalf("Request to %v failed, err: %v", httpURL, err)
+	}
+	if resp.StatusCode != http.StatusMovedPermanently {
+		t.Fatalf("The Route at domain %s didn't serve the expected status code got=%v, want=%v", httpURL, resp.StatusCode, http.StatusMovedPermanently)
+	}
 }

--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -71,7 +71,7 @@ func TestKnativeServiceHTTPRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Request to %v failed, err: %v", httpURL, err)
 	}
-	if resp.StatusCode != http.StatusMovedPermanently {
-		t.Fatalf("The Route at domain %s didn't serve the expected status code got=%v, want=%v", httpURL, resp.StatusCode, http.StatusMovedPermanently)
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("The Route at domain %s didn't serve the expected status code got=%v, want=%v", httpURL, resp.StatusCode, http.StatusFound)
 	}
 }

--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -48,7 +48,8 @@ func TestKnativeServiceHTTPRedirect(t *testing.T) {
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
 	defer test.CleanupAll(t, caCtx)
 
-	ksvc := test.Service("redirect-service", testNamespace, image, map[string]string{"networking.knative.dev/httpOption": "redirected"})
+	ksvc := test.Service("redirect-service", testNamespace, image, nil)
+	ksvc.ObjectMeta.Annotations = map[string]string{"networking.knative.dev/httpOption": "redirected"}
 	ksvc = withServiceReadyOrFail(caCtx, ksvc)
 
 	// Implicitly checks that HTTPS works.

--- a/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
+++ b/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
@@ -52,3 +52,5 @@ spec:
     tracing:
       backend: "none"
       sample-rate: "0.1"
+    network:
+      httpProtocol: "Redirected"

--- a/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
+++ b/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
@@ -52,5 +52,3 @@ spec:
     tracing:
       backend: "none"
       sample-rate: "0.1"
-    network:
-      httpProtocol: "Redirected"


### PR DESCRIPTION
This patch sets termination policy to OCP Route based on ingress's `Spec.HTTPOption`.

Also, it sets `httpProtocol` in config-network to `Redirected`. (I expect some test in
`test/servinge2e/kourier` fail but other test pass.)