### PR TITLE
Remove the note about Metering from CSV

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -65,7 +65,7 @@ spec:
     enables containers, microservices and functions to run "serverless".
     Serverless applications can scale up and down (to zero) on demand and be triggered by a
     number of event sources. OpenShift Serverless integrates with a number of
-    platform services, such as Metering and Monitoring and it is based on the open
+    platform services, such as Monitoring and it is based on the open
     source project Knative.
 
     # Prerequisites

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -65,7 +65,7 @@ spec:
     enables containers, microservices and functions to run "serverless".
     Serverless applications can scale up and down (to zero) on demand and be triggered by a
     number of event sources. OpenShift Serverless integrates with a number of
-    platform services, such as Metering and Monitoring and it is based on the open
+    platform services, such as Monitoring and it is based on the open
     source project Knative.
 
     # Prerequisites


### PR DESCRIPTION
* Support for Metering removed in OCP 4.9. The older versions still have
it (4.6, 4.7, 4.8).

Let's discuss if this is desired before merging.

/hold