### PR TITLE
Apply test object patch statically to the codebase

### DIFF
--- a/hack/patches/001-object.patch
+++ b/hack/patches/001-object.patch
@@ -1,0 +1,17 @@
+diff --git a/vendor/knative.dev/pkg/test/helpers/name.go b/vendor/knative.dev/pkg/test/helpers/name.go
+index 0cd25785b..2f21dd98f 100644
+--- a/vendor/knative.dev/pkg/test/helpers/name.go
++++ b/vendor/knative.dev/pkg/test/helpers/name.go
+@@ -52,7 +52,11 @@ func ObjectPrefixForTest(t named) string {
+ 
+ // ObjectNameForTest generates a random object name based on the test name.
+ func ObjectNameForTest(t named) string {
+-	return kmeta.ChildName(ObjectPrefixForTest(t), string(sep)+RandomString())
++	prefix := ObjectPrefixForTest(t)
++	if len(prefix) > 20 {
++		prefix = prefix[:20]
++	}
++	return kmeta.ChildName(prefix, string(sep)+RandomString())
+ }
+ 
+ // AppendRandomString will generate a random string that begins with prefix.

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -69,3 +69,6 @@ find vendor/ \( -name "OWNERS" \
   -o -name "*_test.go" \) -exec rm -fv {} +
 
 find vendor -type f -name '*.sh' -exec chmod +x {} +
+
+# Apply patches
+git apply "${ROOT_DIR}"/hack/patches/*

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -185,7 +185,7 @@ function downstream_monitoring_e2e_tests {
 function run_rolling_upgrade_tests {
   logger.info "Running rolling upgrade tests"
 
-  local image_version image_template patch channels
+  local image_version image_template channels
 
   # Save the rootdir before changing dir
   rootdir="$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"
@@ -194,12 +194,6 @@ function run_rolling_upgrade_tests {
   prepare_knative_serving_tests
 
   cd "$rootdir"
-
-  # Ensure the generated test case names are short enough for Kubernetes.
-  # The upgrade framework prefixes the base names and the generated
-  # OpenShift Route hostname exceeds the 63-char limit.
-  patch="${KNATIVE_SERVING_HOME}/openshift/patches/001-object.patch"
-  git apply "${patch}"
 
   image_version=$(versions.major_minor "${KNATIVE_SERVING_VERSION}")
   image_template="quay.io/openshift-knative/{{.Name}}:v${image_version}"
@@ -225,8 +219,6 @@ function run_rolling_upgrade_tests {
     --openshiftimage="${UPGRADE_OCP_IMAGE}" \
     --resolvabledomain \
     --https
-
-  git apply -R "${patch}"
 
   # Delete the leftover services.
   oc delete ksvc --all -n serving-tests

--- a/vendor/knative.dev/pkg/test/helpers/name.go
+++ b/vendor/knative.dev/pkg/test/helpers/name.go
@@ -52,7 +52,11 @@ func ObjectPrefixForTest(t named) string {
 
 // ObjectNameForTest generates a random object name based on the test name.
 func ObjectNameForTest(t named) string {
-	return kmeta.ChildName(ObjectPrefixForTest(t), string(sep)+RandomString())
+	prefix := ObjectPrefixForTest(t)
+	if len(prefix) > 20 {
+		prefix = prefix[:20]
+	}
+	return kmeta.ChildName(prefix, string(sep)+RandomString())
 }
 
 // AppendRandomString will generate a random string that begins with prefix.


### PR DESCRIPTION
As per title. The "other" way generates a chicken/egg issue if the codebase changes and forces us to do all the bumps at once.

/assign @nak3 