### PR TITLE
[SRVKS-877] Add common label to namespaces during initial installation

### DIFF
--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -32,27 +32,20 @@ spec:
     # Add namespace you want to include mesh.
 ```
 
-and add `knative.openshift.io/system-namespace` label to system namespaces.
-
-```
-oc label namespace knative-serving knative.openshift.io/system-namespace=true
-oc label namespace knative-serving-ingress knative.openshift.io/system-namespace=true
-```
-
 and add `NetworkPolicy` in your namespace.
 
 ```
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-from-serving-system-namespace
+  name: allow-from-system-namespace
   namespace: $NAMESPACE_YOU_WANT_TO_ADD
 spec:
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
-          knative.openshift.io/system-namespace: "true"
+          knative.openshift.io/part-of: "openshift-serverless"
   podSelector: {}
   policyTypes:
   - Ingress

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring/dashboards"
+	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -48,6 +49,9 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	if ns, required := os.LookupEnv(requiredNsEnvName); required {
 		client.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 			Name: ns,
+			Labels: map[string]string{
+				socommon.ServerlessCommonLabelKey: socommon.ServerlessCommonLabelValue,
+			},
 		}})
 	}
 

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -69,6 +69,9 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	if ns, required := os.LookupEnv(requiredNsEnvName); required {
 		client.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 			Name: ns,
+			Labels: map[string]string{
+				socommon.ServerlessCommonLabelKey: socommon.ServerlessCommonLabelValue,
+			},
 		}})
 	}
 

--- a/test/servicemesh.go
+++ b/test/servicemesh.go
@@ -124,7 +124,7 @@ func CreateServiceMeshMemberRollV1(ctx *Context, smmr *unstructured.Unstructured
 func AllowFromServingSystemNamespaceNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "allow-from-serving-system-namespace",
+			Name:      "allow-from-system-namespace",
 			Namespace: namespace,
 		},
 		Spec: networkingv1.NetworkPolicySpec{

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -27,7 +27,6 @@ function prepare_knative_serving_tests {
   # Add networkpolicy to test namespace and label to serving namespaces for testing under the strict networkpolicy.
   add_networkpolicy "serving-tests"
   add_networkpolicy "serving-tests-alt"
-  add_systemnamespace_label
 
   export GATEWAY_OVERRIDE="kourier"
   export GATEWAY_NAMESPACE_OVERRIDE="${INGRESS_NAMESPACE}"


### PR DESCRIPTION
As per title, serverless-operator deploys namespace before everything this patch adds the label for the duration.