### PR TITLE
Bump olm 1.22

### DIFF
--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.bundle.channels.v1="stable"
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
       name="openshift-serverless-1/serverless-operator-bundle" \
-      version="1.21.0" \
+      version="1.22.0" \
       summary="Red Hat OpenShift Serverless Bundle" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -58,12 +58,12 @@ metadata:
       Deploy and manage event-driven serverless applications and functions using Knative.
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
-    olm.skipRange: '>=1.20.0 <1.21.0'
+    olm.skipRange: '>=1.21.0 <1.22.0'
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: serverless-operator.v1.21.0
+  name: serverless-operator.v1.22.0
   namespace: placeholder
 spec:
   # User-facing metadata
@@ -894,5 +894,5 @@ spec:
       image: "registry.ci.openshift.org/openshift/knative-v1.0.0:knative-eventing-kafka-broker-receiver"
     - name: "KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing"
       image: "registry.ci.openshift.org/openshift/knative-v1.0.0:knative-eventing-kafka-broker-webhook-kafka"
-  replaces: serverless-operator.v1.20.0
-  version: 1.21.0
+  replaces: serverless-operator.v1.21.0
+  version: 1.22.0

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -1,11 +1,11 @@
 ---
 project:
   name: serverless-operator
-  version: 1.21.0
+  version: 1.22.0
 
 olm:
-  replaces: 1.20.0
-  skipRange: '>=1.20.0 <1.21.0'
+  replaces: 1.21.0
+  skipRange: '>=1.21.0 <1.22.0'
   channels:
     default: 'stable'
     list:

--- a/olm-catalog/serverless-operator/stopbundle.Dockerfile
+++ b/olm-catalog/serverless-operator/stopbundle.Dockerfile
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.bundle.channels.v1="stable"
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
       name="openshift-serverless-1/serverless-operator-bundle" \
-      version="1.21.0" \
+      version="1.22.0" \
       summary="Red Hat OpenShift Serverless Bundle" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \


### PR DESCRIPTION
As per title: updating the `olm` manifests to the next version.

I did it in a two step commit approach:
* update the actual `project` file, which contains the source of truth
* running the `make generated-files` target, which is based on the above file

This approach of detailed commits give IMO more context to the actual updates - especially with generated files.