### PR TITLE
Define missing rootdir variable for mesh script

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -195,6 +195,9 @@ EOF
 
   logger.success 'KnativeServing has been updated successfully.'
 
+  local rootdir
+  rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
+
   # metadata-webhook adds istio annotations for e2e test by webhook.
   oc apply -f "${rootdir}/serving/metadata-webhook/config"
 }


### PR DESCRIPTION
As per title, fixes

```
/go/src/github.com/openshift-knative/serverless-operator/hack/lib/serverless.bash: line 199: rootdir: unbound variable
```

in the mesh leg.