### PR TITLE
Add new label to show grafana dashboards in ODC

### DIFF
--- a/knative-operator/deploy/resources/dashboards/serving/grafana-dash-knative-serving-queue-proxy.yaml
+++ b/knative-operator/deploy/resources/dashboards/serving/grafana-dash-knative-serving-queue-proxy.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-config-managed
   labels:
     console.openshift.io/dashboard: "true"
+    console.openshift.io/odc-dashboard: "true"
 data:
   queue-proxy-dashboard.json: |+
     {

--- a/knative-operator/deploy/resources/dashboards/serving/grafana-dash-knative-serving-resources.yaml
+++ b/knative-operator/deploy/resources/dashboards/serving/grafana-dash-knative-serving-resources.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-config-managed
   labels:
     console.openshift.io/dashboard: "true"
+    console.openshift.io/odc-dashboard: "true"
 data:
   resource-dashboard.json: |+
     {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ODC-6340 similar to https://github.com/openshift/cluster-monitoring-operator/pull/1294 by adding a new `console.openshift.io/odc-dashboard` label to two grafana dashboards (ConfigMaps).

This label was already observed by the OpenShift developer console. With this change ODC shows these dashboards in the "Observe" navigation entry as dropdown like this:

![image](https://user-images.githubusercontent.com/139310/136555990-80531b2f-3236-4457-ad49-43c9663cfc20.png)

(Tested this by adding the labels manually on a cluster to the ConfigMaps.)