### PR TITLE
Add errorlint to golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,7 @@ run:
 linters:
   enable:
     - asciicheck
+    - errorlint
     - gofmt
     - goimports
     - gosec

--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -130,7 +130,7 @@ func main() {
 		// signal handling so the process can just tear it down with it.
 		log.Info("Serving CLI artifacts on :8080")
 		http.Handle("/", http.FileServer(http.Dir("/cli-artifacts")))
-		if err := http.ListenAndServe(":8080", nil); err != nil && err != http.ErrServerClosed {
+		if err := http.ListenAndServe(":8080", nil); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Error(err, "Failed to launch CLI artifact server")
 		}
 	}()

--- a/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -420,7 +421,7 @@ func TestMakeRoute(t *testing.T) {
 			if test.want != nil && !cmp.Equal(routes, test.want) {
 				t.Errorf("got = %v, want: %v, diff: %s", routes, test.want, cmp.Diff(routes, test.want))
 			}
-			if err != test.wantErr {
+			if !errors.Is(err, test.wantErr) {
 				t.Errorf("got = %v, want: %v", err, test.wantErr)
 			}
 		})

--- a/test/monitoringe2e/helpers.go
+++ b/test/monitoringe2e/helpers.go
@@ -157,7 +157,7 @@ func VerifyMetrics(caCtx *test.Context, metricQueries []string) error {
 func getBearerTokenForPrometheusAccount(caCtx *test.Context) (string, error) {
 	sa, err := caCtx.Clients.Kube.CoreV1().ServiceAccounts("openshift-monitoring").Get(context.Background(), "prometheus-k8s", meta.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("error getting service account prometheus-k8s %v", err)
+		return "", fmt.Errorf("error getting service account prometheus-k8s: %w", err)
 	}
 	tokenSecret := getSecretNameForToken(sa.Secrets)
 	if tokenSecret == "" {
@@ -165,7 +165,7 @@ func getBearerTokenForPrometheusAccount(caCtx *test.Context) (string, error) {
 	}
 	sec, err := caCtx.Clients.Kube.CoreV1().Secrets("openshift-monitoring").Get(context.Background(), tokenSecret, meta.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("error getting secret %s %v", tokenSecret, err)
+		return "", fmt.Errorf("error getting secret %s: %w", tokenSecret, err)
 	}
 	tokenContents := sec.Data["token"]
 	if len(tokenContents) == 0 {

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -316,7 +316,7 @@ func rsaPublicKeyAsJwks(key rsa.PublicKey, keyID string) (string, error) {
 
 	jwksBytes, err := json.Marshal(jwks)
 	if err != nil {
-		return "", fmt.Errorf("error marshalling jwks: %v", err)
+		return "", fmt.Errorf("error marshalling jwks: %w", err)
 	}
 
 	return string(jwksBytes), nil
@@ -330,12 +330,12 @@ func jwtRs256Token(rsaKey *rsa.PrivateKey, payload map[string]interface{}) (stri
 	}
 	jwtHeaderBytes, err := json.Marshal(jwtHeader)
 	if err != nil {
-		return "", fmt.Errorf("error marshalling jwt header into JSON: %v", err)
+		return "", fmt.Errorf("error marshalling jwt header into JSON: %w", err)
 	}
 
 	jwtPayloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return "", fmt.Errorf("error marshalling jwt payload into JSON: %v", err)
+		return "", fmt.Errorf("error marshalling jwt payload into JSON: %w", err)
 	}
 
 	jwtHeaderBase64 := base64.RawURLEncoding.EncodeToString(jwtHeaderBytes)
@@ -348,7 +348,7 @@ func jwtRs256Token(rsaKey *rsa.PrivateKey, payload map[string]interface{}) (stri
 
 	signature, err := rsa.SignPKCS1v15(rand.Reader, rsaKey, crypto.SHA256, hash)
 	if err != nil {
-		return "", fmt.Errorf("error signing JWT token with PKSC1v15: %v", err)
+		return "", fmt.Errorf("error signing JWT token with PKSC1v15: %w", err)
 	}
 
 	jwtSignatureBase64 := base64.RawURLEncoding.EncodeToString(signature)
@@ -364,12 +364,12 @@ func jwtUnsignedToken(payload map[string]interface{}) (string, error) {
 	}
 	jwtHeaderBytes, err := json.Marshal(jwtHeader)
 	if err != nil {
-		return "", fmt.Errorf("error marshalling jwt header into JSON: %v", err)
+		return "", fmt.Errorf("error marshalling jwt header into JSON: %w", err)
 	}
 
 	jwtPayloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return "", fmt.Errorf("error marshalling jwt payload into JSON: %v", err)
+		return "", fmt.Errorf("error marshalling jwt payload into JSON: %w", err)
 	}
 
 	jwtHeaderBase64 := base64.RawURLEncoding.EncodeToString(jwtHeaderBytes)
@@ -385,7 +385,7 @@ func jwtUnsignedToken(payload map[string]interface{}) (string, error) {
 func jwtHTTPGetRequestBytes(url string, token *string) (*http.Response, []byte, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating HTTP GET request: %v", err)
+		return nil, nil, fmt.Errorf("error creating HTTP GET request: %w", err)
 	}
 	if token != nil {
 		req.Header.Add("Authorization", "Bearer "+*token)
@@ -393,7 +393,7 @@ func jwtHTTPGetRequestBytes(url string, token *string) (*http.Response, []byte, 
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error doing HTTP GET request: %v", err)
+		return nil, nil, fmt.Errorf("error doing HTTP GET request: %w", err)
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Quite useful to lint these properly.