### PR TITLE
[SRVKS-877] Add common label `knative.openshift.io/part-of: openshift-serverless` for namespaces deployed by operator

### DIFF
--- a/openshift-knative-operator/pkg/common/label.go
+++ b/openshift-knative-operator/pkg/common/label.go
@@ -5,12 +5,15 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-var commonLabel = map[string]string{"app.openshift.io/part-of": "openshift-serverless"}
-
 // InjectEnvironmentIntoDeployment injects the common label into the resources.
 func InjectCommonLabel() mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
-		u.SetLabels(commonLabel)
+		labels := u.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string, 1)
+		}
+		labels["app.openshift.io/part-of"] = "openshift-serverless"
+		u.SetLabels(labels)
 		return nil
 	}
 }

--- a/openshift-knative-operator/pkg/common/label.go
+++ b/openshift-knative-operator/pkg/common/label.go
@@ -1,0 +1,16 @@
+package common
+
+import (
+	mf "github.com/manifestival/manifestival"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var commonLabel = map[string]string{"app.openshift.io/part-of": "openshift-serverless"}
+
+// InjectEnvironmentIntoDeployment injects the common label into the resources.
+func InjectCommonLabel() mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		u.SetLabels(commonLabel)
+		return nil
+	}
+}

--- a/openshift-knative-operator/pkg/common/label.go
+++ b/openshift-knative-operator/pkg/common/label.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	mf "github.com/manifestival/manifestival"
+	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -12,7 +13,7 @@ func InjectCommonLabel() mf.Transformer {
 		if labels == nil {
 			labels = make(map[string]string, 1)
 		}
-		labels[ServerlessCommonLabelKey] = ServerlessCommonLabelValue
+		labels[socommon.ServerlessCommonLabelKey] = socommon.ServerlessCommonLabelValue
 		u.SetLabels(labels)
 		return nil
 	}

--- a/openshift-knative-operator/pkg/common/label.go
+++ b/openshift-knative-operator/pkg/common/label.go
@@ -12,7 +12,7 @@ func InjectCommonLabel() mf.Transformer {
 		if labels == nil {
 			labels = make(map[string]string, 1)
 		}
-		labels["app.openshift.io/part-of"] = "openshift-serverless"
+		labels[ServerlessCommonLabelKey] = ServerlessCommonLabelValue
 		u.SetLabels(labels)
 		return nil
 	}

--- a/openshift-knative-operator/pkg/common/label.go
+++ b/openshift-knative-operator/pkg/common/label.go
@@ -6,9 +6,12 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// InjectCommonLabel injects the common label into the resources.
-func InjectCommonLabel() mf.Transformer {
+// InjectCommonLabelIntoNamespace injects the common label into the namespaces.
+func InjectCommonLabelIntoNamespace() mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "Namespace" {
+			return nil
+		}
 		labels := u.GetLabels()
 		if labels == nil {
 			labels = make(map[string]string, 1)

--- a/openshift-knative-operator/pkg/common/label.go
+++ b/openshift-knative-operator/pkg/common/label.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// InjectEnvironmentIntoDeployment injects the common label into the resources.
+// InjectCommonLabel injects the common label into the resources.
 func InjectCommonLabel() mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		labels := u.GetLabels()

--- a/openshift-knative-operator/pkg/common/label_test.go
+++ b/openshift-knative-operator/pkg/common/label_test.go
@@ -1,0 +1,52 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestInjectCommonLabelIntoNamespace(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *unstructured.Unstructured
+		want string
+	}{{
+		name: "inject common label into namespace",
+		in: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+			},
+		},
+		want: "openshift-serverless",
+	}, {
+		name: "do not inject common label into deployment",
+		in: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			u := test.in
+			if err := InjectCommonLabelIntoNamespace()(u); err != nil {
+				t.Fatal("Unexpected error from transformer", err)
+			}
+
+			if !cmp.Equal(u.GetLabels()["knative.openshift.io/part-of"], test.want) {
+				t.Errorf("Unexpected label: Got = %q, want = %q", u.GetLabels()["knative.openshift.io/part-of"], test.want)
+			}
+		})
+	}
+}

--- a/openshift-knative-operator/pkg/common/label_test.go
+++ b/openshift-knative-operator/pkg/common/label_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -23,7 +24,7 @@ func TestInjectCommonLabelIntoNamespace(t *testing.T) {
 				},
 			},
 		},
