### PR TITLE
[SRVKS-829] Add an informer for the Kourier deployments specifically

### DIFF
--- a/openshift-knative-operator/pkg/serving/kourier_test.go
+++ b/openshift-knative-operator/pkg/serving/kourier_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 func TestOverrideKourierNamespace(t *testing.T) {
@@ -22,11 +24,23 @@ func TestOverrideKourierNamespace(t *testing.T) {
 		Name:       "bar",
 	}})
 
+	ks := &v1alpha1.KnativeServing{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "knative-serving",
+			Name:      "test",
+		},
+	}
+
 	want := withKourier.DeepCopy()
 	want.SetNamespace("knative-serving-ingress")
+	want.SetLabels(map[string]string{
+		providerLabel:                  "kourier",
+		socommon.ServingOwnerNamespace: ks.Namespace,
+		socommon.ServingOwnerName:      ks.Name,
+	})
 	want.SetOwnerReferences(nil)
 
-	overrideKourierNamespace("knative-serving-ingress")(withKourier)
+	overrideKourierNamespace(ks)(withKourier)
 
 	if !cmp.Equal(withKourier, want) {
 		t.Errorf("Resource was not as expected:\n%s", cmp.Diff(withKourier, want))
@@ -48,7 +62,14 @@ func TestOverrideKourierNamespaceOther(t *testing.T) {
 	}})
 	want := other.DeepCopy()
 
-	overrideKourierNamespace("knative-serving-ingress")(other)
+	ks := &v1alpha1.KnativeServing{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "knative-serving",
+			Name:      "test",
+		},
+	}
+
+	overrideKourierNamespace(ks)(other)
 
 	if !cmp.Equal(other, want) {
 		t.Errorf("Resource was not as expected:\n%s", cmp.Diff(other, want))


### PR DESCRIPTION
This fixes SRVKS-829 by adding an informer that informs us about the changes to the Kourier deployments specifically. The usual informer does not catch those as they live in a different namespace and hence have no correct OwnerRef set to them. Hence, this PR also adds the correct "ownership-labels" to identify the KnativeServing that created the deployments.