### PR TITLE
Upgrade tests have no prepare steps

### DIFF
--- a/test/eventing.bash
+++ b/test/eventing.bash
@@ -24,7 +24,3 @@ function upstream_knative_eventing_e2e {
   logger.info 'Starting eventing conformance tests'
   run_conformance_tests
 }
-
-function prepare_knative_eventing_tests {
-  logger.info 'Nothing to prepare for Eventing upgrade tests'
-}


### PR DESCRIPTION
* Make it clear there are no "prepare" steps needed except for creating
the test namespace for Serving tests.
* Make it easier to run the tests.

Also sent https://github.com/knative/serving/pull/12366 upstream which will remove the need to create the test namespace for Serving part of the upgrade test suite.