### PR TITLE
Fix patch for mesh tests

### DIFF
--- a/test/serving.bash
+++ b/test/serving.bash
@@ -62,7 +62,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     rm ./test/e2e/grpc_test.go
     rm ./test/e2e/http2_test.go
     # Remove h2c test
-    sed -ie '46,50d' ./test/conformance/runtime/protocol_test.go
+    sed -ie '47,51d' ./test/conformance/runtime/protocol_test.go
   fi
 
   local parallel=3


### PR DESCRIPTION
Fixes this [failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.9-e2e-mesh-ocp-49-continuous/1472899896527818752).

/cc @markusthoemmes 