### PR TITLE
WIP: [SRVKS-911] Move net-kourier controller into knative-serving namespace

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/ingress/1.1/kourier.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/1.1/kourier.yaml
@@ -119,7 +119,7 @@ data:
                 endpoint:
                   address:
                     socket_address:
-                      address: "net-kourier-controller"
+                      address: "net-kourier-controller.knative-serving"
                       port_value: 18000
           http2_protocol_options: {}
           type: STRICT_DNS

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -90,8 +90,6 @@ download_ingress net-istio "v$(metadata.get dependencies.net_istio)" "${istio_fi
 url="https://github.com/knative-sandbox/net-kourier/releases/download/knative-v$(metadata.get dependencies.kourier)/kourier.yaml"
 kourier_file="$root/openshift-knative-operator/cmd/operator/kodata/ingress/$(versions.major_minor "${KNATIVE_SERVING_VERSION}")/kourier.yaml"
 wget --no-check-certificate "$url" -O "$kourier_file"
-# TODO: [SRVKS-610] These values should be replaced by operator instead of sed.
-sed -i -e 's/net-kourier-controller.knative-serving/net-kourier-controller/g' "$kourier_file"
 # Break all image references so we know our overrides work correctly.
 yaml.break_image_references "$kourier_file"
 

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -158,11 +158,23 @@ func (e *extension) Reconcile(ctx context.Context, comp operatorv1alpha1.KCompon
 		common.ConfigureIfUnset(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 	}
 
+	// Explicitly remove deleted Kourier resources.
+	// TODO: Remove after resources are bumped to 1.3
+	if err := removeObsoleteResources(ctx, e.kubeclient, ks); err != nil {
+		return err
+	}
+
 	return monitoring.ReconcileMonitoringForServing(ctx, e.kubeclient, ks)
 }
 
 func (e *extension) Finalize(ctx context.Context, comp operatorv1alpha1.KComponent) error {
 	ks := comp.(*operatorv1alpha1.KnativeServing)
+
+	// Explicitly remove deleted Kourier resources.
+	// TODO: Remove after resources are bumped to 1.3
+	if err := removeObsoleteResources(ctx, e.kubeclient, ks); err != nil {
+		return err
+	}
 
 	// Delete the ingress namespaces manually. Manifestival won't do it for us in upgrade cases.
 	// See: https://github.com/manifestival/manifestival/issues/85

--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -9,18 +9,30 @@ import (
 	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
+var gatewayResources = map[string]string{
+	"knative-serving":        "Namespace",
+	"kourier":                "Service",
+	"kourier-internal":       "Service",
+	"3scale-kourier-gateway": "Deployment",
+	"kourier-bootstrap":      "ConfigMap",
+}
+
 const (
 	providerLabel           = "networking.knative.dev/ingress-provider"
 	kourierIngressClassName = "kourier.ingress.networking.knative.dev"
 )
 
-// overrideKourierNamespace overrides the namespace of all Kourier related resources to
+// overrideKourierNamespace overrides the namespace of Kourier Gateway related resources to
 // the -ingress suffix to be backwards compatible.
 func overrideKourierNamespace(ks operatorv1alpha1.KComponent) mf.Transformer {
 	nsInjector := mf.InjectNamespace(kourierNamespace(ks.GetNamespace()))
 	return func(u *unstructured.Unstructured) error {
 		provider := u.GetLabels()[providerLabel]
 		if provider != "kourier" {
+			return nil
+		}
+
+		if gatewayResources[u.GetName()] != u.GetKind() {
 			return nil
 		}
 

--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -1,11 +1,19 @@
 package serving
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
 	mf "github.com/manifestival/manifestival"
 	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
@@ -60,4 +68,30 @@ func addHTTPOptionDisabledEnvValue() mf.Transformer {
 	return common.InjectEnvironmentIntoDeployment("net-kourier-controller", "controller",
 		corev1.EnvVar{Name: "KOURIER_HTTPOPTION_DISABLED", Value: "true"},
 	)
+}
+
+// removeObsoleteResources removes all resources that couldn't automatically be cleaned up
+// due to namespace transformation.
+// TODO: Remove after resources are bumped to 1.3. (TODO update to 1.4)
+func removeObsoleteResources(ctx context.Context, kubeclient kubernetes.Interface, ks v1alpha1.KComponent) error {
+	if !ks.GetStatus().IsReady() || !strings.Contains(ks.GetStatus().GetVersion(), "1.1.") { // TODO: Update to 1.2.
+		// Do nothing while we're not completely rolled out yet.
+		return nil
+	}
+
+	ns := kourierNamespace(ks.GetNamespace())
+
+	if err := kubeclient.CoreV1().ConfigMaps(ns).Delete(ctx, "config-kourier", metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete obsolete ConfigMap: %w", err)
+	}
+	if err := kubeclient.CoreV1().ServiceAccounts(ns).Delete(ctx, "net-kourier", metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete obsolete ServiceAccount: %w", err)
+	}
+	if err := kubeclient.AppsV1().Deployments(ns).Delete(ctx, "net-kourier-controller", metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete obsolete Deployment: %w", err)
+	}
+	if err := kubeclient.CoreV1().Services(ns).Delete(ctx, "net-kourier-controller", metav1.DeleteOptions{}); !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete obsolete Service: %w", err)
+	}
+	return nil
 }

--- a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/ingress/kourier.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/ingress/kourier.go
@@ -60,7 +60,8 @@ func replaceGWNamespace() mf.Transformer {
 				for j := range c.Env {
 					envVar := &c.Env[j]
 					if envVar.Name == kourierGatewayNSEnvVarKey {
-						envVar.Value = deployment.GetNamespace()
+						//envVar.Value = deployment.GetNamespace()
+						envVar.Value = "knative-serving-ingress"
 					}
 				}
 			}


### PR DESCRIPTION
Since upstream net-kourier controller starts watching config-network
configmap. The configmap and controller must be deploeyd in the same
namespace.