### PR TITLE
Storage Version Migrator for the new Kafka source

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/source/eventing-kafka-post-install.yaml
+++ b/knative-operator/deploy/resources/knativekafka/source/eventing-kafka-post-install.yaml
@@ -198,3 +198,137 @@ spec:
                   fieldPath: metadata.namespace
 
 ---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-kafka-storage-version-migrator
+  labels:
+    kafka.eventing.knative.dev/release: devel
+rules:
+  # Storage version upgrader needs to be able to patch CRDs.
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+      - "customresourcedefinitions/status"
+    verbs:
+      - "get"
+      - "list"
+      - "update"
+      - "patch"
+      - "watch"
+  # Our own resources we care about.
+  - apiGroups:
+      - "sources.knative.dev"
+    resources:
+      - "kafkasources"
+      - "kafkasources/finalizers"
+      - "kafkasources/status"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "patch"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs:
+      - "get"
+      - "list"
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knative-kafka-storage-version-migrator
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-kafka-storage-version-migrator
+  labels:
+    kafka.eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: knative-kafka-storage-version-migrator
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-kafka-storage-version-migrator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: knative-kafka-storage-version-migrator
+  namespace: knative-eventing
+  labels:
+    app: "knative-kafka-storage-version-migrator"
+    kafka.eventing.knative.dev/release: devel
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: "knative-kafka-storage-version-migrator"
+        kafka.eventing.knative.dev/release: devel
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: knative-kafka-storage-version-migrator
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-kafka-storage-version-migration
+          args:
+            - "kafkasources.sources.knative.dev"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Upstream we land a SVM for the kafkasource, we need this here too

Fix:
- adding the manifest to the manually added file for all "post install" aspects.
- reusing the midstream `kafka` image for the migrator 