### PR TITLE
Adding toggle for kafka sink enablement

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/manifest_test.go
+++ b/knative-operator/deploy/resources/knativekafka/manifest_test.go
@@ -37,6 +37,9 @@ func TestUnallowedResourcesInManifest(t *testing.T) {
 		path:  "./broker/1-eventing-kafka-broker.yaml",
 		fails: false,
 	}, {
+		path:  "./sink/1-eventing-kafka-sink.yaml",
+		fails: false,
+	}, {
 		path:  "./testdata/config-logging.yaml",
 		fails: true,
 	}, {

--- a/knative-operator/deploy/resources/knativekafka/sink/1-eventing-kafka-sink.yaml
+++ b/knative-operator/deploy/resources/knativekafka/sink/1-eventing-kafka-sink.yaml
@@ -1,0 +1,316 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-kafka-sink-data-plane
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+data:
+  config-kafka-sink-producer.properties: |
+    key.serializer=org.apache.kafka.common.serialization.StringSerializer
+    value.serializer=io.cloudevents.kafka.CloudEventSerializer
+    acks=all
+    buffer.memory=33554432
+    # compression.type=snappy
+    retries=2147483647
+    batch.size=16384
+    client.dns.lookup=use_all_dns_ips
+    connections.max.idle.ms=600000
+    delivery.timeout.ms=120000
+    linger.ms=0
+    max.block.ms=60000
+    max.request.size=1048576
+    partitioner.class=org.apache.kafka.clients.producer.internals.DefaultPartitioner
+    receive.buffer.bytes=-1
+    request.timeout.ms=30000
+    enable.idempotence=false
+    max.in.flight.requests.per.connection=5
+    metadata.max.age.ms=300000
+    # metric.reporters=""
+    metrics.num.samples=2
+    metrics.recording.level=INFO
+    metrics.sample.window.ms=30000
+    reconnect.backoff.max.ms=1000
+    reconnect.backoff.ms=50
+    retry.backoff.ms=100
+    # transaction.timeout.ms=60000
+    # transactional.id=null
+  config-kafka-sink-httpserver.properties: |
+    idleTimeout=0
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-kafka-sink-data-plane
+  labels:
+    kafka.eventing.knative.dev/release: devel
+rules:
+  - apiGroups:
+      - "*"
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knative-kafka-sink-data-plane
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-kafka-sink-data-plane
+  labels:
+    kafka.eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: knative-kafka-sink-data-plane
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-kafka-sink-data-plane
+  apiGroup: rbac.authorization.k8s.io
+
+---
+---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-sink-receiver
+  namespace: knative-eventing
+  labels:
+    app: kafka-sink-receiver
+    kafka.eventing.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: kafka-sink-receiver
+  template:
+    metadata:
+      name: kafka-sink-receiver
+      labels:
+        app: kafka-sink-receiver
+        kafka.eventing.knative.dev/release: devel
+    spec:
+      serviceAccountName: knative-kafka-sink-data-plane
+      securityContext:
+        runAsNonRoot: true
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: kafka-sink-receiver
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      containers:
+        - name: kafka-sink-receiver
+          image: TO_BE_REPLACED
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /etc/config
+              name: config-kafka-sink-data-plane
+              readOnly: true
+            - mountPath: /etc/sinks
+              name: kafka-sink-sinks
+              readOnly: true
+            - mountPath: /tmp
+              name: cache
+            - mountPath: /etc/logging
+              name: kafka-sink-config-logging
+              readOnly: true
+            - mountPath: /etc/tracing
+              name: config-tracing
+              readOnly: true
+          ports:
+            - containerPort: 9090
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            - name: SERVICE_NAME
+              value: "kafka-sink-receiver"
+            - name: SERVICE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: INGRESS_PORT
+              value: "8080"
+            - name: PRODUCER_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-sink-producer.properties
+            - name: HTTPSERVER_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-sink-httpserver.properties
+            - name: DATA_PLANE_CONFIG_FILE_PATH
+              value: /etc/sinks/data
+            - name: LIVENESS_PROBE_PATH
+              value: /healthz
+            - name: READINESS_PROBE_PATH
+              value: /readyz
+            - name: METRICS_PATH
+              value: /metrics
+            - name: METRICS_PORT
+              value: "9090"
+            - name: METRICS_PUBLISH_QUANTILES
+              value: "false"
+            - name: METRICS_JVM_ENABLED
+              value: "false"
+            - name: CONFIG_TRACING_PATH
+              value: "/etc/tracing"
+            # https://github.com/fabric8io/kubernetes-client/issues/2212
+            - name: HTTP2_DISABLE
+              value: "true"
+            # This should be set according to initial delay seconds
+            - name: WAIT_STARTUP_SECONDS
+              value: "8"
+          command:
+            - "java"
+          args:
+            - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-jar"
+            - "/app/app.jar"
+          # TODO set resources (limits and requests)
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              port: 8080
+              path: /healthz
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              port: 8080
+              path: /readyz
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 1
+          terminationMessagePolicy: FallbackToLogsOnError
+          terminationMessagePath: /dev/temination-log
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: kafka-sink-sinks
+          configMap:
+            name: kafka-sink-sinks
+        - name: config-kafka-sink-data-plane
+          configMap:
+            name: config-kafka-sink-data-plane
+        - name: cache
+          emptyDir: { }
+        - name: kafka-sink-config-logging
+          configMap:
+            name: kafka-config-logging
+        - name: config-tracing
+          configMap:
+            name: config-tracing
+      restartPolicy: Always
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-sink-ingress
+  namespace: knative-eventing
+  labels:
+    app: kafka-sink-receiver
+    kafka.eventing.knative.dev/release: devel
+spec:
+  selector:
+    app: kafka-sink-receiver
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: http-metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+---

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -12,6 +12,7 @@ kafka_channel_files=(channel-consolidated channel-post-install)
 kafka_source_files=(source source-post-install)
 kafka_controller_files=(eventing-kafka-controller)
 kafka_broker_files=(eventing-kafka-broker)
+kafka_sink_files=(eventing-kafka-sink)
 
 function download_kafka {
   component=$1
@@ -56,8 +57,11 @@ git apply "$root/knative-operator/hack/002-kafka-migrator-fixed-names.patch"
 # Control-Plane files:
 download_kafka eventing-kafka-broker controller "$KNATIVE_EVENTING_KAFKA_BROKER_VERSION" "${kafka_controller_files[@]}"
 
-#Data-Plane Files:
+#Data-Plane Files Broker:
 download_kafka eventing-kafka-broker broker "$KNATIVE_EVENTING_KAFKA_BROKER_VERSION" "${kafka_broker_files[@]}"
+
+#Data-Plane Files Sink:
+download_kafka eventing-kafka-broker sink "$KNATIVE_EVENTING_KAFKA_BROKER_VERSION" "${kafka_sink_files[@]}"
 
 # That CM is already there, with Eventing
 git apply "$root/knative-operator/hack/001-broker-config-tracing.patch"

--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
@@ -16,6 +16,9 @@ type KnativeKafkaSpec struct {
 	// +optional
 	Source Source `json:"source,omitempty"`
 
+	// Allows configuration for KafkaSink installation
+	// +optional
+	Sink Sink `json:"sink,omitempty"`
 	// Allows configuration for KafkaChannel installation
 	// +optional
 	Channel Channel `json:"channel,omitempty"`
@@ -87,6 +90,12 @@ type Broker struct {
 // Source allows configuration for KafkaSource installation
 type Source struct {
 	// Enabled defines if the KafkaSource installation is enabled
+	Enabled bool `json:"enabled"`
+}
+
+// Sink allows configuration for KafkaSink installation
+type Sink struct {
+	// Enabled defines if the KafkaSink installation is enabled
 	Enabled bool `json:"enabled"`
 }
 

--- a/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
+++ b/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
@@ -66,6 +66,16 @@ spec:
                 required:
                 - enabled
                 type: object
+              sink:
+                description: Allows configuration for KafkaSink installation
+                properties:
+                  enabled:
+                    description: Enabled defines if the KafkaSink installation is
+                      enabled
+                    type: boolean
+                required:
+                  - enabled
+                type: object
               broker:
                 description: Allows configuration for KafkaBroker installation
                 properties:

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -564,6 +564,8 @@ spec:
                         value: deploy/resources/knativekafka/controller
                       - name: KAFKABROKER_MANIFEST_PATH
                         value: deploy/resources/knativekafka/broker
+                      - name: KAFKASINK_MANIFEST_PATH
+                        value: deploy/resources/knativekafka/sink
                       - name: QUICKSTART_MANIFEST_PATH
                         value: "deploy/resources/quickstart/serverless-application-quickstart.yaml"
                       - name: DASHBOARDS_ROOT_MANIFEST_PATH

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -522,6 +522,8 @@ spec:
                         value: deploy/resources/knativekafka/controller
                       - name: KAFKABROKER_MANIFEST_PATH
                         value: deploy/resources/knativekafka/broker
+                      - name: KAFKASINK_MANIFEST_PATH
+                        value: deploy/resources/knativekafka/sink
                       - name: QUICKSTART_MANIFEST_PATH
                         value: "deploy/resources/quickstart/serverless-application-quickstart.yaml"
                       - name: DASHBOARDS_ROOT_MANIFEST_PATH


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Adding the raw `KafkaSink` as a new tool for the serverless operator.

Follow-up PR: adding some smoke tests for the `KafkaSink` type, and enable it on test deployment