### PR TITLE
Enable tracing for eventing by patching knativeeventing CR

### DIFF
--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -63,19 +63,8 @@ EOF
 
 function enable_eventing_tracing {
   logger.info "Configuring tracing for Eventing"
-
-  cat <<EOF | oc apply -f -
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-tracing
-  namespace: ${EVENTING_NAMESPACE}
-data:
-  enable: "true"
-  zipkin-endpoint: "http://zipkin.${ZIPKIN_NAMESPACE}.svc.cluster.local:9411/api/v2/spans"
-  sample-rate: "1.0"
-  debug: "true"
-EOF
+  oc -n "${EVENTING_NAMESPACE}" patch knativeeventing/knative-eventing --type=merge \
+    --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"http://zipkin.'"${ZIPKIN_NAMESPACE}"'.svc.cluster.local:9411/api/v2/spans", "debug":"true", "sample-rate":"1.0"}}}}'
 }
 
 function teardown_tracing {


### PR DESCRIPTION
Configuring tracing via the ConfigMap in knative-eventing namespace doesn't work as it is overwritten later by reconciling KnativeEventing CR. It worked so far only because there were tests running from eventing-kafka which were patching the knativeeventing CR. However, there's another [PR](https://github.com/openshift-knative/eventing-kafka/pull/625) for eventing-kafka that separates E2E tests and installing tracing. And the patching would not be done anymore. So, I'm fixing this here.
