### PR TITLE
Make all Kube API imports consistent as

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -145,7 +145,7 @@ jobs:
         run: |
           # Don't fail because of misspell
           set +o pipefail
-          git ls-files | grep -Ev '^(vendor/|.git)' | xargs misspell -error xargs misspell -error \
+          git ls-files | grep -Ev '^(vendor/|.git)' | xargs misspell -i importas -error \
             | reviewdog -efm="%f:%l:%c: %m" \
                 -name="github.com/client9/misspell" \
                 -reporter="github-pr-check" \

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,7 @@ linters:
     - gofmt
     - goimports
     - gosec
+    - importas
     - misspell
     - prealloc
     - revive
@@ -22,6 +23,29 @@ linters:
     - unparam
   disable:
     - errcheck
+
+linters-settings:
+  importas:
+    no-unaliased: true
+    alias:
+      - pkg: k8s.io/apimachinery/pkg/apis/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: github.com/openshift/api/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: knative.dev/serving/pkg/apis/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: knative.dev/eventing/pkg/apis/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: knative.dev/pkg/apis/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: knative.dev/operator/pkg/apis/operator/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: github.com/prometheus-operator/prometheus-operator/pkg/apis/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: github.com/operator-framework/api/pkg/(\w+)/(v[\w\d]+)
+        alias: $1$2
 
 issues:
   exclude-rules:

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ lint:
 	golangci-lint run
 	find . -type f -path './**/*.*sh' -not -path '*vendor*' | xargs -r shellcheck
 	operator-sdk bundle validate ./olm-catalog/serverless-operator --select-optional suite=operatorframework --optional-values=k8s-version=1.22
