### PR TITLE
[SRVKS-822] Use CheckEndpointState instead of WaitForEndpointState

### DIFF
--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -22,7 +22,7 @@ const (
 
 func WaitForRouteServingText(t *testing.T, caCtx *test.Context, routeURL *url.URL, expectedText string) {
 	t.Helper()
-	if _, err := pkgTest.WaitForEndpointState(
+	if _, err := pkgTest.CheckEndpointState(
 		context.Background(),
 		caCtx.Clients.Kube,
 		t.Logf,

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -612,7 +612,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 		testKsvc = withServiceReadyOrFail(ctx, testKsvc)
 
 		// Wait until the Route is ready and also verify the route returns a 401 or 403 without a token
-		if _, err := pkgTest.WaitForEndpointState(
+		if _, err := pkgTest.CheckEndpointState(
 			context.Background(),
 			ctx.Clients.Kube,
 			t.Logf,

--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -29,7 +29,7 @@ func TestKnativeServiceHTTPS(t *testing.T) {
 	httpURL := ksvc.Status.URL.DeepCopy()
 
 	httpURL.Scheme = "http"
-	if _, err := pkgTest.WaitForEndpointState(
+	if _, err := pkgTest.CheckEndpointState(
 		context.Background(),
 		caCtx.Clients.Kube,
 		t.Logf,


### PR DESCRIPTION
As per title, this aligns us with upstream.