### PR TITLE
[release-1.20] Add ttl seconds after finished kafka channel job

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml
+++ b/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml
@@ -168,6 +168,7 @@ metadata:
     app: "kafkachannel-retentionduration-update"
     kafka.eventing.knative.dev/release: "v0.26.0"
 spec:
+  ttlSecondsAfterFinished: 600
   backoffLimit: 10
   template:
     metadata:

--- a/knative-operator/hack/010-add-ttlSecondsAfterFinished.patch
+++ b/knative-operator/hack/010-add-ttlSecondsAfterFinished.patch
@@ -1,0 +1,12 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml b/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml
+index dd039a9a7..47bf47a26 100644
+--- a/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml
++++ b/knative-operator/deploy/resources/knativekafka/channel/2-channel-post-install.yaml
+@@ -168,6 +168,7 @@ metadata:
+     app: "kafkachannel-retentionduration-update"
+     kafka.eventing.knative.dev/release: "v0.26.0"
+ spec:
++  ttlSecondsAfterFinished: 600
+   backoffLimit: 10
+   template:
+     metadata:

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -55,6 +55,9 @@ git apply "$root/knative-operator/hack/002-eventing-kafka-ctor-role.patch"
 # With 1.21 (1.0.0 knative) we do not need this. upstream has generated name
 git apply "$root/knative-operator/hack/009-generated-job-name.patch"
 
+# This is only for 1.20 branch, we add the ttlSecondsAfterFinished field so that OCP 4.8 can remove it
+git apply "$root/knative-operator/hack/010-add-ttlSecondsAfterFinished.patch"
+
 # Kafka Broker content:
 download_kafka eventing-kafka-broker broker "$KNATIVE_EVENTING_KAFKA_BROKER_VERSION" "${kafka_broker_files[@]}"
 


### PR DESCRIPTION
In k8s 1.21.1 the `ttlSecondsAfterFinished` is enabled, so why not use it on this job too

And it aligns with other k8s jobs, what have it on the version migrator 