### PR TITLE
Move common constants for labels into the top-level pkg

### DIFF
--- a/knative-operator/pkg/common/constants.go
+++ b/knative-operator/pkg/common/constants.go
@@ -1,15 +1,14 @@
 package common
 
-// Annotation keys being used to tag the owned resources by instance
 const (
-	ServingOwnerName                 = "serving.knative.openshift.io/ownerName"
-	ServingOwnerNamespace            = "serving.knative.openshift.io/ownerNamespace"
-	EventingOwnerName                = "eventing.knative.openshift.io/ownerName"
-	EventingOwnerNamespace           = "eventing.knative.openshift.io/ownerNamespace"
-	ServerlessOperatorOwnerName      = "operator.knative.openshift.io/ownerName"
-	ServerlessOperatorOwnerNamespace = "operator.knative.openshift.io/ownerNamespace"
-	KafkaOwnerName                   = "knativekafkas.operator.serverless.openshift.io/ownerName"
-	KafkaOwnerNamespace              = "knativekafkas.operator.serverless.openshift.io/ownerNamespace"
+	OperatorDownstreamDomain = "operator.knative.openshift.io"
+	KafkaDownstreamDomain    = "knativekafkas.operator.serverless.openshift.io"
+
+	// Label keys being used to tag the owned resources by instance
+	ServerlessOperatorOwnerName      = OperatorDownstreamDomain + "/ownerName"
+	ServerlessOperatorOwnerNamespace = OperatorDownstreamDomain + "/ownerNamespace"
+	KafkaOwnerName                   = KafkaDownstreamDomain + "/ownerName"
+	KafkaOwnerNamespace              = KafkaDownstreamDomain + "/ownerNamespace"
 
 	// The namespace of the pod will be available through this key.
 	NamespaceEnvKey = "NAMESPACE"

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
+	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -127,8 +128,8 @@ func makeRoute(instance *servingv1alpha1.KnativeServing) *routev1.Route {
 			Name:      knCLIDownload,
 			Namespace: operatorNamespace,
 			Annotations: map[string]string{
-				common.ServingOwnerName:      instance.GetName(),
-				common.ServingOwnerNamespace: instance.GetNamespace(),
+				socommon.ServingOwnerName:      instance.GetName(),
+				socommon.ServingOwnerNamespace: instance.GetNamespace(),
 			},
 		},
 		Spec: routev1.RouteSpec{
@@ -154,8 +155,8 @@ func populateKnConsoleCLIDownload(baseURL string, instance *servingv1alpha1.Knat
 		ObjectMeta: metav1.ObjectMeta{
 			Name: knCLIDownload,
 			Annotations: map[string]string{
-				common.ServingOwnerName:      instance.GetName(),
-				common.ServingOwnerNamespace: instance.GetNamespace(),
+				socommon.ServingOwnerName:      instance.GetName(),
+				socommon.ServingOwnerNamespace: instance.GetNamespace(),
 			},
 		},
 		Spec: consolev1.ConsoleCLIDownloadSpec{

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/quickstart"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring/dashboards"
+	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -47,7 +48,7 @@ const (
 
 	// certVersionKey is an annotation key used by the Serverless operator to annotate the Knative Serving
 	// controller's PodTemplate to make it redeploy on certificate changes.
-	certVersionKey = "serving.knative.openshift.io/mounted-cert-version"
+	certVersionKey = socommon.ServingDownstreamDomain + "/mounted-cert-version"
 
 	requiredNsEnvName = "REQUIRED_SERVING_NAMESPACE"
 )
@@ -111,7 +112,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		routev1.GroupVersion.WithKind("Route"):                &routev1.Route{},
 	}
 	for _, t := range gvkToResource {
-		err = c.Watch(&source.Kind{Type: t}, common.EnqueueRequestByOwnerAnnotations(common.ServingOwnerName, common.ServingOwnerNamespace))
+		err = c.Watch(&source.Kind{Type: t}, common.EnqueueRequestByOwnerAnnotations(socommon.ServingOwnerName, socommon.ServingOwnerNamespace))
 		if err != nil {
 			return err
 		}

--- a/knative-operator/pkg/monitoring/dashboards/knative_dashboard_setup.go
+++ b/knative-operator/pkg/monitoring/dashboards/knative_dashboard_setup.go
@@ -10,6 +10,7 @@ import (
 	mfc "github.com/manifestival/controller-runtime-client"
 	mf "github.com/manifestival/manifestival"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
+	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,13 +76,13 @@ func getAnnotationsFromInstance(instance operatorv1alpha1.KComponent) mf.Transfo
 	switch instance.(type) {
 	case *operatorv1alpha1.KnativeEventing:
 		return common.SetAnnotations(map[string]string{
-			common.EventingOwnerName:      instance.GetName(),
-			common.EventingOwnerNamespace: instance.GetNamespace(),
+			socommon.EventingOwnerName:      instance.GetName(),
+			socommon.EventingOwnerNamespace: instance.GetNamespace(),
 		})
 	case *operatorv1alpha1.KnativeServing:
 		return common.SetAnnotations(map[string]string{
-			common.ServingOwnerName:      instance.GetName(),
-			common.ServingOwnerNamespace: instance.GetNamespace(),
+			socommon.ServingOwnerName:      instance.GetName(),
+			socommon.ServingOwnerNamespace: instance.GetNamespace(),
 		})
 	}
 	return nil

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -1,0 +1,12 @@
+package common
+
+const (
+	ServingDownstreamDomain  = "serving.knative.openshift.io"
+	EventingDownstreamDomain = "eventing.knative.openshift.io"
+
+	// Label keys being used to tag the owned resources by instance
+	ServingOwnerName       = ServingDownstreamDomain + "/ownerName"
+	ServingOwnerNamespace  = ServingDownstreamDomain + "/ownerNamespace"
+	EventingOwnerName      = EventingDownstreamDomain + "/ownerName"
+	EventingOwnerNamespace = EventingDownstreamDomain + "/ownerNamespace"
+)

--- a/serving/ingress/pkg/reconciler/ingress/resources/route.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -18,14 +19,14 @@ import (
 
 const (
 	TimeoutAnnotation                = "haproxy.router.openshift.io/timeout"
-	DisableRouteAnnotation           = "serving.knative.openshift.io/disableRoute"
-	EnablePassthroughRouteAnnotation = "serving.knative.openshift.io/enablePassthrough"
+	DisableRouteAnnotation           = socommon.ServingDownstreamDomain + "/disableRoute"
+	EnablePassthroughRouteAnnotation = socommon.ServingDownstreamDomain + "/enablePassthrough"
 
 	HTTPPort  = "http2"
 	HTTPSPort = "https"
 
-	OpenShiftIngressLabelKey          = "serving.knative.openshift.io/ingressName"
-	OpenShiftIngressNamespaceLabelKey = "serving.knative.openshift.io/ingressNamespace"
+	OpenShiftIngressLabelKey          = socommon.ServingDownstreamDomain + "/ingressName"
+	OpenShiftIngressNamespaceLabelKey = socommon.ServingDownstreamDomain + "/ingressNamespace"
 )
 
 // DefaultTimeout is set by DefaultMaxRevisionTimeoutSeconds. So, the OpenShift Route's timeout


### PR DESCRIPTION
As per title, this shuffles some constants around so we guarantee consistency between them. Essentially, this is a prefactor for #1254 