### PR TITLE
Make resource count dynamic in monitoring tests

### DIFF
--- a/openshift-knative-operator/pkg/monitoring/monitoring_eventing_test.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_eventing_test.go
@@ -19,8 +19,15 @@ func TestLoadPlatformEventingMonitoringManifests(t *testing.T) {
 		t.Errorf("Got %d, want %d", len(manifests), 1)
 	}
 	resources := manifests[0].Resources()
-	if len(resources) != 28 {
-		t.Errorf("Got %d, want %d", len(resources), 28)
+
+	// We create a service monitor and a service monitor service per deployment.
+	// One clusterrolebinding (except for mt-broker-controller) per deployment for allowing tokenreviews, subjectaccessreviews
+	// to be used by kube proxy. All but one deployments have a different sa.
+	// Five RBAC resources from rbac-proxy.yaml
+	expectedEventingMonitoringResources := len(eventingDeployments)*2 + len(eventingDeployments) + 4
+
+	if len(resources) != expectedEventingMonitoringResources {
+		t.Errorf("Got %d, want %d", len(resources), expectedEventingMonitoringResources)
 	}
 	for _, u := range resources {
 		kind := strings.ToLower(u.GetKind())

--- a/openshift-knative-operator/pkg/monitoring/monitoring_eventing_test.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_eventing_test.go
@@ -20,11 +20,11 @@ func TestLoadPlatformEventingMonitoringManifests(t *testing.T) {
 	}
 	resources := manifests[0].Resources()
 
-	// We create a service monitor and a service monitor service per deployment.
+	// We create a service monitor and a service monitor service per deployment: len(eventingDeployments)*2 resources.
 	// One clusterrolebinding (except for mt-broker-controller) per deployment for allowing tokenreviews, subjectaccessreviews
-	// to be used by kube proxy. All but one deployments have a different sa.
-	// Five RBAC resources from rbac-proxy.yaml
-	expectedEventingMonitoringResources := len(eventingDeployments)*2 + len(eventingDeployments) + 4
+	// to be used by kube proxy. All but one deployments have a different sa: len(eventingDeployments) -1 resources.
+	// RBAC resources from rbac-proxy.yaml: 5 resources that don't depend on the deployments number.
+	expectedEventingMonitoringResources := len(eventingDeployments)*2 + len(eventingDeployments) - 1 + 5
 
 	if len(resources) != expectedEventingMonitoringResources {
 		t.Errorf("Got %d, want %d", len(resources), expectedEventingMonitoringResources)

--- a/openshift-knative-operator/pkg/monitoring/monitoring_serving_test.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_serving_test.go
@@ -19,8 +19,15 @@ func TestLoadPlatformServingMonitoringManifests(t *testing.T) {
 		t.Errorf("Got %d, want %d", len(manifests), 1)
 	}
 	resources := manifests[0].Resources()
-	if len(resources) != 20 {
-		t.Errorf("Got %d, want %d", len(resources), 20)
+
+	// We create a service monitor and a service monitor service per deployment
+	// One clusterrolebinding for allowing tokenreviews, subjectaccessreviews
+	// to be used by kube proxy. All deployments share the same sa.
+	// Five RBAC resources from rbac-proxy.yaml.
+	expectedServingMonitoringResources := len(servingDeployments)*2 + 6
+
+	if len(resources) != expectedServingMonitoringResources {
+		t.Errorf("Got %d, want %d", len(resources), expectedServingMonitoringResources)
 	}
 	for _, u := range resources {
 		kind := strings.ToLower(u.GetKind())

--- a/openshift-knative-operator/pkg/monitoring/monitoring_serving_test.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_serving_test.go
@@ -20,11 +20,11 @@ func TestLoadPlatformServingMonitoringManifests(t *testing.T) {
 	}
 	resources := manifests[0].Resources()
 
-	// We create a service monitor and a service monitor service per deployment
+	// We create a service monitor and a service monitor service per deployment: len(servingDeployments)*2 resources.
 	// One clusterrolebinding for allowing tokenreviews, subjectaccessreviews
-	// to be used by kube proxy. All deployments share the same sa.
-	// Five RBAC resources from rbac-proxy.yaml.
-	expectedServingMonitoringResources := len(servingDeployments)*2 + 6
+	// to be used by kube proxy. All deployments share the same sa: 1 resource.
+	// RBAC resources from rbac-proxy.yaml: 5 resources that don't depend on the deployments number.
+	expectedServingMonitoringResources := len(servingDeployments)*2 + 5 + 1
 
 	if len(resources) != expectedServingMonitoringResources {
 		t.Errorf("Got %d, want %d", len(resources), expectedServingMonitoringResources)


### PR DESCRIPTION
Improvement to answer comment [here](https://github.com/openshift-knative/serverless-operator/pull/1326#pullrequestreview-822378325).