### PR TITLE
Verify post-install jobs succeeded during eventing and Kafka e2e tests

### DIFF
--- a/test/e2e/knative_eventing_test.go
+++ b/test/e2e/knative_eventing_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/monitoringe2e"
+	"github.com/openshift-knative/serverless-operator/test/upgrade"
 )
 
 const (
@@ -51,5 +52,12 @@ func TestKnativeEventing(t *testing.T) {
 
 	t.Run("make sure no gcr.io references are there", func(t *testing.T) {
 		VerifyNoDisallowedImageReference(t, caCtx, eventingNamespace)
+	})
+
+	t.Run("Verify job succeeded", func(t *testing.T) {
+		upgrade.VerifyPostInstallJobs(upgrade.VerifyPostJobsConfig{
+			Namespace:    eventingNamespace,
+			FailOnNoJobs: true,
+		})
 	})
 }

--- a/test/e2ekafka/knative_kafka_test.go
+++ b/test/e2ekafka/knative_kafka_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/e2e"
 	"github.com/openshift-knative/serverless-operator/test/monitoringe2e"
+	"github.com/openshift-knative/serverless-operator/test/upgrade"
 )
 
 const (
@@ -124,5 +125,12 @@ func TestKnativeKafka(t *testing.T) {
 		if err := caCtx.Clients.Kafka.MessagingV1beta1().KafkaChannels(knativeKafkaNamespace).Delete(context.Background(), ch.Name, metav1.DeleteOptions{}); err != nil {
 			t.Fatal("Failed to remove Knative Channel", err)
 		}
+	})
+
+	t.Run("Verify job succeeded", func(t *testing.T) {
+		upgrade.VerifyPostInstallJobs(upgrade.VerifyPostJobsConfig{
+			Namespace:    knativeKafkaNamespace,
+			FailOnNoJobs: true,
+		})
 	})
 }


### PR DESCRIPTION
Given the recents accidental bad merge, I'd like to verify that
post-install jobs succeed during e2e tests as well.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>