-	git ls-files | grep -Ev '^(vendor/|.git)' | xargs misspell -error
+	git ls-files | grep -Ev '^(vendor/|.git)' | xargs misspell -i importas -error
 	prettier -c templates/*.yaml
 
 # Runs formatters and thelike to fix potential linter warnings.

--- a/knative-operator/pkg/apis/addtoscheme_knative_operator_v1alpha1.go
+++ b/knative-operator/pkg/apis/addtoscheme_knative_operator_v1alpha1.go
@@ -1,11 +1,11 @@
 package apis
 
 import (
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
 	// Adds schema for knative serving
-	AddToSchemes = append(AddToSchemes, v1alpha1.AddToScheme)
+	AddToSchemes = append(AddToSchemes, operatorv1alpha1.AddToScheme)
 }

--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_lifecycle.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_lifecycle.go
@@ -1,14 +1,14 @@
 package v1alpha1
 
 import (
-	knativeoperatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"knative.dev/pkg/apis"
 )
 
 var (
 	kafkaCondSet = apis.NewLivingConditionSet(
-		knativeoperatorv1alpha1.DeploymentsAvailable,
-		knativeoperatorv1alpha1.InstallSucceeded,
+		operatorv1alpha1.DeploymentsAvailable,
+		operatorv1alpha1.InstallSucceeded,
 	)
 )
 
@@ -24,28 +24,28 @@ func (is *KnativeKafkaStatus) IsReady() bool {
 
 // MarkInstallSucceeded marks the InstallationSucceeded status as true.
 func (is *KnativeKafkaStatus) MarkInstallSucceeded() {
-	kafkaCondSet.Manage(is).MarkTrue(knativeoperatorv1alpha1.InstallSucceeded)
+	kafkaCondSet.Manage(is).MarkTrue(operatorv1alpha1.InstallSucceeded)
 }
 
 // MarkInstallFailed marks the InstallationSucceeded status as false with the given
 // message.
 func (is *KnativeKafkaStatus) MarkInstallFailed(msg string) {
 	kafkaCondSet.Manage(is).MarkFalse(
-		knativeoperatorv1alpha1.InstallSucceeded,
+		operatorv1alpha1.InstallSucceeded,
 		"Error",
 		"Install failed with message: %s", msg)
 }
 
 // MarkDeploymentsAvailable marks the DeploymentsAvailable status as true.
 func (is *KnativeKafkaStatus) MarkDeploymentsAvailable() {
-	kafkaCondSet.Manage(is).MarkTrue(knativeoperatorv1alpha1.DeploymentsAvailable)
+	kafkaCondSet.Manage(is).MarkTrue(operatorv1alpha1.DeploymentsAvailable)
 }
 
 // MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
 // it's waiting for deployments.
 func (is *KnativeKafkaStatus) MarkDeploymentsNotReady() {
 	kafkaCondSet.Manage(is).MarkFalse(
-		knativeoperatorv1alpha1.DeploymentsAvailable,
+		operatorv1alpha1.DeploymentsAvailable,
 		"NotReady",
 		"Waiting on deployments")
 }

--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_lifecycle_test.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_lifecycle_test.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
-	knativeoperatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	apistest "knative.dev/pkg/apis/testing"
 )
 
@@ -11,27 +11,27 @@ func TestKnativeKafkaHappyPath(t *testing.T) {
 	ks := &KnativeKafkaStatus{}
 	ks.InitializeConditions()
 
-	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
-	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
+	apistest.CheckConditionOngoing(ks, operatorv1alpha1.DeploymentsAvailable, t)
+	apistest.CheckConditionOngoing(ks, operatorv1alpha1.InstallSucceeded, t)
 
 	// Install succeeds.
 	ks.MarkInstallSucceeded()
 	// Dependencies are assumed successful too.
-	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
+	apistest.CheckConditionOngoing(ks, operatorv1alpha1.DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, operatorv1alpha1.InstallSucceeded, t)
 
 	// Deployments are not available at first.
 	ks.MarkDeploymentsNotReady()
-	apistest.CheckConditionFailed(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
+	apistest.CheckConditionFailed(ks, operatorv1alpha1.DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, operatorv1alpha1.InstallSucceeded, t)
 	if ready := ks.IsReady(); ready {
 		t.Errorf("ks.IsReady() = %v, want false", ready)
 	}
 
 	// Deployments become ready and we're good.
 	ks.MarkDeploymentsAvailable()
-	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
+	apistest.CheckConditionSucceeded(ks, operatorv1alpha1.DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, operatorv1alpha1.InstallSucceeded, t)
 	if ready := ks.IsReady(); !ready {
 		t.Errorf("ks.IsReady() = %v, want true", ready)
 	}
@@ -41,26 +41,26 @@ func TestKnativeKafkaErrorPath(t *testing.T) {
 	ks := &KnativeKafkaStatus{}
 	ks.InitializeConditions()
 
-	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
-	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
+	apistest.CheckConditionOngoing(ks, operatorv1alpha1.DeploymentsAvailable, t)
+	apistest.CheckConditionOngoing(ks, operatorv1alpha1.InstallSucceeded, t)
 
 	// Install fails.
 	ks.MarkInstallFailed("test")
-	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
-	apistest.CheckConditionFailed(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
+	apistest.CheckConditionOngoing(ks, operatorv1alpha1.DeploymentsAvailable, t)
+	apistest.CheckConditionFailed(ks, operatorv1alpha1.InstallSucceeded, t)
 
 	// Install now succeeds.
 	ks.MarkInstallSucceeded()
-	apistest.CheckConditionOngoing(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
+	apistest.CheckConditionOngoing(ks, operatorv1alpha1.DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, operatorv1alpha1.InstallSucceeded, t)
 	if ready := ks.IsReady(); ready {
 		t.Errorf("ks.IsReady() = %v, want false", ready)
 	}
 
 	// Deployments become ready
 	ks.MarkDeploymentsAvailable()
-	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, knativeoperatorv1alpha1.InstallSucceeded, t)
+	apistest.CheckConditionSucceeded(ks, operatorv1alpha1.DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, operatorv1alpha1.InstallSucceeded, t)
 	if ready := ks.IsReady(); !ready {
 		t.Errorf("ks.IsReady() = %v, want true", ready)
 	}

--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	commonv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -19,7 +19,7 @@ type KnativeKafkaSpec struct {
 
 	// HighAvailability allows specification of HA control plane.
 	// +optional
-	HighAvailability *commonv1alpha1.HighAvailability `json:"high-availability,omitempty"`
+	HighAvailability *operatorv1alpha1.HighAvailability `json:"high-availability,omitempty"`
 }
 
 // KnativeKafkaStatus defines the observed state of KnativeKafka

--- a/knative-operator/pkg/common/eventing.go
+++ b/knative-operator/pkg/common/eventing.go
@@ -5,26 +5,26 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
-func MutateEventing(ke *eventingv1alpha1.KnativeEventing) {
+func MutateEventing(ke *operatorv1alpha1.KnativeEventing) {
 	eventingImagesFromEnviron(ke)
 	ensureEventingWebhookMemoryLimit(ke)
 	ensureEventingWebhookInclusionMode(ke)
 	defaultToEventingHa(ke)
 }
 
-func defaultToEventingHa(ke *eventingv1alpha1.KnativeEventing) {
+func defaultToEventingHa(ke *operatorv1alpha1.KnativeEventing) {
 	if ke.Spec.HighAvailability == nil {
-		ke.Spec.HighAvailability = &eventingv1alpha1.HighAvailability{
+		ke.Spec.HighAvailability = &operatorv1alpha1.HighAvailability{
 			Replicas: 2,
 		}
 	}
 }
 
 // eventingImagesFromEnviron overrides registry images
-func eventingImagesFromEnviron(ke *eventingv1alpha1.KnativeEventing) {
+func eventingImagesFromEnviron(ke *operatorv1alpha1.KnativeEventing) {
 	ke.Spec.Registry.Override = BuildImageOverrideMapFromEnviron(os.Environ(), "IMAGE_")
 
 	if defaultVal, ok := ke.Spec.Registry.Override["default"]; ok {
@@ -34,11 +34,11 @@ func eventingImagesFromEnviron(ke *eventingv1alpha1.KnativeEventing) {
 	log.Info("Setting", "registry", ke.Spec.Registry)
 }
 
-func ensureEventingWebhookMemoryLimit(ke *eventingv1alpha1.KnativeEventing) {
+func ensureEventingWebhookMemoryLimit(ke *operatorv1alpha1.KnativeEventing) {
 	EnsureContainerMemoryLimit(&ke.Spec.CommonSpec, "eventing-webhook", resource.MustParse("1024Mi"))
 }
 
-func ensureEventingWebhookInclusionMode(ke *eventingv1alpha1.KnativeEventing) {
+func ensureEventingWebhookInclusionMode(ke *operatorv1alpha1.KnativeEventing) {
 	if ke.Spec.SinkBindingSelectionMode == "" {
 		ke.Spec.SinkBindingSelectionMode = "inclusion"
 	}

--- a/knative-operator/pkg/common/kafka.go
+++ b/knative-operator/pkg/common/kafka.go
@@ -1,17 +1,17 @@
 package common
 
 import (
-	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
-	commonv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	serverlessoperatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
-func MutateKafka(ke *operatorv1alpha1.KnativeKafka) {
+func MutateKafka(ke *serverlessoperatorv1alpha1.KnativeKafka) {
 	defaultToKafkaHa(ke)
 }
 
-func defaultToKafkaHa(ke *operatorv1alpha1.KnativeKafka) {
+func defaultToKafkaHa(ke *serverlessoperatorv1alpha1.KnativeKafka) {
 	if ke.Spec.HighAvailability == nil {
-		ke.Spec.HighAvailability = &commonv1alpha1.HighAvailability{
+		ke.Spec.HighAvailability = &operatorv1alpha1.HighAvailability{
 			Replicas: 1,
 		}
 	}

--- a/knative-operator/pkg/common/util_test.go
+++ b/knative-operator/pkg/common/util_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 func TestBuildImageOverrideMapFromEnviron(t *testing.T) {
@@ -112,7 +112,7 @@ func TestBuildImageOverrideMapFromEnviron(t *testing.T) {
 	}
 }
 
-func verifyImageOverride(t *testing.T, registry *servingv1alpha1.Registry, imageName string, expected string) {
+func verifyImageOverride(t *testing.T, registry *operatorv1alpha1.Registry, imageName string, expected string) {
 	if registry.Override[imageName] != expected {
 		t.Errorf("Missing queue image. Expected a map with following override in it : %v=%v, actual: %v", imageName, expected, registry.Override)
 	}

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller_test.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller_test.go
@@ -12,13 +12,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var (
-	ke = &v1alpha1.KnativeEventing{
+	ke = &operatorv1alpha1.KnativeEventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "knative-eventing",
 			Namespace: "knative-eventing",

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -13,7 +13,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -137,7 +137,7 @@ func TestKnativeKafkaReconcile(t *testing.T) {
 				}
 
 				// Check if the clusterrolebinding for the Kafka deployment is created
-				crb := &v1.ClusterRoleBinding{}
+				crb := &rbacv1.ClusterRoleBinding{}
 				err = cl.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("rbac-proxy-reviews-prom-rb-%s", deployment.Name)}, crb)
 				if err != nil {
 					t.Fatalf("get: (%v)", err)

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -27,7 +27,7 @@ var (
 )
 
 // Apply installs kn ConsoleCLIDownload and its required resources
-func Apply(instance *servingv1alpha1.KnativeServing, apiclient client.Client, scheme *runtime.Scheme) error {
+func Apply(instance *operatorv1alpha1.KnativeServing, apiclient client.Client, scheme *runtime.Scheme) error {
 	route, err := reconcileKnConsoleCLIDownloadRoute(apiclient, instance)
 	if err != nil {
 		return err
@@ -36,7 +36,7 @@ func Apply(instance *servingv1alpha1.KnativeServing, apiclient client.Client, sc
 	return reconcileKnConsoleCLIDownload(apiclient, instance, route)
 }
 
-func reconcileKnConsoleCLIDownloadRoute(apiclient client.Client, instance *servingv1alpha1.KnativeServing) (*routev1.Route, error) {
+func reconcileKnConsoleCLIDownloadRoute(apiclient client.Client, instance *operatorv1alpha1.KnativeServing) (*routev1.Route, error) {
 	log.Info("Installing kn ConsoleCLIDownload Route")
 	ctx := context.Background()
 
@@ -68,7 +68,7 @@ func reconcileKnConsoleCLIDownloadRoute(apiclient client.Client, instance *servi
 
 // reconcileKnConsoleCLIDownload reconciles kn ConsoleCLIDownload by finding
 // kn download resource route URL and populating spec accordingly
-func reconcileKnConsoleCLIDownload(apiclient client.Client, instance *servingv1alpha1.KnativeServing, route *routev1.Route) error {
+func reconcileKnConsoleCLIDownload(apiclient client.Client, instance *operatorv1alpha1.KnativeServing, route *routev1.Route) error {
 	log.Info("Installing kn ConsoleCLIDownload")
 	ctx := context.TODO()
 
@@ -108,7 +108,7 @@ func reconcileKnConsoleCLIDownload(apiclient client.Client, instance *servingv1a
 }
 
 // Delete deletes kn ConsoleCLIDownload CO and respective deployment resources
-func Delete(instance *servingv1alpha1.KnativeServing, apiclient client.Client, scheme *runtime.Scheme) error {
+func Delete(instance *operatorv1alpha1.KnativeServing, apiclient client.Client, scheme *runtime.Scheme) error {
 	log.Info("Deleting kn ConsoleCLIDownload CO")
 	if err := apiclient.Delete(context.TODO(), populateKnConsoleCLIDownload("", instance)); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete kn ConsoleCLIDownload CO: %w", err)
@@ -122,7 +122,7 @@ func Delete(instance *servingv1alpha1.KnativeServing, apiclient client.Client, s
 	return nil
 }
 
-func makeRoute(instance *servingv1alpha1.KnativeServing) *routev1.Route {
+func makeRoute(instance *operatorv1alpha1.KnativeServing) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      knCLIDownload,
@@ -150,7 +150,7 @@ func makeRoute(instance *servingv1alpha1.KnativeServing) *routev1.Route {
 
 // populateKnConsoleCLIDownload populates kn ConsoleCLIDownload object and its SPEC
 // using route's baseURL
-func populateKnConsoleCLIDownload(baseURL string, instance *servingv1alpha1.KnativeServing) *consolev1.ConsoleCLIDownload {
+func populateKnConsoleCLIDownload(baseURL string, instance *operatorv1alpha1.KnativeServing) *consolev1.ConsoleCLIDownload {
 	return &consolev1.ConsoleCLIDownload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: knCLIDownload,

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -88,7 +88,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for changes to primary resource KnativeServing, only in the expected namespace.
 	requiredNs := os.Getenv(requiredNsEnvName)
-	err = c.Watch(&source.Kind{Type: &servingv1alpha1.KnativeServing{}}, &handler.EnqueueRequestForObject{}, predicate.NewPredicateFuncs(func(obj client.Object) bool {
+	err = c.Watch(&source.Kind{Type: &operatorv1alpha1.KnativeServing{}}, &handler.EnqueueRequestForObject{}, predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if requiredNs == "" {
 			return true
 		}
@@ -100,7 +100,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for changes to owned ConfigMaps
 	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForOwner{
-		OwnerType:    &servingv1alpha1.KnativeServing{},
+		OwnerType:    &operatorv1alpha1.KnativeServing{},
 		IsController: true,
 	})
 	if err != nil {
@@ -138,7 +138,7 @@ func (r *ReconcileKnativeServing) Reconcile(ctx context.Context, request reconci
 	reqLogger.Info("Reconciling KnativeServing")
 
 	// Fetch the KnativeServing instance
-	original := &servingv1alpha1.KnativeServing{}
+	original := &operatorv1alpha1.KnativeServing{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, original)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -169,8 +169,8 @@ func (r *ReconcileKnativeServing) Reconcile(ctx context.Context, request reconci
 	return reconcile.Result{}, reconcileErr
 }
 
-func (r *ReconcileKnativeServing) reconcileKnativeServing(instance *servingv1alpha1.KnativeServing) error {
-	stages := []func(*servingv1alpha1.KnativeServing) error{
+func (r *ReconcileKnativeServing) reconcileKnativeServing(instance *operatorv1alpha1.KnativeServing) error {
+	stages := []func(*operatorv1alpha1.KnativeServing) error{
 		r.configure,
 		r.ensureFinalizers,
 		r.ensureCustomCertsConfigMap,
@@ -187,7 +187,7 @@ func (r *ReconcileKnativeServing) reconcileKnativeServing(instance *servingv1alp
 }
 
 // configure default settings for OpenShift
-func (r *ReconcileKnativeServing) configure(instance *servingv1alpha1.KnativeServing) error {
+func (r *ReconcileKnativeServing) configure(instance *operatorv1alpha1.KnativeServing) error {
 	before := instance.DeepCopy()
 	if err := common.Mutate(instance, r.client); err != nil {
 		return err
@@ -205,7 +205,7 @@ func (r *ReconcileKnativeServing) configure(instance *servingv1alpha1.KnativeSer
 }
 
 // set a finalizer to clean up service mesh when instance is deleted
-func (r *ReconcileKnativeServing) ensureFinalizers(instance *servingv1alpha1.KnativeServing) error {
+func (r *ReconcileKnativeServing) ensureFinalizers(instance *operatorv1alpha1.KnativeServing) error {
 	for _, finalizer := range instance.GetFinalizers() {
 		if finalizer == finalizerName {
 			return nil
@@ -217,7 +217,7 @@ func (r *ReconcileKnativeServing) ensureFinalizers(instance *servingv1alpha1.Kna
 }
 
 // create the configmap to be injected with custom certs
-func (r *ReconcileKnativeServing) ensureCustomCertsConfigMap(instance *servingv1alpha1.KnativeServing) error {
+func (r *ReconcileKnativeServing) ensureCustomCertsConfigMap(instance *operatorv1alpha1.KnativeServing) error {
 	certs := instance.Spec.ControllerCustomCerts
 
 	// If the user doesn't specify anything else, this is set by the webhook/controller defaulter to
@@ -278,7 +278,7 @@ func (r *ReconcileKnativeServing) ensureCustomCertsConfigMap(instance *servingv1
 	return nil
 }
 
-func (r *ReconcileKnativeServing) reconcileConfigMap(instance *servingv1alpha1.KnativeServing, name string,
+func (r *ReconcileKnativeServing) reconcileConfigMap(instance *operatorv1alpha1.KnativeServing, name string,
 	annotations, labels map[string]string, data map[string]string) (*corev1.ConfigMap, error) {
 	ctx := context.TODO()
 	cm := &corev1.ConfigMap{}
@@ -330,23 +330,23 @@ func (r *ReconcileKnativeServing) reconcileConfigMap(instance *servingv1alpha1.K
 	return cm, nil
 }
 
-func (r *ReconcileKnativeServing) installQuickstarts(instance *servingv1alpha1.KnativeServing) error {
+func (r *ReconcileKnativeServing) installQuickstarts(instance *operatorv1alpha1.KnativeServing) error {
 	return quickstart.Apply(instance, r.client)
 }
 
 // installKnConsoleCLIDownload creates CR for kn CLI download link
-func (r *ReconcileKnativeServing) installKnConsoleCLIDownload(instance *servingv1alpha1.KnativeServing) error {
+func (r *ReconcileKnativeServing) installKnConsoleCLIDownload(instance *operatorv1alpha1.KnativeServing) error {
 	return consoleclidownload.Apply(instance, r.client, r.scheme)
 }
 
 // installDashboard installs dashboard for OpenShift webconsole
-func (r *ReconcileKnativeServing) installDashboard(instance *servingv1alpha1.KnativeServing) error {
+func (r *ReconcileKnativeServing) installDashboard(instance *operatorv1alpha1.KnativeServing) error {
 	log.Info("Installing Serving Dashboards")
 	return dashboards.Apply("serving", instance, r.client)
 }
 
 // general clean-up, mostly resources in different namespaces from servingv1alpha1.KnativeServing.
-func (r *ReconcileKnativeServing) delete(instance *servingv1alpha1.KnativeServing) error {
+func (r *ReconcileKnativeServing) delete(instance *operatorv1alpha1.KnativeServing) error {
 	defer monitoring.KnativeUp.DeleteLabelValues("serving_status")
 	finalizers := sets.NewString(instance.GetFinalizers()...)
 
@@ -372,7 +372,7 @@ func (r *ReconcileKnativeServing) delete(instance *servingv1alpha1.KnativeServin
 	}
 
 	// The above might take a while, so we refetch the resource again in case it has changed.
-	refetched := &servingv1alpha1.KnativeServing{}
+	refetched := &operatorv1alpha1.KnativeServing{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, refetched); err != nil {
 		return fmt.Errorf("failed to refetch KnativeServing: %w", err)
 	}

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	pkgapis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -26,12 +26,12 @@ import (
 )
 
 var (
-	defaultKnativeServing = v1alpha1.KnativeServing{
+	defaultKnativeServing = operatorv1alpha1.KnativeServing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "knative-serving",
 			Namespace: "knative-serving",
 		},
-		Status: v1alpha1.KnativeServingStatus{
+		Status: operatorv1alpha1.KnativeServingStatus{
 			Status: duckv1.Status{
 				Conditions: []pkgapis.Condition{
 					{
@@ -184,13 +184,13 @@ func TestExtraResourcesReconcile(t *testing.T) {
 }
 
 func TestCustomCertsConfigMap(t *testing.T) {
-	ks := &v1alpha1.KnativeServing{
+	ks := &operatorv1alpha1.KnativeServing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "knative-serving",
 			Namespace: "knative-serving",
 		},
-		Spec: v1alpha1.KnativeServingSpec{
-			ControllerCustomCerts: v1alpha1.CustomCerts{
+		Spec: operatorv1alpha1.KnativeServingSpec{
+			ControllerCustomCerts: operatorv1alpha1.CustomCerts{
 				Name: "test-cm",
 				Type: "ConfigMap",
 			},

--- a/knative-operator/pkg/controller/knativeserving/quickstart/quickstart.go
+++ b/knative-operator/pkg/controller/knativeserving/quickstart/quickstart.go
@@ -8,7 +8,7 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	apierrs "k8s.io/apimachinery/pkg/api/meta"
-	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -18,7 +18,7 @@ const EnvKey = "QUICKSTART_MANIFEST_PATH"
 var log = common.Log.WithName("quickstart")
 
 // Apply applies Quickstart resources.
-func Apply(instance *servingv1alpha1.KnativeServing, api client.Client) error {
+func Apply(instance *operatorv1alpha1.KnativeServing, api client.Client) error {
 	manifest, err := mfc.NewManifest(manifestPath(), api, mf.UseLogger(log.WithName("mf")))
 	if err != nil {
 		return fmt.Errorf("failed to load quickstart manifest: %w", err)
@@ -37,7 +37,7 @@ func Apply(instance *servingv1alpha1.KnativeServing, api client.Client) error {
 }
 
 // Delete deletes Quickstart resources.
-func Delete(instance *servingv1alpha1.KnativeServing, api client.Client) error {
+func Delete(instance *operatorv1alpha1.KnativeServing, api client.Client) error {
 	log.Info("Deleting Quickstarts")
 	manifest, err := mfc.NewManifest(manifestPath(), api, mf.UseLogger(log.WithName("mf")))
 	if err != nil {

--- a/knative-operator/pkg/controller/knativeserving/quickstart/quickstart_test.go
+++ b/knative-operator/pkg/controller/knativeserving/quickstart/quickstart_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	apierrs "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/kubernetes/scheme"
-	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,7 +19,7 @@ func init() {
 }
 
 func TestQuickstartErrors(t *testing.T) {
-	ks := &servingv1alpha1.KnativeServing{}
+	ks := &operatorv1alpha1.KnativeServing{}
 	someErr := errors.New("test")
 
 	tests := []struct {

--- a/knative-operator/pkg/monitoring/dashboards/health/healthdashboard_controller.go
+++ b/knative-operator/pkg/monitoring/dashboards/health/healthdashboard_controller.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -36,7 +36,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	err = c.Watch(&source.Kind{Type: &v1.ConfigMap{}}, common.EnqueueRequestByOwnerAnnotations(common.ServerlessOperatorOwnerName, common.ServerlessOperatorOwnerNamespace), skipCreatePredicate{})
+	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, common.EnqueueRequestByOwnerAnnotations(common.ServerlessOperatorOwnerName, common.ServerlessOperatorOwnerNamespace), skipCreatePredicate{})
 	if err != nil {
 		return err
 	}

--- a/knative-operator/pkg/monitoring/kafka_rbacproxy_transforms.go
+++ b/knative-operator/pkg/monitoring/kafka_rbacproxy_transforms.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 
 	mf "github.com/manifestival/manifestival"
-	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
+	serverlessoperatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
 	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 	"k8s.io/apimachinery/pkg/util/sets"
-	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -17,7 +17,7 @@ var (
 	KafkaSourceComponents  = []string{"kafka-controller-manager"}
 )
 
-func AddRBACProxySupportToManifest(instance *operatorv1alpha1.KnativeKafka, components []string) (*mf.Manifest, error) {
+func AddRBACProxySupportToManifest(instance *serverlessoperatorv1alpha1.KnativeKafka, components []string) (*mf.Manifest, error) {
 	proxyManifest := mf.Manifest{}
 	// Only create the roles needed for the deployment service accounts as Prometheus has already
 	// the rights needed due to eventing that is assumed to be installed.
@@ -35,7 +35,7 @@ func AddRBACProxySupportToManifest(instance *operatorv1alpha1.KnativeKafka, comp
 }
 
 func GetRBACProxyInjectTransformer(apiClient client.Client) (mf.Transformer, error) {
-	eventingList := &eventingv1alpha1.KnativeEventingList{}
+	eventingList := &operatorv1alpha1.KnativeEventingList{}
 	err := apiClient.List(context.Background(), eventingList)
 	if err != nil {
 		return nil, err

--- a/knative-operator/pkg/monitoring/monitoring.go
+++ b/knative-operator/pkg/monitoring/monitoring.go
@@ -11,7 +11,7 @@ import (
 	okomon "github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,7 +59,7 @@ func RemoveOldServiceMonitorResourcesIfExist(namespace string, api client.Client
 			Name:      "knative-openshift-metrics",
 		},
 	}
-	oldService := v1.Service{
+	oldService := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      oldSM.Name,
@@ -108,7 +108,7 @@ func GetServerlessOperatorDeployment(api client.Client, namespace string) (*apps
 }
 
 func addClusterMonitoringLabelToNamespace(namespace string, api client.Client, value bool) error {
-	ns := &v1.Namespace{}
+	ns := &corev1.Namespace{}
 	if err := api.Get(context.TODO(), client.ObjectKey{Name: namespace}, ns); err != nil {
 		return err
 	}

--- a/knative-operator/pkg/monitoring/monitoring_test.go
+++ b/knative-operator/pkg/monitoring/monitoring_test.go
@@ -9,7 +9,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,7 +49,7 @@ func TestSetupMonitoringRequirements(t *testing.T) {
 	if actual := ns.Labels[okomon.EnableMonitoringLabel]; actual != "true" {
 		t.Errorf("got %q, want %q", actual, "true")
 	}
-	role := v1.Role{}
+	role := rbacv1.Role{}
 	err = cl.Get(context.TODO(), client.ObjectKey{Name: rbacName, Namespace: installedNS}, &role)
 	if err != nil {
 		t.Errorf("Failed to get created role: %w", err)
@@ -57,7 +57,7 @@ func TestSetupMonitoringRequirements(t *testing.T) {
 	if len(role.Rules) == 0 {
 		t.Error("Rules should be non empty")
 	}
-	rb := v1.RoleBinding{}
+	rb := rbacv1.RoleBinding{}
 	err = cl.Get(context.TODO(), client.ObjectKey{Name: rbacName, Namespace: installedNS}, &rb)
 	if err != nil {
 		t.Errorf("Failed to get created rolebinding: %w", err)

--- a/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller_test.go
+++ b/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 	okomon "github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -31,12 +31,12 @@ var (
 		NamespacedName: types.NamespacedName{Namespace: "knative-eventing", Name: "ping1"},
 	}
 
-	apiserversourceDeployment = v1.Deployment{
+	apiserversourceDeployment = appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "api1",
 			Namespace: "default",
 		},
-		Spec: v1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					SourceLabel:     "apiserver-source-controller",
@@ -45,12 +45,12 @@ var (
 			},
 		},
 	}
-	pingsourceDeployment = v1.Deployment{
+	pingsourceDeployment = appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ping1",
 			Namespace: "knative-eventing",
 		},
-		Spec: v1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					SourceLabel:     "ping-source-controller",
@@ -78,13 +78,13 @@ func init() {
 
 // TestSourceReconcile runs Reconcile to verify if monitoring resources are created/deleted for sources.
 func TestSourceReconcile(t *testing.T) {
-	eventingInstance := &v1alpha1.KnativeEventing{
+	eventingInstance := &operatorv1alpha1.KnativeEventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "knative-eventing",
 			Namespace: "knative-eventing",
 		},
 	}
-	keUpdate(eventingInstance, func(ke *v1alpha1.KnativeEventing) {
+	keUpdate(eventingInstance, func(ke *operatorv1alpha1.KnativeEventing) {
 		common.Configure(&ke.Spec.CommonSpec, okomon.ObservabilityCMName, okomon.ObservabilityBackendKey, "prometheus")
 	})
 	cl := fake.NewClientBuilder().
@@ -142,7 +142,7 @@ func TestSourceReconcile(t *testing.T) {
 }
 
 func TestSourceMonitoringReconcile(t *testing.T) {
-	eventingInstance := &v1alpha1.KnativeEventing{
+	eventingInstance := &operatorv1alpha1.KnativeEventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "knative-eventing",
 			Namespace: "knative-eventing",
@@ -171,7 +171,7 @@ func TestSourceMonitoringReconcile(t *testing.T) {
 	}
 	checkPrometheusResources(cl, false, t)
 	newEventingInstance := eventingInstance.DeepCopy()
-	newEventingInstance = keUpdate(newEventingInstance, func(ke *v1alpha1.KnativeEventing) {
+	newEventingInstance = keUpdate(newEventingInstance, func(ke *operatorv1alpha1.KnativeEventing) {
 		common.Configure(&ke.Spec.CommonSpec, okomon.ObservabilityCMName, okomon.ObservabilityBackendKey, "none")
 	})
 	if err := cl.Update(context.TODO(), newEventingInstance); err != nil {
@@ -238,7 +238,7 @@ func checkError(err error, shouldExist bool, t *testing.T) bool {
 	return false
 }
 
-func keUpdate(instance *v1alpha1.KnativeEventing, mods ...func(*v1alpha1.KnativeEventing)) *v1alpha1.KnativeEventing {
+func keUpdate(instance *operatorv1alpha1.KnativeEventing, mods ...func(*operatorv1alpha1.KnativeEventing)) *operatorv1alpha1.KnativeEventing {
 	for _, mod := range mods {
 		mod(instance)
 	}

--- a/knative-operator/pkg/monitoring/sources/source_service_monitor.go
+++ b/knative-operator/pkg/monitoring/sources/source_service_monitor.go
@@ -7,7 +7,7 @@ import (
 	mf "github.com/manifestival/manifestival"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -55,14 +55,14 @@ func sourceServiceMonitorManifest(client client.Client, instance *appsv1.Deploym
 func createServiceMonitorManifest(labels map[string]string, depName string, ns string, options mf.Option) (*mf.Manifest, error) {
 	var svU = &unstructured.Unstructured{}
 	var smU = &unstructured.Unstructured{}
-	sms := v1.Service{
+	sms := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      depName,
 			Namespace: ns,
 			Labels:    kmeta.CopyMap(labels),
 		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
 				Name:       "http-metrics",
 				Port:       9090,
 				TargetPort: intstr.FromInt(9090),

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -27,7 +27,7 @@ var _ admission.Handler = (*Configurator)(nil)
 
 // Handle implements the Handler interface.
 func (v *Configurator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	ke := &eventingv1alpha1.KnativeEventing{}
+	ke := &operatorv1alpha1.KnativeEventing{}
 
 	err := v.decoder.Decode(req, ke)
 	if err != nil {

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -31,7 +31,7 @@ var _ admission.Handler = (*Validator)(nil)
 
 // Handle implements the Handler interface.
 func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	ke := &eventingv1alpha1.KnativeEventing{}
+	ke := &operatorv1alpha1.KnativeEventing{}
 
 	err := v.decoder.Decode(req, ke)
 	if err != nil {
@@ -46,9 +46,9 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 }
 
 // Validator checks for a minimum OpenShift version
-func (v *Validator) validate(ctx context.Context, ke *eventingv1alpha1.KnativeEventing) (allowed bool, reason string, err error) {
+func (v *Validator) validate(ctx context.Context, ke *operatorv1alpha1.KnativeEventing) (allowed bool, reason string, err error) {
 	log := common.Log.WithName("validate")
-	stages := []func(context.Context, *eventingv1alpha1.KnativeEventing) (bool, string, error){
+	stages := []func(context.Context, *operatorv1alpha1.KnativeEventing) (bool, string, error){
 		v.validateNamespace,
 		v.validateLoneliness,
 	}
@@ -69,7 +69,7 @@ func (v *Validator) validate(ctx context.Context, ke *eventingv1alpha1.KnativeEv
 }
 
 // validate required namespace, if any
-func (v *Validator) validateNamespace(ctx context.Context, ke *eventingv1alpha1.KnativeEventing) (bool, string, error) {
+func (v *Validator) validateNamespace(ctx context.Context, ke *operatorv1alpha1.KnativeEventing) (bool, string, error) {
 	ns, required := os.LookupEnv("REQUIRED_EVENTING_NAMESPACE")
 	if required && ns != ke.Namespace {
 		return false, fmt.Sprintf("KnativeEventing may only be created in %s namespace", ns), nil
@@ -78,8 +78,8 @@ func (v *Validator) validateNamespace(ctx context.Context, ke *eventingv1alpha1.
 }
 
 // validate this is the only KE in this namespace
-func (v *Validator) validateLoneliness(ctx context.Context, ke *eventingv1alpha1.KnativeEventing) (bool, string, error) {
-	list := &eventingv1alpha1.KnativeEventingList{}
+func (v *Validator) validateLoneliness(ctx context.Context, ke *operatorv1alpha1.KnativeEventing) (bool, string, error) {
+	list := &operatorv1alpha1.KnativeEventingList{}
 	if err := v.client.List(ctx, list, &client.ListOptions{Namespace: ke.Namespace}); err != nil {
 		return false, "Unable to list KnativeEventings", err
 	}

--- a/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeeventing/webhook_validating_test.go
@@ -9,18 +9,18 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 var (
-	ke1 = &eventingv1alpha1.KnativeEventing{
+	ke1 = &operatorv1alpha1.KnativeEventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ke1",
 		},
 	}
-	ke2 = &eventingv1alpha1.KnativeEventing{
+	ke2 = &operatorv1alpha1.KnativeEventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ke2",
 		},

--- a/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativekafka/webhook_validating_test.go
@@ -6,69 +6,69 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
-	operatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
+	serverlessoperatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 var (
-	defaultCR = &operatorv1alpha1.KnativeKafka{
+	defaultCR = &serverlessoperatorv1alpha1.KnativeKafka{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "defaultCR",
 			Namespace: "knative-eventing",
 		},
-		Spec: operatorv1alpha1.KnativeKafkaSpec{
-			Source: operatorv1alpha1.Source{
+		Spec: serverlessoperatorv1alpha1.KnativeKafkaSpec{
+			Source: serverlessoperatorv1alpha1.Source{
 				Enabled: false,
 			},
-			Channel: operatorv1alpha1.Channel{
+			Channel: serverlessoperatorv1alpha1.Channel{
 				Enabled: false,
 			},
 		},
 	}
-	duplicateCR = &operatorv1alpha1.KnativeKafka{
+	duplicateCR = &serverlessoperatorv1alpha1.KnativeKafka{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "duplicateCR",
 			Namespace: "knative-eventing",
 		},
-		Spec: operatorv1alpha1.KnativeKafkaSpec{
-			Source: operatorv1alpha1.Source{
+		Spec: serverlessoperatorv1alpha1.KnativeKafkaSpec{
+			Source: serverlessoperatorv1alpha1.Source{
 				Enabled: false,
 			},
-			Channel: operatorv1alpha1.Channel{
+			Channel: serverlessoperatorv1alpha1.Channel{
 				Enabled: false,
 			},
 		},
 	}
-	invalidNamespaceCR = &operatorv1alpha1.KnativeKafka{
+	invalidNamespaceCR = &serverlessoperatorv1alpha1.KnativeKafka{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "invalidNamespaceCR",
 			Namespace: "FOO",
 		},
-		Spec: operatorv1alpha1.KnativeKafkaSpec{
-			Source: operatorv1alpha1.Source{
+		Spec: serverlessoperatorv1alpha1.KnativeKafkaSpec{
+			Source: serverlessoperatorv1alpha1.Source{
 				Enabled: false,
 			},
-			Channel: operatorv1alpha1.Channel{
+			Channel: serverlessoperatorv1alpha1.Channel{
 				Enabled: false,
 			},
 		},
 	}
-	invalidShapeCRs = []operatorv1alpha1.KnativeKafka{
+	invalidShapeCRs = []serverlessoperatorv1alpha1.KnativeKafka{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "invalidShapeCR-1",
 				Namespace: "knative-eventing",
 			},
-			Spec: operatorv1alpha1.KnativeKafkaSpec{
-				Source: operatorv1alpha1.Source{
+			Spec: serverlessoperatorv1alpha1.KnativeKafkaSpec{
+				Source: serverlessoperatorv1alpha1.Source{
 					Enabled: false,
 				},
-				Channel: operatorv1alpha1.Channel{
+				Channel: serverlessoperatorv1alpha1.Channel{
 					Enabled: true,
 					// need to have bootstrapServers defined here!
 				},
@@ -79,11 +79,11 @@ var (
 				Name:      "invalidShapeCR-2",
 				Namespace: "knative-eventing",
 			},
-			Spec: operatorv1alpha1.KnativeKafkaSpec{
-				Source: operatorv1alpha1.Source{
+			Spec: serverlessoperatorv1alpha1.KnativeKafkaSpec{
+				Source: serverlessoperatorv1alpha1.Source{
 					Enabled: false,
 				},
-				Channel: operatorv1alpha1.Channel{
+				Channel: serverlessoperatorv1alpha1.Channel{
 					Enabled:             true,
 					BootstrapServers:    "foo.example.com",
 					AuthSecretNamespace: "my-ns",
@@ -96,11 +96,11 @@ var (
 				Name:      "invalidShapeCR-3",
 				Namespace: "knative-eventing",
 			},
-			Spec: operatorv1alpha1.KnativeKafkaSpec{
-				Source: operatorv1alpha1.Source{
+			Spec: serverlessoperatorv1alpha1.KnativeKafkaSpec{
+				Source: serverlessoperatorv1alpha1.Source{
 					Enabled: false,
 				},
-				Channel: operatorv1alpha1.Channel{
+				Channel: serverlessoperatorv1alpha1.Channel{
 					Enabled:          true,
 					BootstrapServers: "foo.example.com",
 					AuthSecretName:   "my-secret",
@@ -109,7 +109,7 @@ var (
 			},
 		},
 	}
-	validKnativeEventingCR = &eventingv1alpha1.KnativeEventing{
+	validKnativeEventingCR = &operatorv1alpha1.KnativeEventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "validKnativeEventing",
 			Namespace: "knative-eventing",

--- a/knative-operator/pkg/webhook/knativeserving/webhook_mutating.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_mutating.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -30,7 +30,7 @@ var _ admission.Handler = (*Configurator)(nil)
 
 // Handle implements the Handler interface.
 func (v *Configurator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	ks := &servingv1alpha1.KnativeServing{}
+	ks := &operatorv1alpha1.KnativeServing{}
 
 	err := v.decoder.Decode(req, ks)
 	if err != nil {

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -31,7 +31,7 @@ var _ admission.Handler = (*Validator)(nil)
 
 // Handle implements the Handler interface.
 func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	ks := &servingv1alpha1.KnativeServing{}
+	ks := &operatorv1alpha1.KnativeServing{}
 
 	err := v.decoder.Decode(req, ks)
 	if err != nil {
@@ -46,9 +46,9 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 }
 
 // Validator checks for a minimum OpenShift version
-func (v *Validator) validate(ctx context.Context, ks *servingv1alpha1.KnativeServing) (allowed bool, reason string, err error) {
+func (v *Validator) validate(ctx context.Context, ks *operatorv1alpha1.KnativeServing) (allowed bool, reason string, err error) {
 	log := common.Log.WithName("validate")
-	stages := []func(context.Context, *servingv1alpha1.KnativeServing) (bool, string, error){
+	stages := []func(context.Context, *operatorv1alpha1.KnativeServing) (bool, string, error){
 		v.validateNamespace,
 		v.validateLoneliness,
 	}
@@ -69,7 +69,7 @@ func (v *Validator) validate(ctx context.Context, ks *servingv1alpha1.KnativeSer
 }
 
 // validate required namespace, if any
-func (v *Validator) validateNamespace(ctx context.Context, ks *servingv1alpha1.KnativeServing) (bool, string, error) {
+func (v *Validator) validateNamespace(ctx context.Context, ks *operatorv1alpha1.KnativeServing) (bool, string, error) {
 	ns, required := os.LookupEnv("REQUIRED_SERVING_NAMESPACE")
 	if required && ns != ks.Namespace {
 		return false, fmt.Sprintf("KnativeServing may only be created in %s namespace", ns), nil
@@ -78,8 +78,8 @@ func (v *Validator) validateNamespace(ctx context.Context, ks *servingv1alpha1.K
 }
 
 // validate this is the only KS in this namespace
-func (v *Validator) validateLoneliness(ctx context.Context, ks *servingv1alpha1.KnativeServing) (bool, string, error) {
-	list := &servingv1alpha1.KnativeServingList{}
+func (v *Validator) validateLoneliness(ctx context.Context, ks *operatorv1alpha1.KnativeServing) (bool, string, error) {
+	list := &operatorv1alpha1.KnativeServingList{}
 	if err := v.client.List(ctx, list, &client.ListOptions{Namespace: ks.Namespace}); err != nil {
 		return false, "Unable to list KnativeServings", err
 	}

--- a/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
+++ b/knative-operator/pkg/webhook/knativeserving/webhook_validating_test.go
@@ -9,18 +9,18 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 var (
-	ks1 = &servingv1alpha1.KnativeServing{
+	ks1 = &operatorv1alpha1.KnativeServing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ks1",
 		},
 	}
-	ks2 = &servingv1alpha1.KnativeServing{
+	ks2 = &operatorv1alpha1.KnativeServing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ks2",
 		},

--- a/knative-operator/pkg/webhook/testutil/testutil.go
+++ b/knative-operator/pkg/webhook/testutil/testutil.go
@@ -3,7 +3,7 @@ package testutil
 import (
 	"encoding/json"
 
-	v1 "k8s.io/api/admission/v1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -15,7 +15,7 @@ func RequestFor(obj runtime.Object) (admission.Request, error) {
 		return admission.Request{}, err
 	}
 	return admission.Request{
-		AdmissionRequest: v1.AdmissionRequest{
+		AdmissionRequest: admissionv1.AdmissionRequest{
 			Object: runtime.RawExtension{
 				Raw:    b,
 				Object: obj,

--- a/openshift-knative-operator/pkg/common/config.go
+++ b/openshift-knative-operator/pkg/common/config.go
@@ -1,9 +1,11 @@
 package common
 
-import "knative.dev/operator/pkg/apis/operator/v1alpha1"
+import (
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
 
 // Configure sets a value in the given ConfigMap under the given key.
-func Configure(s *v1alpha1.CommonSpec, cm, key, value string) {
+func Configure(s *operatorv1alpha1.CommonSpec, cm, key, value string) {
 	if s.Config == nil {
 		s.Config = make(map[string]map[string]string, 1)
 	}
@@ -17,7 +19,7 @@ func Configure(s *v1alpha1.CommonSpec, cm, key, value string) {
 
 // ConfigureIfUnset sets a value in the given ConfigMap under the given key if it's not
 // already set.
-func ConfigureIfUnset(s *v1alpha1.CommonSpec, cm, key, value string) {
+func ConfigureIfUnset(s *operatorv1alpha1.CommonSpec, cm, key, value string) {
 	if s.Config == nil {
 		s.Config = make(map[string]map[string]string, 1)
 	}

--- a/openshift-knative-operator/pkg/common/config_test.go
+++ b/openshift-knative-operator/pkg/common/config_test.go
@@ -5,46 +5,46 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 func TestConfigure(t *testing.T) {
 	cases := []struct {
 		name     string
-		in       v1alpha1.ConfigMapData
-		expected v1alpha1.ConfigMapData
+		in       operatorv1alpha1.ConfigMapData
+		expected operatorv1alpha1.ConfigMapData
 	}{{
 		name: "all nil",
-		expected: v1alpha1.ConfigMapData{
+		expected: operatorv1alpha1.ConfigMapData{
 			"foo": map[string]string{
 				"bar": "baz",
 			},
 		},
 	}, {
 		name: "first level already set",
-		in: v1alpha1.ConfigMapData{
+		in: operatorv1alpha1.ConfigMapData{
 			"foo": map[string]string{},
 		},
-		expected: v1alpha1.ConfigMapData{
+		expected: operatorv1alpha1.ConfigMapData{
 			"foo": map[string]string{
 				"bar": "baz",
 			},
 		},
 	}, {
 		name: "override",
-		in: v1alpha1.ConfigMapData{
+		in: operatorv1alpha1.ConfigMapData{
 			"foo": map[string]string{
 				"bar": "nope",
 			},
 		},
-		expected: v1alpha1.ConfigMapData{
+		expected: operatorv1alpha1.ConfigMapData{
 			"foo": map[string]string{
 				"bar": "baz",
 			},
 		},
 	}, {
 		name: "unrelated values",
-		in: v1alpha1.ConfigMapData{
+		in: operatorv1alpha1.ConfigMapData{
 			"foo": map[string]string{
 				"bar2": "baz2",
 			},
@@ -52,7 +52,7 @@ func TestConfigure(t *testing.T) {
 				"bar": "baz",
 			},
 		},
-		expected: v1alpha1.ConfigMapData{
+		expected: operatorv1alpha1.ConfigMapData{
 			"foo": map[string]string{
 				"bar":  "baz",
 				"bar2": "baz2",
@@ -65,7 +65,7 @@ func TestConfigure(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := &v1alpha1.CommonSpec{Config: c.in}
+			s := &operatorv1alpha1.CommonSpec{Config: c.in}
 			Configure(s, "foo", "bar", "baz")
 
 			if !cmp.Equal(s.Config, c.expected) {

--- a/openshift-knative-operator/pkg/common/resources.go
+++ b/openshift-knative-operator/pkg/common/resources.go
@@ -3,12 +3,12 @@ package common
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 // EnsureContainerMemoryLimit makes sure the memory limit for the given container is set
 // to the specified amount if not otherwise configured already.
-func EnsureContainerMemoryLimit(s *v1alpha1.CommonSpec, containerName string, memory resource.Quantity) {
+func EnsureContainerMemoryLimit(s *operatorv1alpha1.CommonSpec, containerName string, memory resource.Quantity) {
 	for i, v := range s.Resources {
 		if v.Container == containerName {
 			if v.Limits == nil {
@@ -22,7 +22,7 @@ func EnsureContainerMemoryLimit(s *v1alpha1.CommonSpec, containerName string, me
 			return
 		}
 	}
-	s.Resources = append(s.Resources, v1alpha1.ResourceRequirementsOverride{
+	s.Resources = append(s.Resources, operatorv1alpha1.ResourceRequirementsOverride{
 		Container: containerName,
 		ResourceRequirements: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{

--- a/openshift-knative-operator/pkg/common/resources_test.go
+++ b/openshift-knative-operator/pkg/common/resources_test.go
@@ -6,17 +6,17 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 func TestEnsureContainerMemoryLimit(t *testing.T) {
 	cases := []struct {
 		name     string
-		in       []v1alpha1.ResourceRequirementsOverride
-		expected []v1alpha1.ResourceRequirementsOverride
+		in       []operatorv1alpha1.ResourceRequirementsOverride
+		expected []operatorv1alpha1.ResourceRequirementsOverride
 	}{{
 		name: "all nil",
-		expected: []v1alpha1.ResourceRequirementsOverride{{
+		expected: []operatorv1alpha1.ResourceRequirementsOverride{{
 			Container: "foo",
 			ResourceRequirements: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
@@ -26,7 +26,7 @@ func TestEnsureContainerMemoryLimit(t *testing.T) {
 		}},
 	}, {
 		name: "don't override",
-		in: []v1alpha1.ResourceRequirementsOverride{{
+		in: []operatorv1alpha1.ResourceRequirementsOverride{{
 			Container: "foo",
 			ResourceRequirements: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
@@ -34,7 +34,7 @@ func TestEnsureContainerMemoryLimit(t *testing.T) {
 				},
 			},
 		}},
-		expected: []v1alpha1.ResourceRequirementsOverride{{
+		expected: []operatorv1alpha1.ResourceRequirementsOverride{{
 			Container: "foo",
 			ResourceRequirements: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
@@ -44,7 +44,7 @@ func TestEnsureContainerMemoryLimit(t *testing.T) {
 		}},
 	}, {
 		name: "leave other values alone",
-		in: []v1alpha1.ResourceRequirementsOverride{{
+		in: []operatorv1alpha1.ResourceRequirementsOverride{{
 			Container: "foo",
 			ResourceRequirements: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
@@ -52,7 +52,7 @@ func TestEnsureContainerMemoryLimit(t *testing.T) {
 				},
 			},
 		}},
-		expected: []v1alpha1.ResourceRequirementsOverride{{
+		expected: []operatorv1alpha1.ResourceRequirementsOverride{{
 			Container: "foo",
 			ResourceRequirements: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
@@ -63,7 +63,7 @@ func TestEnsureContainerMemoryLimit(t *testing.T) {
 		}},
 	}, {
 		name: "leave request values alone",
-		in: []v1alpha1.ResourceRequirementsOverride{{
+		in: []operatorv1alpha1.ResourceRequirementsOverride{{
 			Container: "foo",
 			ResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -71,7 +71,7 @@ func TestEnsureContainerMemoryLimit(t *testing.T) {
 				},
 			},
 		}},
-		expected: []v1alpha1.ResourceRequirementsOverride{{
+		expected: []operatorv1alpha1.ResourceRequirementsOverride{{
 			Container: "foo",
 			ResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -86,7 +86,7 @@ func TestEnsureContainerMemoryLimit(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := &v1alpha1.CommonSpec{Resources: c.in}
+			s := &operatorv1alpha1.CommonSpec{Resources: c.in}
 			EnsureContainerMemoryLimit(s, "foo", resource.MustParse("1024Mi"))
 
 			if !cmp.Equal(s.Resources, c.expected) {

--- a/openshift-knative-operator/pkg/eventing/extension.go
+++ b/openshift-knative-operator/pkg/eventing/extension.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	operator "knative.dev/operator/pkg/reconciler/common"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/controller"
@@ -29,16 +29,16 @@ type extension struct {
 	kubeclient kubernetes.Interface
 }
 
-func (e *extension) Manifests(ke v1alpha1.KComponent) ([]mf.Manifest, error) {
+func (e *extension) Manifests(ke operatorv1alpha1.KComponent) ([]mf.Manifest, error) {
 	return monitoring.GetEventingMonitoringPlatformManifests(ke)
 }
 
-func (e *extension) Transformers(ke v1alpha1.KComponent) []mf.Transformer {
+func (e *extension) Transformers(ke operatorv1alpha1.KComponent) []mf.Transformer {
 	return monitoring.GetEventingTransformers(ke)
 }
 
-func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) error {
-	ke := comp.(*v1alpha1.KnativeEventing)
+func (e *extension) Reconcile(ctx context.Context, comp operatorv1alpha1.KComponent) error {
+	ke := comp.(*operatorv1alpha1.KnativeEventing)
 
 	requiredNs := os.Getenv(requiredNsEnvName)
 	if requiredNs != "" && ke.Namespace != requiredNs {
@@ -62,7 +62,7 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 
 	// Default to 2 replicas.
 	if ke.Spec.HighAvailability == nil {
-		ke.Spec.HighAvailability = &v1alpha1.HighAvailability{
+		ke.Spec.HighAvailability = &operatorv1alpha1.HighAvailability{
 			Replicas: 2,
 		}
 	}
@@ -70,6 +70,6 @@ func (e *extension) Reconcile(ctx context.Context, comp v1alpha1.KComponent) err
 	return monitoring.ReconcileMonitoringForEventing(ctx, e.kubeclient, ke)
 }
 
-func (e *extension) Finalize(context.Context, v1alpha1.KComponent) error {
+func (e *extension) Finalize(context.Context, operatorv1alpha1.KComponent) error {
 	return nil
 }

--- a/openshift-knative-operator/pkg/eventing/extension_test.go
+++ b/openshift-knative-operator/pkg/eventing/extension_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"knative.dev/pkg/apis"
 	kubefake "knative.dev/pkg/client/injection/kube/client/fake"
 )
@@ -39,62 +39,62 @@ func TestReconcile(t *testing.T) {
 
 	cases := []struct {
 		name     string
-		in       *v1alpha1.KnativeEventing
-		expected *v1alpha1.KnativeEventing
+		in       *operatorv1alpha1.KnativeEventing
+		expected *operatorv1alpha1.KnativeEventing
 	}{{
 		name:     "all nil",
-		in:       &v1alpha1.KnativeEventing{},
+		in:       &operatorv1alpha1.KnativeEventing{},
 		expected: ke(),
 	}, {
 		name: "different HA settings",
-		in: &v1alpha1.KnativeEventing{
-			Spec: v1alpha1.KnativeEventingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
-					HighAvailability: &v1alpha1.HighAvailability{
+		in: &operatorv1alpha1.KnativeEventing{
+			Spec: operatorv1alpha1.KnativeEventingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
+					HighAvailability: &operatorv1alpha1.HighAvailability{
 						Replicas: 3,
 					},
 				},
 			},
 		},
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			ke.Spec.HighAvailability.Replicas = 3
 		}),
 	}, {
 		name: "With inclusion sinkbinding setting",
-		in: &v1alpha1.KnativeEventing{
-			Spec: v1alpha1.KnativeEventingSpec{
+		in: &operatorv1alpha1.KnativeEventing{
+			Spec: operatorv1alpha1.KnativeEventingSpec{
 				SinkBindingSelectionMode: "inclusion",
 			},
 		},
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			ke.Spec.SinkBindingSelectionMode = "inclusion"
 		}),
 	}, {
 		name: "With exclusion sinkbinding setting",
-		in: &v1alpha1.KnativeEventing{
-			Spec: v1alpha1.KnativeEventingSpec{
+		in: &operatorv1alpha1.KnativeEventing{
+			Spec: operatorv1alpha1.KnativeEventingSpec{
 				SinkBindingSelectionMode: "exclusion",
 			},
 		},
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			ke.Spec.SinkBindingSelectionMode = "exclusion"
 		}),
 	}, {
 		name: "With empty sinkbinding setting",
-		in: &v1alpha1.KnativeEventing{
-			Spec: v1alpha1.KnativeEventingSpec{
+		in: &operatorv1alpha1.KnativeEventing{
+			Spec: operatorv1alpha1.KnativeEventingSpec{
 				SinkBindingSelectionMode: "",
 			},
 		},
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			ke.Spec.SinkBindingSelectionMode = "inclusion"
 		}),
 	}, {
 		name: "Wrong namespace",
-		in: ke(func(ke *v1alpha1.KnativeEventing) {
+		in: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			ke.Namespace = "foo"
 		}),
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			ke.Namespace = "foo"
 			ke.Status.MarkInstallFailed(`Knative Eventing must be installed into the namespace "knative-eventing"`)
 		}),
@@ -127,56 +127,56 @@ func TestReconcile(t *testing.T) {
 func TestMonitoring(t *testing.T) {
 	cases := []struct {
 		name     string
-		in       *v1alpha1.KnativeEventing
-		expected *v1alpha1.KnativeEventing
+		in       *operatorv1alpha1.KnativeEventing
+		expected *operatorv1alpha1.KnativeEventing
 		// Returns the expected status for monitoring
 		setupMonitoringToggle func() (bool, error)
 	}{{
 		name:                  "enable monitoring when monitoring toggle is not defined, backend is not defined",
-		in:                    &v1alpha1.KnativeEventing{},
+		in:                    &operatorv1alpha1.KnativeEventing{},
 		expected:              ke(),
 		setupMonitoringToggle: func() (bool, error) { return true, nil },
 	}, {
 		name: "enable monitoring when monitoring toggle = not defined, backend = defined and not `none`",
-		in: &v1alpha1.KnativeEventing{
-			Spec: v1alpha1.KnativeEventingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeEventing{
+			Spec: operatorv1alpha1.KnativeEventingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "prometheus"}},
 				},
 			},
 		},
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			common.Configure(&ke.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "prometheus")
 		}),
 		setupMonitoringToggle: func() (bool, error) { return true, nil },
 	}, {
 		name: "disable monitoring when monitoring toggle is not defined, backend is `none`",
-		in: &v1alpha1.KnativeEventing{
-			Spec: v1alpha1.KnativeEventingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeEventing{
+			Spec: operatorv1alpha1.KnativeEventingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "none"}},
 				},
 			},
 		},
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			common.Configure(&ke.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 		}),
 		setupMonitoringToggle: func() (bool, error) { return false, nil },
 	}, {
 		name:                  "enable monitoring when monitoring toggle is on, backend is not defined",
-		in:                    &v1alpha1.KnativeEventing{},
+		in:                    &operatorv1alpha1.KnativeEventing{},
 		expected:              ke(),
 		setupMonitoringToggle: func() (bool, error) { return true, os.Setenv(monitoring.EnableMonitoringEnvVar, "true") },
 	}, {
 		name: "enable monitoring when monitoring toggle is on, backend is defined and not `none`",
-		in: &v1alpha1.KnativeEventing{
-			Spec: v1alpha1.KnativeEventingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeEventing{
+			Spec: operatorv1alpha1.KnativeEventingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "prometheus"}},
 				},
 			},
 		},
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			common.Configure(&ke.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "prometheus")
 		}),
 		setupMonitoringToggle: func() (bool, error) {
@@ -184,14 +184,14 @@ func TestMonitoring(t *testing.T) {
 		},
 	}, {
 		name: "disable monitoring when monitoring toggle is on, backend is `none`",
-		in: &v1alpha1.KnativeEventing{
-			Spec: v1alpha1.KnativeEventingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeEventing{
+			Spec: operatorv1alpha1.KnativeEventingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "none"}},
 				},
 			},
 		},
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			common.Configure(&ke.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 		}),
 		setupMonitoringToggle: func() (bool, error) {
@@ -199,34 +199,34 @@ func TestMonitoring(t *testing.T) {
 		},
 	}, {
 		name: "disable monitoring when monitoring toggle is off, backend is not defined",
-		in:   &v1alpha1.KnativeEventing{},
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		in:   &operatorv1alpha1.KnativeEventing{},
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			common.Configure(&ke.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 		}),
 		setupMonitoringToggle: func() (bool, error) { return false, os.Setenv(monitoring.EnableMonitoringEnvVar, "false") },
 	}, {
 		name: "enable monitoring when monitoring toggle = off, backend = defined and not `none`",
-		in: &v1alpha1.KnativeEventing{
-			Spec: v1alpha1.KnativeEventingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeEventing{
+			Spec: operatorv1alpha1.KnativeEventingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "prometheus"}},
 				},
 			},
 		},
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			common.Configure(&ke.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "prometheus")
 		}),
 		setupMonitoringToggle: func() (bool, error) { return true, os.Setenv(monitoring.EnableMonitoringEnvVar, "false") },
 	}, {
 		name: "disable monitoring when monitoring toggle is off, backend is `none`",
-		in: &v1alpha1.KnativeEventing{
-			Spec: v1alpha1.KnativeEventingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeEventing{
+			Spec: operatorv1alpha1.KnativeEventingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "none"}},
 				},
 			},
 		},
-		expected: ke(func(ke *v1alpha1.KnativeEventing) {
+		expected: ke(func(ke *operatorv1alpha1.KnativeEventing) {
 			common.Configure(&ke.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 		}),
 		setupMonitoringToggle: func() (bool, error) { return false, os.Setenv(monitoring.EnableMonitoringEnvVar, "false") },
@@ -268,25 +268,25 @@ func TestMonitoring(t *testing.T) {
 	}
 }
 
-func ke(mods ...func(*v1alpha1.KnativeEventing)) *v1alpha1.KnativeEventing {
-	base := &v1alpha1.KnativeEventing{
+func ke(mods ...func(*operatorv1alpha1.KnativeEventing)) *operatorv1alpha1.KnativeEventing {
+	base := &operatorv1alpha1.KnativeEventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: requiredNs,
 		},
-		Spec: v1alpha1.KnativeEventingSpec{
+		Spec: operatorv1alpha1.KnativeEventingSpec{
 			SinkBindingSelectionMode: "inclusion",
-			CommonSpec: v1alpha1.CommonSpec{
-				HighAvailability: &v1alpha1.HighAvailability{
+			CommonSpec: operatorv1alpha1.CommonSpec{
+				HighAvailability: &operatorv1alpha1.HighAvailability{
 					Replicas: 2,
 				},
-				Registry: v1alpha1.Registry{
+				Registry: operatorv1alpha1.Registry{
 					Default: "bar2",
 					Override: map[string]string{
 						"default": "bar2",
 						"foo":     "bar",
 					},
 				},
-				Resources: []v1alpha1.ResourceRequirementsOverride{{
+				Resources: []operatorv1alpha1.ResourceRequirementsOverride{{
 					Container: "eventing-webhook",
 					ResourceRequirements: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{

--- a/openshift-knative-operator/pkg/monitoring/helpers.go
+++ b/openshift-knative-operator/pkg/monitoring/helpers.go
@@ -11,12 +11,12 @@ import (
 	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"knative.dev/pkg/logging"
 )
 
@@ -60,7 +60,7 @@ func injectNamespaceWithSubject(resourceNamespace string, subjectNamespace strin
 	}
 }
 
-func reconcileMonitoring(ctx context.Context, api kubernetes.Interface, spec *v1alpha1.CommonSpec, ns string) error {
+func reconcileMonitoring(ctx context.Context, api kubernetes.Interface, spec *operatorv1alpha1.CommonSpec, ns string) error {
 	if ShouldEnableMonitoring(spec.GetConfig()) {
 		if err := reconcileMonitoringLabelOnNamespace(ctx, ns, api, true); err != nil {
 			return fmt.Errorf("failed to enable monitoring %w ", err)
@@ -76,7 +76,7 @@ func reconcileMonitoring(ctx context.Context, api kubernetes.Interface, spec *v1
 	return nil
 }
 
-func ShouldEnableMonitoring(config v1alpha1.ConfigMapData) bool {
+func ShouldEnableMonitoring(config operatorv1alpha1.ConfigMapData) bool {
 	backend := config[ObservabilityCMName][ObservabilityBackendKey]
 	if backend == "none" || backend == "opencensus" {
 		return false
@@ -199,16 +199,16 @@ func createServiceMonitorService(component string, ns string) corev1.Service {
 }
 
 func CreateClusterRoleBindingManifest(serviceAccountName string, ns string) (*mf.Manifest, error) {
-	crb := v1.ClusterRoleBinding{
+	crb := rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("rbac-proxy-reviews-prom-rb-%s", serviceAccountName),
 		},
-		RoleRef: v1.RoleRef{
+		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
 			Name:     "rbac-proxy-reviews-prom",
 		},
-		Subjects: []v1.Subject{{
+		Subjects: []rbacv1.Subject{{
 			Kind:      "ServiceAccount",
 			Name:      serviceAccountName,
 			Namespace: ns,

--- a/openshift-knative-operator/pkg/monitoring/monitoring_eventing.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_eventing.go
@@ -6,18 +6,18 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 var (
 	eventingDeployments = sets.NewString("eventing-controller", "eventing-webhook", "imc-controller", "imc-dispatcher", "mt-broker-controller", "mt-broker-filter", "mt-broker-ingress", "sugar-controller")
 )
 
-func ReconcileMonitoringForEventing(ctx context.Context, api kubernetes.Interface, ke *v1alpha1.KnativeEventing) error {
+func ReconcileMonitoringForEventing(ctx context.Context, api kubernetes.Interface, ke *operatorv1alpha1.KnativeEventing) error {
 	return reconcileMonitoring(ctx, api, &ke.Spec.CommonSpec, ke.GetNamespace())
 }
 
-func GetEventingTransformers(comp v1alpha1.KComponent) []mf.Transformer {
+func GetEventingTransformers(comp operatorv1alpha1.KComponent) []mf.Transformer {
 	// When monitoring is off we keep around the required resources, only rbac-proxy is removed
 	transformers := []mf.Transformer{injectNamespaceWithSubject(comp.GetNamespace(), OpenshiftMonitoringNamespace)}
 	if ShouldEnableMonitoring(comp.GetSpec().GetConfig()) {
@@ -26,7 +26,7 @@ func GetEventingTransformers(comp v1alpha1.KComponent) []mf.Transformer {
 	return transformers
 }
 
-func GetEventingMonitoringPlatformManifests(ke v1alpha1.KComponent) ([]mf.Manifest, error) {
+func GetEventingMonitoringPlatformManifests(ke operatorv1alpha1.KComponent) ([]mf.Manifest, error) {
 	rbacManifest, err := getRBACManifest()
 	if err != nil {
 		return nil, err

--- a/openshift-knative-operator/pkg/monitoring/monitoring_eventing_test.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_eventing_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 func TestLoadPlatformEventingMonitoringManifests(t *testing.T) {
-	manifests, err := GetEventingMonitoringPlatformManifests(&v1alpha1.KnativeEventing{
+	manifests, err := GetEventingMonitoringPlatformManifests(&operatorv1alpha1.KnativeEventing{
 		ObjectMeta: metav1.ObjectMeta{Namespace: eventingNamespace},
 	})
 	if err != nil {

--- a/openshift-knative-operator/pkg/monitoring/monitoring_serving.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_serving.go
@@ -6,18 +6,18 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 var (
 	servingDeployments = sets.NewString("activator", "autoscaler", "autoscaler-hpa", "controller", "domain-mapping", "domainmapping-webhook", "webhook")
 )
 
-func ReconcileMonitoringForServing(ctx context.Context, api kubernetes.Interface, ks *v1alpha1.KnativeServing) error {
+func ReconcileMonitoringForServing(ctx context.Context, api kubernetes.Interface, ks *operatorv1alpha1.KnativeServing) error {
 	return reconcileMonitoring(ctx, api, &ks.Spec.CommonSpec, ks.GetNamespace())
 }
 
-func GetServingTransformers(comp v1alpha1.KComponent) []mf.Transformer {
+func GetServingTransformers(comp operatorv1alpha1.KComponent) []mf.Transformer {
 	// When monitoring is off we keep around the required resources, only rbac-proxy is removed
 	transformers := []mf.Transformer{injectNamespaceWithSubject(comp.GetNamespace(), OpenshiftMonitoringNamespace)}
 	if ShouldEnableMonitoring(comp.GetSpec().GetConfig()) {
@@ -26,7 +26,7 @@ func GetServingTransformers(comp v1alpha1.KComponent) []mf.Transformer {
 	return transformers
 }
 
-func GetServingMonitoringPlatformManifests(ks v1alpha1.KComponent) ([]mf.Manifest, error) {
+func GetServingMonitoringPlatformManifests(ks operatorv1alpha1.KComponent) ([]mf.Manifest, error) {
 	rbacManifest, err := getRBACManifest()
 	if err != nil {
 		return nil, err

--- a/openshift-knative-operator/pkg/monitoring/monitoring_serving_test.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_serving_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 func TestLoadPlatformServingMonitoringManifests(t *testing.T) {
-	manifests, err := GetServingMonitoringPlatformManifests(&v1alpha1.KnativeServing{
+	manifests, err := GetServingMonitoringPlatformManifests(&operatorv1alpha1.KnativeServing{
 		ObjectMeta: metav1.ObjectMeta{Namespace: servingNamespace},
 	})
 	if err != nil {

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	operator "knative.dev/operator/pkg/reconciler/common"
 	"knative.dev/pkg/apis"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -67,44 +67,44 @@ func TestReconcile(t *testing.T) {
 	cases := []struct {
 		name       string
 		k8sVersion string
-		in         *v1alpha1.KnativeServing
+		in         *operatorv1alpha1.KnativeServing
 		objs       []runtime.Object
-		expected   *v1alpha1.KnativeServing
+		expected   *operatorv1alpha1.KnativeServing
 	}{{
 		name:     "all nil",
-		in:       &v1alpha1.KnativeServing{},
+		in:       &operatorv1alpha1.KnativeServing{},
 		expected: ks(),
 	}, {
 		name: "different HA settings",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
-					HighAvailability: &v1alpha1.HighAvailability{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
+					HighAvailability: &operatorv1alpha1.HighAvailability{
 						Replicas: 3,
 					},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			ks.Spec.HighAvailability.Replicas = 3
 		}),
 	}, {
 		name: "different certificate settings",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				ControllerCustomCerts: v1alpha1.CustomCerts{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				ControllerCustomCerts: operatorv1alpha1.CustomCerts{
 					Type: "Secret",
 					Name: "foo",
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			ks.Spec.ControllerCustomCerts.Type = "Secret"
 			ks.Spec.ControllerCustomCerts.Name = "foo"
 		}),
 	}, {
 		name: "existing logging route",
-		in:   &v1alpha1.KnativeServing{},
+		in:   &operatorv1alpha1.KnativeServing{},
 		objs: []runtime.Object{
 			defaultIngress,
 			&routev1.Route{
@@ -119,16 +119,16 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, "logging.revision-url-template",
 				fmt.Sprintf(loggingURLTemplate, "logging.example.com"))
 		}),
 	}, {
 		name: "override image settings",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
-					Registry: v1alpha1.Registry{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
+					Registry: operatorv1alpha1.Registry{
 						Override: map[string]string{
 							"foo":         "not",
 							"queue-proxy": "correct",
@@ -140,10 +140,10 @@ func TestReconcile(t *testing.T) {
 		expected: ks(),
 	}, {
 		name: "override ingress class",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
-					Config: v1alpha1.ConfigMapData{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
+					Config: operatorv1alpha1.ConfigMapData{
 						"network": map[string]string{
 							"ingress.class": "foo",
 						},
@@ -151,23 +151,23 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			common.Configure(&ks.Spec.CommonSpec, "network", "ingress.class", "foo")
 		}),
 	}, {
 		name: "default kourier service type",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				Ingress: &v1alpha1.IngressConfigs{
-					Kourier: v1alpha1.KourierIngressConfiguration{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				Ingress: &operatorv1alpha1.IngressConfigs{
+					Kourier: operatorv1alpha1.KourierIngressConfiguration{
 						Enabled: true,
 					},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
-			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
-				Kourier: v1alpha1.KourierIngressConfiguration{
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
+			ks.Spec.Ingress = &operatorv1alpha1.IngressConfigs{
+				Kourier: operatorv1alpha1.KourierIngressConfiguration{
 					Enabled:     true,
 					ServiceType: "ClusterIP",
 				},
@@ -175,19 +175,19 @@ func TestReconcile(t *testing.T) {
 		}),
 	}, {
 		name: "override kourier service type",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				Ingress: &v1alpha1.IngressConfigs{
-					Kourier: v1alpha1.KourierIngressConfiguration{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				Ingress: &operatorv1alpha1.IngressConfigs{
+					Kourier: operatorv1alpha1.KourierIngressConfiguration{
 						Enabled:     true,
 						ServiceType: "LoadBalancer",
 					},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
-			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
-				Kourier: v1alpha1.KourierIngressConfiguration{
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
+			ks.Spec.Ingress = &operatorv1alpha1.IngressConfigs{
+				Kourier: operatorv1alpha1.KourierIngressConfiguration{
 					Enabled:     true,
 					ServiceType: "LoadBalancer",
 				},
@@ -195,18 +195,18 @@ func TestReconcile(t *testing.T) {
 		}),
 	}, {
 		name: "override ingress config",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				Ingress: &v1alpha1.IngressConfigs{
-					Istio: v1alpha1.IstioIngressConfiguration{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				Ingress: &operatorv1alpha1.IngressConfigs{
+					Istio: operatorv1alpha1.IstioIngressConfiguration{
 						Enabled: true,
 					},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
-			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
-				Istio: v1alpha1.IstioIngressConfiguration{
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
+			ks.Spec.Ingress = &operatorv1alpha1.IngressConfigs{
+				Istio: operatorv1alpha1.IstioIngressConfiguration{
 					Enabled: true,
 				},
 			}
@@ -215,24 +215,24 @@ func TestReconcile(t *testing.T) {
 		}),
 	}, {
 		name: "fix 'wrong' ingress config", // https://github.com/knative/operator/issues/568
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				Ingress: &v1alpha1.IngressConfigs{
-					Istio: v1alpha1.IstioIngressConfiguration{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				Ingress: &operatorv1alpha1.IngressConfigs{
+					Istio: operatorv1alpha1.IstioIngressConfiguration{
 						Enabled: false,
 					},
-					Kourier: v1alpha1.KourierIngressConfiguration{
+					Kourier: operatorv1alpha1.KourierIngressConfiguration{
 						Enabled: false,
 					},
-					Contour: v1alpha1.ContourIngressConfiguration{
+					Contour: operatorv1alpha1.ContourIngressConfiguration{
 						Enabled: false,
 					},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
-			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
-				Kourier: v1alpha1.KourierIngressConfiguration{
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
+			ks.Spec.Ingress = &operatorv1alpha1.IngressConfigs{
+				Kourier: operatorv1alpha1.KourierIngressConfiguration{
 					Enabled:     true,
 					ServiceType: "ClusterIP",
 				},
@@ -240,19 +240,19 @@ func TestReconcile(t *testing.T) {
 		}),
 	}, {
 		name: "respect kourier settings",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				Ingress: &v1alpha1.IngressConfigs{
-					Kourier: v1alpha1.KourierIngressConfiguration{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				Ingress: &operatorv1alpha1.IngressConfigs{
+					Kourier: operatorv1alpha1.KourierIngressConfiguration{
 						// Enabled: true omitted explicitly.
 						ServiceType: corev1.ServiceTypeClusterIP,
 					},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
-			ks.Spec.Ingress = &v1alpha1.IngressConfigs{
-				Kourier: v1alpha1.KourierIngressConfiguration{
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
+			ks.Spec.Ingress = &operatorv1alpha1.IngressConfigs{
+				Kourier: operatorv1alpha1.KourierIngressConfiguration{
 					Enabled:     true,
 					ServiceType: corev1.ServiceTypeClusterIP,
 				},
@@ -260,10 +260,10 @@ func TestReconcile(t *testing.T) {
 		}),
 	}, {
 		name: "override default url scheme",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
-					Config: v1alpha1.ConfigMapData{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
+					Config: operatorv1alpha1.ConfigMapData{
 						"network": map[string]string{
 							"defaultExternalScheme": "http",
 						},
@@ -271,15 +271,15 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			common.Configure(&ks.Spec.CommonSpec, "network", "defaultExternalScheme", "http")
 		}),
 	}, {
 		name: "override autocreateClusterDomainClaims config",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
-					Config: v1alpha1.ConfigMapData{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
+					Config: operatorv1alpha1.ConfigMapData{
 						"network": map[string]string{
 							"autocreateClusterDomainClaims": "false",
 						},
@@ -287,23 +287,23 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			common.Configure(&ks.Spec.CommonSpec, "network", "autocreateClusterDomainClaims", "false")
 		}),
 	}, {
 		name: "respects different status",
-		in: ks(func(ks *v1alpha1.KnativeServing) {
+		in: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			ks.Status.MarkDependenciesInstalled()
 		}),
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			ks.Status.MarkDependenciesInstalled()
 		}),
 	}, {
 		name: "wrong namespace",
-		in: ks(func(ks *v1alpha1.KnativeServing) {
+		in: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			ks.Namespace = "foo"
 		}),
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			ks.Namespace = "foo"
 			ks.Status.MarkInstallFailed(`Knative Serving must be installed into the namespace "knative-serving"`)
 		}),
@@ -356,56 +356,56 @@ func newFakeExtension(ctx context.Context, t *testing.T) operator.Extension {
 func TestMonitoring(t *testing.T) {
 	cases := []struct {
 		name     string
-		in       *v1alpha1.KnativeServing
-		expected *v1alpha1.KnativeServing
+		in       *operatorv1alpha1.KnativeServing
+		expected *operatorv1alpha1.KnativeServing
 		// Returns the expected status for monitoring
 		setupMonitoringToggle func() (bool, error)
 	}{{
 		name:                  "enable monitoring when monitoring toggle is not defined, backend is not defined",
-		in:                    &v1alpha1.KnativeServing{},
+		in:                    &operatorv1alpha1.KnativeServing{},
 		expected:              ks(),
 		setupMonitoringToggle: func() (bool, error) { return true, nil },
 	}, {
 		name: "enable monitoring when monitoring toggle = not defined, backend = defined and not `none`",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "prometheus"}},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "prometheus")
 		}),
 		setupMonitoringToggle: func() (bool, error) { return true, nil },
 	}, {
 		name: "disable monitoring when monitoring toggle is not defined, backend is `none`",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "none"}},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 		}),
 		setupMonitoringToggle: func() (bool, error) { return false, nil },
 	}, {
 		name:                  "enable monitoring when monitoring toggle is on, backend is not defined",
-		in:                    &v1alpha1.KnativeServing{},
+		in:                    &operatorv1alpha1.KnativeServing{},
 		expected:              ks(),
 		setupMonitoringToggle: func() (bool, error) { return true, os.Setenv(monitoring.EnableMonitoringEnvVar, "true") },
 	}, {
 		name: "enable monitoring when monitoring toggle is on, backend is defined and not `none`",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "prometheus"}},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "prometheus")
 		}),
 		setupMonitoringToggle: func() (bool, error) {
@@ -413,14 +413,14 @@ func TestMonitoring(t *testing.T) {
 		},
 	}, {
 		name: "disable monitoring when monitoring toggle is on, backend is `none`",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "none"}},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 		}),
 		setupMonitoringToggle: func() (bool, error) {
@@ -428,34 +428,34 @@ func TestMonitoring(t *testing.T) {
 		},
 	}, {
 		name: "disable monitoring when monitoring toggle is off, backend is not defined",
-		in:   &v1alpha1.KnativeServing{},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		in:   &operatorv1alpha1.KnativeServing{},
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 		}),
 		setupMonitoringToggle: func() (bool, error) { return false, os.Setenv(monitoring.EnableMonitoringEnvVar, "false") },
 	}, {
 		name: "enable monitoring when monitoring toggle = off, backend = defined and not `none`",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "prometheus"}},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "prometheus")
 		}),
 		setupMonitoringToggle: func() (bool, error) { return true, os.Setenv(monitoring.EnableMonitoringEnvVar, "false") },
 	}, {
 		name: "disable monitoring when monitoring toggle is off, backend is `none`",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				CommonSpec: v1alpha1.CommonSpec{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				CommonSpec: operatorv1alpha1.CommonSpec{
 					Config: map[string]map[string]string{monitoring.ObservabilityCMName: {monitoring.ObservabilityBackendKey: "none"}},
 				},
 			},
 		},
-		expected: ks(func(ks *v1alpha1.KnativeServing) {
+		expected: ks(func(ks *operatorv1alpha1.KnativeServing) {
 			common.Configure(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 		}),
 		setupMonitoringToggle: func() (bool, error) { return false, os.Setenv(monitoring.EnableMonitoringEnvVar, "false") },
@@ -495,17 +495,17 @@ func TestMonitoring(t *testing.T) {
 	}
 }
 
-func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
-	base := &v1alpha1.KnativeServing{
+func ks(mods ...func(*operatorv1alpha1.KnativeServing)) *operatorv1alpha1.KnativeServing {
+	base := &operatorv1alpha1.KnativeServing{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: servingNamespace.Name,
 		},
-		Spec: v1alpha1.KnativeServingSpec{
-			CommonSpec: v1alpha1.CommonSpec{
-				HighAvailability: &v1alpha1.HighAvailability{
+		Spec: operatorv1alpha1.KnativeServingSpec{
+			CommonSpec: operatorv1alpha1.CommonSpec{
+				HighAvailability: &operatorv1alpha1.HighAvailability{
 					Replicas: 2,
 				},
-				Config: v1alpha1.ConfigMapData{
+				Config: operatorv1alpha1.ConfigMapData{
 					"deployment": map[string]string{
 						"queueSidecarImage": "baz",
 					},
@@ -519,7 +519,7 @@ func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
 						"defaultExternalScheme":         "https",
 					},
 				},
-				Registry: v1alpha1.Registry{
+				Registry: operatorv1alpha1.Registry{
 					Default: "bar2",
 					Override: map[string]string{
 						"default":     "bar2",
@@ -527,7 +527,7 @@ func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
 						"queue-proxy": "baz",
 					},
 				},
-				Resources: []v1alpha1.ResourceRequirementsOverride{{
+				Resources: []operatorv1alpha1.ResourceRequirementsOverride{{
 					Container: "webhook",
 					ResourceRequirements: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
@@ -536,12 +536,12 @@ func ks(mods ...func(*v1alpha1.KnativeServing)) *v1alpha1.KnativeServing {
 					},
 				}},
 			},
-			ControllerCustomCerts: v1alpha1.CustomCerts{
+			ControllerCustomCerts: operatorv1alpha1.CustomCerts{
 				Type: "ConfigMap",
 				Name: "config-service-ca",
 			},
-			Ingress: &v1alpha1.IngressConfigs{
-				Kourier: v1alpha1.KourierIngressConfiguration{
+			Ingress: &operatorv1alpha1.IngressConfigs{
+				Kourier: operatorv1alpha1.KourierIngressConfiguration{
 					Enabled:     true,
 					ServiceType: "ClusterIP",
 				},

--- a/openshift-knative-operator/pkg/serving/ingress.go
+++ b/openshift-knative-operator/pkg/serving/ingress.go
@@ -1,9 +1,8 @@
 package serving
 
 import (
-	v1 "k8s.io/api/core/v1"
-
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 const istioIngressClassName = "istio.ingress.networking.knative.dev"
@@ -11,10 +10,10 @@ const istioIngressClassName = "istio.ingress.networking.knative.dev"
 // defaultToKourier applies an Ingress config with Kourier enabled if nothing else is defined.
 // Also handles the (buggy) case, where all Ingresses are disabled.
 // See https://github.com/knative/operator/issues/568.
-func defaultToKourier(ks *v1alpha1.KnativeServing) {
+func defaultToKourier(ks *operatorv1alpha1.KnativeServing) {
 	if ks.Spec.Ingress == nil {
-		ks.Spec.Ingress = &v1alpha1.IngressConfigs{
-			Kourier: v1alpha1.KourierIngressConfiguration{
+		ks.Spec.Ingress = &operatorv1alpha1.IngressConfigs{
+			Kourier: operatorv1alpha1.KourierIngressConfiguration{
 				Enabled: true,
 			},
 		}
@@ -27,10 +26,10 @@ func defaultToKourier(ks *v1alpha1.KnativeServing) {
 
 }
 
-func defaultKourierServiceType(ks *v1alpha1.KnativeServing) {
+func defaultKourierServiceType(ks *operatorv1alpha1.KnativeServing) {
 	if ks.Spec.Ingress != nil && ks.Spec.Ingress.Kourier.Enabled {
 		if ks.Spec.Ingress.Kourier.ServiceType == "" {
-			ks.Spec.Ingress.Kourier.ServiceType = v1.ServiceTypeClusterIP
+			ks.Spec.Ingress.Kourier.ServiceType = corev1.ServiceTypeClusterIP
 		}
 	}
 }
@@ -39,7 +38,7 @@ func defaultKourierServiceType(ks *v1alpha1.KnativeServing) {
 // - If nothing is defined, Kourier will be used.
 // - If Kourier is enabled, it'll always take precedence.
 // - If only Istio is enabled, it'll be used.
-func defaultIngressClass(ks *v1alpha1.KnativeServing) string {
+func defaultIngressClass(ks *operatorv1alpha1.KnativeServing) string {
 	if ks.Spec.Ingress == nil {
 		return kourierIngressClassName
 	}

--- a/openshift-knative-operator/pkg/serving/ingress_test.go
+++ b/openshift-knative-operator/pkg/serving/ingress_test.go
@@ -4,32 +4,32 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 func TestDefaultIngressClass(t *testing.T) {
 	cases := []struct {
 		name     string
-		in       *v1alpha1.KnativeServing
+		in       *operatorv1alpha1.KnativeServing
 		expected string
 	}{{
 		name:     "unset",
-		in:       &v1alpha1.KnativeServing{},
+		in:       &operatorv1alpha1.KnativeServing{},
 		expected: kourierIngressClassName,
 	}, {
 		name: "all disabled",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				Ingress: &v1alpha1.IngressConfigs{},
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				Ingress: &operatorv1alpha1.IngressConfigs{},
 			},
 		},
 		expected: kourierIngressClassName,
 	}, {
 		name: "istio enabled",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				Ingress: &v1alpha1.IngressConfigs{
-					Istio: v1alpha1.IstioIngressConfiguration{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				Ingress: &operatorv1alpha1.IngressConfigs{
+					Istio: operatorv1alpha1.IstioIngressConfiguration{
 						Enabled: true,
 					},
 				},
@@ -38,13 +38,13 @@ func TestDefaultIngressClass(t *testing.T) {
 		expected: istioIngressClassName,
 	}, {
 		name: "kourier and istio enabled",
-		in: &v1alpha1.KnativeServing{
-			Spec: v1alpha1.KnativeServingSpec{
-				Ingress: &v1alpha1.IngressConfigs{
-					Kourier: v1alpha1.KourierIngressConfiguration{
+		in: &operatorv1alpha1.KnativeServing{
+			Spec: operatorv1alpha1.KnativeServingSpec{
+				Ingress: &operatorv1alpha1.IngressConfigs{
+					Kourier: operatorv1alpha1.KourierIngressConfiguration{
 						Enabled: true,
 					},
-					Istio: v1alpha1.IstioIngressConfiguration{
+					Istio: operatorv1alpha1.IstioIngressConfiguration{
 						Enabled: true,
 					},
 				},

--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -9,11 +9,11 @@ import (
 	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 const (
@@ -23,7 +23,7 @@ const (
 
 // overrideKourierNamespace overrides the namespace of all Kourier related resources to
 // the -ingress suffix to be backwards compatible.
-func overrideKourierNamespace(ks v1alpha1.KComponent) mf.Transformer {
+func overrideKourierNamespace(ks operatorv1alpha1.KComponent) mf.Transformer {
 	nsInjector := mf.InjectNamespace(kourierNamespace(ks.GetNamespace()))
 	return func(u *unstructured.Unstructured) error {
 		provider := u.GetLabels()[providerLabel]
@@ -48,7 +48,7 @@ func overrideKourierNamespace(ks v1alpha1.KComponent) mf.Transformer {
 // replaceServiceSelector replaces the selector of the kourier-control service to the new
 // selector after all components have successfully been rolled out.
 // TODO: Remove after resources are bumped to 0.26
-func replaceServiceSelector(ks v1alpha1.KComponent) mf.Transformer {
+func replaceServiceSelector(ks operatorv1alpha1.KComponent) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if !ks.GetStatus().IsReady() || !strings.Contains(ks.GetStatus().GetVersion(), "0.25.") {
 			// Do nothing while we're not completely rolled out yet.
@@ -75,23 +75,23 @@ func replaceServiceSelector(ks v1alpha1.KComponent) mf.Transformer {
 // removeObsoleteResources removes all resources that couldn't automatically be cleaned up
 // due to renaming.
 // TODO: Remove after resources are bumped to 0.26
-func removeObsoleteResources(ctx context.Context, kubeclient kubernetes.Interface, ks v1alpha1.KComponent) error {
+func removeObsoleteResources(ctx context.Context, kubeclient kubernetes.Interface, ks operatorv1alpha1.KComponent) error {
 	if !ks.GetStatus().IsReady() || !strings.Contains(ks.GetStatus().GetVersion(), "0.25.") {
 		// Do nothing while we're not completely rolled out yet.
 		return nil
 	}
 
 	ns := kourierNamespace(ks.GetNamespace())
-	if err := kubeclient.AppsV1().Deployments(ns).Delete(ctx, "3scale-kourier-control", v1.DeleteOptions{}); !apierrors.IsNotFound(err) {
+	if err := kubeclient.AppsV1().Deployments(ns).Delete(ctx, "3scale-kourier-control", metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete obsolete Deployment: %w", err)
 	}
-	if err := kubeclient.CoreV1().ServiceAccounts(ns).Delete(ctx, "3scale-kourier", v1.DeleteOptions{}); !apierrors.IsNotFound(err) {
+	if err := kubeclient.CoreV1().ServiceAccounts(ns).Delete(ctx, "3scale-kourier", metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete obsolete ServiceAccount: %w", err)
 	}
-	if err := kubeclient.RbacV1().ClusterRoles().Delete(ctx, "3scale-kourier", v1.DeleteOptions{}); !apierrors.IsNotFound(err) {
+	if err := kubeclient.RbacV1().ClusterRoles().Delete(ctx, "3scale-kourier", metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete obsolete ClusterRole: %w", err)
 	}
-	if err := kubeclient.RbacV1().ClusterRoleBindings().Delete(ctx, "3scale-kourier", v1.DeleteOptions{}); !apierrors.IsNotFound(err) {
+	if err := kubeclient.RbacV1().ClusterRoleBindings().Delete(ctx, "3scale-kourier", metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete obsolete ClusterRoleBinding: %w", err)
 	}
 	return nil

--- a/openshift-knative-operator/pkg/serving/kourier_test.go
+++ b/openshift-knative-operator/pkg/serving/kourier_test.go
@@ -7,7 +7,7 @@ import (
 	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
 func TestOverrideKourierNamespace(t *testing.T) {
@@ -24,7 +24,7 @@ func TestOverrideKourierNamespace(t *testing.T) {
 		Name:       "bar",
 	}})
 
-	ks := &v1alpha1.KnativeServing{
+	ks := &operatorv1alpha1.KnativeServing{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "knative-serving",
 			Name:      "test",
@@ -62,7 +62,7 @@ func TestOverrideKourierNamespaceOther(t *testing.T) {
 	}})
 	want := other.DeepCopy()
 
-	ks := &v1alpha1.KnativeServing{
+	ks := &operatorv1alpha1.KnativeServing{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "knative-serving",
 			Name:      "test",

--- a/test/eventinge2e/source_broker_ksvc_test.go
+++ b/test/eventinge2e/source_broker_ksvc_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
-	eventingsourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -93,12 +93,12 @@ kind: %q`, channelAPIVersion, channelKind),
 		t.Fatal("Unable to create trigger: ", err)
 	}
 
-	ps := &eventingsourcesv1.PingSource{
+	ps := &sourcesv1.PingSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pingSourceName,
 			Namespace: testNamespace,
 		},
-		Spec: eventingsourcesv1.PingSourceSpec{
+		Spec: sourcesv1.PingSourceSpec{
 			Data: helloWorldText,
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{

--- a/test/eventinge2e/source_channel_ksvc_test.go
+++ b/test/eventinge2e/source_channel_ksvc_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	eventingmessagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
-	eventingsourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -37,7 +37,7 @@ func TestKnativeSourceChannelKnativeService(t *testing.T) {
 		t.Fatal("Knative Service not ready", err)
 	}
 
-	imc := &eventingmessagingv1.Channel{
+	imc := &messagingv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      channelName,
 			Namespace: testNamespace,
@@ -47,12 +47,12 @@ func TestKnativeSourceChannelKnativeService(t *testing.T) {
 	if err != nil {
 		t.Fatal("Unable to create Channel: ", err)
 	}
-	subscription := &eventingmessagingv1.Subscription{
+	subscription := &messagingv1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      subscriptionName,
 			Namespace: testNamespace,
 		},
-		Spec: eventingmessagingv1.SubscriptionSpec{
+		Spec: messagingv1.SubscriptionSpec{
 			Channel: duckv1.KReference{
 				APIVersion: channelAPIVersion,
 				Kind:       channelKind,
@@ -71,12 +71,12 @@ func TestKnativeSourceChannelKnativeService(t *testing.T) {
 	if err != nil {
 		t.Fatal("Unable to create Subscription: ", err)
 	}
-	ps := &eventingsourcesv1.PingSource{
+	ps := &sourcesv1.PingSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pingSourceName,
 			Namespace: testNamespace,
 		},
-		Spec: eventingsourcesv1.PingSourceSpec{
+		Spec: sourcesv1.PingSourceSpec{
 			Data: helloWorldText,
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{

--- a/test/eventinge2e/source_to_ksvc_test.go
+++ b/test/eventinge2e/source_to_ksvc_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	eventingsourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -37,12 +37,12 @@ func TestKnativeSourceToKnativeService(t *testing.T) {
 		t.Fatal("Knative Service not ready", err)
 	}
 
-	ps := &eventingsourcesv1.PingSource{
+	ps := &sourcesv1.PingSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pingSourceName,
 			Namespace: testNamespace,
 		},
-		Spec: eventingsourcesv1.PingSourceSpec{
+		Spec: sourcesv1.PingSourceSpec{
 			Data: helloWorldText,
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{

--- a/test/eventinge2e/user_permissions_test.go
+++ b/test/eventinge2e/user_permissions_test.go
@@ -3,7 +3,7 @@ package eventinge2e
 import (
 	"testing"
 
-	eventingmessagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
@@ -12,15 +12,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
-	eventingflowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
-	eventingsourcesv1beta2 "knative.dev/eventing/pkg/apis/sources/v1beta2"
+	flowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
+	sourcesv1beta2 "knative.dev/eventing/pkg/apis/sources/v1beta2"
 )
 
 func init() {
 	eventingv1.AddToScheme(scheme.Scheme)
-	eventingsourcesv1beta2.AddToScheme(scheme.Scheme)
-	eventingmessagingv1.AddToScheme(scheme.Scheme)
-	eventingflowsv1.AddToScheme(scheme.Scheme)
+	sourcesv1beta2.AddToScheme(scheme.Scheme)
+	messagingv1.AddToScheme(scheme.Scheme)
+	flowsv1.AddToScheme(scheme.Scheme)
 }
 
 func TestEventingUserPermissions(t *testing.T) {
@@ -31,16 +31,16 @@ func TestEventingUserPermissions(t *testing.T) {
 	defer test.CleanupAll(t, paCtx, editCtx, viewCtx)
 
 	brokersGVR := eventingv1.SchemeGroupVersion.WithResource("brokers")
-	pingSourcesGVR := eventingsourcesv1beta2.SchemeGroupVersion.WithResource("pingsources")
-	channelsGVR := eventingmessagingv1.SchemeGroupVersion.WithResource("channels")
-	sequencesGVR := eventingflowsv1.SchemeGroupVersion.WithResource("sequences")
+	pingSourcesGVR := sourcesv1beta2.SchemeGroupVersion.WithResource("pingsources")
+	channelsGVR := messagingv1.SchemeGroupVersion.WithResource("channels")
+	sequencesGVR := flowsv1.SchemeGroupVersion.WithResource("sequences")
 
 	broker := &eventingv1.Broker{
 		Spec: eventingv1.BrokerSpec{},
 	}
 
-	pingSource := &eventingsourcesv1beta2.PingSource{
-		Spec: eventingsourcesv1beta2.PingSourceSpec{
+	pingSource := &sourcesv1beta2.PingSource{
+		Spec: sourcesv1beta2.PingSourceSpec{
 			Data: "foo",
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{
@@ -54,11 +54,11 @@ func TestEventingUserPermissions(t *testing.T) {
 		},
 	}
 
-	imc := &eventingmessagingv1.Channel{}
+	imc := &messagingv1.Channel{}
 
-	sequence := &eventingflowsv1.Sequence{
-		Spec: eventingflowsv1.SequenceSpec{
-			Steps: []eventingflowsv1.SequenceStep{
+	sequence := &flowsv1.Sequence{
+		Spec: flowsv1.SequenceSpec{
+			Steps: []flowsv1.SequenceStep{
 				{
 					Destination: duckv1.Destination{
 						URI: apis.HTTP("mydomain"),

--- a/test/extensione2e/kafka/kafka_channel_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_channel_ksvc_test.go
@@ -6,8 +6,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kafkachannelv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
-	eventingmessagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
-	eventingsourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/openshift-knative/serverless-operator/test"
@@ -36,12 +36,12 @@ var (
 		},
 	}
 
-	subscription = &eventingmessagingv1.Subscription{
+	subscription = &messagingv1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      subscriptionName,
 			Namespace: testNamespace,
 		},
-		Spec: eventingmessagingv1.SubscriptionSpec{
+		Spec: messagingv1.SubscriptionSpec{
 			Channel: duckv1.KReference{
 				APIVersion: channelAPIVersion,
 				Kind:       kafkaChannelKind,
@@ -57,12 +57,12 @@ var (
 		},
 	}
 
-	ps = &eventingsourcesv1.PingSource{
+	ps = &sourcesv1.PingSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pingSourceName,
 			Namespace: testNamespace,
 		},
-		Spec: eventingsourcesv1.PingSourceSpec{
+		Spec: sourcesv1.PingSourceSpec{
 			Data: helloWorldText,
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{

--- a/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
-	eventingsourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/pkg/utils"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
@@ -68,12 +68,12 @@ kind: %q`, channelAPIVersion, kafkaChannelKind),
 		},
 	}
 
-	brokerps = &eventingsourcesv1.PingSource{
+	brokerps = &sourcesv1.PingSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pingSourceName,
 			Namespace: testNamespace,
 		},
-		Spec: eventingsourcesv1.PingSourceSpec{
+		Spec: sourcesv1.PingSourceSpec{
 			Data: helloWorldText,
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{

--- a/test/installplan.go
+++ b/test/installplan.go
@@ -9,12 +9,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func WaitForInstallPlan(ctx *Context, namespace string, csvName, olmSource string) (*v1alpha1.InstallPlan, error) {
-	var plan *v1alpha1.InstallPlan
+func WaitForInstallPlan(ctx *Context, namespace string, csvName, olmSource string) (*operatorsv1alpha1.InstallPlan, error) {
+	var plan *operatorsv1alpha1.InstallPlan
 	if waitErr := wait.PollImmediate(Interval, 15*time.Minute, func() (bool, error) {
 		installPlans, err := ctx.Clients.OLM.OperatorsV1alpha1().InstallPlans(namespace).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
@@ -33,7 +33,7 @@ func WaitForInstallPlan(ctx *Context, namespace string, csvName, olmSource strin
 	return plan, nil
 }
 
-func installsCSVFromSource(installPlan v1alpha1.InstallPlan, csvName, olmSource string) bool {
+func installsCSVFromSource(installPlan operatorsv1alpha1.InstallPlan, csvName, olmSource string) bool {
 	if installPlan.Status.BundleLookups == nil ||
 		len(installPlan.Status.BundleLookups) == 0 ||
 		installPlan.Status.BundleLookups[0].CatalogSourceRef == nil ||

--- a/test/monitoringe2e/helpers.go
+++ b/test/monitoringe2e/helpers.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/openshift-knative/serverless-operator/test"
-	v1 "github.com/openshift/api/route/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	prom "github.com/prometheus/client_golang/api"
@@ -95,8 +95,8 @@ func newPrometheusClient(caCtx *test.Context) (promv1.API, error) {
 	return promv1.NewAPI(client), nil
 }
 
-func getPrometheusRoute(caCtx *test.Context) (*v1.Route, error) {
-	r, err := caCtx.Clients.Route.Routes("openshift-monitoring").Get(context.Background(), "prometheus-k8s", meta.GetOptions{})
+func getPrometheusRoute(caCtx *test.Context) (*routev1.Route, error) {
+	r, err := caCtx.Clients.Route.Routes("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting Prometheus route: %w", err)
 	}
@@ -155,7 +155,7 @@ func VerifyMetrics(caCtx *test.Context, metricQueries []string) error {
 }
 
 func getBearerTokenForPrometheusAccount(caCtx *test.Context) (string, error) {
-	sa, err := caCtx.Clients.Kube.CoreV1().ServiceAccounts("openshift-monitoring").Get(context.Background(), "prometheus-k8s", meta.GetOptions{})
+	sa, err := caCtx.Clients.Kube.CoreV1().ServiceAccounts("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("error getting service account prometheus-k8s: %w", err)
 	}
@@ -163,7 +163,7 @@ func getBearerTokenForPrometheusAccount(caCtx *test.Context) (string, error) {
 	if tokenSecret == "" {
 		return "", errors.New("token name for prometheus-k8s service account not found")
 	}
-	sec, err := caCtx.Clients.Kube.CoreV1().Secrets("openshift-monitoring").Get(context.Background(), tokenSecret, meta.GetOptions{})
+	sec, err := caCtx.Clients.Kube.CoreV1().Secrets("openshift-monitoring").Get(context.Background(), tokenSecret, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("error getting secret %s: %w", tokenSecret, err)
 	}

--- a/test/servinge2e/kourier/custom_route_test.go
+++ b/test/servinge2e/kourier/custom_route_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	routev1 "github.com/openshift/api/route/v1"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/test/spoof"
@@ -43,7 +43,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	ksvc = withServiceReadyOrFail(caCtx, ksvc)
 
 	// Verify that operator did not create OpenShift route.
-	routes, err := caCtx.Clients.Route.Routes("knative-serving-ingress").List(context.Background(), meta.ListOptions{
+	routes, err := caCtx.Clients.Route.Routes("knative-serving-ingress").List(context.Background(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", resources.OpenShiftIngressLabelKey, ksvc.Name),
 	})
 	if err != nil {
@@ -55,7 +55,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 
 	// Create OpenShift Route manually
 	route := &routev1.Route{
-		ObjectMeta: meta.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myroute",
 			Namespace: "knative-serving-ingress",
 		},
@@ -74,21 +74,21 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 			},
 		},
 	}
-	route, err = caCtx.Clients.Route.Routes("knative-serving-ingress").Create(context.Background(), route, meta.CreateOptions{})
+	route, err = caCtx.Clients.Route.Routes("knative-serving-ingress").Create(context.Background(), route, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating OpenShift Route: %v", err)
 	}
 
 	caCtx.AddToCleanup(func() error {
 		t.Logf("Cleaning up OpenShift Route %s", route.Name)
-		return caCtx.Clients.Route.Routes(route.Namespace).Delete(context.Background(), route.Name, meta.DeleteOptions{})
+		return caCtx.Clients.Route.Routes(route.Namespace).Delete(context.Background(), route.Name, metav1.DeleteOptions{})
 	})
 
 	servinge2e.WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
 
 	// Create DomainMapping with disable Annotation.
 	dm := &servingv1alpha1.DomainMapping{
-		ObjectMeta: meta.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:        domainMappingName,
 			Namespace:   testNamespace,
 			Annotations: map[string]string{resources.DisableRouteAnnotation: "true"},
@@ -105,7 +105,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	dm = withDomainMappingReadyOrFail(caCtx, dm)
 
 	// Verify that operator did not create OpenShift route.
-	routes, err = caCtx.Clients.Route.Routes("knative-serving-ingress").List(context.Background(), meta.ListOptions{
+	routes, err = caCtx.Clients.Route.Routes("knative-serving-ingress").List(context.Background(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", resources.OpenShiftIngressLabelKey, dm.Name),
 	})
 	if err != nil {
@@ -117,7 +117,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 
 	// Create OpenShift Route manually
 	route = &routev1.Route{
-		ObjectMeta: meta.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myroute-for-dm",
 			Namespace: "knative-serving-ingress",
 		},
@@ -132,14 +132,14 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 			},
 		},
 	}
-	route, err = caCtx.Clients.Route.Routes("knative-serving-ingress").Create(context.Background(), route, meta.CreateOptions{})
+	route, err = caCtx.Clients.Route.Routes("knative-serving-ingress").Create(context.Background(), route, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating OpenShift Route: %v", err)
 	}
 
 	caCtx.AddToCleanup(func() error {
 		t.Logf("Cleaning up OpenShift Route %s", route.Name)
-		return caCtx.Clients.Route.Routes(route.Namespace).Delete(context.Background(), route.Name, meta.DeleteOptions{})
+		return caCtx.Clients.Route.Routes(route.Namespace).Delete(context.Background(), route.Name, metav1.DeleteOptions{})
 	})
 
 	routerIP := lookupOpenShiftRouterIP(caCtx)

--- a/test/servinge2e/kourier/helpers.go
+++ b/test/servinge2e/kourier/helpers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/openshift-knative/serverless-operator/test"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
@@ -16,7 +16,7 @@ const (
 )
 
 func withServiceReadyOrFail(ctx *test.Context, service *servingv1.Service) *servingv1.Service {
-	service, err := ctx.Clients.Serving.ServingV1().Services(service.Namespace).Create(context.Background(), service, meta.CreateOptions{})
+	service, err := ctx.Clients.Serving.ServingV1().Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
 	if err != nil {
 		ctx.T.Fatalf("Error creating ksvc: %v", err)
 	}
@@ -24,7 +24,7 @@ func withServiceReadyOrFail(ctx *test.Context, service *servingv1.Service) *serv
 	// Let the ksvc be deleted after test
 	ctx.AddToCleanup(func() error {
 		ctx.T.Logf("Cleaning up Knative Service '%s/%s'", service.Namespace, service.Name)
-		return ctx.Clients.Serving.ServingV1().Services(service.Namespace).Delete(context.Background(), service.Name, meta.DeleteOptions{})
+		return ctx.Clients.Serving.ServingV1().Services(service.Namespace).Delete(context.Background(), service.Name, metav1.DeleteOptions{})
 	})
 
 	service, err = test.WaitForServiceState(ctx, service.Name, service.Namespace, test.IsServiceReady)
@@ -36,7 +36,7 @@ func withServiceReadyOrFail(ctx *test.Context, service *servingv1.Service) *serv
 }
 
 func withDomainMappingReadyOrFail(ctx *test.Context, dm *servingv1alpha1.DomainMapping) *servingv1alpha1.DomainMapping {
-	dm, err := ctx.Clients.Serving.ServingV1alpha1().DomainMappings(dm.Namespace).Create(context.Background(), dm, meta.CreateOptions{})
+	dm, err := ctx.Clients.Serving.ServingV1alpha1().DomainMappings(dm.Namespace).Create(context.Background(), dm, metav1.CreateOptions{})
 	if err != nil {
 		ctx.T.Fatalf("Error creating ksvc: %v", err)
 	}
@@ -44,7 +44,7 @@ func withDomainMappingReadyOrFail(ctx *test.Context, dm *servingv1alpha1.DomainM
 	// Let the ksvc be deleted after test
 	ctx.AddToCleanup(func() error {
 		ctx.T.Logf("Cleaning up Knative Service '%s/%s'", dm.Namespace, dm.Name)
-		return ctx.Clients.Serving.ServingV1alpha1().DomainMappings(dm.Namespace).Delete(context.Background(), dm.Name, meta.DeleteOptions{})
+		return ctx.Clients.Serving.ServingV1alpha1().DomainMappings(dm.Namespace).Delete(context.Background(), dm.Name, metav1.DeleteOptions{})
 	})
 
 	dm, err = test.WaitForDomainMappingState(ctx, dm.Name, dm.Namespace, test.IsDomainMappingReady)

--- a/test/servinge2e/kourier/service_to_service_test.go
+++ b/test/servinge2e/kourier/service_to_service_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	network "knative.dev/networking/pkg"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
@@ -80,7 +80,7 @@ func testServiceToService(t *testing.T, ctx *test.Context, namespace string, tc 
 	servinge2e.WaitForRouteServingText(t, ctx, serviceURL, helloworldText)
 
 	// Verify the expected istio-proxy is really there
-	podList, err := ctx.Clients.Kube.CoreV1().Pods(namespace).List(context.Background(), meta.ListOptions{LabelSelector: "serving.knative.dev/service=" + service.Name})
+	podList, err := ctx.Clients.Kube.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "serving.knative.dev/service=" + service.Name})
 	if err != nil {
 		t.Errorf("error listing pods: %v", err)
 		return

--- a/test/subscription.go
+++ b/test/subscription.go
@@ -10,7 +10,7 @@ import (
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -25,28 +25,28 @@ const (
 	ServerlessOperatorPackage = "serverless-operator"
 )
 
-func Subscription(subscriptionName string) *v1alpha1.Subscription {
+func Subscription(subscriptionName string) *operatorsv1alpha1.Subscription {
 	//namespace, name, catalogSourceName, packageName, channel string, approval v1alpha1.Approval
-	return &v1alpha1.Subscription{
+	return &operatorsv1alpha1.Subscription{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alpha1.SubscriptionKind,
-			APIVersion: v1alpha1.SubscriptionCRDAPIVersion,
+			Kind:       operatorsv1alpha1.SubscriptionKind,
+			APIVersion: operatorsv1alpha1.SubscriptionCRDAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: OperatorsNamespace,
 			Name:      subscriptionName,
 		},
-		Spec: &v1alpha1.SubscriptionSpec{
+		Spec: &operatorsv1alpha1.SubscriptionSpec{
 			CatalogSource:          Flags.CatalogSource,
 			CatalogSourceNamespace: OLMNamespace,
 			Package:                ServerlessOperatorPackage,
 			Channel:                Flags.Channel,
-			InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
+			InstallPlanApproval:    operatorsv1alpha1.ApprovalAutomatic,
 		},
 	}
 }
 
-func WithOperatorReady(ctx *Context, subscriptionName string) (*v1alpha1.Subscription, error) {
+func WithOperatorReady(ctx *Context, subscriptionName string) (*operatorsv1alpha1.Subscription, error) {
 	if _, err := CreateSubscription(ctx, subscriptionName); err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func WithOperatorReady(ctx *Context, subscriptionName string) (*v1alpha1.Subscri
 	return subs, nil
 }
 
-func CreateSubscription(ctx *Context, name string) (*v1alpha1.Subscription, error) {
+func CreateSubscription(ctx *Context, name string) (*operatorsv1alpha1.Subscription, error) {
 	subs, err := ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(OperatorsNamespace).Create(context.Background(), Subscription(name), metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -82,8 +82,8 @@ func CreateSubscription(ctx *Context, name string) (*v1alpha1.Subscription, erro
 	return subs, nil
 }
 
-func WaitForSubscriptionState(ctx *Context, name, namespace string, inState func(s *v1alpha1.Subscription, err error) (bool, error)) (*v1alpha1.Subscription, error) {
-	var lastState *v1alpha1.Subscription
+func WaitForSubscriptionState(ctx *Context, name, namespace string, inState func(s *operatorsv1alpha1.Subscription, err error) (bool, error)) (*operatorsv1alpha1.Subscription, error) {
+	var lastState *operatorsv1alpha1.Subscription
 	var err error
 	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
 		lastState, err = ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(namespace).Get(context.Background(), name, metav1.GetOptions{})
@@ -96,14 +96,14 @@ func WaitForSubscriptionState(ctx *Context, name, namespace string, inState func
 	return lastState, nil
 }
 
-func UpdateSubscriptionChannelSource(ctx *Context, name, channel, source string) (*v1alpha1.Subscription, error) {
+func UpdateSubscriptionChannelSource(ctx *Context, name, channel, source string) (*operatorsv1alpha1.Subscription, error) {
 	patch := []byte(fmt.Sprintf(`{"spec":{"channel":"%s","source":"%s"}}`, channel, source))
 	return ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(OperatorsNamespace).
 		Patch(context.Background(), name, types.MergePatchType, patch, metav1.PatchOptions{})
 }
 
-func WaitForClusterServiceVersionState(ctx *Context, name, namespace string, inState func(s *v1alpha1.ClusterServiceVersion, err error) (bool, error)) (*v1alpha1.ClusterServiceVersion, error) {
-	var lastState *v1alpha1.ClusterServiceVersion
+func WaitForClusterServiceVersionState(ctx *Context, name, namespace string, inState func(s *operatorsv1alpha1.ClusterServiceVersion, err error) (bool, error)) (*operatorsv1alpha1.ClusterServiceVersion, error) {
+	var lastState *operatorsv1alpha1.ClusterServiceVersion
 	var err error
 	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
 		lastState, err = ctx.Clients.OLM.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.Background(), name, metav1.GetOptions{})
@@ -115,7 +115,7 @@ func WaitForClusterServiceVersionState(ctx *Context, name, namespace string, inS
 	return lastState, nil
 }
 
-func IsCSVSucceeded(c *v1alpha1.ClusterServiceVersion, err error) (bool, error) {
+func IsCSVSucceeded(c *operatorsv1alpha1.ClusterServiceVersion, err error) (bool, error) {
 	// The CSV might not exist yet.
 	if apierrs.IsNotFound(err) {
 		return false, nil
@@ -123,7 +123,7 @@ func IsCSVSucceeded(c *v1alpha1.ClusterServiceVersion, err error) (bool, error) 
 	return c.Status.Phase == "Succeeded", err
 }
 
-func IsSubscriptionInstalledCSVPresent(s *v1alpha1.Subscription, err error) (bool, error) {
+func IsSubscriptionInstalledCSVPresent(s *operatorsv1alpha1.Subscription, err error) (bool, error) {
 	return s.Status.InstalledCSV != "" && s.Status.InstalledCSV != "<none>", err
 }
 

--- a/test/unstructured.go
+++ b/test/unstructured.go
@@ -6,21 +6,21 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func CreateUnstructured(ctx *Context, schema schema.GroupVersionResource, unstructured *unstructured.Unstructured) *unstructured.Unstructured {
-	ret, err := ctx.Clients.Dynamic.Resource(schema).Namespace(unstructured.GetNamespace()).Create(context.Background(), unstructured, meta.CreateOptions{})
+	ret, err := ctx.Clients.Dynamic.Resource(schema).Namespace(unstructured.GetNamespace()).Create(context.Background(), unstructured, metav1.CreateOptions{})
 	if err != nil {
 		ctx.T.Fatalf("Error creating %s %s: %v", schema.GroupResource(), unstructured.GetName(), err)
 	}
 
 	ctx.AddToCleanup(func() error {
 		ctx.T.Logf("Cleaning up %s %s", schema.GroupResource(), ret.GetName())
-		return ctx.Clients.Dynamic.Resource(schema).Namespace(ret.GetNamespace()).Delete(context.Background(), ret.GetName(), meta.DeleteOptions{})
+		return ctx.Clients.Dynamic.Resource(schema).Namespace(ret.GetNamespace()).Delete(context.Background(), ret.GetName(), metav1.DeleteOptions{})
 	})
 
 	return ret
@@ -63,7 +63,7 @@ func WaitForUnstructuredState(ctx *Context, schema schema.GroupVersionResource, 
 		err       error
 	)
 	waitErr := wait.PollImmediate(Interval, 10*time.Minute, func() (bool, error) {
-		lastState, err = ctx.Clients.Dynamic.Resource(schema).Namespace(namespace).Get(context.Background(), name, meta.GetOptions{})
+		lastState, err = ctx.Clients.Dynamic.Resource(schema).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		return inState(lastState, err)
 	})
 

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift-knative/serverless-operator/test"
@@ -60,7 +60,7 @@ func UpgradeServerless(ctx *test.Context) error {
 
 func WaitForPodsWithImage(ctx *test.Context, namespace string, podSelector, containerName, expectedImage string) error {
 	if waitErr := wait.PollImmediate(test.Interval, test.Timeout, func() (bool, error) {
-		podList, err := ctx.Clients.Kube.CoreV1().Pods(namespace).List(context.Background(), meta.ListOptions{LabelSelector: podSelector})
+		podList, err := ctx.Clients.Kube.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: podSelector})
 		if err != nil {
 			return false, err
 		}

--- a/test/v1alpha1/knativeeventing.go
+++ b/test/v1alpha1/knativeeventing.go
@@ -8,11 +8,11 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	eventingoperatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
-func KnativeEventing(name, namespace string) *eventingoperatorv1alpha1.KnativeEventing {
-	return &eventingoperatorv1alpha1.KnativeEventing{
+func KnativeEventing(name, namespace string) *operatorv1alpha1.KnativeEventing {
+	return &operatorv1alpha1.KnativeEventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -20,7 +20,7 @@ func KnativeEventing(name, namespace string) *eventingoperatorv1alpha1.KnativeEv
 	}
 }
 
-func WithKnativeEventingReady(ctx *test.Context, name, namespace string) (*eventingoperatorv1alpha1.KnativeEventing, error) {
+func WithKnativeEventingReady(ctx *test.Context, name, namespace string) (*operatorv1alpha1.KnativeEventing, error) {
 	eventing, err := CreateKnativeEventing(ctx, name, namespace)
 	if err != nil {
 		return nil, err
@@ -31,7 +31,7 @@ func WithKnativeEventingReady(ctx *test.Context, name, namespace string) (*event
 	return eventing, nil
 }
 
-func CreateKnativeEventing(ctx *test.Context, name, namespace string) (*eventingoperatorv1alpha1.KnativeEventing, error) {
+func CreateKnativeEventing(ctx *test.Context, name, namespace string) (*operatorv1alpha1.KnativeEventing, error) {
 	eventing, err := ctx.Clients.Operator.KnativeEventings(namespace).Create(context.Background(), KnativeEventing(name, namespace), metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func DeleteKnativeEventing(ctx *test.Context, name, namespace string) error {
 
 	// Wait until the KnativeEventing got removed.
 	_, err := WaitForKnativeEventingState(ctx, name, namespace,
-		func(s *eventingoperatorv1alpha1.KnativeEventing, err error) (bool, error) {
+		func(s *operatorv1alpha1.KnativeEventing, err error) (bool, error) {
 			if apierrs.IsNotFound(err) {
 				return true, nil
 			}
@@ -59,9 +59,9 @@ func DeleteKnativeEventing(ctx *test.Context, name, namespace string) error {
 	return err
 }
 
-func WaitForKnativeEventingState(ctx *test.Context, name, namespace string, inState EventingInStateFunc) (*eventingoperatorv1alpha1.KnativeEventing, error) {
+func WaitForKnativeEventingState(ctx *test.Context, name, namespace string, inState EventingInStateFunc) (*operatorv1alpha1.KnativeEventing, error) {
 	var (
-		lastState *eventingoperatorv1alpha1.KnativeEventing
+		lastState *operatorv1alpha1.KnativeEventing
 		err       error
 	)
 	waitErr := wait.PollImmediate(test.Interval, test.Timeout, func() (bool, error) {
@@ -75,14 +75,14 @@ func WaitForKnativeEventingState(ctx *test.Context, name, namespace string, inSt
 	return lastState, nil
 }
 
-func IsKnativeEventingReady(e *eventingoperatorv1alpha1.KnativeEventing, err error) (bool, error) {
+func IsKnativeEventingReady(e *operatorv1alpha1.KnativeEventing, err error) (bool, error) {
 	return e.Status.IsReady(), err
 }
 
-type EventingInStateFunc func(e *eventingoperatorv1alpha1.KnativeEventing, err error) (bool, error)
+type EventingInStateFunc func(e *operatorv1alpha1.KnativeEventing, err error) (bool, error)
 
 func IsKnativeEventingWithVersionReady(version string) EventingInStateFunc {
-	return func(e *eventingoperatorv1alpha1.KnativeEventing, err error) (bool, error) {
+	return func(e *operatorv1alpha1.KnativeEventing, err error) (bool, error) {
 		return e.Status.Version == version && e.Status.IsReady(), err
 	}
 }

--- a/test/v1alpha1/knativeserving.go
+++ b/test/v1alpha1/knativeserving.go
@@ -8,11 +8,11 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	servingoperatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
-func KnativeServing(name, namespace string) *servingoperatorv1alpha1.KnativeServing {
-	return &servingoperatorv1alpha1.KnativeServing{
+func KnativeServing(name, namespace string) *operatorv1alpha1.KnativeServing {
+	return &operatorv1alpha1.KnativeServing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -20,7 +20,7 @@ func KnativeServing(name, namespace string) *servingoperatorv1alpha1.KnativeServ
 	}
 }
 
-func WithKnativeServingReady(ctx *test.Context, name, namespace string) (*servingoperatorv1alpha1.KnativeServing, error) {
+func WithKnativeServingReady(ctx *test.Context, name, namespace string) (*operatorv1alpha1.KnativeServing, error) {
 	serving, err := CreateKnativeServing(ctx, name, namespace)
 	if err != nil {
 		return nil, err
@@ -31,7 +31,7 @@ func WithKnativeServingReady(ctx *test.Context, name, namespace string) (*servin
 	return serving, nil
 }
 
-func CreateKnativeServing(ctx *test.Context, name, namespace string) (*servingoperatorv1alpha1.KnativeServing, error) {
+func CreateKnativeServing(ctx *test.Context, name, namespace string) (*operatorv1alpha1.KnativeServing, error) {
 	serving, err := ctx.Clients.Operator.KnativeServings(namespace).Create(context.Background(), KnativeServing(name, namespace), metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func DeleteKnativeServing(ctx *test.Context, name, namespace string) error {
 
 	// Wait until the KnativeServing got removed.
 	_, err := WaitForKnativeServingState(ctx, name, namespace,
-		func(s *servingoperatorv1alpha1.KnativeServing, err error) (bool, error) {
+		func(s *operatorv1alpha1.KnativeServing, err error) (bool, error) {
 			if apierrs.IsNotFound(err) {
 				return true, nil
 			}
@@ -59,9 +59,9 @@ func DeleteKnativeServing(ctx *test.Context, name, namespace string) error {
 	return err
 }
 
-func WaitForKnativeServingState(ctx *test.Context, name, namespace string, inState ServingInStateFunc) (*servingoperatorv1alpha1.KnativeServing, error) {
+func WaitForKnativeServingState(ctx *test.Context, name, namespace string, inState ServingInStateFunc) (*operatorv1alpha1.KnativeServing, error) {
 	var (
-		lastState *servingoperatorv1alpha1.KnativeServing
+		lastState *operatorv1alpha1.KnativeServing
 		err       error
 	)
 	waitErr := wait.PollImmediate(test.Interval, test.Timeout, func() (bool, error) {
@@ -75,14 +75,14 @@ func WaitForKnativeServingState(ctx *test.Context, name, namespace string, inSta
 	return lastState, nil
 }
 
-func IsKnativeServingReady(s *servingoperatorv1alpha1.KnativeServing, err error) (bool, error) {
+func IsKnativeServingReady(s *operatorv1alpha1.KnativeServing, err error) (bool, error) {
 	return s.Status.IsReady(), err
 }
 
-type ServingInStateFunc func(s *servingoperatorv1alpha1.KnativeServing, err error) (bool, error)
+type ServingInStateFunc func(s *operatorv1alpha1.KnativeServing, err error) (bool, error)
 
 func IsKnativeServingWithVersionReady(version string) ServingInStateFunc {
-	return func(s *servingoperatorv1alpha1.KnativeServing, err error) (bool, error) {
+	return func(s *operatorv1alpha1.KnativeServing, err error) (bool, error) {
 		return s.Status.Version == version && s.Status.IsReady(), err
 	}
 }


### PR DESCRIPTION
A ton of code already imports packages this way naturally. `corev1` and `metav1` for instance have been mostly consistent. This makes the imports consistent for all APIs we use to make it much easier to follow code and copy code around (been bitten by this recently quite hard).

No actual changes intended. Only import renames.