### PR TITLE
[release-1.20] add v4.10 to com.redhat.openshift.versions

### DIFF
--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -18,6 +18,6 @@ LABEL \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \
       io.k8s.display-name="Red Hat OpenShift Serverless Bundle" \
-      com.redhat.openshift.versions="v4.6-v4.9" \
+      com.redhat.openshift.versions="v4.6-v4.10" \
       com.redhat.delivery.operator.bundle=true \
       com.redhat.delivery.backport=false

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -18,7 +18,7 @@ requirements:
   nodejs: 14.x
   ocpVersion:
     min: '4.6'
-    label: 'v4.6-v4.9'
+    label: 'v4.6-v4.10'
 
 dependencies:
   serving: 0.26.0

--- a/olm-catalog/serverless-operator/stopbundle.Dockerfile
+++ b/olm-catalog/serverless-operator/stopbundle.Dockerfile
@@ -18,7 +18,7 @@ LABEL \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \
       io.k8s.display-name="Red Hat OpenShift Serverless Bundle" \
-      com.redhat.openshift.versions="v4.6-v4.9" \
+      com.redhat.openshift.versions="v4.6-v4.10" \
       com.redhat.delivery.operator.bundle=true \
       com.redhat.delivery.backport=false
 


### PR DESCRIPTION
Per discussion in https://coreos.slack.com/archives/CD87JDUB0/p1641476878011400 , we want to try to unblock dev console and layered product testing on 4.10 by Serverless 1.20 release. 