-		want: "openshift-serverless",
+		want: socommon.ServerlessCommonLabelValue,
 	}, {
 		name: "do not inject common label into deployment",
 		in: &unstructured.Unstructured{
@@ -44,8 +45,8 @@ func TestInjectCommonLabelIntoNamespace(t *testing.T) {
 				t.Fatal("Unexpected error from transformer", err)
 			}
 
-			if !cmp.Equal(u.GetLabels()["knative.openshift.io/part-of"], test.want) {
-				t.Errorf("Unexpected label: Got = %q, want = %q", u.GetLabels()["knative.openshift.io/part-of"], test.want)
+			if !cmp.Equal(u.GetLabels()[socommon.ServerlessCommonLabelKey], test.want) {
+				t.Errorf("Unexpected label: Got = %q, want = %q", u.GetLabels()[socommon.ServerlessCommonLabelKey], test.want)
 			}
 		})
 	}

--- a/openshift-knative-operator/pkg/eventing/extension.go
+++ b/openshift-knative-operator/pkg/eventing/extension.go
@@ -34,7 +34,8 @@ func (e *extension) Manifests(ke operatorv1alpha1.KComponent) ([]mf.Manifest, er
 }
 
 func (e *extension) Transformers(ke operatorv1alpha1.KComponent) []mf.Transformer {
-	return monitoring.GetEventingTransformers(ke)
+	return append([]mf.Transformer{common.InjectCommonLabel()},
+		monitoring.GetEventingTransformers(ke)...)
 }
 
 func (e *extension) Reconcile(ctx context.Context, comp operatorv1alpha1.KComponent) error {

--- a/openshift-knative-operator/pkg/eventing/extension.go
+++ b/openshift-knative-operator/pkg/eventing/extension.go
@@ -34,7 +34,7 @@ func (e *extension) Manifests(ke operatorv1alpha1.KComponent) ([]mf.Manifest, er
 }
 
 func (e *extension) Transformers(ke operatorv1alpha1.KComponent) []mf.Transformer {
-	return append([]mf.Transformer{common.InjectCommonLabel()},
+	return append([]mf.Transformer{common.InjectCommonLabelIntoNamespace()},
 		monitoring.GetEventingTransformers(ke)...)
 }
 

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -64,7 +64,7 @@ func (e *extension) Manifests(ks operatorv1alpha1.KComponent) ([]mf.Manifest, er
 
 func (e *extension) Transformers(ks operatorv1alpha1.KComponent) []mf.Transformer {
 	return append([]mf.Transformer{
-		common.InjectCommonLabel(),
+		common.InjectCommonLabelIntoNamespace(),
 		common.InjectEnvironmentIntoDeployment("controller", "controller",
 			corev1.EnvVar{Name: "HTTP_PROXY", Value: os.Getenv("HTTP_PROXY")},
 			corev1.EnvVar{Name: "HTTPS_PROXY", Value: os.Getenv("HTTPS_PROXY")},

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -64,6 +64,7 @@ func (e *extension) Manifests(ks operatorv1alpha1.KComponent) ([]mf.Manifest, er
 
 func (e *extension) Transformers(ks operatorv1alpha1.KComponent) []mf.Transformer {
 	return append([]mf.Transformer{
+		common.InjectCommonLabel(),
 		common.InjectEnvironmentIntoDeployment("controller", "controller",
 			corev1.EnvVar{Name: "HTTP_PROXY", Value: os.Getenv("HTTP_PROXY")},
 			corev1.EnvVar{Name: "HTTPS_PROXY", Value: os.Getenv("HTTPS_PROXY")},

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -1,9 +1,9 @@
 package common
 
 const (
-	ServerlessDownstreamDomain = "serverless.knative.openshift.io"
-	ServingDownstreamDomain    = "serving.knative.openshift.io"
-	EventingDownstreamDomain   = "eventing.knative.openshift.io"
+	DownstreamDomain         = "knative.openshift.io"
+	ServingDownstreamDomain  = "serving.knative.openshift.io"
+	EventingDownstreamDomain = "eventing.knative.openshift.io"
 
 	// Label keys being used to tag the owned resources by instance
 	ServingOwnerName       = ServingDownstreamDomain + "/ownerName"
@@ -11,6 +11,6 @@ const (
 	EventingOwnerName      = EventingDownstreamDomain + "/ownerName"
 	EventingOwnerNamespace = EventingDownstreamDomain + "/ownerNamespace"
 
-	ServerlessCommonLabelKey   = ServerlessDownstreamDomain + "/part-of"
+	ServerlessCommonLabelKey   = DownstreamDomain + "/part-of"
 	ServerlessCommonLabelValue = "openshift-serverless"
 )

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -1,12 +1,16 @@
 package common
 
 const (
-	ServingDownstreamDomain  = "serving.knative.openshift.io"
-	EventingDownstreamDomain = "eventing.knative.openshift.io"
+	ServerlessDownstreamDomain = "serverless.knative.openshift.io"
+	ServingDownstreamDomain    = "serving.knative.openshift.io"
+	EventingDownstreamDomain   = "eventing.knative.openshift.io"
 
 	// Label keys being used to tag the owned resources by instance
 	ServingOwnerName       = ServingDownstreamDomain + "/ownerName"
 	ServingOwnerNamespace  = ServingDownstreamDomain + "/ownerNamespace"
 	EventingOwnerName      = EventingDownstreamDomain + "/ownerName"
 	EventingOwnerNamespace = EventingDownstreamDomain + "/ownerNamespace"
+
+	ServerlessCommonLabelKey   = ServerlessDownstreamDomain + "/part-of"
+	ServerlessCommonLabelValue = "openshift-serverless"
 )

--- a/test/servicemesh.go
+++ b/test/servicemesh.go
@@ -2,14 +2,12 @@ package test
 
 import (
 	"context"
-	"fmt"
 
 	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func ServiceMeshControlPlaneV1(name, namespace string) *unstructured.Unstructured {
@@ -162,16 +160,4 @@ func CreateNetworkPolicy(ctx *Context, networkPolicy *networkingv1.NetworkPolicy
 	})
 
 	return createdNetworkPolicy
-}
-
-func LabelNamespace(ctx *Context, namespace, key, value string) {
-	_, err := ctx.Clients.Kube.CoreV1().Namespaces().Patch(
-		context.Background(),
-		namespace,
-		types.MergePatchType,
-		[]byte(fmt.Sprintf("{\"metadata\":{\"labels\":{\"%s\":\"%s\"}}}", key, value)),
-		metav1.PatchOptions{})
-	if err != nil {
-		ctx.T.Fatalf("Error labelling namespace %q: %v", namespace, err)
-	}
 }

--- a/test/servicemesh.go
+++ b/test/servicemesh.go
@@ -135,7 +135,7 @@ func AllowFromServingSystemNamespaceNetworkPolicy(namespace string) *networkingv
 						{
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app.openshift.io/part-of": "openshift-serverless",
+									"serverless.knative.openshift.io/part-of": "openshift-serverless",
 								},
 							},
 						},

--- a/test/servicemesh.go
+++ b/test/servicemesh.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	KnativeSystemNamespaceKey = "knative.openshift.io/system-namespace"
+	commonLabelKey = "app.openshift.io/part-of"
 )
 
 func ServiceMeshControlPlaneV1(name, namespace string) *unstructured.Unstructured {
@@ -139,7 +139,7 @@ func AllowFromServingSystemNamespaceNetworkPolicy(namespace string) *networkingv
 						{
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									KnativeSystemNamespaceKey: "true",
+									"app.openshift.io/part-of": "openshift-serverless",
 								},
 							},
 						},

--- a/test/servicemesh.go
+++ b/test/servicemesh.go
@@ -11,10 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-const (
-	commonLabelKey = "app.openshift.io/part-of"
-)
-
 func ServiceMeshControlPlaneV1(name, namespace string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/test/servicemesh.go
+++ b/test/servicemesh.go
@@ -135,7 +135,7 @@ func AllowFromServingSystemNamespaceNetworkPolicy(namespace string) *networkingv
 						{
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"serverless.knative.openshift.io/part-of": "openshift-serverless",
+									"knative.openshift.io/part-of": "openshift-serverless",
 								},
 							},
 						},

--- a/test/servicemesh.go
+++ b/test/servicemesh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -135,7 +136,7 @@ func AllowFromServingSystemNamespaceNetworkPolicy(namespace string) *networkingv
 						{
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"knative.openshift.io/part-of": "openshift-serverless",
+									socommon.ServerlessCommonLabelKey: socommon.ServerlessCommonLabelValue,
 								},
 							},
 						},

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -72,8 +72,6 @@ func setupNamespaceForServiceMesh(ctx *test.Context, serviceMeshNamespace, testN
 	test.CreateServiceMeshMemberRollV1(ctx, test.ServiceMeshMemberRollV1("default", serviceMeshNamespace, testNamespace))
 
 	test.CreateNetworkPolicy(ctx, test.AllowFromServingSystemNamespaceNetworkPolicy(testNamespace))
-	test.LabelNamespace(ctx, "knative-serving", test.KnativeSystemNamespaceKey, "true")
-	test.LabelNamespace(ctx, "knative-serving-ingress", test.KnativeSystemNamespaceKey, "true")
 }
 
 func runTestForAllServiceMeshVersions(t *testing.T, testFunc func(ctx *test.Context)) {


### PR DESCRIPTION
This patch adds common label `knative.openshift.io/part-of:
openshift-serverless` 
for resources deployed by operator.

Currently users needs to add `knative.openshift.io/system-namespace`
label manually but they can use `knative.openshift.io/part-of` label
instead after this PR.