### PR TITLE
Use actual certs instead of skip insecure

### DIFF
--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -17,9 +17,6 @@ const (
 	helloworldService2    = "helloworld-go2"
 	kubeHelloworldService = "kube-helloworld-go"
 	helloworldText        = "Hello World!"
-
-	caSecretNamespace = "cert-manager"
-	caSecretName      = "ca-key-pair"
 )
 
 func WaitForRouteServingText(t *testing.T, caCtx *test.Context, routeURL *url.URL, expectedText string) {

--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -44,13 +44,6 @@ func WaitForRouteServingText(t *testing.T, caCtx *test.Context, routeURL *url.UR
 	}
 }
 
-func insecureSkipVerify() spoof.TransportOption {
-	return func(transport *http.Transport) *http.Transport {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-		return transport
-	}
-}
-
 // addRootCAtoTransport returns TransportOption when HTTPS option is true. Otherwise it returns plain spoof.TransportOption.
 func addRootCAtoTransport(ctx context.Context, logf logging.FormatLogger, clients *test.Clients) spoof.TransportOption {
 	return func(transport *http.Transport) *http.Transport {

--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -2,18 +2,12 @@ package servinge2e
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"net/http"
 	"net/url"
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgTest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/logging"
-	"knative.dev/pkg/test/spoof"
+	servingTest "knative.dev/serving/test"
 )
 
 const (
@@ -38,38 +32,8 @@ func WaitForRouteServingText(t *testing.T, caCtx *test.Context, routeURL *url.UR
 		pkgTest.EventuallyMatchesBody(expectedText),
 		"WaitForRouteToServeText",
 		true,
-		addRootCAtoTransport(context.Background(), t.Logf, caCtx.Clients),
+		servingTest.AddRootCAtoTransport(context.Background(), t.Logf, &servingTest.Clients{KubeClient: caCtx.Clients.Kube}, true),
 	); err != nil {
 		t.Fatalf("The Route at domain %s didn't serve the expected text \"%s\": %v", routeURL, expectedText, err)
 	}
-}
-
-// addRootCAtoTransport returns TransportOption when HTTPS option is true. Otherwise it returns plain spoof.TransportOption.
-func addRootCAtoTransport(ctx context.Context, logf logging.FormatLogger, clients *test.Clients) spoof.TransportOption {
-	return func(transport *http.Transport) *http.Transport {
-		transport.TLSClientConfig = TLSClientConfig(ctx, logf, clients)
-		return transport
-	}
-}
-
-func TLSClientConfig(ctx context.Context, logf logging.FormatLogger, clients *test.Clients) *tls.Config {
-	rootCAs, _ := x509.SystemCertPool()
-	if rootCAs == nil {
-		rootCAs = x509.NewCertPool()
-	}
-	if !rootCAs.AppendCertsFromPEM(PemDataFromSecret(ctx, logf, clients, caSecretNamespace, caSecretName)) {
-		logf("Failed to add the certificate to the root CA")
-	}
-	return &tls.Config{RootCAs: rootCAs}
-}
-
-// PemDataFromSecret gets pem data from secret.
-func PemDataFromSecret(ctx context.Context, logf logging.FormatLogger, clients *test.Clients, ns, secretName string) []byte {
-	secret, err := clients.Kube.CoreV1().Secrets(ns).Get(
-		ctx, secretName, metav1.GetOptions{})
-	if err != nil {
-		logf("Failed to get Secret %s: %v", secretName, err)
-		return []byte{}
-	}
-	return secret.Data[corev1.TLSCertKey]
 }

--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -3,12 +3,16 @@ package servinge2e
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"net/http"
 	"net/url"
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/spoof"
 )
 
