### PR TITLE
Add k8s version patch to run OCP 4.6

### DIFF
--- a/hack/patches/005-k8s-min.patch
+++ b/hack/patches/005-k8s-min.patch
@@ -1,0 +1,13 @@
+diff --git a/vendor/knative.dev/pkg/version/version.go b/vendor/knative.dev/pkg/version/version.go
+index 3cbd846ea..81b1ba46a 100644
+--- a/vendor/knative.dev/pkg/version/version.go
++++ b/vendor/knative.dev/pkg/version/version.go
+@@ -33,7 +33,7 @@ const (
+ 	// NOTE: If you are changing this line, please also update the minimum kubernetes
+ 	// version listed here:
+ 	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
+-	defaultMinimumVersion = "v1.20.0"
++	defaultMinimumVersion = "v1.19.0"
+ )
+ 
+ func getMinimumVersion() string {

--- a/vendor/knative.dev/pkg/version/version.go
+++ b/vendor/knative.dev/pkg/version/version.go
@@ -33,7 +33,7 @@ const (
 	// NOTE: If you are changing this line, please also update the minimum kubernetes
 	// version listed here:
 	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
-	defaultMinimumVersion = "v1.20.0"
+	defaultMinimumVersion = "v1.19.0"
 )
 
 func getMinimumVersion() string {


### PR DESCRIPTION
As per title, OCP 4.6 is based on k8s 1.19 so the operator fails to start without patch.