### PR TITLE
[SRVKS-854] Remove domain-mapping replicas=2 from test yaml

### DIFF
--- a/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
+++ b/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
@@ -3,9 +3,6 @@ kind: KnativeServing
 metadata:
   name: knative-serving
 spec:
-  deployments:
-  - name: domain-mapping
-    replicas: 2
   config:
     autoscaler:
       container-concurrency-target-default: "100"


### PR DESCRIPTION
Since domain-mapping has been included in `spec.replicas` by https://github.com/knative/operator/commit/ba3e058a20893580a98a731080bd7b20433eaa6b, we do not need to set it in yaml.