### PR TITLE
[KafkaSource] Update post-install / storage migrator jobs

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -74,7 +74,6 @@ image "DISPATCHER_IMAGE"     "${eventing}-channel-dispatcher"
 kafka_image "kafka-ch-controller__controller"      "${eventing_kafka}-consolidated-controller"
 kafka_image "DISPATCHER_IMAGE"                     "${eventing_kafka}-consolidated-dispatcher"
 kafka_image "kafka-webhook__kafka-webhook"         "${eventing_kafka}-webhook"
-kafka_image "storage-version-migration-kafka-source-$(metadata.get dependencies.eventing_kafka)__migrate" "${eventing_kafka}-storage-version-migration"
 kafka_image "storage-version-migration-kafka-channel-$(metadata.get dependencies.eventing_kafka)__migrate" "${eventing_kafka}-storage-version-migration"
 
 kafka_image "kafka-broker-receiver__kafka-broker-receiver"      "${eventing_kafka_broker}-broker-receiver"
@@ -83,6 +82,11 @@ kafka_image "kafka-controller__controller"                      "${eventing_kafk
 kafka_image "kafka-sink-receiver__kafka-sink-receiver"          "${eventing_kafka_broker}-broker-receiver"
 kafka_image "kafka-source-dispatcher__kafka-source-dispatcher"  "${eventing_kafka_broker}-broker-dispatcher"
 kafka_image "kafka-webhook-eventing__kafka-webhook-eventing"    "${eventing_kafka_broker}-broker-webhook-kafka"
+kafka_image "kafka-controller-post-install__post-install"    "${eventing_kafka_broker}-broker-post-install"
+
+## Todo: For the source we currently reuse one one from eventing core.
+## We might want to rethink this. for direct build on the "broker" repo.
+kafka_image "knative-kafka-storage-version-migrator__migrate"    "${eventing}-storage-version-migration"
 
 image 'KUBE_RBAC_PROXY'          "${rbac_proxy}"
 image 'KN_PLUGIN_EVENT_SENDER'   "${kn_event}-sender"

--- a/knative-operator/deploy/resources/knativekafka/source/eventing-kafka-post-install.yaml
+++ b/knative-operator/deploy/resources/knativekafka/source/eventing-kafka-post-install.yaml
@@ -190,7 +190,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: post-install
-          image: registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-post-install
+          image: TO_BE_REPLACED
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -329,6 +329,6 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-kafka-storage-version-migration
+          image: TO_BE_REPLACED
           args:
             - "kafkasources.sources.knative.dev"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -635,8 +635,6 @@ spec:
                         value: "registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-kafka-consolidated-dispatcher"
                       - name: "KAFKA_IMAGE_kafka-webhook__kafka-webhook"
                         value: "registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-kafka-webhook"
-                      - name: "KAFKA_IMAGE_storage-version-migration-kafka-source-1.1.0__migrate"
-                        value: "registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-kafka-storage-version-migration"
                       - name: "KAFKA_IMAGE_storage-version-migration-kafka-channel-1.1.0__migrate"
                         value: "registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-kafka-storage-version-migration"
                       - name: "KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver"
@@ -651,6 +649,10 @@ spec:
                         value: "registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-dispatcher"
                       - name: "KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing"
                         value: "registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-webhook-kafka"
+                      - name: "KAFKA_IMAGE_kafka-controller-post-install__post-install"
+                        value: "registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-post-install"
+                      - name: "KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate"
+                        value: "registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-storage-version-migration"
                       - name: "KNATIVE_EVENTING_KAFKA_VERSION"
                         value: "1.1.0"
                     securityContext:
@@ -874,8 +876,6 @@ spec:
       image: "registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-kafka-consolidated-dispatcher"
     - name: "KAFKA_IMAGE_kafka-webhook__kafka-webhook"
       image: "registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-kafka-webhook"
-    - name: "KAFKA_IMAGE_storage-version-migration-kafka-source-1.1.0__migrate"
-      image: "registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-kafka-storage-version-migration"
     - name: "KAFKA_IMAGE_storage-version-migration-kafka-channel-1.1.0__migrate"
       image: "registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-kafka-storage-version-migration"
     - name: "KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver"
@@ -890,5 +890,9 @@ spec:
       image: "registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-dispatcher"
     - name: "KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing"
       image: "registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-webhook-kafka"
+    - name: "KAFKA_IMAGE_kafka-controller-post-install__post-install"
+      image: "registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-post-install"
+    - name: "KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate"
+      image: "registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-storage-version-migration"
   replaces: serverless-operator.v1.21.0
   version: 1.22.0


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Adding new image to the generated CSV for completeness.

* Removing the old `storage-version-migration-kafka-source` post job from the `csv` generator;
* Do not use midstream images in manifest, but `TO_BE_REPLACED` so that our script does replace them (helps also witth productization)
* adding new post-job and a storage version migrator for the new source implementation to the CSV generator;
 
**NOTE:** For the storage version migrator we current reuse the image that we do already build for knative eventing-core. This might change in the future.
