### PR TITLE
Go style fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.17
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.6
 	github.com/manifestival/controller-runtime-client v0.4.0
 	github.com/manifestival/manifestival v0.7.0
@@ -64,6 +63,7 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-kit/log v0.1.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect

--- a/knative-operator/pkg/controller/knativekafka/images.go
+++ b/knative-operator/pkg/controller/knativekafka/images.go
@@ -3,7 +3,6 @@ package knativekafka
 import (
 	"fmt"
 
-	"github.com/go-logr/logr"
 	mf "github.com/manifestival/manifestival"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -16,7 +15,7 @@ import (
 var delimiter = "/"
 
 // ImageTransform updates image with a new registry and tag
-func ImageTransform(overrideMap map[string]string, log logr.Logger) mf.Transformer {
+func ImageTransform(overrideMap map[string]string) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		var podSpec *corev1.PodSpec
 		var obj metav1.Object

--- a/knative-operator/pkg/controller/knativekafka/images_test.go
+++ b/knative-operator/pkg/controller/knativekafka/images_test.go
@@ -227,19 +227,19 @@ func TestResourceTransform(t *testing.T) {
 func runResourceTransformTest(t *testing.T, tt *updateImageTest) {
 	// test for deployment
 	unstructuredDeployment := util.MakeUnstructured(t, util.MakeDeployment(tt.name, corev1.PodSpec{Containers: tt.containers}))
-	deploymentTransform := ImageTransform(tt.overrideMap, log)
+	deploymentTransform := ImageTransform(tt.overrideMap)
 	deploymentTransform(&unstructuredDeployment)
 	validateUnstructuredDeploymentChanged(t, tt, &unstructuredDeployment)
 
 	// test for daemonSet
 	unstructuredDaemonSet := util.MakeUnstructured(t, makeDaemonSet(tt.name, corev1.PodSpec{Containers: tt.containers}))
-	daemonSetTransform := ImageTransform(tt.overrideMap, log)
+	daemonSetTransform := ImageTransform(tt.overrideMap)
 	daemonSetTransform(&unstructuredDaemonSet)
 	validateUnstructuredDaemonSetChanged(t, tt, &unstructuredDaemonSet)
 
 	// test for job
 	unstructuredJob := util.MakeUnstructured(t, makeJob(tt.name, corev1.PodSpec{Containers: tt.containers}))
-	jobTransform := ImageTransform(tt.overrideMap, log)
+	jobTransform := ImageTransform(tt.overrideMap)
 	jobTransform(&unstructuredJob)
 	validateUnstructuredJobChanged(t, tt, &unstructuredJob)
 }

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -247,7 +247,7 @@ func (r *ReconcileKnativeKafka) configure(manifest *mf.Manifest, instance *serve
 }
 
 // set a finalizer to clean up cluster-scoped resources and resources from other namespaces
-func (r *ReconcileKnativeKafka) ensureFinalizers(_ *mf.Manifest, instance *serverlessoperatorv1alpha1.KnativeKafka) error {
+func (r *ReconcileKnativeKafka) ensureFinalizers(manifest *mf.Manifest, instance *serverlessoperatorv1alpha1.KnativeKafka) error {
 	for _, finalizer := range instance.GetFinalizers() {
 		if finalizer == finalizerName {
 			return nil
@@ -278,7 +278,7 @@ func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *serve
 		configureLegacyEventingKafka(instance.Spec.Channel),
 		operatorcommon.ConfigMapTransform(instance.Spec.Config, logging.FromContext(context.TODO())),
 		configureEventingKafka(instance.Spec),
-		ImageTransform(common.BuildImageOverrideMapFromEnviron(os.Environ(), "KAFKA_IMAGE_"), log),
+		ImageTransform(common.BuildImageOverrideMapFromEnviron(os.Environ(), "KAFKA_IMAGE_")),
 		replicasTransform(manifest.Client),
 		configMapHashTransform(manifest.Client),
 		rbacProxyTranform,

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -314,7 +314,7 @@ func (r *ReconcileKnativeServing) reconcileConfigMap(instance *operatorv1alpha1.
 }
 
 func (r *ReconcileKnativeServing) installQuickstarts(instance *operatorv1alpha1.KnativeServing) error {
-	return quickstart.Apply(instance, r.client)
+	return quickstart.Apply(r.client)
 }
 
 // installKnConsoleCLIDownload creates CR for kn CLI download link
@@ -350,7 +350,7 @@ func (r *ReconcileKnativeServing) delete(instance *operatorv1alpha1.KnativeServi
 	}
 
 	log.Info("Deleting quickstart")
-	if err := quickstart.Delete(instance, r.client); err != nil {
+	if err := quickstart.Delete(r.client); err != nil {
 		return fmt.Errorf("failed to delete quickstarts: %w", err)
 	}
 

--- a/knative-operator/pkg/controller/knativeserving/quickstart/quickstart.go
+++ b/knative-operator/pkg/controller/knativeserving/quickstart/quickstart.go
@@ -8,7 +8,6 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	apierrs "k8s.io/apimachinery/pkg/api/meta"
-	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -18,7 +17,7 @@ const EnvKey = "QUICKSTART_MANIFEST_PATH"
 var log = common.Log.WithName("quickstart")
 
 // Apply applies Quickstart resources.
-func Apply(instance *operatorv1alpha1.KnativeServing, api client.Client) error {
+func Apply(api client.Client) error {
 	manifest, err := mfc.NewManifest(manifestPath(), api, mf.UseLogger(log.WithName("mf")))
 	if err != nil {
 		return fmt.Errorf("failed to load quickstart manifest: %w", err)
@@ -37,7 +36,7 @@ func Apply(instance *operatorv1alpha1.KnativeServing, api client.Client) error {
 }
 
 // Delete deletes Quickstart resources.
-func Delete(instance *operatorv1alpha1.KnativeServing, api client.Client) error {
+func Delete(api client.Client) error {
 	log.Info("Deleting Quickstarts")
 	manifest, err := mfc.NewManifest(manifestPath(), api, mf.UseLogger(log.WithName("mf")))
 	if err != nil {

--- a/knative-operator/pkg/controller/knativeserving/quickstart/quickstart_test.go
+++ b/knative-operator/pkg/controller/knativeserving/quickstart/quickstart_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	apierrs "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/kubernetes/scheme"
-	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,7 +18,6 @@ func init() {
 }
 
 func TestQuickstartErrors(t *testing.T) {
-	ks := &operatorv1alpha1.KnativeServing{}
 	someErr := errors.New("test")
 
 	tests := []struct {
@@ -37,10 +35,10 @@ func TestQuickstartErrors(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		if err := Apply(ks, &fakeClient{err: test.err}); !errors.Is(err, test.expected) {
+		if err := Apply(&fakeClient{err: test.err}); !errors.Is(err, test.expected) {
 			t.Errorf("Apply() = %v, want %v", err, test.expected)
 		}
-		if err := Delete(ks, &fakeClient{err: test.err}); !errors.Is(err, test.expected) {
+		if err := Delete(&fakeClient{err: test.err}); !errors.Is(err, test.expected) {
 			t.Errorf("Delete() = %v, want %v", err, test.expected)
 		}
 	}

--- a/knative-operator/pkg/monitoring/sources/source_service_monitor.go
+++ b/knative-operator/pkg/monitoring/sources/source_service_monitor.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
-	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/kmap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -59,7 +59,7 @@ func createServiceMonitorManifest(labels map[string]string, depName string, ns s
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      depName,
 			Namespace: ns,
-			Labels:    kmeta.CopyMap(labels),
+			Labels:    kmap.Copy(labels),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
@@ -68,7 +68,7 @@ func createServiceMonitorManifest(labels map[string]string, depName string, ns s
 				TargetPort: intstr.FromInt(9090),
 				Protocol:   "TCP",
 			}},
-			Selector: kmeta.CopyMap(labels),
+			Selector: kmap.Copy(labels),
 		}}
 	sms.Labels["name"] = sms.Name
 	if err := scheme.Scheme.Convert(&sms, svU, nil); err != nil {
@@ -78,7 +78,7 @@ func createServiceMonitorManifest(labels map[string]string, depName string, ns s
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      depName,
 			Namespace: ns,
-			Labels:    kmeta.CopyMap(labels),
+			Labels:    kmap.Copy(labels),
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{{Port: "http-metrics"}},

--- a/serving/ingress/pkg/reconciler/ingress/resources/route.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/networking/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
-	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/kmap"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/config"
 )
@@ -85,7 +85,7 @@ func makeRoute(ci *networkingv1alpha1.Ingress, host string, rule networkingv1alp
 	// Set timeout for OpenShift Route
 	annotations[TimeoutAnnotation] = DefaultTimeout
 
-	labels := kmeta.UnionMaps(ci.Labels, map[string]string{
+	labels := kmap.Union(ci.Labels, map[string]string{
 		networking.IngressLabelKey:        ci.GetName(),
 		OpenShiftIngressLabelKey:          ci.GetName(),
 		OpenShiftIngressNamespaceLabelKey: ci.GetNamespace(),

--- a/test/servinge2e/deploy_kn_k8s_svc_in_same_namespace_test.go
+++ b/test/servinge2e/deploy_kn_k8s_svc_in_same_namespace_test.go
@@ -51,15 +51,23 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, kubeServiceURL, helloworldText)
 
 	// Delete Knative service
-	caCtx.Clients.Serving.ServingV1().Services(testNamespace2).Delete(context.Background(), ksvc.Name, metav1.DeleteOptions{})
+	if err = caCtx.Clients.Serving.ServingV1().Services(testNamespace2).Delete(context.Background(), ksvc.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatal("Failed to remove service", err)
+	}
 
 	// Check that Kube service still responds
 	WaitForRouteServingText(t, caCtx, kubeServiceURL, helloworldText)
 
 	// Remove the Kube service
-	caCtx.Clients.Route.Routes(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{})
-	caCtx.Clients.Kube.CoreV1().Services(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{})
-	caCtx.Clients.Kube.AppsV1().Deployments(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{})
+	if err = caCtx.Clients.Route.Routes(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatal("Failed to remove route", err)
+	}
+	if err = caCtx.Clients.Kube.CoreV1().Services(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatal("Failed to remove service", err)
+	}
+	if err = caCtx.Clients.Kube.AppsV1().Deployments(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatal("Failed to remove deployment", err)
+	}
 
 	// Deploy Knative service in the namespace first
 	ksvc, err = test.WithServiceReady(caCtx, helloworldService2, testNamespace2, image)
@@ -94,15 +102,23 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, kubeServiceURL, helloworldText)
 
 	// Remove the Kube service
-	caCtx.Clients.Route.Routes(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{})
-	caCtx.Clients.Kube.CoreV1().Services(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{})
-	caCtx.Clients.Kube.AppsV1().Deployments(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{})
+	if err = caCtx.Clients.Route.Routes(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatal("Failed to remove route", err)
+	}
+	if err = caCtx.Clients.Kube.CoreV1().Services(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatal("Failed to remove service", err)
+	}
+	if err = caCtx.Clients.Kube.AppsV1().Deployments(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatal("Failed to remove deployment", err)
+	}
 
 	// Check that Knative service still responds
 	WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
 
 	// Delete the Knative service
-	caCtx.Clients.Serving.ServingV1().Services(testNamespace2).Delete(context.Background(), ksvc.Name, metav1.DeleteOptions{})
+	if err = caCtx.Clients.Serving.ServingV1().Services(testNamespace2).Delete(context.Background(), ksvc.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatal("Failed to remove service", err)
+	}
 }
 
 func withRouteForServiceReady(ctx *test.Context, serviceName, namespace string) (*routev1.Route, error) {


### PR DESCRIPTION
As per title. It covers:
- unused params. Methods that implement some interface will keep for now the unused param. We could however replace with `_` or consider simplifying them in another round.
- unhandled errors
- deprecations