### PR TITLE
Move test namespace definitions to flags.go

### DIFF
--- a/test/eventinge2e/source_broker_ksvc_test.go
+++ b/test/eventinge2e/source_broker_ksvc_test.go
@@ -27,16 +27,16 @@ func TestKnativeSourceBrokerTriggerKnativeService(t *testing.T) {
 	client := test.SetupClusterAdmin(t)
 	cleanup := func() {
 		test.CleanupAll(t, client)
-		client.Clients.Eventing.EventingV1().Brokers(testNamespace).Delete(context.Background(), brokerName, metav1.DeleteOptions{})
-		client.Clients.Eventing.EventingV1().Triggers(testNamespace).Delete(context.Background(), triggerName, metav1.DeleteOptions{})
-		client.Clients.Eventing.SourcesV1().PingSources(testNamespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
-		client.Clients.Kube.CoreV1().ConfigMaps(testNamespace).Delete(context.Background(), cmName, metav1.DeleteOptions{})
+		client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Delete(context.Background(), brokerName, metav1.DeleteOptions{})
+		client.Clients.Eventing.EventingV1().Triggers(test.Namespace).Delete(context.Background(), triggerName, metav1.DeleteOptions{})
+		client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
+		client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 	}
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()
 
 	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, testNamespace, image)
+	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, image)
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}
@@ -51,14 +51,14 @@ apiVersion: %q
 kind: %q`, channelAPIVersion, channelKind),
 		},
 	}
-	configMap, err := client.Clients.Kube.CoreV1().ConfigMaps(testNamespace).Create(context.Background(), cm, metav1.CreateOptions{})
+	configMap, err := client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Create(context.Background(), cm, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("Unable to create ConfigMap: ", err)
 	}
 	br := &eventingv1.Broker{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      brokerName,
-			Namespace: testNamespace,
+			Namespace: test.Namespace,
 		},
 		Spec: eventingv1.BrokerSpec{
 			Config: &duckv1.KReference{
@@ -68,14 +68,14 @@ kind: %q`, channelAPIVersion, channelKind),
 			},
 		},
 	}
-	broker, err := client.Clients.Eventing.EventingV1().Brokers(testNamespace).Create(context.Background(), br, metav1.CreateOptions{})
+	broker, err := client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Create(context.Background(), br, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("Unable to create broker: ", err)
 	}
 	tr := &eventingv1.Trigger{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      triggerName,
-			Namespace: testNamespace,
+			Namespace: test.Namespace,
 		},
 		Spec: eventingv1.TriggerSpec{
 			Broker: broker.Name,
@@ -88,7 +88,7 @@ kind: %q`, channelAPIVersion, channelKind),
 			},
 		},
 	}
-	_, err = client.Clients.Eventing.EventingV1().Triggers(testNamespace).Create(context.Background(), tr, metav1.CreateOptions{})
+	_, err = client.Clients.Eventing.EventingV1().Triggers(test.Namespace).Create(context.Background(), tr, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("Unable to create trigger: ", err)
 	}
@@ -96,7 +96,7 @@ kind: %q`, channelAPIVersion, channelKind),
 	ps := &sourcesv1.PingSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pingSourceName,
