### PR TITLE
Run clean metadata before installing nodejs

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -13,7 +13,7 @@ RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd
 
-RUN yum install -y https://rpm.nodesource.com/pub_14.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+RUN yum install -y https://rpm.nodesource.com/pub_14.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm && yum --enablerepo=nodesource clean metadata
 RUN yum install -y \
   gcc-c++ \
   make \

--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -13,7 +13,7 @@ RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd
 
-RUN yum install -y https://rpm.nodesource.com/pub___NODEJS_VERSION__/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+RUN yum install -y https://rpm.nodesource.com/pub___NODEJS_VERSION__/el/7/x86_64/nodesource-release-el7-1.noarch.rpm && yum --enablerepo=nodesource clean metadata
 RUN yum install -y \
   gcc-c++ \
   make \


### PR DESCRIPTION
As per title this patch fixes the following issue in current CI:

```
https://rpm.nodesource.com/pub_14.x/el/7/x86_64/nodejs-14.18.1-1nodesource.x86_64.rpm: [Errno -1] Package does not match intended download. Suggestion: run yum --enablerepo=nodesource clean metadata
Trying other mirror.


Error downloading packages:
  2:nodejs-14.18.1-1nodesource.x86_64: [Errno 256] No more mirrors to try.
```