### PR TITLE
Update golangci-lint, fix issues and add bidichk

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Go Lint - knative-operator
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42
+          version: v1.43
           working-directory: ./src/github.com/${{ github.repository }}
 
       # This is mostly copied from https://github.com/get-woke/woke-action-reviewdog/blob/main/entrypoint.sh

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,7 @@ run:
 linters:
   enable:
     - asciicheck
+    - bidichk
     - errorlint
     - gofmt
     - goimports

--- a/knative-operator/pkg/monitoring/monitoring_test.go
+++ b/knative-operator/pkg/monitoring/monitoring_test.go
@@ -39,12 +39,12 @@ func TestSetupMonitoringRequirements(t *testing.T) {
 	cl := fake.NewClientBuilder().WithObjects(&operatorNamespace, &serverlessDeployment).Build()
 	err := SetupClusterMonitoringRequirements(cl, &serverlessDeployment, serverlessDeployment.GetNamespace(), nil)
 	if err != nil {
-		t.Errorf("Failed to set up monitoring requirements: %w", err)
+		t.Errorf("Failed to set up monitoring requirements: %v", err)
 	}
 	ns := corev1.Namespace{}
 	err = cl.Get(context.TODO(), client.ObjectKey{Name: installedNS}, &ns)
 	if err != nil {
-		t.Errorf("Failed to get modified namespace: %w", err)
+		t.Errorf("Failed to get modified namespace: %v", err)
 	}
 	if actual := ns.Labels[okomon.EnableMonitoringLabel]; actual != "true" {
 		t.Errorf("got %q, want %q", actual, "true")
@@ -52,7 +52,7 @@ func TestSetupMonitoringRequirements(t *testing.T) {
 	role := rbacv1.Role{}
 	err = cl.Get(context.TODO(), client.ObjectKey{Name: rbacName, Namespace: installedNS}, &role)
 	if err != nil {
-		t.Errorf("Failed to get created role: %w", err)
+		t.Errorf("Failed to get created role: %v", err)
 	}
 	if len(role.Rules) == 0 {
 		t.Error("Rules should be non empty")
@@ -60,7 +60,7 @@ func TestSetupMonitoringRequirements(t *testing.T) {
 	rb := rbacv1.RoleBinding{}
 	err = cl.Get(context.TODO(), client.ObjectKey{Name: rbacName, Namespace: installedNS}, &rb)
 	if err != nil {
-		t.Errorf("Failed to get created rolebinding: %w", err)
+		t.Errorf("Failed to get created rolebinding: %v", err)
 	}
 	if len(rb.Subjects) == 0 {
 		t.Error("Subjects should be non empty")
@@ -117,11 +117,11 @@ func TestRemoveOldServiceMonitorResources(t *testing.T) {
 	initObjs := []client.Object{&operatorNamespace, &oldSM, &oldSMService, &newSM, &newSMService, &randomSM, &randomService}
 	cl := fake.NewClientBuilder().WithObjects(initObjs...).Build()
 	if err := RemoveOldServiceMonitorResourcesIfExist(operatorNamespace.Name, cl); err != nil {
-		t.Errorf("Failed to remove old service monitor resources: %w", err)
+		t.Errorf("Failed to remove old service monitor resources: %v", err)
 	}
 	smList := monitoringv1.ServiceMonitorList{}
 	if err := cl.List(context.TODO(), &smList, client.InNamespace(operatorNamespace.Name)); err != nil {
-		t.Errorf("Failed to list available service monitors: %w", err)
+		t.Errorf("Failed to list available service monitors: %v", err)
 	}
 	if len(smList.Items) != 2 {
 		t.Errorf("got %d, want %d", len(smList.Items), 2)
@@ -133,7 +133,7 @@ func TestRemoveOldServiceMonitorResources(t *testing.T) {
 	}
 	smServiceList := corev1.ServiceList{}
 	if err := cl.List(context.TODO(), &smServiceList, client.InNamespace(operatorNamespace.Name)); err != nil {
-		t.Errorf("Failed to list available services: %w", err)
+		t.Errorf("Failed to list available services: %v", err)
 	}
 	if len(smServiceList.Items) != 2 {
 		t.Errorf("got %d, want %d", len(smServiceList.Items), 2)

--- a/openshift-knative-operator/pkg/eventing/extension_test.go
+++ b/openshift-knative-operator/pkg/eventing/extension_test.go
@@ -246,7 +246,7 @@ func TestMonitoring(t *testing.T) {
 			shouldEnableMonitoring, err := c.setupMonitoringToggle()
 
 			if err != nil {
-				t.Errorf("Failed to setup the monitoring toggle %w", err)
+				t.Errorf("Failed to setup the monitoring toggle %v", err)
 			}
 			ext.Reconcile(context.Background(), ke)
 

--- a/openshift-knative-operator/pkg/monitoring/helpers_test.go
+++ b/openshift-knative-operator/pkg/monitoring/helpers_test.go
@@ -22,53 +22,53 @@ func TestSetupServingRbacTransformation(t *testing.T) {
 	client := fake.New()
 	manifest, err := mf.NewManifest("testdata/rbac.yaml", mf.UseClient(client))
 	if err != nil {
-		t.Errorf("Unable to load test manifest: %w", err)
+		t.Errorf("Unable to load test manifest: %v", err)
 	}
 	transforms := []mf.Transformer{injectNamespaceWithSubject(servingNamespace, OpenshiftMonitoringNamespace)}
 	if manifest, err = manifest.Transform(transforms...); err != nil {
-		t.Errorf("Unable to transform test manifest: %w", err)
+		t.Errorf("Unable to transform test manifest: %v", err)
 	}
 	if err := manifest.Apply(); err != nil {
-		t.Errorf("Unable to apply the test manifest %w", err)
+		t.Errorf("Unable to apply the test manifest %v", err)
 	}
 	u := createRole(prometheusRoleName, servingNamespace)
 	_, err = client.Get(u)
 	if err != nil {
-		t.Errorf("Unable to get the role %w", err)
+		t.Errorf("Unable to get the role %v", err)
 	}
 	u = createRole("test-role", "default")
 	_, err = client.Get(u)
 	if err != nil {
-		t.Errorf("Unable to get the role %w", err)
+		t.Errorf("Unable to get the role %v", err)
 	}
 	u = createClusterRole()
 	_, err = client.Get(u)
 	if err != nil {
-		t.Errorf("Unable to get the cluster role %w", err)
+		t.Errorf("Unable to get the cluster role %v", err)
 	}
 	u = createRoleBinding(prometheusRoleName, servingNamespace)
 	resultRoleBinding, err := client.Get(u)
 	if err != nil {
-		t.Errorf("Unable to get the rolebinding %w", err)
+		t.Errorf("Unable to get the rolebinding %v", err)
 	}
 	checkSubjects(t, resultRoleBinding.Object, OpenshiftMonitoringNamespace)
 	u = createRoleBinding("test-rb", "default")
 	resultRoleBinding, err = client.Get(u)
 	if err != nil {
-		t.Errorf("Unable to get the rolebinding %w", err)
+		t.Errorf("Unable to get the rolebinding %v", err)
 	}
 	checkSubjects(t, resultRoleBinding.Object, "default")
 	u = createClusterRoleBinding()
 	resultClusterRoleBinding, err := client.Get(u)
 	if err != nil {
-		t.Errorf("Unable to get the cluster rolebinding %w", err)
+		t.Errorf("Unable to get the cluster rolebinding %v", err)
 	}
 	checkSubjects(t, resultClusterRoleBinding.Object, OpenshiftMonitoringNamespace)
 	// Make sure unrelated resources are not touched
 	u = createService("activator-sm-service", "test")
 	_, err = client.Get(u)
 	if err != nil {
-		t.Errorf("Unable to get the service %w", err)
+		t.Errorf("Unable to get the service %v", err)
 	}
 }
 

--- a/openshift-knative-operator/pkg/monitoring/monitoring_eventing_test.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_eventing_test.go
@@ -13,7 +13,7 @@ func TestLoadPlatformEventingMonitoringManifests(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: eventingNamespace},
 	})
 	if err != nil {
-		t.Errorf("Unable to load eventing monitoring platform manifests: %w", err)
+		t.Errorf("Unable to load eventing monitoring platform manifests: %v", err)
 	}
 	if len(manifests) != 1 {
 		t.Errorf("Got %d, want %d", len(manifests), 1)

--- a/openshift-knative-operator/pkg/monitoring/monitoring_serving_test.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_serving_test.go
@@ -13,7 +13,7 @@ func TestLoadPlatformServingMonitoringManifests(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: servingNamespace},
 	})
 	if err != nil {
-		t.Errorf("Unable to load serving monitoring platform manifests: %w", err)
+		t.Errorf("Unable to load serving monitoring platform manifests: %v", err)
 	}
 	if len(manifests) != 1 {
 		t.Errorf("Got %d, want %d", len(manifests), 1)

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -473,7 +473,7 @@ func TestMonitoring(t *testing.T) {
 			shouldEnableMonitoring, err := c.setupMonitoringToggle()
 
 			if err != nil {
-				t.Errorf("Failed to setup the monitoring toggle %w", err)
+				t.Errorf("Failed to setup the monitoring toggle %v", err)
 			}
 			ext.Reconcile(context.Background(), ks)
 


### PR DESCRIPTION
As per title, this updates golangci-lint to 1.43 and fixes issues that that surfaces.