### PR TITLE
Fix issue with Node.js installation by pinning an earlier version

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -17,7 +17,7 @@ RUN yum install -y https://rpm.nodesource.com/pub_14.x/el/7/x86_64/nodesource-re
 RUN yum install -y \
   gcc-c++ \
   make \
-  nodejs \
+  nodejs-14.18.0-1nodesource \
   xorg-x11-server-Xvfb \
   gtk2-devel \
   gtk3-devel \

--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -17,7 +17,7 @@ RUN yum install -y https://rpm.nodesource.com/pub___NODEJS_VERSION__/el/7/x86_64
 RUN yum install -y \
   gcc-c++ \
   make \
-  nodejs \
+  nodejs-14.18.0-1nodesource \
   xorg-x11-server-Xvfb \
   gtk2-devel \
   gtk3-devel \


### PR DESCRIPTION
This unwedges the installation issues we're seeing, that look like

```
https://rpm.nodesource.com/pub_14.x/el/7/x86_64/nodejs-14.18.1-1nodesource.x86_64.rpm: [Errno -1] Package does not match intended download. Suggestion: run yum --enablerepo=nodesource clean metadata
Trying other mirror.


Error downloading packages:
  2:nodejs-14.18.1-1nodesource.x86_64: [Errno 256] No more mirrors to try.
```