### PR TITLE
Download zipkin from Github's container registry

### DIFF
--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: docker.io/openzipkin/zipkin:latest
+        image: ghcr.io/openzipkin/zipkin:2
         ports:
         - containerPort: 9411
         env:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

as per title... to avoid DockerHub limit problems.

/assign @cardil 