### PR TITLE
Wait for KServices to be deleted in foreground

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -221,8 +221,7 @@ function run_rolling_upgrade_tests {
     --https
 
   # Delete the leftover services.
-  oc delete ksvc --all -n serving-tests
-  timeout 120 "[[ \$(oc get all --no-headers -n serving-tests | wc -l) != 0 ]]"
+  oc delete ksvc --all --cascade='foreground' -n serving-tests
 
   logger.success 'Upgrade tests passed'
 }


### PR DESCRIPTION
Fix for https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.6-upgrade-tests-aws-ocp-46-continuous/1466014323192107008

The KServices are being deleted by default with
propagationPolicy=Background which can be seen in garbage collector logs
in kube-controller-manager pod.
The logs also show that some resources are still in process of deletion
when the 120 second timeout expires.
By forcing the "foreground" deletion this command will wait as long as the deletion is in progress.