### PR TITLE
Bump golangci-lint to latest

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Go Lint - knative-operator
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.43
+          version: v1.45.2
           working-directory: ./src/github.com/${{ github.repository }}
 
       # This is mostly copied from https://github.com/get-woke/woke-action-reviewdog/blob/main/entrypoint.sh


### PR DESCRIPTION
Hitting this [multiple times](https://github.com/openshift-knative/serverless-operator/runs/5829404731?check_suite_focus=true). See discussion [here](https://coreos.slack.com/archives/CD87JDUB0/p1649082942219109). 