### PR TITLE
Set expired time 10 minutes ago instead of 10 sec

### DIFF
--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -578,9 +578,9 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 				"iss": issuer,
 				"sub": subject,
 				"foo": "bar",
-				// as if generated before an hour, expiring 10 seconds ago
+				// as if generated before an hour, expiring 10 minutes ago
 				"iat": time.Now().Unix() - 3600,
-				"exp": time.Now().Unix() - 10,
+				"exp": time.Now().Unix() - 600,
 			},
 		}, {
 			// A token signed by a different key


### PR DESCRIPTION
Currently `TestKsvcWithServiceMeshJWTDefaultPolicy/v2/expired` is flaky as it returns `200` even though the JWT was expired 10 seconds ago.

e.g. [example logs](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.9-vsphere-e2e-vsphere-ocp-49-continuous/1462209355343466496)
```
    servicemesh_test.go:651: Unexpected response with an invalid token, expecting 401 or 403, got 200: Hello World!
```

The all JWT test (including SMCP v1/expired) look fine so the test code and JWT settings are fine but only expired payload is not working as expected.

```
PASS test/servinge2e/kourier.TestKsvcWithServiceMeshJWTDefaultPolicy/v1/valid (0.02s)
PASS test/servinge2e/kourier.TestKsvcWithServiceMeshJWTDefaultPolicy/v1/no_token (0.01s)
PASS test/servinge2e/kourier.TestKsvcWithServiceMeshJWTDefaultPolicy/v1/unsigned (0.02s)
PASS test/servinge2e/kourier.TestKsvcWithServiceMeshJWTDefaultPolicy/v1/expired (0.02s)
PASS test/servinge2e/kourier.TestKsvcWithServiceMeshJWTDefaultPolicy/v1/bad_key (0.02s)
PASS test/servinge2e/kourier.TestKsvcWithServiceMeshJWTDefaultPolicy/v1/bad_iss (0.02s)
PASS test/servinge2e/kourier.TestKsvcWithServiceMeshJWTDefaultPolicy/v1 (121.44s)
PASS test/servinge2e/kourier.TestKsvcWithServiceMeshJWTDefaultPolicy/v2/valid (0.03s)
PASS test/servinge2e/kourier.TestKsvcWithServiceMeshJWTDefaultPolicy/v2/no_token (0.02s)
PASS test/servinge2e/kourier.TestKsvcWithServiceMeshJWTDefaultPolicy/v2/unsigned (0.02s)
=== RUN   TestKsvcWithServiceMeshJWTDefaultPolicy/v2/expired
    servicemesh_test.go:651: Unexpected response with an invalid token, expecting 401 or 403, got 200: Hello World!
        --- FAIL: TestKsvcWithServiceMeshJWTDefaultPolicy/v2/expired (0.02s)
FAIL test/servinge2e/kourier.TestKsvcWithServiceMeshJWTDefaultPolicy/v2/expired (0.02s)
```

So, this patch tries to set expired time more to 10 minutes from 10 sec to see if the flake could be fixed.

/cc @markusthoemmes @maschmid 