### PR TITLE
Ensure ordering in test

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -584,7 +584,8 @@ func TestDisabledControllers(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		defaultDeployment := makeEventingKafkaDeployment(t, "")
+		// by default we assume all disabled:
+		defaultDeployment := makeEventingKafkaDeployment(t, "broker-controller,trigger-controller,sink-controller")
 		t.Run(test.name, func(t *testing.T) {
 			err := configureEventingKafka(test.knativeKafka)(defaultDeployment)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Tmp quick fix for CI nightly/periodic:
since on the runtime the order is pretty much  irrelevant, I change the test to ensure the order of "all" disabled controllers.


/assign @pierDipi 