### PR TITLE
Eventing-Kafka 0.26 KafkaChannel post job update

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -72,6 +72,7 @@ kafka_image "KAFKA_RA_IMAGE"                       "${eventing_kafka}-receive-ad
 kafka_image "kafka-ch-controller__controller"      "${eventing_kafka}-consolidated-controller"
 kafka_image "DISPATCHER_IMAGE"                     "${eventing_kafka}-consolidated-dispatcher"
 kafka_image "kafka-webhook__kafka-webhook"         "${eventing_kafka}-webhook"
+kafka_image "v0.26-eventing-kafka-channel-post-install-job__post-install" "${eventing_kafka}-post-install"
 
 image "KUBE_RBAC_PROXY"   "${rbac_proxy}"
 

--- a/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml
+++ b/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml
@@ -1,0 +1,198 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eventing-kafka-v0.26-channel-post-install-job
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: "v0.26.0"
+
+---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eventing-kafka-v0.26-channel-post-install-job
+  labels:
+    eventing.knative.dev/release: devel
+rules:
+  - apiGroups:
+      - "messaging.knative.dev"
+    resources:
+      - "kafkachannels"
+    verbs:
+      - "get"
+      - "list"
+      - "update"
+
+---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-kafka-v0.26-channel-post-install-job
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: "v0.26.0"
+rules:
+  - apiGroups:
+      - "" # Core API Group
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - list
+
+---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-kafka-v0.26-channel-post-install-job
+  labels:
+    kafka.eventing.knative.dev/release: "v0.26.0"
+subjects:
+  - kind: ServiceAccount
+    name: eventing-kafka-v0.26-channel-post-install-job
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: eventing-kafka-v0.26-channel-post-install-job
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-kafka-v0.26-channel-post-install-job
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: "v0.26.0"
+subjects:
+  - kind: ServiceAccount
+    name: eventing-kafka-v0.26-channel-post-install-job
+    namespace: knative-eventing
+roleRef:
+  kind: Role
+  name: eventing-kafka-v0.26-channel-post-install-job
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: v0.26-eventing-kafka-channel-post-install-job
+  namespace: knative-eventing
+  labels:
+    app: "kafkachannel-retentionduration-update"
+    kafka.eventing.knative.dev/release: "v0.26.0"
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: "kafkachannel-v0.26-post-install"
+        eventing.knative.dev/release: devel
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: eventing-kafka-v0.26-channel-post-install-job
+      restartPolicy: OnFailure
+      containers:
+        - name: post-install
+          image: TO_BE_REPLACED
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: config-kafka
+              mountPath: /etc/config-kafka
+      volumes:
+        - name: config-kafka
+          configMap:
+            name: config-kafka
+
+---

--- a/knative-operator/deploy/resources/knativekafka/manifest_test.go
+++ b/knative-operator/deploy/resources/knativekafka/manifest_test.go
@@ -22,6 +22,9 @@ func TestUnallowedResourcesInManifest(t *testing.T) {
 		path:  "./channel/1-channel-consolidated.yaml",
 		fails: false,
 	}, {
+		path:  "./channel/2-channel-post-install.yaml",
+		fails: false,
+	}, {
 		path:  "./source/1-source.yaml",
 		fails: false,
 	}, {

--- a/knative-operator/hack/009-generated-job-name.patch
+++ b/knative-operator/hack/009-generated-job-name.patch
@@ -1,0 +1,13 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml b/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml
+index c316076c..8258531c 100644
+--- a/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml
++++ b/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml
+@@ -162,7 +162,7 @@ roleRef:
+ apiVersion: batch/v1
+ kind: Job
+ metadata:
+-  name: eventing-kafka-v0.26-channel-post-install-job
++  name: v0.26-eventing-kafka-channel-post-install-job
+   namespace: knative-eventing
+   labels:
+     app: "kafkachannel-retentionduration-update"

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -8,7 +8,7 @@ root="$(dirname "${BASH_SOURCE[0]}")/../.."
 # shellcheck disable=SC1091,SC1090
 source "$root/hack/lib/__sources__.bash"
 
-kafka_channel_files=(channel-consolidated)
+kafka_channel_files=(channel-consolidated channel-post-install)
 kafka_source_files=(source)
 
 function download_kafka {
@@ -50,3 +50,6 @@ git apply "$root/knative-operator/hack/007-eventing-kafka-patch-pdb.patch"
 # NOTE: With upstream 0.27 (1.0) this patch is not needed:
 # The kafka-ch-controller requires DELETE on deployment in OpenShift
 git apply "$root/knative-operator/hack/002-eventing-kafka-ctor-role.patch"
+
+# With 1.21 (1.0.0 knative) we do not need this. upstream has generated name
+git apply "$root/knative-operator/hack/009-generated-job-name.patch"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -622,6 +622,8 @@ spec:
                         value: "registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-kafka-consolidated-dispatcher"
                       - name: "KAFKA_IMAGE_kafka-webhook__kafka-webhook"
                         value: "registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-kafka-webhook"
+                      - name: "KAFKA_IMAGE_v0.26-eventing-kafka-channel-post-install-job__post-install"
+                        value: "registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-kafka-post-install"
                       - name: "KNATIVE_EVENTING_KAFKA_VERSION"
                         value: "0.26.0"
                     securityContext:
@@ -847,5 +849,7 @@ spec:
       image: "registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-kafka-consolidated-dispatcher"
     - name: "KAFKA_IMAGE_kafka-webhook__kafka-webhook"
       image: "registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-kafka-webhook"
+    - name: "KAFKA_IMAGE_v0.26-eventing-kafka-channel-post-install-job__post-install"
+      image: "registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-kafka-post-install"
   replaces: serverless-operator.v1.19.0
   version: 1.20.0


### PR DESCRIPTION
Adding the post-install job for the channel, a follow-up PR for https://github.com/openshift-knative/serverless-operator/pull/1286 