### PR TITLE
[main] Roll in the Eventing-Kafka patch for 857

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
@@ -677,8 +677,6 @@ spec:
             status:
               description: Status represents the current state of the KafkaChannel. This data may be out of date.
               type: object
-              required:
-                - address
               properties:
                 address:
                   type: object

--- a/knative-operator/hack/009-remove-required-address.patch
+++ b/knative-operator/hack/009-remove-required-address.patch
@@ -1,0 +1,13 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+index e5b3a080..30f38397 100644
+--- a/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
++++ b/knative-operator/deploy/resources/knativekafka/1-channel-consolidated.yaml
+@@ -677,8 +677,6 @@ spec:
+             status:
+               description: Status represents the current state of the KafkaChannel. This data may be out of date.
+               type: object
+-              required:
+-                - address
+               properties:
+                 address:
+                   type: object

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -48,3 +48,7 @@ git apply "$root/knative-operator/hack/002-eventing-kafka-ctor-role.patch"
 
 # Will be no longer needed with SRVKE-812
 git apply "$root/knative-operator/hack/008-keep-old-config-as-default.patch"
+
+# For 1.20 this patch is no longer needed, since it is available upstream.
+# See original upstream PR: https://github.com/knative-sandbox/eventing-kafka/pull/857
+git apply "$root/knative-operator/hack/009-remove-required-address.patch"


### PR DESCRIPTION
Applying one more patch on the `KafkaChannel` manifest that we ship via product.

Reason: Yaml change in here: https://github.com/knative-sandbox/eventing-kafka/pull/857

/assign @aliok 