### PR TITLE
[release-1.22][SRVKE-1202] Add ConfigMap knative-eventing/config-kafka-source-defaults  (#1499)

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/broker/1-eventing-kafka-broker.yaml
+++ b/knative-operator/deploy/resources/knativekafka/broker/1-eventing-kafka-broker.yaml
@@ -527,3 +527,61 @@ spec:
 
 
 ---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-kafka-source-defaults
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: "b6ed351d"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # autoscalingClass is the autoscaler class name to use.
+    # valid value: keda.autoscaling.knative.dev
+    # autoscalingClass: ""
+
+    # minScale is the minimum number of replicas to scale down to.
+    # minScale: "1"
+
+    # maxScale is the maximum number of replicas to scale up to.
+    # maxScale: "1"
+
+    # pollingInterval is the interval in seconds KEDA uses to poll metrics.
+    # pollingInterval: "30"
+
+    # cooldownPeriod is the period of time in seconds KEDA waits until it scales down.
+    # cooldownPeriod: "300"
+
+    # kafkaLagThreshold is the lag (ie. number of messages in a partition) threshold for KEDA to scale up sources.
+    # kafkaLagThreshold: "10"

--- a/knative-operator/hack/017-eventing-kafka-configmap-knative-eventing-config-kafka-source-defaults.patch
+++ b/knative-operator/hack/017-eventing-kafka-configmap-knative-eventing-config-kafka-source-defaults.patch
@@ -1,0 +1,66 @@
+diff --git a/knative-operator/deploy/resources/knativekafka/broker/1-eventing-kafka-broker.yaml b/knative-operator/deploy/resources/knativekafka/broker/1-eventing-kafka-broker.yaml
+index f69388e9..c9eb9134 100644
+--- a/knative-operator/deploy/resources/knativekafka/broker/1-eventing-kafka-broker.yaml
++++ b/knative-operator/deploy/resources/knativekafka/broker/1-eventing-kafka-broker.yaml
+@@ -527,3 +527,61 @@ spec:
+ 
+ 
+ ---
++# Copyright 2020 The Knative Authors
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++apiVersion: v1
++kind: ConfigMap
++metadata:
++  name: config-kafka-source-defaults
++  namespace: knative-eventing
++  labels:
++    kafka.eventing.knative.dev/release: devel
++  annotations:
++    knative.dev/example-checksum: "b6ed351d"
++data:
++  _example: |
++    ################################
++    #                              #
++    #    EXAMPLE CONFIGURATION     #
++    #                              #
++    ################################
++
++    # This block is not actually functional configuration,
++    # but serves to illustrate the available configuration
++    # options and document them in a way that is accessible
++    # to users that `kubectl edit` this config map.
++    #
++    # These sample configuration options may be copied out of
++    # this example block and unindented to be in the data block
++    # to actually change the configuration.
++
++    # autoscalingClass is the autoscaler class name to use.
++    # valid value: keda.autoscaling.knative.dev
++    # autoscalingClass: ""
++
++    # minScale is the minimum number of replicas to scale down to.
++    # minScale: "1"
++
++    # maxScale is the maximum number of replicas to scale up to.
++    # maxScale: "1"
++
++    # pollingInterval is the interval in seconds KEDA uses to poll metrics.
++    # pollingInterval: "30"
++
++    # cooldownPeriod is the period of time in seconds KEDA waits until it scales down.
++    # cooldownPeriod: "300"
++
++    # kafkaLagThreshold is the lag (ie. number of messages in a partition) threshold for KEDA to scale up sources.
++    # kafkaLagThreshold: "10"

--- a/knative-operator/hack/update-manifests.sh
+++ b/knative-operator/hack/update-manifests.sh
@@ -80,5 +80,8 @@ git apply "$root/knative-operator/hack/012-eventing-kafkachannel-addressable-res
 
 git apply "$root/knative-operator/hack/013-eventing-generate-name-jobs.patch"
 
+# SRVKE-1202 temporary fix for a missing ConfigMap knative-eventing/config-kafka-source-defaults
+git apply "$root/knative-operator/hack/017-eventing-kafka-configmap-knative-eventing-config-kafka-source-defaults.patch"
+
 # SRVKE-1184 Migration to Broker components
 git apply "$root/knative-operator/hack/014-eventing-kafka-lease-name-remapping.patch"


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift-knative/serverless-operator/commit/ea8732d671de4b6def48d7bd7021e49868bb58ac

This ConfigMap is used by the KEDA integration, while it's not a supported
integration leaving a zombie resource isn't what we want.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>