### PR TITLE
WIP: Swap image names openshift-knative-operator and knative-operator

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -104,7 +104,7 @@ EOF
 function add_downstream_operator_deployment_env {
   cat << EOF | yq write --inplace --script - "$1"
 - command: update
-  path: spec.install.spec.deployments(name==knative-openshift).spec.template.spec.containers(name==knative-openshift).env[+]
+  path: spec.install.spec.deployments(name==knative-operator).spec.template.spec.containers(name==knative-operator).env[+]
   value:
     name: "${2}"
     value: "${3}"
@@ -118,7 +118,7 @@ EOF
 function add_upstream_operator_deployment_env {
   cat << EOF | yq write --inplace --script - "$1"
 - command: update
-  path: spec.install.spec.deployments(name==knative-operator).spec.template.spec.containers(name==knative-operator).env[+]
+  path: spec.install.spec.deployments(name==knative-openshift).spec.template.spec.containers(name==knative-openshift).env[+]
   value:
     name: "${2}"
     value: "${3}"
@@ -146,7 +146,7 @@ done
 add_downstream_operator_deployment_env "$target" "KNATIVE_EVENTING_KAFKA_VERSION" "$(metadata.get dependencies.eventing_kafka)"
 
 # Override the image for the CLI artifact deployment
-yq write --inplace "$target" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.initContainers(name==cli-artifacts).image" "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
+yq write --inplace "$target" "spec.install.spec.deployments(name==knative-operator).spec.template.spec.initContainers(name==cli-artifacts).image" "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
 
 for name in "${!yaml_keys[@]}"; do
   echo "Value: ${name} -> ${yaml_keys[$name]}"

--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -104,7 +104,7 @@ EOF
 function add_downstream_operator_deployment_env {
   cat << EOF | yq write --inplace --script - "$1"
 - command: update
-  path: spec.install.spec.deployments(name==knative-operator).spec.template.spec.containers(name==knative-operator).env[+]
+  path: spec.install.spec.deployments(name==knative-openshift).spec.template.spec.containers(name==knative-openshift).env[+]
   value:
     name: "${2}"
     value: "${3}"
@@ -118,7 +118,7 @@ EOF
 function add_upstream_operator_deployment_env {
   cat << EOF | yq write --inplace --script - "$1"
 - command: update
-  path: spec.install.spec.deployments(name==knative-openshift).spec.template.spec.containers(name==knative-openshift).env[+]
+  path: spec.install.spec.deployments(name==knative-operator).spec.template.spec.containers(name==knative-operator).env[+]
   value:
     name: "${2}"
     value: "${3}"
@@ -146,7 +146,7 @@ done
 add_downstream_operator_deployment_env "$target" "KNATIVE_EVENTING_KAFKA_VERSION" "$(metadata.get dependencies.eventing_kafka)"
 
 # Override the image for the CLI artifact deployment
-yq write --inplace "$target" "spec.install.spec.deployments(name==knative-operator).spec.template.spec.initContainers(name==cli-artifacts).image" "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
+yq write --inplace "$target" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.initContainers(name==cli-artifacts).image" "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
 
 for name in "${!yaml_keys[@]}"; do
   echo "Value: ${name} -> ${yaml_keys[$name]}"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -399,7 +399,7 @@ spec:
                 containers:
                   - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -509,7 +509,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -788,10 +788,10 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -382,22 +382,22 @@ spec:
       deployments:
         # Our version of the upstream operator. This is responsible for installing Knative
         # itself.
-        - name: knative-operator
+        - name: knative-openshift
           spec:
             replicas: 1
             selector:
               matchLabels:
-                name: knative-operator
+                name: knative-openshift
             template:
               metadata:
                 annotations:
                   sidecar.istio.io/inject: "false"
                 labels:
-                  name: knative-operator
+                  name: knative-openshift
               spec:
-                serviceAccountName: knative-operator
+                serviceAccountName: knative-openshift
                 containers:
-                  - name: knative-operator
+                  - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
                     imagePullPolicy: Always
@@ -410,7 +410,7 @@ spec:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
-                        value: knative-operator
+                        value: knative-openshift
                       - name: SYSTEM_NAMESPACE
                         valueFrom:
                           fieldRef:
@@ -486,16 +486,16 @@ spec:
                           - all
         # Openshift specific extensions in the "old" operator format. Ships KnativeKafka and
         # other Openshift specifica that have not yet been moved to the operator above.
-        - name: knative-openshift
+        - name: knative-operator
           spec:
             replicas: 1
             selector:
               matchLabels:
-                name: knative-openshift
+                name: knative-operator
             template:
               metadata:
                 labels:
-                  name: knative-openshift
+                  name: knative-operator
               spec:
                 serviceAccountName: knative-operator
                 initContainers:
@@ -507,7 +507,7 @@ spec:
                       - mountPath: /cli-artifacts
                         name: cli-artifacts
                 containers:
-                  - name: knative-openshift
+                  - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
                     imagePullPolicy: Always
@@ -533,13 +533,13 @@ spec:
                           fieldRef:
                             fieldPath: metadata.namespace
                       - name: DEPLOYMENT_NAME
-                        value: "knative-openshift"
+                        value: "knative-operator"
                       - name: POD_NAME
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
-                        value: "knative-openshift"
+                        value: "knative-operator"
                       - name: REQUIRED_SERVING_NAMESPACE
                         value: "knative-serving"
                       - name: REQUIRED_EVENTING_NAMESPACE
@@ -786,10 +786,10 @@ spec:
       sideEffects: None
       webhookPath: /mutate-knativeservings
   relatedImages:
-    - name: knative-operator
+    - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
-    - name: knative-openshift
+    - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
     - name: knative-openshift-ingress

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -382,22 +382,22 @@ spec:
       deployments:
         # Our version of the upstream operator. This is responsible for installing Knative
         # itself.
-        - name: knative-openshift
+        - name: knative-operator
           spec:
             replicas: 1
             selector:
               matchLabels:
-                name: knative-openshift
+                name: knative-operator
             template:
               metadata:
                 annotations:
                   sidecar.istio.io/inject: "false"
                 labels:
-                  name: knative-openshift
+                  name: knative-operator
               spec:
-                serviceAccountName: knative-openshift
+                serviceAccountName: knative-operator
                 containers:
-                  - name: knative-openshift
+                  - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
                     imagePullPolicy: Always
@@ -410,7 +410,7 @@ spec:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
-                        value: knative-openshift
+                        value: knative-operator
                       - name: SYSTEM_NAMESPACE
                         valueFrom:
                           fieldRef:
@@ -486,16 +486,16 @@ spec:
                           - all
         # Openshift specific extensions in the "old" operator format. Ships KnativeKafka and
         # other Openshift specifica that have not yet been moved to the operator above.
-        - name: knative-operator
+        - name: knative-openshift
           spec:
             replicas: 1
             selector:
               matchLabels:
-                name: knative-operator
+                name: knative-openshift
             template:
               metadata:
                 labels:
-                  name: knative-operator
+                  name: knative-openshift
               spec:
                 serviceAccountName: knative-operator
                 initContainers:
@@ -507,7 +507,7 @@ spec:
                       - mountPath: /cli-artifacts
                         name: cli-artifacts
                 containers:
-                  - name: knative-operator
+                  - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
                     imagePullPolicy: Always
@@ -533,13 +533,13 @@ spec:
                           fieldRef:
                             fieldPath: metadata.namespace
                       - name: DEPLOYMENT_NAME
-                        value: "knative-operator"
+                        value: "knative-openshift"
                       - name: POD_NAME
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
-                        value: "knative-operator"
+                        value: "knative-openshift"
                       - name: REQUIRED_SERVING_NAMESPACE
                         value: "knative-serving"
                       - name: REQUIRED_EVENTING_NAMESPACE
@@ -786,10 +786,10 @@ spec:
       sideEffects: None
       webhookPath: /mutate-knativeservings
   relatedImages:
-    - name: knative-openshift
+    - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
-    - name: knative-operator
+    - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
     - name: knative-openshift-ingress

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -390,22 +390,22 @@ spec:
       deployments:
         # Our version of the upstream operator. This is responsible for installing Knative
         # itself.
-        - name: knative-openshift
+        - name: knative-operator
           spec:
             replicas: 1
             selector:
               matchLabels:
-                name: knative-openshift
+                name: knative-operator
             template:
               metadata:
                 annotations:
                   sidecar.istio.io/inject: "false"
                 labels:
-                  name: knative-openshift
+                  name: knative-operator
               spec:
-                serviceAccountName: knative-openshift
+                serviceAccountName: knative-operator
                 containers:
-                  - name: knative-openshift
+                  - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
                     imagePullPolicy: Always
@@ -418,7 +418,7 @@ spec:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
-                        value: knative-openshift
+                        value: knative-operator
                       - name: SYSTEM_NAMESPACE
                         valueFrom:
                           fieldRef:
@@ -441,16 +441,16 @@ spec:
 
         # Openshift specific extensions in the "old" operator format. Ships KnativeKafka and
         # other Openshift specifica that have not yet been moved to the operator above.
-        - name: knative-operator
+        - name: knative-openshift
           spec:
             replicas: 1
             selector:
               matchLabels:
-                name: knative-operator
+                name: knative-openshift
             template:
               metadata:
                 labels:
-                  name: knative-operator
+                  name: knative-openshift
               spec:
                 serviceAccountName: knative-operator
                 initContainers:
@@ -467,7 +467,7 @@ spec:
                       - mountPath: /cli-artifacts
                         name: cli-artifacts
                 containers:
-                  - name: knative-operator
+                  - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
                     imagePullPolicy: Always
@@ -493,13 +493,13 @@ spec:
                           fieldRef:
                             fieldPath: metadata.namespace
                       - name: DEPLOYMENT_NAME
-                        value: "knative-operator"
+                        value: "knative-openshift"
                       - name: POD_NAME
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
-                        value: "knative-operator"
+                        value: "knative-openshift"
                       - name: REQUIRED_SERVING_NAMESPACE
                         value: "knative-serving"
                       - name: REQUIRED_EVENTING_NAMESPACE
@@ -673,10 +673,10 @@ spec:
       webhookPath: /mutate-knativeservings
 
   relatedImages:
-    - name: knative-openshift
+    - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
-    - name: knative-operator
+    - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
     - name: knative-openshift-ingress

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -390,22 +390,22 @@ spec:
       deployments:
         # Our version of the upstream operator. This is responsible for installing Knative
         # itself.
-        - name: knative-operator
+        - name: knative-openshift
           spec:
             replicas: 1
             selector:
               matchLabels:
-                name: knative-operator
+                name: knative-openshift
             template:
               metadata:
                 annotations:
                   sidecar.istio.io/inject: "false"
                 labels:
-                  name: knative-operator
+                  name: knative-openshift
               spec:
-                serviceAccountName: knative-operator
+                serviceAccountName: knative-openshift
                 containers:
-                  - name: knative-operator
+                  - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
                     imagePullPolicy: Always
@@ -418,7 +418,7 @@ spec:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
-                        value: knative-operator
+                        value: knative-openshift
                       - name: SYSTEM_NAMESPACE
                         valueFrom:
                           fieldRef:
@@ -441,16 +441,16 @@ spec:
 
         # Openshift specific extensions in the "old" operator format. Ships KnativeKafka and
         # other Openshift specifica that have not yet been moved to the operator above.
-        - name: knative-openshift
+        - name: knative-operator
           spec:
             replicas: 1
             selector:
               matchLabels:
-                name: knative-openshift
+                name: knative-operator
             template:
               metadata:
                 labels:
-                  name: knative-openshift
+                  name: knative-operator
               spec:
                 serviceAccountName: knative-operator
                 initContainers:
@@ -467,7 +467,7 @@ spec:
                       - mountPath: /cli-artifacts
                         name: cli-artifacts
                 containers:
-                  - name: knative-openshift
+                  - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
                     image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
                     imagePullPolicy: Always
@@ -493,13 +493,13 @@ spec:
                           fieldRef:
                             fieldPath: metadata.namespace
                       - name: DEPLOYMENT_NAME
-                        value: "knative-openshift"
+                        value: "knative-operator"
                       - name: POD_NAME
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
-                        value: "knative-openshift"
+                        value: "knative-operator"
                       - name: REQUIRED_SERVING_NAMESPACE
                         value: "knative-serving"
                       - name: REQUIRED_EVENTING_NAMESPACE
@@ -673,10 +673,10 @@ spec:
       webhookPath: /mutate-knativeservings
 
   relatedImages:
-    - name: knative-operator
+    - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
-    - name: knative-openshift
+    - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
     - name: knative-openshift-ingress

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -407,7 +407,7 @@ spec:
                 containers:
                   - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -469,7 +469,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -675,10 +675,10 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:openshift-knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
       image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress


### PR DESCRIPTION
Serverless operator has confusing image names as:
- `knative-operator` pod has `openshift-knative-operator` image.
- `knative-openshift` pod has `knative-operator` image.

This patch swap the image names.