### PR TITLE
SRVCOM-1629 Ensure KUBECONFIG for upstream tests in container

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -337,48 +337,9 @@ function create_htpasswd_users {
   local occmd num_users
   num_users=${num_users:-3}
   logger.info "Creating htpasswd for ${num_users} users"
-
-  if oc get secret htpass-secret -n openshift-config -o jsonpath='{.data.htpasswd}' 2>/dev/null | base64 -d > users.htpasswd; then
-    logger.info 'Secret htpass-secret already existed, updating it.'
-    # Add a newline to the end of the file if not already present (htpasswd will butcher it otherwise).
-    [ -n "$(tail -c1 users.htpasswd)" ] && echo >> users.htpasswd
-  else
-    touch users.htpasswd
-  fi
-
-  logger.info 'Add users to htpasswd'
   for i in $(seq 1 "$num_users"); do
-    htpasswd -b users.htpasswd "user${i}" "password${i}"
+    add_user "user${i}" "password${i}"
   done
-
-  oc create secret generic htpass-secret \
-    --from-file=htpasswd="$(pwd)/users.htpasswd" \
-    -n openshift-config \
-    --dry-run=client -o yaml | oc apply -f -
-
-  if oc get oauth.config.openshift.io cluster > /dev/null 2>&1; then
-    oc replace -f openshift/identity/htpasswd.yaml
-  else
-    oc apply -f openshift/identity/htpasswd.yaml
-  fi
-
-  logger.info 'Generate kubeconfig for each user'
-
-  if oc config current-context >&/dev/null; then
-    ctx=$(oc config current-context)
-    cluster=$(oc config view -ojsonpath="{.contexts[?(@.name == \"$ctx\")].context.cluster}")
-    server=$(oc config view -ojsonpath="{.clusters[?(@.name == \"$cluster\")].cluster.server}")
-    logger.debug "Context: $ctx, Cluster: $cluster, Server: $server"
-  else
-    # Fallback to in-cluster api server service.
-    server="https://kubernetes.default.svc"
-  fi
-
-  for i in $(seq 1 "$num_users"); do
-    occmd="bash -c '! oc login --insecure-skip-tls-verify=true --kubeconfig=user${i}.kubeconfig --username=user${i} --password=password${i} ${server} > /dev/null'"
-    timeout 600 "${occmd}"
-  done
-
   logger.success "${num_users} htpasswd users created"
 }
 
@@ -387,6 +348,15 @@ function add_roles {
   oc adm policy add-role-to-user admin user1 -n "$TEST_NAMESPACE"
   oc adm policy add-role-to-user edit user2 -n "$TEST_NAMESPACE"
   oc adm policy add-role-to-user view user3 -n "$TEST_NAMESPACE"
+}
+
+function ensure_kubeconfig {
+  if [[ -z "$KUBECONFIG" ]]; then
+    add_user "kubeadmin" "kubeadmin"
+    oc adm policy add-cluster-role-to-user cluster-admin kubeadmin
+    KUBECONFIG="$(pwd)/kubeadmin.kubeconfig"
+    export KUBECONFIG
+  fi
 }
 
 function delete_users {

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -352,7 +352,7 @@ function add_roles {
 
 function ensure_kubeconfig {
   if [[ -z "$KUBECONFIG" ]]; then
-    add_user "kubeadmin" "kubeadmin"
+    add_user "kubeadmin" "$(head -c 128 < /dev/urandom | base64 | fold -w 8 | head -n 1)"
     oc adm policy add-cluster-role-to-user cluster-admin kubeadmin
     KUBECONFIG="$(pwd)/kubeadmin.kubeconfig"
     export KUBECONFIG

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -31,6 +31,9 @@ fi
 
 # Run upstream knative serving, eventing and eventing-kafka tests
 if [[ $TEST_KNATIVE_E2E == true ]]; then
+  # TODO: Remove this when upstream tests can use in-cluster config.
+  # See https://github.com/knative/eventing/issues/5996 (the same issue affects Eventing Kafka)
+  ensure_kubeconfig
   if [[ $TEST_KNATIVE_KAFKA == true ]]; then
     upstream_knative_eventing_kafka_e2e
   fi


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVCOM-1629

This PR makes it possible to run upstream tests within a container in Kubernetes cluster.
