### PR TITLE
Prevent deleting knative-serving NS when uninstalling Service Mesh

### DIFF
--- a/hack/lib/mesh.bash
+++ b/hack/lib/mesh.bash
@@ -89,9 +89,7 @@ function deploy_gateways {
       --key="${out_dir}"/wildcard.key \
       --cert="${out_dir}"/wildcard.crt --dry-run=client -o yaml | oc apply -f -
 
-  if ! oc get namespace "${SERVING_NAMESPACE}" &>/dev/null; then
-    oc create namespace "${SERVING_NAMESPACE}"
-  fi
+  oc apply -f "${resources_dir}"/namespace.yaml || return $?
   oc apply -f "${resources_dir}"/gateway.yaml || return $?
   oc apply -f "${resources_dir}"/peerauthentication.yaml || return $?
 }

--- a/hack/lib/mesh.bash
+++ b/hack/lib/mesh.bash
@@ -89,6 +89,9 @@ function deploy_gateways {
       --key="${out_dir}"/wildcard.key \
       --cert="${out_dir}"/wildcard.crt --dry-run=client -o yaml | oc apply -f -
 
+  if ! oc get namespace "${SERVING_NAMESPACE}" &>/dev/null; then
+    oc create namespace "${SERVING_NAMESPACE}"
+  fi
   oc apply -f "${resources_dir}"/gateway.yaml || return $?
   oc apply -f "${resources_dir}"/peerauthentication.yaml || return $?
 }

--- a/hack/lib/mesh_resources/gateway.yaml
+++ b/hack/lib/mesh_resources/gateway.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: knative-serving
----
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:

--- a/hack/lib/mesh_resources/namespace.yaml
+++ b/hack/lib/mesh_resources/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving


### PR DESCRIPTION
Pulling this commit out of https://github.com/openshift-knative/serverless-operator/pull/1453 and sending it separately.