@@ -19,6 +23,9 @@ const (
 	helloworldService2    = "helloworld-go2"
 	kubeHelloworldService = "kube-helloworld-go"
 	helloworldText        = "Hello World!"
+
+	caSecretNamespace = "cert-manager"
+	caSecretName      = "ca-key-pair"
 )
 
 func WaitForRouteServingText(t *testing.T, caCtx *test.Context, routeURL *url.URL, expectedText string) {
@@ -31,7 +38,7 @@ func WaitForRouteServingText(t *testing.T, caCtx *test.Context, routeURL *url.UR
 		pkgTest.EventuallyMatchesBody(expectedText),
 		"WaitForRouteToServeText",
 		true,
-		insecureSkipVerify(),
+		addRootCAtoTransport(context.Background(), t.Logf, caCtx.Clients),
 	); err != nil {
 		t.Fatalf("The Route at domain %s didn't serve the expected text \"%s\": %v", routeURL, expectedText, err)
 	}
@@ -42,4 +49,34 @@ func insecureSkipVerify() spoof.TransportOption {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		return transport
 	}
+}
+
+// addRootCAtoTransport returns TransportOption when HTTPS option is true. Otherwise it returns plain spoof.TransportOption.
+func addRootCAtoTransport(ctx context.Context, logf logging.FormatLogger, clients *test.Clients) spoof.TransportOption {
+	return func(transport *http.Transport) *http.Transport {
+		transport.TLSClientConfig = TLSClientConfig(ctx, logf, clients)
+		return transport
+	}
+}
+
+func TLSClientConfig(ctx context.Context, logf logging.FormatLogger, clients *test.Clients) *tls.Config {
+	rootCAs, _ := x509.SystemCertPool()
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+	if !rootCAs.AppendCertsFromPEM(PemDataFromSecret(ctx, logf, clients, caSecretNamespace, caSecretName)) {
+		logf("Failed to add the certificate to the root CA")
+	}
+	return &tls.Config{RootCAs: rootCAs}
+}
+
+// PemDataFromSecret gets pem data from secret.
+func PemDataFromSecret(ctx context.Context, logf logging.FormatLogger, clients *test.Clients, ns, secretName string) []byte {
+	secret, err := clients.Kube.CoreV1().Secrets(ns).Get(
+		ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		logf("Failed to get Secret %s: %v", secretName, err)
+		return []byte{}
+	}
+	return secret.Data[corev1.TLSCertKey]
 }

--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -31,6 +31,6 @@ func WaitForRouteServingText(t *testing.T, caCtx *test.Context, routeURL *url.UR
 		true,
 		servingTest.AddRootCAtoTransport(context.Background(), t.Logf, &servingTest.Clients{KubeClient: caCtx.Clients.Kube}, true),
 	); err != nil {
-		t.Fatalf("The Route at domain %s didn't serve the expected text \"%s\": %v", routeURL, expectedText, err)
+		t.Fatalf("The Route at domain %s didn't serve the expected text %q: %v", routeURL, expectedText, err)
 	}
 }

--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -1,10 +1,6 @@
 package kourier
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"io/ioutil"
-	"net/http"
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
@@ -22,46 +18,13 @@ func TestKnativeServiceHTTPS(t *testing.T) {
 		t.Fatal("Knative Service not ready", err)
 	}
 
-	// Implicitly checks that HTTP works.
+	// Checks that HTTPS works.
 	servinge2e.WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
 
-	// Now check that HTTPS works.
+	// Now check that HTTP works.
 	httpsURL := ksvc.Status.URL.DeepCopy()
-	httpsURL.Scheme = "https"
 
-	// First, download the cert from the host so we can trust it later.
-	conn, err := tls.Dial("tcp", httpsURL.Host+":443", &tls.Config{
-		InsecureSkipVerify: true,
-	})
-	if err != nil {
-		t.Fatal("Failed to connect to download certificate", err)
-	}
-	defer conn.Close()
-
-	// Add the cert to our cert pool, so it's trusted.
-	certPool, err := x509.SystemCertPool()
-	if err != nil {
-		t.Fatal("Failed to load system cert pool", err)
-	}
-	for _, cert := range conn.ConnectionState().PeerCertificates {
-		certPool.AddCert(cert)
-	}
-
-	client := &http.Client{Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{
-			RootCAs: certPool,
-		},
-	}}
-	t.Log("Requesting", httpsURL.String())
-	resp, err := client.Get(httpsURL.String())
-	if err != nil {
-		t.Fatalf("Request to %v failed, err: %v", httpsURL, err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			t.Error("Failed to read body", err)
-		}
-		t.Fatalf("Response failed, status %v, body %v", resp.StatusCode, string(body))
-	}
+	httpsURL.Scheme = "http"
+	// Implicitly checks that HTTP works.
+	servinge2e.WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
 }


### PR DESCRIPTION
Current downstream kourier tests HTTPS with skip insecure.
But now the certs are prepared by `trust_router_ca()` so we can use it.
