### PR TITLE
[SRVKE-1154] Deploy RBAC proxy for kafka broker and sink components

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -426,16 +426,17 @@ func (r *ReconcileKnativeKafka) buildManifest(instance *serverlessoperatorv1alph
 	var resources []unstructured.Unstructured
 
 	if build == manifestBuildAll || (build == manifestBuildEnabledOnly && instance.Spec.Channel.Enabled) || (build == manifestBuildDisabledOnly && !instance.Spec.Channel.Enabled) {
-		channelRBACProxy, err := monitoring.AddRBACProxySupportToManifest(instance, monitoring.KafkaChannelComponents)
+		rbacProxy, err := monitoring.AddRBACProxyToManifest(instance, monitoring.KafkaChannelController, monitoring.KafkaChannelWebhook)
 		if err != nil {
 			return nil, err
 		}
-		resources = append(resources, channelRBACProxy.Resources()...)
+		resources = append(resources, rbacProxy.Resources()...)
 		resources = append(resources, r.rawKafkaChannelManifest.Resources()...)
 	}
+
 	// Kafka Control Plane
 	if build == manifestBuildAll || (build == manifestBuildEnabledOnly && enableControlPlaneManifest(instance.Spec)) || (build == manifestBuildDisabledOnly && !enableControlPlaneManifest(instance.Spec)) {
-		rbacProxy, err := monitoring.AddRBACProxySupportToManifest(instance, monitoring.KafkaControllerComponents)
+		rbacProxy, err := monitoring.AddRBACProxyToManifest(instance, monitoring.KafkaController, monitoring.KafkaWebhook)
 		if err != nil {
 			return nil, err
 		}
@@ -455,7 +456,7 @@ func (r *ReconcileKnativeKafka) buildManifest(instance *serverlessoperatorv1alph
 
 	// Kafka Broker Data Plane
 	if build == manifestBuildAll || (build == manifestBuildEnabledOnly && instance.Spec.Broker.Enabled) || (build == manifestBuildDisabledOnly && !instance.Spec.Broker.Enabled) {
-		rbacProxy, err := monitoring.AddRBACProxySupportToManifest(instance, monitoring.KafkaBrokerDataPlaneComponents)
+		rbacProxy, err := monitoring.AddRBACProxyToManifest(instance, monitoring.KafkaBrokerReceiver, monitoring.KafkaBrokerDispatcher)
 		if err != nil {
 			return nil, err
 		}
@@ -465,7 +466,7 @@ func (r *ReconcileKnativeKafka) buildManifest(instance *serverlessoperatorv1alph
 
 	// Kafka Sink Data Plan
 	if build == manifestBuildAll || (build == manifestBuildEnabledOnly && instance.Spec.Sink.Enabled) || (build == manifestBuildDisabledOnly && !instance.Spec.Sink.Enabled) {
-		rbacProxy, err := monitoring.AddRBACProxySupportToManifest(instance, monitoring.KafkaSinkDataPlaneComponents)
+		rbacProxy, err := monitoring.AddRBACProxyToManifest(instance, monitoring.KafkaSinkReceiver)
 		if err != nil {
 			return nil, err
 		}

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring"
 )
 
 var (
@@ -764,6 +765,21 @@ func TestMonitoringResources(t *testing.T) {
 		Kind:    "Service",
 	}
 
+	components := []monitoring.Component{
+		monitoring.KafkaController,
+		monitoring.KafkaWebhook,
+		monitoring.KafkaBrokerReceiver,
+		monitoring.KafkaBrokerDispatcher,
+		monitoring.KafkaSinkReceiver,
+	}
+	svcs := sets.NewString()
+	sMon := sets.NewString()
+
+	for _, c := range components {
+		svcs.Insert(c.Name + "-sm-service")
+		sMon.Insert(c.Name + "-sm")
+	}
+
 	expected := map[schema.GroupVersionKind]sets.String{
 		crGvk: sets.NewString(
 			"rbac-proxy-reviews-prom-rb-kafka-controller",
@@ -771,20 +787,8 @@ func TestMonitoringResources(t *testing.T) {
 			"rbac-proxy-reviews-prom-rb-knative-kafka-broker-data-plane",
 			"rbac-proxy-reviews-prom-rb-knative-kafka-sink-data-plane",
 		),
-		svGvk: sets.NewString(
-			"kafka-controller-sm",
-			"kafka-webhook-eventing-sm",
-			"kafka-broker-receiver-sm",
-			"kafka-broker-dispatcher-sm",
-			"kafka-sink-receiver-sm",
-		),
-		svcGvk: sets.NewString(
-			"kafka-controller-sm-service",
-			"kafka-webhook-eventing-sm-service",
-			"kafka-broker-receiver-sm-service",
-			"kafka-broker-dispatcher-sm-service",
-			"kafka-sink-receiver-sm-service",
-		),
+		svGvk:  sMon,
+		svcGvk: svcs,
 	}
 
 	for _, r := range manifests.Resources() {

--- a/knative-operator/pkg/monitoring/kafka_rbacproxy_transforms.go
+++ b/knative-operator/pkg/monitoring/kafka_rbacproxy_transforms.go
@@ -5,16 +5,20 @@ import (
 	"errors"
 
 	mf "github.com/manifestival/manifestival"
-	serverlessoperatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
-	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 	"k8s.io/apimachinery/pkg/util/sets"
 	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	serverlessoperatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 )
 
 var (
-	KafkaChannelComponents = []string{"kafka-ch-controller", "kafka-webhook"}
-	KafkaSourceComponents  = []string{"kafka-controller-manager"}
+	KafkaChannelComponents         = []string{"kafka-ch-controller", "kafka-webhook"}
+	KafkaSourceComponents          = []string{"kafka-controller-manager"}
+	KafkaBrokerDataPlaneComponents = []string{"kafka-broker-dispatcher", "kafka-broker-receiver"}
+	KafkaSinkDataPlaneComponents   = []string{"kafka-sink-receiver"}
+	KafkaControllerComponents      = []string{"kafka-controller"}
 )
 
 func AddRBACProxySupportToManifest(instance *serverlessoperatorv1alpha1.KnativeKafka, components []string) (*mf.Manifest, error) {
@@ -44,7 +48,19 @@ func GetRBACProxyInjectTransformer(apiClient client.Client) (mf.Transformer, err
 		return nil, errors.New("eventing instance not found")
 	}
 	if monitoring.ShouldEnableMonitoring(eventingList.Items[0].GetSpec().GetConfig()) {
-		return monitoring.InjectRbacProxyContainerToDeployments(sets.NewString(append(KafkaChannelComponents, KafkaSourceComponents...)...)), nil
+		components := make([]string,
+			len(KafkaChannelComponents)+
+				len(KafkaSourceComponents)+
+				len(KafkaControllerComponents)+
+				len(KafkaBrokerDataPlaneComponents)+
+				len(KafkaSinkDataPlaneComponents),
+		)
+		components = append(components, KafkaChannelComponents...)
+		components = append(components, KafkaSourceComponents...)
+		components = append(components, KafkaBrokerDataPlaneComponents...)
+		components = append(components, KafkaControllerComponents...)
+		components = append(components, KafkaSinkDataPlaneComponents...)
+		return monitoring.InjectRbacProxyContainerToDeployments(sets.NewString(components...)), nil
 	}
 	return nil, nil
 }

--- a/openshift-knative-operator/pkg/monitoring/helpers.go
+++ b/openshift-knative-operator/pkg/monitoring/helpers.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	mf "github.com/manifestival/manifestival"
-	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -18,6 +17,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"knative.dev/pkg/logging"
+
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 )
 
 const (

--- a/test/e2ekafka/knative_kafka_test.go
+++ b/test/e2ekafka/knative_kafka_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
+
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/e2e"
 	"github.com/openshift-knative/serverless-operator/test/monitoringe2e"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
 )
 
 const (
@@ -98,9 +99,20 @@ func TestKnativeKafka(t *testing.T) {
 	})
 
 	t.Run("verify Kafka control plane metrics work correctly", func(t *testing.T) {
-		// Kafka control plane metrics should work
 		if err := monitoringe2e.VerifyMetrics(caCtx, monitoringe2e.KafkaQueries); err != nil {
 			t.Fatal("Failed to verify that Kafka control plane metrics work correctly", err)
+		}
+	})
+
+	t.Run("verify Kafka Broker data plane metrics work correctly", func(t *testing.T) {
+		if err := monitoringe2e.VerifyMetrics(caCtx, monitoringe2e.KafkaBrokerDataPlaneQueries); err != nil {
+			t.Fatal("Failed to verify that Kafka Broker data plane metrics work correctly", err)
+		}
+	})
+
+	t.Run("verify Kafka controller metrics work correctly", func(t *testing.T) {
+		if err := monitoringe2e.VerifyMetrics(caCtx, monitoringe2e.KafkaControllerQueries); err != nil {
+			t.Fatal("Failed to verify that Kafka Broker data plane metrics work correctly", err)
 		}
 	})
 

--- a/test/monitoringe2e/helpers.go
+++ b/test/monitoringe2e/helpers.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift-knative/serverless-operator/test"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift-knative/serverless-operator/test"
 
 	prom "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -47,6 +48,18 @@ var (
 		"kafka_controller_go_mallocs",
 		"kafkachannel_webhook_go_mallocs",
 		"kafkachannel_dispatcher_go_mallocs",
+	}
+
+	KafkaBrokerDataPlaneQueries = []string{
+		"sum(rate(event_dispatch_latencies_ms_bucket{le=\"100.0\", namespace=\"knative-eventing\", job=\"kafka-broker-receiver-sm-service\"}[5m])) by (name, namespace_name) / sum(rate(event_dispatch_latencies_ms_count{job=\"kafka-broker-receiver-sm-service\", namespace=\"knative-eventing\",}[5m])) by (name, namespace_name)",
+		"sum(rate(event_dispatch_latencies_ms_bucket{le=\"100.0\", job=\"kafka-broker-dispatcher-sm-service\", namespace=\"knative-eventing\"}[5m])) by (name, namespace_name) / sum(rate(event_dispatch_latencies_ms_count{job=\"kafka-broker-dispatcher-sm-service\", namespace=\"knative-eventing\"}[5m])) by (name, namespace_name)",
+		"sum(event_count_1_total{job=\"kafka-broker-receiver-sm-service\", namespace=\"knative-eventing\"}) by (name, namespace_name)",
+		"sum(event_count_1_total{job=\"kafka-broker-dispatcher-sm-service\", namespace=\"knative-eventing\"}) by (name, namespace_name)",
+	}
+
+	KafkaControllerQueries = []string{
+		"sum(rate(kafka_broker_controller_reconcile_latency_bucket{le=\"100\", job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}[5m])) / sum(rate(kafka_broker_controller_reconcile_latency_count{job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}[5m]))",
+		"sum(kafka_broker_controller_workqueue_depth{job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}) by (name)",
 	}
 
 	serverlessComponentQueries = []string{


### PR DESCRIPTION
For scraping metrics over TLS in OpenShift we need to deploy Service
monitors and the RBAC proxy for:

- kafka-controller
- kafka-broker-receiver and kafka-broker-dispatcher
- kafka-sink-receiver

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>