### PR TITLE
[SRVCLI-328] Remove CLI artifacts before copying to make command idempotent

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -512,7 +512,7 @@ spec:
                   - name: cli-artifacts
                     image: registry.ci.openshift.org/openshift/knative-v0.26.0:kn-cli-artifacts
                     imagePullPolicy: Always
-                    command: ["sh", "-c", "cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*"]
+                    command: ["sh", "-c", "rm -rf /cli-artifacts && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*"]
                     volumeMounts:
                       - mountPath: /cli-artifacts
                         name: cli-artifacts

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -512,7 +512,7 @@ spec:
                   - name: cli-artifacts
                     image: registry.ci.openshift.org/openshift/knative-v0.26.0:kn-cli-artifacts
                     imagePullPolicy: Always
-                    command: ["sh", "-c", "sudo rm -rf /cli-artifacts && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*"]
+                    command: ["sh", "-c", "rm -rf /cli-artifacts/* && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*"]
                     volumeMounts:
                       - mountPath: /cli-artifacts
                         name: cli-artifacts

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -512,7 +512,7 @@ spec:
                   - name: cli-artifacts
                     image: registry.ci.openshift.org/openshift/knative-v0.26.0:kn-cli-artifacts
                     imagePullPolicy: Always
-                    command: ["sh", "-c", "rm -rf /cli-artifacts && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*"]
+                    command: ["sh", "-c", "sudo rm -rf /cli-artifacts && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*"]
                     volumeMounts:
                       - mountPath: /cli-artifacts
                         name: cli-artifacts

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -469,7 +469,7 @@ spec:
                       [
                         "sh",
                         "-c",
-                        "cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*",
+                        "rm -rf /cli-artifacts && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*",
                       ]
                     volumeMounts:
                       - mountPath: /cli-artifacts

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -469,7 +469,7 @@ spec:
                       [
                         "sh",
                         "-c",
-                        "sudo rm -rf /cli-artifacts && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*",
+                        "rm -rf /cli-artifacts/* && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*",
                       ]
                     volumeMounts:
                       - mountPath: /cli-artifacts

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -469,7 +469,7 @@ spec:
                       [
                         "sh",
                         "-c",
-                        "rm -rf /cli-artifacts && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*",
+                        "sudo rm -rf /cli-artifacts && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*",
                       ]
                     volumeMounts:
                       - mountPath: /cli-artifacts


### PR DESCRIPTION
As per https://issues.redhat.com/browse/SRVCLI-328, there are edge-cases where the current copy mechanism fails, if the actual pod isn't recreated (node restarts for instance). This makes the mechanism idempotent.

/assign @maschmid 