### PR TITLE
SRVCOM-1623 Separate tests and install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test-e2e-testonly:
 
 test-e2e: install
 	./test/e2e-tests.sh
-	./hack/teardown
+	./hack/teardown.sh
 
 # Run E2E tests from the current repo for serving+eventing+knativeKafka
 test-e2e-with-kafka-testonly:
@@ -84,7 +84,6 @@ test-e2e-with-mesh-testonly:
 test-e2e-with-mesh: install-full-mesh
 	FULL_MESH=true ./hack/install.sh
 	FULL_MESH=true ./test/e2e-tests.sh
-	./hack/teardown.sh
 
 # Run both unit and E2E tests from the current repo.
 test-operator: test-unit test-e2e
@@ -98,7 +97,6 @@ test-upstream-e2e-mesh: install-full-mesh
 	FULL_MESH=true ./hack/install.sh
 	FULL_MESH=true ./test/e2e-tests.sh
 	FULL_MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
-	./hack/teardown.sh
 
 # Run upstream E2E tests without upgrades.
 test-upstream-e2e-no-upgrade-testonly:
@@ -106,7 +104,6 @@ test-upstream-e2e-no-upgrade-testonly:
 
 test-upstream-e2e-no-upgrade: install-all
 	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
-	./hack/teardown.sh
 
 # Run only upstream upgrade tests.
 test-upstream-upgrade-testonly:
@@ -115,7 +112,6 @@ test-upstream-upgrade-testonly:
 test-upstream-upgrade: install-strimzi
 	INSTALL_PREVIOUS_VERSION="true" INSTALL_KAFKA="true" ./hack/install.sh
 	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
-	./hack/teardown.sh
 
 # Alias.
 test-upgrade: test-upstream-upgrade
@@ -126,7 +122,6 @@ test-ui-e2e-testonly:
 
 test-ui-e2e: install
 	./test/ui-e2e-tests.sh
-	./hack/teardown.sh
 
 # Run all E2E tests.
 test-all-e2e: install

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ install-full-mesh:
 uninstall-full-mesh:
 	FULL_MESH="true" UNINSTALL_MESH="true" ./hack/mesh.sh
 
+install-with-mesh-enabled:
+  FULL_MESH=true ./hack/install.sh
+
 teardown:
 	./hack/teardown.sh
 
@@ -56,16 +59,22 @@ test-unit:
 	go test ./serving/metadata-webhook/...
 
 # Run only SERVING/EVENTING E2E tests from the current repo.
-test-e2e:
+test-e2e-testonly:
 	./test/e2e-tests.sh
 
+test-e2e: install test-e2e-testonly teardown
+
 # Run E2E tests from the current repo for serving+eventing+knativeKafka
-test-e2e-with-kafka:
-	INSTALL_KAFKA=true TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
+test-e2e-with-kafka-testonly:
+	TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
+
+test-e2e-with-kafka: install-all test-e2e-with-kafka-testonly teardown
 
 # Run E2E tests from the current repo for serving+eventing+mesh
-test-e2e-with-mesh:
+test-e2e-with-mesh-testonly:
 	FULL_MESH=true ./test/e2e-tests.sh
+
+test-e2e-with-mesh: install-full-mesh install-with-mesh-enabled test-e2e-with-mesh-testonly teardown
 
 # Run both unit and E2E tests from the current repo.
 test-operator: test-unit test-e2e

--- a/Makefile
+++ b/Makefile
@@ -92,29 +92,29 @@ test-operator: test-unit test-e2e
 # Run upstream E2E tests with net-istio and sidecar.
 # TODO: Enable upgrade tests once upstream fixed the issue https://github.com/knative/serving/issues/11535.
 test-upstream-e2e-mesh-testonly:
-	FULL_MESH=true INSTALL_KAFKA=false TEST_KNATIVE_KAFKA=false TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	FULL_MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
 test-upstream-e2e-mesh: install-full-mesh
 	FULL_MESH=true ./hack/install.sh
 	FULL_MESH=true ./test/e2e-tests.sh
-	FULL_MESH=true INSTALL_KAFKA=false TEST_KNATIVE_KAFKA=false TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	FULL_MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 	./hack/teardown.sh
 
 # Run upstream E2E tests without upgrades.
 test-upstream-e2e-no-upgrade-testonly:
