### PR TITLE
[release-1.21] Bump serverless operators 1.21.1

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -405,7 +405,7 @@ spec:
                 containers:
                   - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:openshift-knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:openshift-knative-operator
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -517,7 +517,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -682,7 +682,7 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:knative-openshift-ingress
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:knative-openshift-ingress
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -808,13 +808,13 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:openshift-knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:knative-openshift-ingress
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:knative-openshift-ingress
     - name: "IMAGE_queue-proxy"
       image: "registry.ci.openshift.org/openshift/knative-v1.0.1:knative-serving-queue"
     - name: "IMAGE_activator"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -413,7 +413,7 @@ spec:
                 containers:
                   - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:openshift-knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:openshift-knative-operator
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -475,7 +475,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:knative-operator
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -557,7 +557,7 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:knative-openshift-ingress
+                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:knative-openshift-ingress
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -685,12 +685,12 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:openshift-knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:knative-operator
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.0:knative-openshift-ingress
+      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.21.1:knative-openshift-ingress
   replaces:
   version:


### PR DESCRIPTION
Using the actual matching `1.21.1` images, instead of the `.0` images 