### PR TITLE
[release-1.21] [SRVKE-1171] `deadLetterSinkUri` to `KafkaChannel` CRD and addressable resolver binding

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml
+++ b/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml
@@ -502,6 +502,40 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-ch-controller-addressable-resolver
+  labels:
+    kafka.eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: kafka-ch-controller
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: addressable-resolver
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-ch-dispatcher-addressable-resolver
+  labels:
+    kafka.eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: kafka-ch-dispatcher
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: addressable-resolver
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml
+++ b/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml
@@ -736,6 +736,9 @@ spec:
                     namespace:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
                       type: string
+                deadLetterSinkUri:
+                  description: DeadLetterSinkURI is the resolved URI of the dead letter sink that will be used as a fallback when not specified by Triggers.
+                  type: string
                 observedGeneration:
                   description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                   type: integer

--- a/knative-operator/hack/011-eventing-kafkachannel-dead-letter-sink-uri.patch
+++ b/knative-operator/hack/011-eventing-kafkachannel-dead-letter-sink-uri.patch
@@ -1,0 +1,14 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml b/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml
+index 5d64f171..dd9b23f2 100644
+--- a/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml
++++ b/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml
+@@ -736,6 +736,9 @@ spec:
+                     namespace:
+                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
+                       type: string
++                deadLetterSinkUri:
++                  description: DeadLetterSinkURI is the resolved URI of the dead letter sink that will be used as a fallback when not specified by Triggers.
++                  type: string
+                 observedGeneration:
+                   description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                   type: integer

--- a/knative-operator/hack/012-eventing-kafkachannel-addressable-resolver-binding.patch
+++ b/knative-operator/hack/012-eventing-kafkachannel-addressable-resolver-binding.patch
@@ -1,0 +1,45 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml b/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml
+index dd9b23f2..d128ad6c 100644
+--- a/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml
++++ b/knative-operator/deploy/resources/knativekafka/channel/1-channel-consolidated.yaml
+@@ -502,6 +502,40 @@ roleRef:
+   apiGroup: rbac.authorization.k8s.io
+ 
+ ---
++apiVersion: rbac.authorization.k8s.io/v1
++kind: ClusterRoleBinding
++metadata:
++  name: kafka-ch-controller-addressable-resolver
++  labels:
++    kafka.eventing.knative.dev/release: devel
++subjects:
++  - kind: ServiceAccount
++    name: kafka-ch-controller
++    namespace: knative-eventing
++roleRef:
++  kind: ClusterRole
++  name: addressable-resolver
++  apiGroup: rbac.authorization.k8s.io
++
++---
++
++apiVersion: rbac.authorization.k8s.io/v1
++kind: ClusterRoleBinding
++metadata:
++  name: kafka-ch-dispatcher-addressable-resolver
++  labels:
++    kafka.eventing.knative.dev/release: devel
++subjects:
++  - kind: ServiceAccount
++    name: kafka-ch-dispatcher
++    namespace: knative-eventing
++roleRef:
++  kind: ClusterRole
++  name: addressable-resolver
++  apiGroup: rbac.authorization.k8s.io
++
++---
++
+ # Copyright 2020 The Knative Authors
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -74,3 +74,6 @@ git apply "$root/knative-operator/hack/004-kafka-broker-prober-env.patch"
 
 # For now we need to add broker read access to the webhook.
 git apply "$root/knative-operator/hack/005-kafka-broker-webhook-role.patch"
+
+# Fix for SRVKE-1171
+git apply "$root/knative-operator/hack/011-eventing-kafkachannel-dead-letter-sink-uri.patch"

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -77,3 +77,4 @@ git apply "$root/knative-operator/hack/005-kafka-broker-webhook-role.patch"
 
 # Fix for SRVKE-1171
 git apply "$root/knative-operator/hack/011-eventing-kafkachannel-dead-letter-sink-uri.patch"
+git apply "$root/knative-operator/hack/012-eventing-kafkachannel-addressable-resolver-binding.patch"


### PR DESCRIPTION
See individual commits for details.