-	INSTALL_KAFKA=true TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
 test-upstream-e2e-no-upgrade: install-all
-	INSTALL_KAFKA=true TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 	./hack/teardown.sh
 
 # Run only upstream upgrade tests.
 test-upstream-upgrade-testonly:
-	INSTALL_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
+	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
 test-upstream-upgrade: install-strimzi
 	INSTALL_PREVIOUS_VERSION="true" INSTALL_KAFKA="true" ./hack/install.sh
-	INSTALL_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
+	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 	./hack/teardown.sh
 
 # Alias.
@@ -131,8 +131,8 @@ test-ui-e2e: install
 # Run all E2E tests.
 test-all-e2e: install
 	./test/e2e-tests.sh
-	INSTALL_KAFKA=true TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
-	INSTALL_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
+	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 	./test/ui-e2e-tests.sh
 	./hack/teardown.sh
 

--- a/Makefile
+++ b/Makefile
@@ -65,19 +65,26 @@ test-unit:
 test-e2e-testonly:
 	./test/e2e-tests.sh
 
-test-e2e: install test-e2e-testonly teardown
+test-e2e: install
+	./test/e2e-tests.sh
+	./hack/teardown
 
 # Run E2E tests from the current repo for serving+eventing+knativeKafka
 test-e2e-with-kafka-testonly:
 	TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
 
-test-e2e-with-kafka: install-all test-e2e-with-kafka-testonly teardown
+test-e2e-with-kafka: install-all
+	TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
+	./hack/teardown.sh
 
 # Run E2E tests from the current repo for serving+eventing+mesh
 test-e2e-with-mesh-testonly:
 	FULL_MESH=true ./test/e2e-tests.sh
 
-test-e2e-with-mesh: install-full-mesh install-with-mesh-enabled test-e2e-with-mesh-testonly teardown
+test-e2e-with-mesh: install-full-mesh
+	FULL_MESH=true ./hack/install.sh
+	FULL_MESH=true ./test/e2e-tests.sh
+	./hack/teardown.sh
 
 # Run both unit and E2E tests from the current repo.
 test-operator: test-unit test-e2e
@@ -87,19 +94,28 @@ test-operator: test-unit test-e2e
 test-upstream-e2e-mesh-testonly:
 	FULL_MESH=true INSTALL_KAFKA=false TEST_KNATIVE_KAFKA=false TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
-test-upstream-e2e-mesh: install-full-mesh install-with-mesh-enabled test-e2e-with-mesh-testonly test-upstream-e2e-mesh-testonly teardown
+test-upstream-e2e-mesh: install-full-mesh
+	FULL_MESH=true ./hack/install.sh
+	FULL_MESH=true ./test/e2e-tests.sh
+	FULL_MESH=true INSTALL_KAFKA=false TEST_KNATIVE_KAFKA=false TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	./hack/teardown.sh
 
 # Run upstream E2E tests without upgrades.
 test-upstream-e2e-no-upgrade-testonly:
 	INSTALL_KAFKA=true TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
-test-upstream-e2e-no-upgrade: install-all test-upstream-e2e-no-upgrade-testonly teardown
+test-upstream-e2e-no-upgrade: install-all
+	INSTALL_KAFKA=true TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	./hack/teardown.sh
 
 # Run only upstream upgrade tests.
 test-upstream-upgrade-testonly:
 	INSTALL_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
-test-upstream-upgrade: install-strimzi install-previous-with-kafka test-upstream-upgrade-testonly teardown
+test-upstream-upgrade: install-strimzi
+	INSTALL_PREVIOUS_VERSION="true" INSTALL_KAFKA="true" ./hack/install.sh
+	INSTALL_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
+	./hack/teardown.sh
 
 # Alias.
 test-upgrade: test-upstream-upgrade
@@ -108,10 +124,17 @@ test-upgrade: test-upstream-upgrade
 test-ui-e2e-testonly:
 	./test/ui-e2e-tests.sh
 
-test-ui-e2e: install test-ui-e2e-testonly teardown
+test-ui-e2e: install
+	./test/ui-e2e-tests.sh
+	./hack/teardown.sh
 
 # Run all E2E tests.
