### PR TITLE
[release-v1.22] Like upstream we run the job transformer before the image

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -280,10 +280,10 @@ func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *serve
 		configureLegacyEventingKafka(instance.Spec.Channel),
 		operatorcommon.ConfigMapTransform(instance.Spec.Config, logging.FromContext(context.TODO())),
 		configureEventingKafka(instance.Spec),
+		replaceJobGenerateName(),
 		ImageTransform(common.BuildImageOverrideMapFromEnviron(os.Environ(), "KAFKA_IMAGE_")),
 		replicasTransform(manifest.Client),
 		configMapHashTransform(manifest.Client),
-		replaceJobGenerateName(),
 		rbacProxyTranform,
 	)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

like upstream, we run the image transformer after the one for the jobs