### PR TITLE
Remove double quote from must-gather image option

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -269,13 +269,13 @@ function gather_knative_state {
   logger.info 'Gather knative state'
   local gather_dir="${ARTIFACT_DIR:-/tmp}/gather-knative"
   mkdir -p "$gather_dir"
-  IMAGE_OPTION="--image=quay.io/openshift-knative/must-gather"
+  IMAGE_OPTION=(--image=quay.io/openshift-knative/must-gather)
   if [[ $FULL_MESH == true ]]; then
-    IMAGE_OPTION="${IMAGE_OPTION} --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7"
+    IMAGE_OPTION=(${IMAGE_OPTION[@]} --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7)
   fi
 
   oc --insecure-skip-tls-verify adm must-gather \
-    ${IMAGE_OPTION} \
+    "${IMAGE_OPTION[@]}" \
     --dest-dir "$gather_dir" > "${gather_dir}/gather-knative.log"
 }
 

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -269,9 +269,9 @@ function gather_knative_state {
   logger.info 'Gather knative state'
   local gather_dir="${ARTIFACT_DIR:-/tmp}/gather-knative"
   mkdir -p "$gather_dir"
-  IMAGE_OPTION=(--image=quay.io/openshift-knative/must-gather)
+  IMAGE_OPTION=("--image=quay.io/openshift-knative/must-gather")
   if [[ $FULL_MESH == true ]]; then
-    IMAGE_OPTION=(${IMAGE_OPTION[@]} --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7)
+    IMAGE_OPTION=("${IMAGE_OPTION[@]}" "--image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7")
   fi
 
   oc --insecure-skip-tls-verify adm must-gather \

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -275,7 +275,7 @@ function gather_knative_state {
   fi
 
   oc --insecure-skip-tls-verify adm must-gather \
-    "${IMAGE_OPTION}" \
+    ${IMAGE_OPTION} \
     --dest-dir "$gather_dir" > "${gather_dir}/gather-knative.log"
 }
 


### PR DESCRIPTION
This patch removes double quote from must-gather image option.

The current script can produce the error as:

```sh
IMAGE_OPTION="--image=quay.io/openshift-knative/must-gather"
IMAGE_OPTION="${IMAGE_OPTION} --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7"

oc adm must-gather "${IMAGE_OPTION}"
```

the same error happens.

```
  ...
[must-gather      ] OUT unable to parse image reference quay.io/openshift-knative/must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7: invalid reference format
  ...
```

But by removing the double quote as this PR:

```sh
IMAGE_OPTION="--image=quay.io/openshift-knative/must-gather"
IMAGE_OPTION="${IMAGE_OPTION} --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7"

oc adm must-gather ${IMAGE_OPTION}
```
no error happens.
```
  ...
[must-gather      ] OUT pod for plug-in image quay.io/openshift-knative/must-gather created
[must-gather      ] OUT pod for plug-in image registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7 created
 ...
```
