### PR TITLE
Handle already succeeded jobs in verify jobs

### DIFF
--- a/test/upgrade/verify_jobs.go
+++ b/test/upgrade/verify_jobs.go
@@ -46,6 +46,13 @@ func verifyPostInstallJobs(ctx context.Context, c upgrade.Context, cfg VerifyPos
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, j := range jobs.Items {
 		j := j
+
+		if j.Status.Succeeded > 0 {
+			// We don't need to wait for a job that is already succeeded.
+			// In addition, an already succeeded job might go away due to the job's TTL.
+			continue
+		}
+
 		eg.Go(func() error {
 			err := wait.Poll(5*time.Second, 10*time.Minute, func() (done bool, err error) {
 				j, err := kubeClient.


### PR DESCRIPTION
In this error
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/1490/pull-ci-openshift-knative-serverless-operator-main-4.10-upgrade-tests-aws-ocp-410/1513811936028921856#1:build-log.txt%3A29021
we have a succeeded job that wasn't found when we try to get
it again, this patch handles these cases (see comment in code
for more info)

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>