### PR TITLE
Log prometheus API errors but not fail

### DIFF
--- a/test/monitoringe2e/helpers.go
+++ b/test/monitoringe2e/helpers.go
@@ -112,7 +112,7 @@ func VerifyHealthStatusMetric(caCtx *test.Context, label string, expectedValue s
 	if err := wait.PollImmediate(test.Interval, prometheusTargetTimeout, func() (bool, error) {
 		value, _, err := pc.Query(context.Background(), fmt.Sprintf(`knative_up{type="%s"}`, label), time.Time{})
 		if err != nil {
-			caCtx.T.Log("Error:", err)
+			caCtx.T.Log("Error querying prometheus metrics:", err)
 			return false, nil
 		}
 
@@ -143,7 +143,7 @@ func VerifyMetrics(caCtx *test.Context, metricQueries []string) error {
 		if err := wait.PollImmediate(test.Interval, prometheusTargetTimeout, func() (bool, error) {
 			value, _, err := pc.Query(context.Background(), metric, time.Time{})
 			if err != nil {
-				caCtx.T.Log("Error:", err)
+				caCtx.T.Log("Error querying prometheus metrics:", err)
 				return false, nil
 			}
 			return value.Type() == prommodel.ValVector, nil


### PR DESCRIPTION
Account for Prometheus startup time.
The test will fail after expiring the timeout anyway.