### PR TITLE
Replace generateName with version-based name for Kafka-related jobs

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -153,6 +153,7 @@ for name in "${kafka_images[@]}"; do
 done
 
 # Add Knative Kafka version to the downstream operator
+add_downstream_operator_deployment_env "$target" "CURRENT_VERSION" "$(metadata.get project.version)"
 add_downstream_operator_deployment_env "$target" "KNATIVE_EVENTING_KAFKA_VERSION" "$(metadata.get dependencies.eventing_kafka)"
 
 # Override the image for the CLI artifact deployment

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -652,6 +652,8 @@ spec:
                         value: "registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-post-install"
                       - name: "KAFKA_IMAGE_knative-kafka-storage-version-migrator-__migrate"
                         value: "registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-storage-version-migration"
+                      - name: "CURRENT_VERSION"
+                        value: "1.22.0"
                       - name: "KNATIVE_EVENTING_KAFKA_VERSION"
                         value: "1.1.0"
                     securityContext:


### PR DESCRIPTION
Marek saw that we're running the post-install jobs too many times,
I believe because we're using generate name while upstream is
replacing the `generateName` field with a `name` based on the
`KnativeServing` or `KnativeEventing` version [1].

The fix is to do a similar transformation for Kafka-related jobs.

[1] https://github.com/knative/operator/blob/0f37c1e64154f4a78675feffe81c7e0c6fe3b39c/pkg/reconciler/common/job.go#L32-L57

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>