### PR TITLE
Fix invalid makefile target install-with-mesh-enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ uninstall-full-mesh:
 	FULL_MESH="true" UNINSTALL_MESH="true" ./hack/mesh.sh
 
 install-with-mesh-enabled:
-  FULL_MESH=true ./hack/install.sh
+	FULL_MESH=true ./hack/install.sh
 
 teardown:
 	./hack/teardown.sh


### PR DESCRIPTION
As per title, current `install-with-mesh-enabled` target has a broken indent and it does not work as below:

```
$ make install-with-mesh-enabled 
make: Nothing to be done for 'install-with-mesh-enabled'.
```

This patch fixes it.

/cc @mgencur 