### PR TITLE
[SRVKS-825] Remove annotation handling for termination policy

### DIFF
--- a/serving/ingress/pkg/reconciler/ingress/resources/route.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route.go
@@ -117,21 +117,6 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 		terminationPolicy = routev1.InsecureEdgeTerminationPolicyRedirect
 	}
 
-	// TODO: Remove this annotation handling after serving 0.26+.
-	// Ingress configures the HTTPOption based on the annotation.
-	// https://github.com/knative/serving/commit/d9c1342b5761afdac88c563535885e37fae27c7e
-	if annotations[networking.HTTPOptionAnnotationKey] != "" {
-		annotation := annotations[networking.HTTPOptionAnnotationKey]
-		switch strings.ToLower(annotation) {
-		case "enabled":
-			terminationPolicy = routev1.InsecureEdgeTerminationPolicyAllow
-		case "redirected":
-			terminationPolicy = routev1.InsecureEdgeTerminationPolicyRedirect
-		default:
-			return nil, fmt.Errorf("incorrect HTTPOption annotation: " + annotation)
-		}
-	}
-
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,

--- a/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
@@ -332,87 +332,6 @@ func TestMakeRoute(t *testing.T) {
 				},
 			}},
 		},
-		{
-			name: "valid, http redirect option by annotation",
-			ingress: ingress(
-				withRules(rule(withHosts([]string{localDomain, externalDomain}))),
-				withHTTPOptionAnnotation("redirected"),
-			),
-			want: []*routev1.Route{{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						networking.IngressLabelKey:        "ingress",
-						serving.RouteLabelKey:             "route1",
-						serving.RouteNamespaceLabelKey:    "default",
-						OpenShiftIngressLabelKey:          "ingress",
-						OpenShiftIngressNamespaceLabelKey: "default",
-					},
-					Annotations: map[string]string{
-						TimeoutAnnotation:                   DefaultTimeout,
-						"networking.knative.dev/httpOption": "redirected",
-					},
-					Namespace: lbNamespace,
-					Name:      routeName0,
-				},
-				Spec: routev1.RouteSpec{
-					Host: externalDomain,
-					To: routev1.RouteTargetReference{
-						Kind:   "Service",
-						Name:   lbService,
-						Weight: ptr.Int32(100),
-					},
-					Port: &routev1.RoutePort{
-						TargetPort: intstr.FromString(HTTPPort),
-					},
-					TLS: &routev1.TLSConfig{
-						Termination:                   routev1.TLSTerminationEdge,
-						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-					},
-					WildcardPolicy: routev1.WildcardPolicyNone,
-				},
-			}},
-		},
-		{
-			name: "valid, http enabled option by annotation over global option",
-			ingress: ingress(
-				withRules(rule(withHosts([]string{localDomain, externalDomain}))),
-				withRedirect(),
-				withHTTPOptionAnnotation("enabled"),
-			),
-			want: []*routev1.Route{{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						networking.IngressLabelKey:        "ingress",
-						serving.RouteLabelKey:             "route1",
-						serving.RouteNamespaceLabelKey:    "default",
-						OpenShiftIngressLabelKey:          "ingress",
-						OpenShiftIngressNamespaceLabelKey: "default",
-					},
-					Annotations: map[string]string{
-						TimeoutAnnotation:                   DefaultTimeout,
-						"networking.knative.dev/httpOption": "enabled",
-					},
-					Namespace: lbNamespace,
-					Name:      routeName0,
-				},
-				Spec: routev1.RouteSpec{
-					Host: externalDomain,
-					To: routev1.RouteTargetReference{
-						Kind:   "Service",
-						Name:   lbService,
-						Weight: ptr.Int32(100),
-					},
-					Port: &routev1.RoutePort{
-						TargetPort: intstr.FromString(HTTPPort),
-					},
-					TLS: &routev1.TLSConfig{
-						Termination:                   routev1.TLSTerminationEdge,
-						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
-					},
-					WildcardPolicy: routev1.WildcardPolicyNone,
-				},
-			}},
-		},
 	}
 
 	for _, test := range tests {
@@ -486,18 +405,6 @@ func withRules(rules ...networkingv1alpha1.IngressRule) ingressOption {
 func withRedirect() ingressOption {
 	return func(ing *networkingv1alpha1.Ingress) {
 		ing.Spec.HTTPOption = networkingv1alpha1.HTTPOptionRedirected
-	}
-}
-
-func withHTTPOptionAnnotation(httpOpt string) ingressOption {
-	return func(ing *networkingv1alpha1.Ingress) {
-		ing.Spec.HTTPOption = networkingv1alpha1.HTTPOptionRedirected
-		annos := ing.GetAnnotations()
-		if annos == nil {
-			annos = map[string]string{}
-		}
-		annos[networking.HTTPOptionAnnotationKey] = httpOpt
-		ing.SetAnnotations(annos)
 	}
 }
 


### PR DESCRIPTION
0.26 shipped **actual** handling of the fields, so we don't need explicit annotation handling anymore.

/assign @nak3 