-			Namespace: testNamespace,
+			Namespace: test.Namespace,
 		},
 		Spec: sourcesv1.PingSourceSpec{
 			Data: helloWorldText,
@@ -111,7 +111,7 @@ kind: %q`, channelAPIVersion, channelKind),
 			},
 		},
 	}
-	_, err = client.Clients.Eventing.SourcesV1().PingSources(testNamespace).Create(context.Background(), ps, metav1.CreateOptions{})
+	_, err = client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), ps, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("Knative PingSource not created: %+V", err)
 	}

--- a/test/eventinge2e/source_channel_ksvc_test.go
+++ b/test/eventinge2e/source_channel_ksvc_test.go
@@ -24,15 +24,15 @@ func TestKnativeSourceChannelKnativeService(t *testing.T) {
 	client := test.SetupClusterAdmin(t)
 	cleanup := func() {
 		test.CleanupAll(t, client)
-		client.Clients.Eventing.MessagingV1().Subscriptions(testNamespace).Delete(context.Background(), subscriptionName, metav1.DeleteOptions{})
-		client.Clients.Eventing.MessagingV1().Channels(testNamespace).Delete(context.Background(), channelName, metav1.DeleteOptions{})
-		client.Clients.Eventing.SourcesV1().PingSources(testNamespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
+		client.Clients.Eventing.MessagingV1().Subscriptions(test.Namespace).Delete(context.Background(), subscriptionName, metav1.DeleteOptions{})
+		client.Clients.Eventing.MessagingV1().Channels(test.Namespace).Delete(context.Background(), channelName, metav1.DeleteOptions{})
+		client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
 	}
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()
 
 	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, testNamespace, image)
+	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, image)
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}
@@ -40,17 +40,17 @@ func TestKnativeSourceChannelKnativeService(t *testing.T) {
 	imc := &messagingv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      channelName,
-			Namespace: testNamespace,
+			Namespace: test.Namespace,
 		},
 	}
-	channel, err := client.Clients.Eventing.MessagingV1().Channels(testNamespace).Create(context.Background(), imc, metav1.CreateOptions{})
+	channel, err := client.Clients.Eventing.MessagingV1().Channels(test.Namespace).Create(context.Background(), imc, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("Unable to create Channel: ", err)
 	}
 	subscription := &messagingv1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      subscriptionName,
-			Namespace: testNamespace,
+			Namespace: test.Namespace,
 		},
 		Spec: messagingv1.SubscriptionSpec{
 			Channel: duckv1.KReference{
@@ -67,14 +67,14 @@ func TestKnativeSourceChannelKnativeService(t *testing.T) {
 			},
 		},
 	}
-	_, err = client.Clients.Eventing.MessagingV1().Subscriptions(testNamespace).Create(context.Background(), subscription, metav1.CreateOptions{})
+	_, err = client.Clients.Eventing.MessagingV1().Subscriptions(test.Namespace).Create(context.Background(), subscription, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("Unable to create Subscription: ", err)
 	}
 	ps := &sourcesv1.PingSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pingSourceName,
-			Namespace: testNamespace,
+			Namespace: test.Namespace,
 		},
 		Spec: sourcesv1.PingSourceSpec{
 			Data: helloWorldText,
@@ -89,7 +89,7 @@ func TestKnativeSourceChannelKnativeService(t *testing.T) {
 			},
 		},
 	}
-	_, err = client.Clients.Eventing.SourcesV1().PingSources(testNamespace).Create(context.Background(), ps, metav1.CreateOptions{})
+	_, err = client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), ps, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("Knative PingSource not created: %+V", err)
 	}

--- a/test/eventinge2e/source_to_ksvc_test.go
+++ b/test/eventinge2e/source_to_ksvc_test.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	pingSourceName    = "smoke-test-ping"
-	testNamespace     = "serverless-tests"
 	image             = "gcr.io/knative-samples/helloworld-go"
 	helloWorldService = "helloworld-go"
 	helloWorldText    = "Hello World!"
@@ -26,13 +25,13 @@ func TestKnativeSourceToKnativeService(t *testing.T) {
 	client := test.SetupClusterAdmin(t)
 	cleanup := func() {
 		test.CleanupAll(t, client)
-		client.Clients.Eventing.SourcesV1().PingSources(testNamespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
+		client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
 	}
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()
 
 	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, testNamespace, image)
+	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, image)
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}
@@ -40,7 +39,7 @@ func TestKnativeSourceToKnativeService(t *testing.T) {
 	ps := &sourcesv1.PingSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pingSourceName,
-			Namespace: testNamespace,
+			Namespace: test.Namespace,
 		},
 		Spec: sourcesv1.PingSourceSpec{
 			Data: helloWorldText,
@@ -55,7 +54,7 @@ func TestKnativeSourceToKnativeService(t *testing.T) {
 			},
 		},
 	}
-	_, err = client.Clients.Eventing.SourcesV1().PingSources(testNamespace).Create(context.Background(), ps, metav1.CreateOptions{})
+	_, err = client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), ps, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("Knative PingSource not created: %+V", err)
 	}

--- a/test/flags.go
+++ b/test/flags.go
@@ -8,6 +8,11 @@ import (
 	"testing"
 )
 
+const (
+	Namespace  = "serverless-tests"
+	Namespace2 = "serverless-tests2"
+)
+
 // Flags holds the initialized test flags
 var Flags = initializeFlags()
 

--- a/test/servinge2e/deploy_kn_k8s_svc_in_same_namespace_test.go
+++ b/test/servinge2e/deploy_kn_k8s_svc_in_same_namespace_test.go
@@ -19,16 +19,16 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	defer test.CleanupAll(t, caCtx)
 
 	//Create deployment
-	err := test.CreateDeployment(caCtx, kubeHelloworldService, testNamespace2, image)
+	err := test.CreateDeployment(caCtx, kubeHelloworldService, test.Namespace2, image)
 	if err != nil {
 		t.Fatal("Deployment not created", err)
 	}
 	// Deploy plain Kube service
-	svc, err := createKubeService(caCtx, kubeHelloworldService, testNamespace2)
+	svc, err := createKubeService(caCtx, kubeHelloworldService, test.Namespace2)
 	if err != nil {
 		t.Fatal("Kubernetes service not created", err)
 	}
-	route, err := withRouteForServiceReady(caCtx, svc.Name, testNamespace2)
+	route, err := withRouteForServiceReady(caCtx, svc.Name, test.Namespace2)
 	if err != nil {
 		t.Fatal("Failed to create route for service", svc.Name, err)
 	}
@@ -41,7 +41,7 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, kubeServiceURL, helloworldText)
 
 	// Deploy Knative service in the same namespace
-	ksvc, err := test.WithServiceReady(caCtx, helloworldService, testNamespace2, image)
+	ksvc, err := test.WithServiceReady(caCtx, helloworldService, test.Namespace2, image)
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}
@@ -51,7 +51,7 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, kubeServiceURL, helloworldText)
 
 	// Delete Knative service
-	if err = caCtx.Clients.Serving.ServingV1().Services(testNamespace2).Delete(context.Background(), ksvc.Name, metav1.DeleteOptions{}); err != nil {
+	if err = caCtx.Clients.Serving.ServingV1().Services(test.Namespace2).Delete(context.Background(), ksvc.Name, metav1.DeleteOptions{}); err != nil {
 		t.Fatal("Failed to remove service", err)
 	}
 
@@ -59,18 +59,18 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, kubeServiceURL, helloworldText)
 
 	// Remove the Kube service
-	if err = caCtx.Clients.Route.Routes(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+	if err = caCtx.Clients.Route.Routes(test.Namespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
 		t.Fatal("Failed to remove route", err)
 	}
-	if err = caCtx.Clients.Kube.CoreV1().Services(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+	if err = caCtx.Clients.Kube.CoreV1().Services(test.Namespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
 		t.Fatal("Failed to remove service", err)
 	}
-	if err = caCtx.Clients.Kube.AppsV1().Deployments(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+	if err = caCtx.Clients.Kube.AppsV1().Deployments(test.Namespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
 		t.Fatal("Failed to remove deployment", err)
 	}
 
 	// Deploy Knative service in the namespace first
-	ksvc, err = test.WithServiceReady(caCtx, helloworldService2, testNamespace2, image)
+	ksvc, err = test.WithServiceReady(caCtx, helloworldService2, test.Namespace2, image)
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}
@@ -79,16 +79,16 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
 
 	//Create deployment
-	err = test.CreateDeployment(caCtx, kubeHelloworldService, testNamespace2, image)
+	err = test.CreateDeployment(caCtx, kubeHelloworldService, test.Namespace2, image)
 	if err != nil {
 		t.Fatal("Deployment not created", err)
 	}
 	// Deploy plain Kube service
-	svc, err = createKubeService(caCtx, kubeHelloworldService, testNamespace2)
+	svc, err = createKubeService(caCtx, kubeHelloworldService, test.Namespace2)
 	if err != nil {
 		t.Fatal("Kubernetes service not created", err)
 	}
-	route, err = withRouteForServiceReady(caCtx, svc.Name, testNamespace2)
+	route, err = withRouteForServiceReady(caCtx, svc.Name, test.Namespace2)
 	if err != nil {
 		t.Fatal("Failed to create route for service", svc.Name, err)
 	}
@@ -102,13 +102,13 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, kubeServiceURL, helloworldText)
 
 	// Remove the Kube service
-	if err = caCtx.Clients.Route.Routes(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+	if err = caCtx.Clients.Route.Routes(test.Namespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
 		t.Fatal("Failed to remove route", err)
 	}
-	if err = caCtx.Clients.Kube.CoreV1().Services(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+	if err = caCtx.Clients.Kube.CoreV1().Services(test.Namespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
 		t.Fatal("Failed to remove service", err)
 	}
-	if err = caCtx.Clients.Kube.AppsV1().Deployments(testNamespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
+	if err = caCtx.Clients.Kube.AppsV1().Deployments(test.Namespace2).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {
 		t.Fatal("Failed to remove deployment", err)
 	}
 
@@ -116,7 +116,7 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
 
 	// Delete the Knative service
-	if err = caCtx.Clients.Serving.ServingV1().Services(testNamespace2).Delete(context.Background(), ksvc.Name, metav1.DeleteOptions{}); err != nil {
+	if err = caCtx.Clients.Serving.ServingV1().Services(test.Namespace2).Delete(context.Background(), ksvc.Name, metav1.DeleteOptions{}); err != nil {
 		t.Fatal("Failed to remove service", err)
 	}
 }

--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	testNamespace2        = "serverless-tests2"
 	image                 = "gcr.io/knative-samples/helloworld-go"
 	helloworldService     = "helloworld-go"
 	helloworldService2    = "helloworld-go2"

--- a/test/servinge2e/kourier/custom_route_test.go
+++ b/test/servinge2e/kourier/custom_route_test.go
@@ -38,7 +38,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	defer test.CleanupAll(t, caCtx)
 
 	// Create Kservice with disable Annotation.
-	ksvc := test.Service(serviceName, testNamespace, image, nil)
+	ksvc := test.Service(serviceName, test.Namespace, image, nil)
 	ksvc.ObjectMeta.Annotations = map[string]string{resources.DisableRouteAnnotation: "true"}
 	ksvc = withServiceReadyOrFail(caCtx, ksvc)
 
@@ -90,7 +90,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	dm := &servingv1alpha1.DomainMapping{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        domainMappingName,
-			Namespace:   testNamespace,
+			Namespace:   test.Namespace,
 			Annotations: map[string]string{resources.DisableRouteAnnotation: "true"},
 		},
 		Spec: servingv1alpha1.DomainMappingSpec{

--- a/test/servinge2e/kourier/helpers.go
+++ b/test/servinge2e/kourier/helpers.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	testNamespace  = "serverless-tests"
 	image          = "gcr.io/knative-samples/helloworld-go"
 	helloworldText = "Hello World!"
 )

--- a/test/servinge2e/kourier/service_to_service_test.go
+++ b/test/servinge2e/kourier/service_to_service_test.go
@@ -56,7 +56,7 @@ func TestServiceToServiceCalls(t *testing.T) {
 	for _, scenario := range tests {
 		scenario := scenario
 		t.Run(scenario.name, func(t *testing.T) {
-			testServiceToService(t, caCtx, testNamespace, scenario)
+			testServiceToService(t, caCtx, test.Namespace, scenario)
 		})
 	}
 }

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -113,7 +113,7 @@ func runTestForAllServiceMeshVersions(t *testing.T, testFunc func(ctx *test.Cont
 			version.smcpCreationFunc(ctx)
 
 			// Follow documented steps to add a namespace to ServiceMesh (including NetworkPolicy setup and namespace labels)
-			setupNamespaceForServiceMesh(ctx, serviceMeshTestNamespaceName, testNamespace)
+			setupNamespaceForServiceMesh(ctx, serviceMeshTestNamespaceName, test.Namespace)
 
 			test.WaitForServiceMeshControlPlaneReady(ctx, smcpName, serviceMeshTestNamespaceName)
 
@@ -191,7 +191,7 @@ func TestKsvcWithServiceMeshSidecar(t *testing.T) {
 		for _, scenario := range tests {
 			scenario := scenario
 			t.Run(scenario.name, func(t *testing.T) {
-				testServiceToService(t, ctx, testNamespace, scenario)
+				testServiceToService(t, ctx, test.Namespace, scenario)
 			})
 		}
 	})
@@ -355,7 +355,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 		// istio-pilot caches the JWKS content if a new Policy has the same jwksUri as some old policy.
 		// Rerunning this test would fail if we kept the jwksUri constant across invocations then,
 		// hence the random suffix for the jwks ksvc.
-		jwksKsvc := test.Service(helpers.AppendRandomString("jwks"), testNamespace, "quay.io/openshift-knative/hello-openshift", nil)
+		jwksKsvc := test.Service(helpers.AppendRandomString("jwks"), test.Namespace, "quay.io/openshift-knative/hello-openshift", nil)
 		jwksKsvc.Spec.Template.Spec.Containers[0].Env = append(jwksKsvc.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 			Name:  "RESPONSE",
 			Value: jwks,
@@ -375,7 +375,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 					"kind":       "Policy",
 					"metadata": map[string]interface{}{
 						"name":      "default",
-						"namespace": testNamespace,
+						"namespace": test.Namespace,
 					},
 					"spec": map[string]interface{}{
 						"principalBinding": "USE_ORIGIN",
@@ -418,7 +418,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 					"kind":       "RequestAuthentication",
 					"metadata": map[string]interface{}{
 						"name":      "jwt-example",
-						"namespace": testNamespace,
+						"namespace": test.Namespace,
 					},
 					"spec": map[string]interface{}{
 						"jwtRules": []map[string]interface{}{
@@ -445,7 +445,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 					"kind":       "AuthorizationPolicy",
 					"metadata": map[string]interface{}{
 						"name":      "allowlist-by-paths",
-						"namespace": testNamespace,
+						"namespace": test.Namespace,
 					},
 					"spec": map[string]interface{}{
 						"action": "ALLOW",
@@ -481,7 +481,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 					"kind":       "AuthorizationPolicy",
 					"metadata": map[string]interface{}{
 						"name":      "require-jwt",
-						"namespace": testNamespace,
+						"namespace": test.Namespace,
 					},
 					"spec": map[string]interface{}{
 						"action": "ALLOW",
@@ -506,7 +506,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 		}
 
 		// Create a test ksvc, should be accessible only via proper JWT token
-		testKsvc := test.Service("jwt-test", testNamespace, image, map[string]string{
+		testKsvc := test.Service("jwt-test", test.Namespace, image, map[string]string{
 			"sidecar.istio.io/inject":                "true",
 			"sidecar.istio.io/rewriteAppHTTPProbers": "true",
 		})
@@ -656,7 +656,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 
 func lookupOpenShiftRouterIP(ctx *test.Context) net.IP {
 	// Deploy an auxiliary ksvc accessible via an OpenShift route, so that we have a route hostname that we can resolve
-	aux := test.Service("aux", testNamespace, image, nil)
+	aux := test.Service("aux", test.Namespace, image, nil)
 	aux = withServiceReadyOrFail(ctx, aux)
 
 	ips, err := net.LookupIP(aux.Status.URL.Host)

--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -17,7 +17,7 @@ func TestKnativeServiceHTTPS(t *testing.T) {
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
 	defer test.CleanupAll(t, caCtx)
 
-	ksvc, err := test.WithServiceReady(caCtx, "https-service", testNamespace, image)
+	ksvc, err := test.WithServiceReady(caCtx, "https-service", test.Namespace, image)
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}
@@ -49,7 +49,7 @@ func TestKnativeServiceHTTPRedirect(t *testing.T) {
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
 	defer test.CleanupAll(t, caCtx)
 
-	ksvc := test.Service("redirect-service", testNamespace, image, nil)
+	ksvc := test.Service("redirect-service", test.Namespace, image, nil)
 	ksvc.ObjectMeta.Annotations = map[string]string{"networking.knative.dev/httpOption": "redirected"}
 	ksvc = withServiceReadyOrFail(caCtx, ksvc)
 


### PR DESCRIPTION
We had the testNamespace and testNamespace re-defined in multiple places. This PR moves them to a common place.

Pulling this out of https://github.com/openshift-knative/serverless-operator/pull/1453 and sending it separately.