### PR TITLE
Remove fixed namespace from kourier-bootstrap

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/ingress/0.26/kourier.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/0.26/kourier.yaml
@@ -113,7 +113,7 @@ data:
                 endpoint:
                   address:
                     socket_address:
-                      address: "net-kourier-controller.knative-serving-ingress"
+                      address: "net-kourier-controller"
                       port_value: 18000
           http2_protocol_options: {}
           type: STRICT_DNS

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -91,7 +91,7 @@ url="https://github.com/knative-sandbox/net-kourier/releases/download/v$(metadat
 kourier_file="$root/openshift-knative-operator/cmd/operator/kodata/ingress/$(versions.major_minor "${KNATIVE_SERVING_VERSION}")/kourier.yaml"
 wget --no-check-certificate "$url" -O "$kourier_file"
 # TODO: [SRVKS-610] These values should be replaced by operator instead of sed.
-sed -i -e 's/net-kourier-controller.knative-serving/net-kourier-controller.knative-serving-ingress/g' "$kourier_file"
+sed -i -e 's/net-kourier-controller.knative-serving/net-kourier-controller/g' "$kourier_file"
 # Break all image references so we know our overrides work correctly.
 yaml.break_image_references "$kourier_file"
 


### PR DESCRIPTION
When controller and gateway are deployed in the same namespace,
the namespace (`knative-serving-ingress`) should not need to be specified.

serverless-operator deploys kourier gateway and controller in the same
namespace so it could be omitted.