### PR TITLE
Add disabled controllers

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
+++ b/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
@@ -951,7 +951,7 @@ spec:
         - name: controller
           image: TO_BE_REPLACED
           args:
-            - "--disable-controllers=broker-controller, trigger-controller, sink-controller"
+            - "--disable-controllers=broker-controller,trigger-controller,sink-controller"
           imagePullPolicy: IfNotPresent
           env:
             - name: BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE

--- a/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
+++ b/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
@@ -950,6 +950,8 @@ spec:
       containers:
         - name: controller
           image: TO_BE_REPLACED
+          args:
+            - "--disable-controllers=broker-controller, trigger-controller, sink-controller"
           imagePullPolicy: IfNotPresent
           env:
             - name: BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE

--- a/knative-operator/hack/002-broker-disabled-controllers.patch
+++ b/knative-operator/hack/002-broker-disabled-controllers.patch
@@ -1,0 +1,13 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml b/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
+index 67c586a06..93388a995 100644
+--- a/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
++++ b/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
+@@ -950,6 +950,8 @@ spec:
+       containers:
+         - name: controller
+           image: TO_BE_REPLACED
++          args:
++            - "--disable-controllers=broker-controller, trigger-controller, sink-controller"
+           imagePullPolicy: IfNotPresent
+           env:
+             - name: BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE

--- a/knative-operator/hack/002-broker-disabled-controllers.patch
+++ b/knative-operator/hack/002-broker-disabled-controllers.patch
@@ -7,7 +7,7 @@ index 67c586a06..93388a995 100644
          - name: controller
            image: TO_BE_REPLACED
 +          args:
-+            - "--disable-controllers=broker-controller, trigger-controller, sink-controller"
++            - "--disable-controllers=broker-controller,trigger-controller,sink-controller"
            imagePullPolicy: IfNotPresent
            env:
              - name: BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -61,3 +61,6 @@ download_kafka eventing-kafka-broker broker "$KNATIVE_EVENTING_KAFKA_BROKER_VERS
 
 # That CM is already there, with Eventing
 git apply "$root/knative-operator/hack/001-broker-config-tracing.patch"
+
+# By default we disable all controllers, based on user choice we add them back
+git apply "$root/knative-operator/hack/002-broker-disabled-controllers.patch"


### PR DESCRIPTION
another prefactor PR for enabling the sink.

We just want to have those controllers enabled, that we actually have "enabled". Following changes:
* patch the manifest to disable all controllers for broker/sink
* if broker is enabled, update the deployment and just keep the `sink` disabled

Follow up PR: Enabling the sink