### PR TITLE
Wait for cert-manager ns to be created

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -456,5 +456,6 @@ function trust_router_ca() {
   certs=$(mktemp -d)
   oc -n openshift-config-managed get cm default-ingress-cert --template="{{index .data \"ca-bundle.crt\"}}" > "$certs/tls.crt"
   oc get ns $certns || oc create namespace $certns
+  timeout 30 "[[ \$(oc get ns $certns --no-headers | wc -l) != 1 ]]"
   oc -n $certns get secret $certname || oc -n $certns create secret generic $certname --from-file=tls.crt="$certs/tls.crt"
 }


### PR DESCRIPTION
* Prevents errors such as this one which happens in OpenShift Dedicated
cluster:
INFO    14:22:22.175 Setting up cert-manager/ca-key-pair secret to trust
router CA
Error from server (NotFound): namespaces "cert-manager" not found
namespace/cert-manager created
Error from server (NotFound): secrets "ca-key-pair" not found
secret/ca-key-pair created