### PR TITLE
Rewrite unit tests with inline YAML to Golang types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	knative.dev/pkg v0.0.0-20210902173607-844a6bc45596
 	knative.dev/serving v0.25.1
 	sigs.k8s.io/controller-runtime v0.8.3
-	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1288,7 +1288,6 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.3
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
-## explicit
 sigs.k8s.io/yaml
 # contrib.go.opencensus.io/exporter/prometheus => contrib.go.opencensus.io/exporter/prometheus v0.3.1-0.20210621165811-f3a7283b3002
 # k8s.io/api => k8s.io/api v0.20.7


### PR DESCRIPTION
This drops the last tests we had that would work on inline YAML and uses the Golang types instead. Drops a dependency too, which is YAY.

/assign @rhuss 