### PR TITLE
Patch kafka broker manifests

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
+++ b/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
@@ -561,6 +561,10 @@ spec:
               value: kafka-broker-config
             - name: SINK_GENERAL_CONFIG_MAP_NAME
               value: kafka-broker-config
+            - name: BROKER_INGRESS_POD_PORT
+              value: "8080"
+            - name: SINK_INGRESS_POD_PORT
+              value: "8080"
             - name: BROKER_SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
+++ b/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
@@ -688,6 +688,16 @@ rules:
     verbs:
       - "update"
 
+  # Eventing resources care about
+  - apiGroups:
+      - "eventing.knative.dev"
+    resources:
+      - "brokers"
+    verbs:
+      - list
+      - get
+      - watch
+
 ---
 # Copyright 2020 The Knative Authors
 #

--- a/knative-operator/hack/004-kafka-broker-prober-env.patch
+++ b/knative-operator/hack/004-kafka-broker-prober-env.patch
@@ -1,0 +1,15 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml b/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
+index b9979867..3e18c798 100644
+--- a/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
++++ b/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
+@@ -561,6 +561,10 @@ spec:
+               value: kafka-broker-config
+             - name: SINK_GENERAL_CONFIG_MAP_NAME
+               value: kafka-broker-config
++            - name: BROKER_INGRESS_POD_PORT
++              value: "8080"
++            - name: SINK_INGRESS_POD_PORT
++              value: "8080"
+             - name: BROKER_SYSTEM_NAMESPACE
+               valueFrom:
+                 fieldRef:

--- a/knative-operator/hack/005-kafka-broker-webhook-role.patch
+++ b/knative-operator/hack/005-kafka-broker-webhook-role.patch
@@ -1,0 +1,21 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml b/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
+index 3e18c798..537e7a77 100644
+--- a/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
++++ b/knative-operator/deploy/resources/knativekafka/controller/1-eventing-kafka-controller.yaml
+@@ -688,6 +688,16 @@ rules:
+     verbs:
+       - "update"
+ 
++  # Eventing resources care about
++  - apiGroups:
++      - "eventing.knative.dev"
++    resources:
++      - "brokers"
++    verbs:
++      - list
++      - get
++      - watch
++
+ ---
+ # Copyright 2020 The Knative Authors
+ #

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -68,3 +68,6 @@ git apply "$root/knative-operator/hack/001-broker-config-tracing.patch"
 
 # For now we remove the CRDs, since the "broker" does not yet do anything with them
 git apply "$root/knative-operator/hack/003-broker-remove-duplicated-crds.patch"
+
+# For now we need to add prober env variables.
+git apply "$root/knative-operator/hack/004-kafka-broker-prober-env.patch"

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -71,3 +71,6 @@ git apply "$root/knative-operator/hack/003-broker-remove-duplicated-crds.patch"
 
 # For now we need to add prober env variables.
 git apply "$root/knative-operator/hack/004-kafka-broker-prober-env.patch"
+
+# For now we need to add broker read access to the webhook.
+git apply "$root/knative-operator/hack/005-kafka-broker-webhook-role.patch"


### PR DESCRIPTION
In midstream, we're using v1.2.2 code, so we need
additional env variables for the controller and 
read-only access to brokers for the webhook