### PR TITLE
Migrate KafkaSource dashboards to Broker components

### DIFF
--- a/knative-operator/deploy/resources/dashboards/eventing/grafana-dash-knative-eventing-source.yaml
+++ b/knative-operator/deploy/resources/dashboards/eventing/grafana-dash-knative-eventing-source.yaml
@@ -866,7 +866,7 @@ data:
              "tableColumn": "",
              "targets": [
                {
-                 "expr": "sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+                 "expr": "sum(rate(event_count_1_total{job=\"kafka-source-dispatcher-sm-service\", namespace=\"knative-eventing\", namespace_name=\"$eventNamespace\"}[1m]))",
                  "format": "time_series",
                  "instant": false,
                  "refId": "A"
@@ -875,7 +875,7 @@ data:
              "thresholds": "",
              "timeFrom": null,
              "timeShift": null,
-             "title": "Kafka: Event Count (avg/sec, over 1m window)",
+             "title": "KafkaSource: Event Count (avg/sec, over 1m window)",
              "type": "singlestat",
              "valueFontSize": "80%",
              "valueMaps": [
@@ -954,7 +954,7 @@ data:
              "tableColumn": "",
              "targets": [
                {
-                 "expr": "sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+                 "expr": "sum(rate(event_count_1_total{job=\"kafka-source-dispatcher-sm-service\", namespace=\"knative-eventing\", namespace_name=\"$eventNamespace\", response_code_class=\"2xx\"}[1m])) / sum(rate(event_count_1_total{job=\"kafka-source-dispatcher-sm-service\", namespace=\"knative-eventing\", namespace_name=\"$eventNamespace\"}[1m]))",
                  "format": "time_series",
                  "instant": false,
                  "refId": "A"
@@ -1020,7 +1020,7 @@ data:
              "steppedLine": false,
              "targets": [
                {
-                 "expr": "sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\"}[1m])) by (response_code_class)",
+                 "expr": "sum(rate(event_count_1_total{job=\"kafka-source-dispatcher-sm-service\", namespace=\"knative-eventing\", namespace_name=\"$eventNamespace\"}[1m])) by (response_code_class)",
                  "format": "time_series",
                  "hide": false,
                  "instant": false,
@@ -1138,7 +1138,7 @@ data:
              "tableColumn": "",
              "targets": [
                {
-                 "expr": "sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(kafkasource_event_count{namespace_name=\"$eventNamespace\"}[1m]))",
+                 "expr": "sum(rate(event_count_1_total{job=\"kafka-source-dispatcher-sm-service\", namespace=\"knative-eventing\", namespace_name=\"$eventNamespace\", response_code_class!=\"2xx\"}[1m])) / sum(rate(event_count_1_total{job=\"kafka-source-dispatcher-sm-service\", namespace=\"knative-eventing\", namespace_name=\"$eventNamespace\"}[1m]))",
                  "format": "time_series",
                  "instant": false,
                  "refId": "A"
@@ -1172,7 +1172,7 @@ data:
             "multi": false,
             "name": "eventNamespace",
             "options": [],
-            "query": "label_values((pingsource_event_count{} OR kafkasource_event_count{} OR apiserversource_event_count{}), namespace_name)",
+            "query": "label_values((pingsource_event_count{} OR event_count_1_total{job=\"kafka-source-dispatcher-sm-service\"} OR apiserversource_event_count{}), namespace_name)",
             "refresh": 2,
             "regex": "",
             "sort": 1,

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -444,13 +444,13 @@ func (r *ReconcileKnativeKafka) buildManifest(instance *serverlessoperatorv1alph
 		resources = append(resources, r.rawKafkaControllerManifest.Resources()...)
 	}
 
-	// Kafka Source Data Plan
+	// Kafka Source Data Plane
 	if build == manifestBuildAll || (build == manifestBuildEnabledOnly && instance.Spec.Source.Enabled) || (build == manifestBuildDisabledOnly && !instance.Spec.Source.Enabled) {
-		//sourceRBACProxy, err := monitoring.AddRBACProxySupportToManifest(instance, monitoring.KafkaSourceComponents)
-		//if err != nil {
-		//	return nil, err
-		//}
-		//resources = append(resources, sourceRBACProxy.Resources()...)
+		sourceRBACProxy, err := monitoring.AddRBACProxyToManifest(instance, monitoring.KafkaSourceDispatcher)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, sourceRBACProxy.Resources()...)
 		resources = append(resources, r.rawKafkaSourceManifest.Resources()...)
 	}
 

--- a/knative-operator/pkg/monitoring/kafka_rbacproxy_transforms.go
+++ b/knative-operator/pkg/monitoring/kafka_rbacproxy_transforms.go
@@ -46,9 +46,9 @@ var (
 		ServiceAccountName: "kafka-webhook",
 	}
 
-	KafkaSourceController = Component{
-		Name:               "kafka-controller-manager",
-		ServiceAccountName: "kafka-controller-manager",
+	KafkaSourceDispatcher = Component{
+		Name:               "kafka-source-dispatcher",
+		ServiceAccountName: "knative-kafka-source-data-plane",
 	}
 
 	deployments = []string{
@@ -59,7 +59,7 @@ var (
 		KafkaSinkReceiver.Name,
 		KafkaChannelController.Name,
 		KafkaChannelWebhook.Name,
-		KafkaSourceController.Name,
+		KafkaSourceDispatcher.Name,
 	}
 )
 


### PR DESCRIPTION
- Enable RBAC proxy injection for KafkaSource (temporarly
  disabled in #1414
- Use the new metric names for KafkaSource

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Images:
![kafka-source-dashboards-namespace-selection](https://user-images.githubusercontent.com/33736985/156153876-1c95eed4-2b19-4ff6-9321-7448b86004d3.png)

![kafka-source-metrics-dashboards](https://user-images.githubusercontent.com/33736985/156153957-15ab1365-242a-47e4-b2b4-c462f655f6d4.png)

