### PR TITLE
[SRVKS-893] Do not apply serving-tests namespace when already exist

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -192,6 +192,8 @@ EOF
   yq merge -a append "${rootdir}/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml" "$patchfile" | \
     oc apply -n "${SERVING_NAMESPACE}" -f -
 
+  # Create serving-tests namespace only when it does not exist.
+  ensure_namespace serving-tests
   # metadata-webhook adds istio annotations for e2e test by webhook.
   oc apply -f "${rootdir}/serving/metadata-webhook/config"
 }

--- a/serving/metadata-webhook/test/config/100-namespace.yaml
+++ b/serving/metadata-webhook/test/config/100-namespace.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: serving-tests
-  labels:
-    samples.knative.dev/release: devel


### PR DESCRIPTION
When running `make test-upstream-e2e-mesh`, `serving-tests` namespace was applied several times.
And for some reasons, the several `oc apply` drop the label in the namespace including Maistra label.

This patch changes to stop `oc apply` against namespace in metadata-webhook if it exists.
