### PR TITLE
Adding `config` field, leveraging tested upstream operator APIs

### DIFF
--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
@@ -23,6 +23,10 @@ type KnativeKafkaSpec struct {
 	// +optional
 	Channel Channel `json:"channel,omitempty"`
 
+	// A means to override the corresponding entries in the upstream configmaps
+	// +optional
+	Config operatorv1alpha1.ConfigMapData `json:"config,omitempty"`
+
 	// HighAvailability allows specification of HA control plane.
 	// +optional
 	HighAvailability *operatorv1alpha1.HighAvailability `json:"high-availability,omitempty"`

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"strconv"
 
+	operatorcommon "knative.dev/operator/pkg/reconciler/common"
+	"knative.dev/pkg/logging"
+
 	mfc "github.com/manifestival/controller-runtime-client"
 
 	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
@@ -272,6 +275,7 @@ func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *serve
 		}),
 		setKafkaDeployments(instance.Spec.HighAvailability.Replicas),
 		configureLegacyEventingKafka(instance.Spec.Channel),
+		operatorcommon.ConfigMapTransform(instance.Spec.Config, logging.FromContext(context.TODO())),
 		configureEventingKafka(instance.Spec),
 		ImageTransform(common.BuildImageOverrideMapFromEnviron(os.Environ(), "KAFKA_IMAGE_"), log),
 		replicasTransform(manifest.Client),

--- a/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
+++ b/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
@@ -34,6 +34,14 @@ spec:
             - channel
             - source
             properties:
+              config:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
+                description: A means to override the corresponding entries in the
+                  upstream configmaps
+                type: object
               channel:
                 description: Allows configuration for KafkaChannel installation
                 properties:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

/assign @mgencur 