### PR TITLE
Make sure nothing is left in the serving-tests namespace before teardown

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -220,8 +220,9 @@ function run_rolling_upgrade_tests {
     --resolvabledomain \
     --https
 
-  # Delete the leftover namespace.
-  oc delete namespace serving-tests
+  # Delete the leftover services.
+  oc delete ksvc all -n serving-tests
+  timeout 120 "[[ \$(oc get all --no-headers -n ${SERVING_NAMESPACE} | wc -l) != 0 ]]"
 
   logger.success 'Upgrade tests passed'
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -221,7 +221,7 @@ function run_rolling_upgrade_tests {
     --https
 
   # Delete the leftover services.
-  oc delete ksvc --all -n ${SERVING_NAMESPACE}
+  oc delete ksvc --all -n "${SERVING_NAMESPACE}"
   timeout 120 "[[ \$(oc get all --no-headers -n ${SERVING_NAMESPACE} | wc -l) != 0 ]]"
 
   logger.success 'Upgrade tests passed'

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -221,8 +221,8 @@ function run_rolling_upgrade_tests {
     --https
 
   # Delete the leftover services.
-  oc delete ksvc --all -n "${SERVING_NAMESPACE}"
-  timeout 120 "[[ \$(oc get all --no-headers -n ${SERVING_NAMESPACE} | wc -l) != 0 ]]"
+  oc delete ksvc --all -n serving-tests
+  timeout 120 "[[ \$(oc get all --no-headers -n serving-tests | wc -l) != 0 ]]"
 
   logger.success 'Upgrade tests passed'
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -221,7 +221,7 @@ function run_rolling_upgrade_tests {
     --https
 
   # Delete the leftover services.
-  oc delete ksvc all -n serving-tests
+  oc delete ksvc --all -n ${SERVING_NAMESPACE}
   timeout 120 "[[ \$(oc get all --no-headers -n ${SERVING_NAMESPACE} | wc -l) != 0 ]]"
 
   logger.success 'Upgrade tests passed'

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -220,8 +220,8 @@ function run_rolling_upgrade_tests {
     --resolvabledomain \
     --https
 
-  # Delete the leftover services.
-  oc delete ksvc --all -n serving-tests
+  # Delete the leftover namespace.
+  oc delete namespace serving-tests
 
   logger.success 'Upgrade tests passed'
 }


### PR DESCRIPTION
* Calling teardown while there are active knative resources being
deleted might leave some inconsistent resources there and prevent
deleting CRDs in the end.

This is to address https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.7-upgrade-tests-aws-ocp-47-continuous/1465470749794897920
There was still an active Configuration and Revision but not Service even though blockOwnerDeletion: true is set on Configuration and the Service should only be removed once the Configuration is deleted. I suppose it's a race condition between deleting resources and uninstalling Knative Serving. There are no Knative Serving pods to search for logs. Waiting for the namespace to be deleted seems like a more robust solution - it will either wait for all the resources to be gone before proceeding or time out, and in this case we'll be able to look at logs because it will all happen before Serverless teardown.