-test-all-e2e: install test-e2e-testonly test-upstream-e2e-no-upgrade-testonly test-upstream-upgrade-testonly test-ui-e2e-testonly teardown
+test-all-e2e: install
+	./test/e2e-tests.sh
+	INSTALL_KAFKA=true TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	INSTALL_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
+	./test/ui-e2e-tests.sh
+	./hack/teardown.sh
 
 # Generates a ci-operator configuration for a specific branch.
 generate-ci-config:

--- a/hack/dependencies.sh
+++ b/hack/dependencies.sh
@@ -16,4 +16,4 @@ set -Eeuo pipefail
 
 debugging.setup
 
-create_namespaces
+create_namespaces "${SYSTEM_NAMESPACES[@]}"

--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -16,5 +16,5 @@ set -Eeuo pipefail
 
 debugging.setup
 
-create_namespaces
+create_namespaces "${SYSTEM_NAMESPACES[@]}"
 ensure_catalogsource_installed

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -15,7 +15,7 @@ set -Eeuo pipefail
 
 debugging.setup
 
-create_namespaces
+create_namespaces "${SYSTEM_NAMESPACES[@]}"
 
 ensure_catalogsource_installed
 ensure_serverless_installed "${INSTALL_PREVIOUS_VERSION}"

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -174,11 +174,6 @@ function add_user {
   name=${1:?Pass a username as arg[1]}
   pass=${2:?Pass a password as arg[2]}
 
-  if oc get user "$name" >/dev/null 2>&1; then
-    logger.success "User ${name} already exists."
-    return 0
-  fi
-
   logger.info "Creating user $name:***"
   if oc get secret htpass-secret -n openshift-config -o jsonpath='{.data.htpasswd}' 2>/dev/null | base64 -d > users.htpasswd; then
     logger.debug 'Secret htpass-secret already existed, updating it.'

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -374,7 +374,7 @@ function teardown_serverless {
   if oc get namespace "${SERVING_NAMESPACE}" &>/dev/null; then
     oc delete namespace "${SERVING_NAMESPACE}"
   fi
-  logger.info 'Ensure ingress namespace no pods running'
+  logger.info 'Ensure no ingress pods running'
   timeout 600 "[[ \$(oc get pods -n ${INGRESS_NAMESPACE} --field-selector=status.phase!=Succeeded -o jsonpath='{.items}') != '[]' ]]"
   timeout 600 "[[ \$(oc get ns ${INGRESS_NAMESPACE} --no-headers | wc -l) == 1 ]]"
   if oc get knativeeventing.operator.knative.dev knative-eventing -n "${EVENTING_NAMESPACE}" >/dev/null 2>&1; then
@@ -398,7 +398,7 @@ function teardown_serverless {
   oc delete subscriptions.operators.coreos.com \
     -n "${OPERATORS_NAMESPACE}" "${OPERATOR}" \
     --ignore-not-found
-  logger.info 'Deleting CSVs'
+  logger.info 'Deleting ClusterServiceVersion'
   for csv in $(set +o pipefail && oc get csv -n "${OPERATORS_NAMESPACE}" --no-headers 2>/dev/null \
       | grep "${OPERATOR}" | cut -f1 -d' '); do
     oc delete csv -n "${OPERATORS_NAMESPACE}" "${csv}"

--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -3,7 +3,9 @@
 function install_strimzi_operator {
   strimzi_version=$(curl https://github.com/strimzi/strimzi-kafka-operator/releases/latest |  awk -F 'tag/' '{print $2}' | awk -F '"' '{print $1}' 2>/dev/null)
   header "Installing Strimzi Kafka operator"
-  oc create namespace kafka
+  if ! oc get ns kafka &>/dev/null; then
+    oc create namespace kafka
+  fi
   oc -n kafka apply --selector strimzi.io/crd-install=true -f "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml"
   curl -L "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml" \
   | sed 's/namespace: .*/namespace: kafka/' \

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -42,9 +42,9 @@ export EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-knative-eventing}"
 # eventing e2e and conformance tests use a container for tracing tests that has hardcoded `istio-system` in it
 export ZIPKIN_NAMESPACE="${ZIPKIN_NAMESPACE:-istio-system}"
 
-declare -a NAMESPACES
-NAMESPACES=("${ZIPKIN_NAMESPACE}" "${OPERATORS_NAMESPACE}")
-export NAMESPACES
+declare -a SYSTEM_NAMESPACES
+SYSTEM_NAMESPACES=("${ZIPKIN_NAMESPACE}" "${OPERATORS_NAMESPACE}")
+export SYSTEM_NAMESPACES
 export UPGRADE_SERVERLESS="${UPGRADE_SERVERLESS:-"true"}"
 export UPGRADE_CLUSTER="${UPGRADE_CLUSTER:-"false"}"
 # Change this when forcing the upgrade to an image that is not yet available via upgrade channel

--- a/hack/teardown.sh
+++ b/hack/teardown.sh
@@ -10,4 +10,4 @@ debugging.setup
 teardown_serverless
 teardown_tracing
 delete_catalog_source
-delete_namespaces "${SYSTEM_NAMESPACES[@]}" "${TEST_NAMESPACES[@]}"
+delete_namespaces "${SYSTEM_NAMESPACES[@]}"

--- a/hack/teardown.sh
+++ b/hack/teardown.sh
@@ -8,6 +8,6 @@ set -Eeuo pipefail
 debugging.setup
 
 teardown_serverless
-teardown_tracing
-delete_catalog_source
-delete_namespaces
+#teardown_tracing
+#delete_catalog_source
+#delete_namespaces

--- a/hack/teardown.sh
+++ b/hack/teardown.sh
@@ -8,6 +8,6 @@ set -Eeuo pipefail
 debugging.setup
 
 teardown_serverless
-#teardown_tracing
-#delete_catalog_source
-#delete_namespaces
+teardown_tracing
+delete_catalog_source
+delete_namespaces "${SYSTEM_NAMESPACES[@]}" "${TEST_NAMESPACES[@]}"

--- a/test/deployment.go
+++ b/test/deployment.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -28,22 +27,4 @@ func WithDeploymentReady(ctx *Context, name string, namespace string) (*appsv1.D
 		return nil, fmt.Errorf("deployment %s in namespace %s not ready in time: %w", name, namespace, waitErr)
 	}
 	return deployment, nil
-}
-
-func WithDeploymentGone(ctx *Context, name string, namespace string) error {
-	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
-		_, err := ctx.Clients.Kube.AppsV1().Deployments(namespace).Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil && apierrs.IsNotFound(err) {
-			return true, nil
-		} else if err != nil {
-			return false, err
-		} else {
-			return false, nil
-		}
-	})
-
-	if waitErr != nil {
-		return fmt.Errorf("deployment %s in namespace %s not gone in time: %w", name, namespace, waitErr)
-	}
-	return nil
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -12,51 +12,52 @@ fi
 debugging.setup
 dump_state.setup
 
-# TODO: Split this to system namespaces and test namespaces
-create_namespaces
-# TODO: Move this to later stage (this is for tests)
-create_htpasswd_users
-add_roles
+create_namespaces "${SYSTEM_NAMESPACES[@]}"
+install_catalogsource
 
-#install_catalogsource
+if [[ $INSTALL_KAFKA == true ]]; then
+  install_strimzi
+fi
+
+if [[ $FULL_MESH == "true" ]]; then
+  # net-istio does not use knative-serving-ingress namespace.
+  export INGRESS_NAMESPACE="knative-serving"
+  UNINSTALL_MESH="false" install_mesh
+  ensure_serverless_installed
+  enable_net_istio
+else
+  ensure_serverless_installed
+  trust_router_ca
+fi
+
 logger.success '🚀 Cluster prepared for testing.'
 
 # Run serverless-operator specific tests.
-#serverless_operator_e2e_tests
+create_htpasswd_users && add_roles
+create_namespaces "${TEST_NAMESPACES[@]}"
+serverless_operator_e2e_tests
 if [[ $TEST_KNATIVE_KAFKA == true ]]; then
-  #install_strimzi
   serverless_operator_kafka_e2e_tests
 fi
-#
-#if [[ $FULL_MESH == "true" ]]; then
-#  # net-istio does not use knative-serving-ingress namespace.
-#  export INGRESS_NAMESPACE="knative-serving"
-#  UNINSTALL_MESH="false" install_mesh
-#  ensure_serverless_installed
-#  enable_net_istio
-#else
-#  ensure_serverless_installed
-#  trust_router_ca
-#fi
-#
-#[ -n "$OPENSHIFT_CI" ] && setup_quick_api_deprecation_alerts
-#
-## Run Knative Serving & Eventing downstream E2E tests.
-#downstream_serving_e2e_tests
-#downstream_eventing_e2e_tests
-#downstream_monitoring_e2e_tests
-#if [[ $TEST_KNATIVE_KAFKA == true ]]; then
-#  # TODO: Remove this as this is already installed in ensure_serverless_installed, or use deploy_knativekafka_cr
-#  ensure_kafka_no_auth
-#  downstream_knative_kafka_e2e_tests
-#  # ensure_kafka_tls_auth
-#  # downstream_knative_kafka_e2e_tests
-#  # ensure_kafka_sasl_auth
-#  # downstream_knative_kafka_e2e_tests
-#fi
-#
-#[ -n "$OPENSHIFT_CI" ] && check_serverless_alerts
-#
-#teardown_serverless
+
+[ -n "$OPENSHIFT_CI" ] && setup_quick_api_deprecation_alerts
+
+# Run Knative Serving & Eventing downstream E2E tests.
+downstream_serving_e2e_tests
+downstream_eventing_e2e_tests
+downstream_monitoring_e2e_tests
+if [[ $TEST_KNATIVE_KAFKA == true ]]; then
+  # TODO: Remove this as this is already installed in ensure_serverless_installed, or use deploy_knativekafka_cr
+  ensure_kafka_no_auth
+  downstream_knative_kafka_e2e_tests
+  # ensure_kafka_tls_auth
+  # downstream_knative_kafka_e2e_tests
+  # ensure_kafka_sasl_auth
+  # downstream_knative_kafka_e2e_tests
+fi
+
+[ -n "$OPENSHIFT_CI" ] && check_serverless_alerts
+
+teardown_serverless
 
 success

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -33,8 +33,8 @@ fi
 logger.success '🚀 Cluster prepared for testing.'
 
 # Run serverless-operator specific tests.
-create_htpasswd_users && add_roles
 create_namespaces "${TEST_NAMESPACES[@]}"
+create_htpasswd_users && add_roles
 serverless_operator_e2e_tests
 if [[ $TEST_KNATIVE_KAFKA == true ]]; then
   serverless_operator_kafka_e2e_tests

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -9,24 +9,13 @@ set -Eeuo pipefail
 if [ -n "$OPENSHIFT_CI" ]; then
   env
 fi
-debugging.setup
-dump_state.setup
-
-create_namespaces "${SYSTEM_NAMESPACES[@]}"
-install_catalogsource
-
-if [[ $INSTALL_KAFKA == true ]]; then
-  install_strimzi
-fi
+debugging.setup # both install and test
+dump_state.setup # test
 
 if [[ $FULL_MESH == "true" ]]; then
   # net-istio does not use knative-serving-ingress namespace.
   export INGRESS_NAMESPACE="knative-serving"
-  UNINSTALL_MESH="false" install_mesh
-  ensure_serverless_installed
-  enable_net_istio
 else
-  ensure_serverless_installed
   trust_router_ca
 fi
 
@@ -57,7 +46,5 @@ if [[ $TEST_KNATIVE_KAFKA == true ]]; then
 fi
 
 [ -n "$OPENSHIFT_CI" ] && check_serverless_alerts
-
-teardown_serverless
 
 success

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -12,46 +12,51 @@ fi
 debugging.setup
 dump_state.setup
 
+# TODO: Split this to system namespaces and test namespaces
 create_namespaces
+# TODO: Move this to later stage (this is for tests)
 create_htpasswd_users
 add_roles
 
-install_catalogsource
+#install_catalogsource
 logger.success '🚀 Cluster prepared for testing.'
 
 # Run serverless-operator specific tests.
-serverless_operator_e2e_tests
+#serverless_operator_e2e_tests
 if [[ $TEST_KNATIVE_KAFKA == true ]]; then
-  install_strimzi
+  #install_strimzi
   serverless_operator_kafka_e2e_tests
 fi
-
-if [[ $FULL_MESH == "true" ]]; then
-  # net-istio does not use knative-serving-ingress namespace.
-  export INGRESS_NAMESPACE="knative-serving"
-  UNINSTALL_MESH="false" install_mesh
-  ensure_serverless_installed
-  enable_net_istio
-else
-  ensure_serverless_installed
-  trust_router_ca
-fi
-
-[ -n "$OPENSHIFT_CI" ] && setup_quick_api_deprecation_alerts
-
-# Run Knative Serving & Eventing downstream E2E tests.
-downstream_serving_e2e_tests
-downstream_eventing_e2e_tests
-downstream_monitoring_e2e_tests
-if [[ $TEST_KNATIVE_KAFKA == true ]]; then
-  ensure_kafka_no_auth
-  downstream_knative_kafka_e2e_tests
-  # ensure_kafka_tls_auth
-  # downstream_knative_kafka_e2e_tests
-  # ensure_kafka_sasl_auth
-  # downstream_knative_kafka_e2e_tests
-fi
-
-[ -n "$OPENSHIFT_CI" ] && check_serverless_alerts
+#
+#if [[ $FULL_MESH == "true" ]]; then
+#  # net-istio does not use knative-serving-ingress namespace.
+#  export INGRESS_NAMESPACE="knative-serving"
+#  UNINSTALL_MESH="false" install_mesh
+#  ensure_serverless_installed
+#  enable_net_istio
+#else
+#  ensure_serverless_installed
+#  trust_router_ca
+#fi
+#
+#[ -n "$OPENSHIFT_CI" ] && setup_quick_api_deprecation_alerts
+#
+## Run Knative Serving & Eventing downstream E2E tests.
+#downstream_serving_e2e_tests
+#downstream_eventing_e2e_tests
+#downstream_monitoring_e2e_tests
+#if [[ $TEST_KNATIVE_KAFKA == true ]]; then
+#  # TODO: Remove this as this is already installed in ensure_serverless_installed, or use deploy_knativekafka_cr
+#  ensure_kafka_no_auth
+#  downstream_knative_kafka_e2e_tests
+#  # ensure_kafka_tls_auth
+#  # downstream_knative_kafka_e2e_tests
+#  # ensure_kafka_sasl_auth
+#  # downstream_knative_kafka_e2e_tests
+#fi
+#
+#[ -n "$OPENSHIFT_CI" ] && check_serverless_alerts
+#
+#teardown_serverless
 
 success

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	servingName      = "knative-serving"
 	servingNamespace = "knative-serving"
 	haReplicas       = 2
 )

--- a/test/e2ekafka/knative_kafka_test.go
+++ b/test/e2ekafka/knative_kafka_test.go
@@ -39,7 +39,7 @@ func TestKnativeKafka(t *testing.T) {
 	// Ensure KnativeEventing is already installed.
 	if ev, err := caCtx.Clients.Operator.KnativeEventings(eventingNamespace).
 		Get(context.Background(), eventingName, metav1.GetOptions{}); err != nil || !ev.Status.IsReady() {
-			t.Fatal("KnativeEventing CR must be ready:", err)
+		t.Fatal("KnativeEventing CR must be ready:", err)
 	}
 
 	ch := &v1beta1.KafkaChannel{

--- a/test/e2ekafka/knative_kafka_test.go
+++ b/test/e2ekafka/knative_kafka_test.go
@@ -14,13 +14,13 @@ import (
 const (
 	eventingName          = "knative-eventing"
 	eventingNamespace     = "knative-eventing"
-	knativeKafkaName      = "knative-kafka"
 	knativeKafkaNamespace = "knative-eventing"
 )
 
 var knativeKafkaChannelControlPlaneDeploymentNames = []string{
 	"kafka-ch-controller",
 	"kafka-webhook",
+	"kafka-ch-dispatcher",
 }
 
 var knativeKafkaSourceControlPlaneDeploymentNames = []string{

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -80,9 +80,6 @@ function serverless_operator_e2e_tests {
     --channel "$OLM_CHANNEL" \
     --kubeconfigs "${kubeconfigs_str}" \
     "$@"
-
-  # make sure knative-serving-ingress namespace is deleted.
-  timeout 600 "[[ \$(oc get ns ${SERVING_NAMESPACE}-ingress --no-headers | wc -l) == 1 ]]"
 }
 
 function serverless_operator_kafka_e2e_tests {

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -7,9 +7,9 @@ source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/hack/lib/__sou
 
 readonly TEARDOWN="${TEARDOWN:-on_exit}"
 export TEST_NAMESPACE="${TEST_NAMESPACE:-serverless-tests}"
-NAMESPACES+=("${TEST_NAMESPACE}")
-NAMESPACES+=("serverless-tests2")
-NAMESPACES+=("serverless-tests-mesh")
+declare -a TEST_NAMESPACES
+TEST_NAMESPACES=("${TEST_NAMESPACE}" "serverless-tests2" "serverless-tests-mesh")
+export TEST_NAMESPACES
 
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/serving.bash"
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/eventing.bash"
@@ -243,7 +243,7 @@ function teardown {
   logger.warn "Teardown 💀"
   teardown_serverless
   teardown_tracing
-  delete_namespaces
+  delete_namespaces "${SYSTEM_NAMESPACES[@]}" "${TEST_NAMESPACES[@]}"
   delete_catalog_source
   delete_users
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -243,6 +243,7 @@ function teardown {
   logger.warn "Teardown 💀"
   teardown_serverless
   teardown_tracing
+  # shellcheck disable=SC2153
   delete_namespaces "${SYSTEM_NAMESPACES[@]}" "${TEST_NAMESPACES[@]}"
   delete_catalog_source
   delete_users

--- a/test/subscription.go
+++ b/test/subscription.go
@@ -18,8 +18,8 @@ const (
 	// Interval specifies the time between two polls.
 	Interval = 10 * time.Second
 	// Timeout specifies the timeout for the function PollImmediate to reach a certain status.
-	Timeout                   = 5 * time.Minute
-	OperatorsNamespace        = "openshift-serverless"
+	Timeout            = 5 * time.Minute
+	OperatorsNamespace = "openshift-serverless"
 )
 
 func UpdateSubscriptionChannelSource(ctx *Context, name, channel, source string) (*operatorsv1alpha1.Subscription, error) {

--- a/test/ui-e2e-tests.sh
+++ b/test/ui-e2e-tests.sh
@@ -39,7 +39,7 @@ INSTALL_SERVERLESS="${INSTALL_SERVERLESS:-true}"
 NPM_TARGET="${NPM_TARGET:-test}"
 export OCP_VERSION OCP_USERNAME OCP_PASSWORD OCP_LOGIN_PROVIDER CYPRESS_BASE_URL
 
-create_namespaces
+create_namespaces "${SYSTEM_NAMESPACES[@]}"
 add_user "$OCP_USERNAME" "$OCP_PASSWORD"
 oc adm policy add-role-to-user edit "$OCP_USERNAME" -n "$TEST_NAMESPACE"
 if [[ 'true' == "$INSTALL_SERVERLESS" ]]; then
@@ -50,6 +50,7 @@ check_node
 archive_cypress_artifacts
 logger.success '🚀 Cluster prepared for testing.'
 
+create_namespaces "${TEST_NAMESPACES[@]}"
 pushd "$(dirname "${BASH_SOURCE[0]}")/ui" >/dev/null
 npm install
 npm run install

--- a/test/ui-e2e-tests.sh
+++ b/test/ui-e2e-tests.sh
@@ -34,23 +34,17 @@ OCP_USERNAME="${OCP_USERNAME:-uitesting}"
 OCP_PASSWORD="${OCP_PASSWORD:-$(echo "$OCP_USERNAME" | sha1sum - | awk '{print $1}')}"
 OCP_LOGIN_PROVIDER="${OCP_LOGIN_PROVIDER:-my_htpasswd_provider}"
 CYPRESS_BASE_URL="https://$(oc get route console -n openshift-console -o jsonpath='{.status.ingress[].host}')"
-INSTALL_SERVERLESS="${INSTALL_SERVERLESS:-true}"
 # use dev to run test development UI
 NPM_TARGET="${NPM_TARGET:-test}"
 export OCP_VERSION OCP_USERNAME OCP_PASSWORD OCP_LOGIN_PROVIDER CYPRESS_BASE_URL
 
-create_namespaces "${SYSTEM_NAMESPACES[@]}"
+create_namespaces "${TEST_NAMESPACES[@]}"
 add_user "$OCP_USERNAME" "$OCP_PASSWORD"
 oc adm policy add-role-to-user edit "$OCP_USERNAME" -n "$TEST_NAMESPACE"
-if [[ 'true' == "$INSTALL_SERVERLESS" ]]; then
-  install_catalogsource
-  ensure_serverless_installed
-fi
 check_node
 archive_cypress_artifacts
 logger.success '🚀 Cluster prepared for testing.'
 
-create_namespaces "${TEST_NAMESPACES[@]}"
 pushd "$(dirname "${BASH_SOURCE[0]}")/ui" >/dev/null
 npm install
 npm run install

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -13,10 +13,11 @@ debugging.setup
 dump_state.setup
 
 teardown_serverless
-create_namespaces
+create_namespaces "${SYSTEM_NAMESPACES[@]}"
 install_catalogsource
 logger.success '🚀 Cluster prepared for testing.'
 
+create_namespaces "${TEST_NAMESPACES[@]}"
 # Install ServiceMesh and enable mTLS.
 if [[ $FULL_MESH == true ]]; then
   UNINSTALL_MESH="false" install_mesh

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -12,16 +12,11 @@ fi
 debugging.setup
 dump_state.setup
 
-teardown_serverless
-create_namespaces "${SYSTEM_NAMESPACES[@]}"
-install_catalogsource
 logger.success '🚀 Cluster prepared for testing.'
 
 create_namespaces "${TEST_NAMESPACES[@]}"
 # Install ServiceMesh and enable mTLS.
-if [[ $FULL_MESH == true ]]; then
-  UNINSTALL_MESH="false" install_mesh
-else
+if [[ $FULL_MESH != true ]]; then
   trust_router_ca
 fi
 
@@ -29,16 +24,14 @@ fi
 if [[ $TEST_KNATIVE_UPGRADE == true ]]; then
   install_serverless_previous
   # Set KafkaChannel as default for upgrade tests.
-  if [[ $INSTALL_KAFKA == "true" ]]; then
+  if [[ $TEST_KNATIVE_KAFKA == "true" ]]; then
     ensure_kafka_channel_default
   fi
   run_rolling_upgrade_tests
-  teardown_serverless
 fi
 
 # Run upstream knative serving, eventing and eventing-kafka tests
 if [[ $TEST_KNATIVE_E2E == true ]]; then
-  ensure_serverless_installed
   if [[ $TEST_KNATIVE_KAFKA == true ]]; then
     upstream_knative_eventing_kafka_e2e
   fi

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -22,7 +22,6 @@ fi
 
 # Run upgrade tests
 if [[ $TEST_KNATIVE_UPGRADE == true ]]; then
-  install_serverless_previous
   # Set KafkaChannel as default for upgrade tests.
   if [[ $TEST_KNATIVE_KAFKA == "true" ]]; then
     ensure_kafka_channel_default


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVCOM-1623 (see issue description for more information)

This should allow for:
* Quicker execution of E2E tests in CI due to removing redundant installs/uninstalls. Preliminary results show the runs are 3-4 minutes faster than before, for the operator-e2e check.
* Creating an image with tests which we can use to execute only tests, not installations. And all of that within OpenShift cluster

Changes:
* Use more specific Makefile targets. The ones with `-testonly` suffix only run tests. They do not install the product.
* Make it possible to contact kube API server from inside a Pod when creating new users for tests.
* Separate "system" and "test" namespaces and their creation.
* Move "Ensure no operators present" check from Golang to teardown script. The rest of the checks in teardown already included what we had in the Golang tests (there was redundancy).
* Make sure the "install.sh" scripts is called before tests and "teardown" after tests.
* Add `kafka-ch-dispatcher` among the tested deployments here: https://github.com/openshift-knative/serverless-operator/pull/1333/files#diff-a3c3e9170b364a9794db5994c3032aa25383b6816c9d3d3be51a52e8fc397660R23 (it was removed before but since the tests still create an extra Kafka channel to trigger creation of this kafka-ch-dispatcher they should also check it.