### PR TITLE
kntest moved to tools

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -8,7 +8,7 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 RUN yum install -y kubectl httpd-tools
 
 RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
-  knative.dev/test-infra/kntest/cmd/kntest
+  knative.dev/test-infra/tools/kntest/cmd/kntest
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd

--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -8,7 +8,7 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 RUN yum install -y kubectl httpd-tools
 
 RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 \
-  knative.dev/test-infra/kntest/cmd/kntest
+  knative.dev/test-infra/tools/kntest/cmd/kntest
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
Looks like kntest has been moved, https://github.com/knative/test-infra/commit/1715ad474811ff608d1581adba5044959ab60592

causing 

```
go get: module knative.dev/test-infra@upgrade found (v0.0.0-20220215044403-4226a7ba1173), but does not contain package knative.dev/test-infra/kntest/cmd/kntest
```

Attepting to fix by updating the path.