### PR TITLE
Bump Node.js to 16 (LTS)

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -13,7 +13,7 @@ RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd
 
-RUN yum install -y https://rpm.nodesource.com/pub_14.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+RUN yum install -y https://rpm.nodesource.com/pub_16.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
 RUN yum install -y \
   gcc-c++ \
   make \


### PR DESCRIPTION
Node.js 14 installation started to fail

```
https://rpm.nodesource.com/pub_14.x/el/7/x86_64/nodejs-14.18.1-1nodesource.x86_64.rpm: [Errno -1] Package does not match intended download. Suggestion: run yum --enablerepo=nodesource clean metadata
Trying other mirror.


Error downloading packages:
  2:nodejs-14.18.1-1nodesource.x86_64: [Errno 256] No more mirrors to try.
```

While that might be temporary, it seemed reasonable to me to update onto a LTS release anyway, and that seems to continue to work.