### PR TITLE
[SRVKS-840] Inject KOURIER_HTTPOPTION_DISABLED to Kourier controller

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -70,6 +70,7 @@ func (e *extension) Transformers(ks operatorv1alpha1.KComponent) []mf.Transforme
 			corev1.EnvVar{Name: "NO_PROXY", Value: os.Getenv("NO_PROXY")},
 		),
 		overrideKourierNamespace(ks),
+		addHTTPOptionDisabledEnvValue(ks),
 	}, monitoring.GetServingTransformers(ks)...)
 }
 

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -70,7 +70,7 @@ func (e *extension) Transformers(ks operatorv1alpha1.KComponent) []mf.Transforme
 			corev1.EnvVar{Name: "NO_PROXY", Value: os.Getenv("NO_PROXY")},
 		),
 		overrideKourierNamespace(ks),
-		addHTTPOptionDisabledEnvValue(ks),
+		addHTTPOptionDisabledEnvValue(),
 	}, monitoring.GetServingTransformers(ks)...)
 }
 

--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -2,7 +2,9 @@ package serving
 
 import (
 	mf "github.com/manifestival/manifestival"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
@@ -40,4 +42,10 @@ func overrideKourierNamespace(ks operatorv1alpha1.KComponent) mf.Transformer {
 // compatibility.
 func kourierNamespace(servingNs string) string {
 	return servingNs + "-ingress"
+}
+
+func addHTTPOptionDisabledEnvValue(ks operatorv1alpha1.KComponent) mf.Transformer {
+	return common.InjectEnvironmentIntoDeployment("net-kourier-controller", "controller",
+		corev1.EnvVar{Name: "KOURIER_HTTPOPTION_DISABLED", Value: "true"},
+	)
 }

--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -44,7 +44,7 @@ func kourierNamespace(servingNs string) string {
 	return servingNs + "-ingress"
 }
 
-func addHTTPOptionDisabledEnvValue(ks operatorv1alpha1.KComponent) mf.Transformer {
+func addHTTPOptionDisabledEnvValue() mf.Transformer {
 	return common.InjectEnvironmentIntoDeployment("net-kourier-controller", "controller",
 		corev1.EnvVar{Name: "KOURIER_HTTPOPTION_DISABLED", Value: "true"},
 	)


### PR DESCRIPTION
As per title, this patch injects `KOURIER_HTTPOPTION_DISABLED` to kourier controller which was introduced by https://github.com/knative-sandbox/net-kourier/pull/704