### PR TITLE
Delete serving-tests ns after upgrade tests

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -221,8 +221,8 @@ function run_rolling_upgrade_tests {
     --resolvabledomain \
     --https
 
-  # Delete the leftover services.
-  oc delete ksvc --all --cascade='foreground' -n serving-tests
+  # Delete the leftover namespace with services.
+  oc delete namespace serving-tests
 
   logger.success 'Upgrade tests passed'
 }


### PR DESCRIPTION
Compared with previous solution this also works on OCP 4.6 (Kube 1.19).