### PR TITLE
Rollout new gateways and controllers next to the old ones

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/ingress/0.26/kourier.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/0.26/kourier.yaml
@@ -260,6 +260,11 @@ metadata:
     networking.knative.dev/ingress-provider: kourier
     serving.knative.dev/release: "v0.26.0"
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
   replicas: 1
   selector:
     matchLabels:
@@ -348,7 +353,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
-      maxSurge: 1
+      maxSurge: 100%
   selector:
     matchLabels:
       app: 3scale-kourier-gateway

--- a/openshift-knative-operator/hack/008-kourier-rollout.patch
+++ b/openshift-knative-operator/hack/008-kourier-rollout.patch
@@ -1,0 +1,25 @@
+diff --git a/openshift-knative-operator/cmd/operator/kodata/ingress/0.26/kourier.yaml b/openshift-knative-operator/cmd/operator/kodata/ingress/0.26/kourier.yaml
+index cc4ba341..edaefcd7 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/ingress/0.26/kourier.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/ingress/0.26/kourier.yaml
+@@ -260,6 +260,11 @@ metadata:
+     networking.knative.dev/ingress-provider: kourier
+     serving.knative.dev/release: "v0.26.0"
+ spec:
++  strategy:
++    type: RollingUpdate
++    rollingUpdate:
++      maxUnavailable: 0
++      maxSurge: 100%
+   replicas: 1
+   selector:
+     matchLabels:
+@@ -348,7 +353,7 @@ spec:
+     type: RollingUpdate
+     rollingUpdate:
+       maxUnavailable: 0
+-      maxSurge: 1
++      maxSurge: 100%
+   selector:
+     matchLabels:
+       app: 3scale-kourier-gateway

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -95,6 +95,10 @@ sed -i -e 's/net-kourier-controller.knative-serving/net-kourier-controller.knati
 # Break all image references so we know our overrides work correctly.
 yaml.break_image_references "$kourier_file"
 
+# Make Kourier rollout in a more defensive way so no requests get dropped.
+# TODO: Can probably be removed in 1.21 and/or be sent upstream.
+git apply "$root/openshift-knative-operator/hack/008-kourier-rollout.patch"
+
 #
 # DOWNLOAD EVENTING
 #


### PR DESCRIPTION
This adjusts the controllers and gateways to rollout with `minUnavailable: 0` and `maxSurge: 100%`, which means that it'll fully rollout the new version before shutting down the old ones.

The effect I'm hoping for is, that the old gateways stay connected to the v2 based controllers while the new ones (having the new bootstrap config) should try to reconnect until they eventually connect to one of the new controllers with v3 connectivity. There is still a potential race here (if the gateways take way longer to rollout than the controllers), but maybe it's enough or at least a bit better?