### PR TITLE
Use the nightly built image for the metadata webhook

### DIFF
--- a/serving/metadata-webhook/config/webhook.yaml
+++ b/serving/metadata-webhook/config/webhook.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: controller
       containers:
       - name: webhook
-        image: quay.io/skontopo/openshift-serverless:metadata-webhook
+        image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:metadata-webhook
         resources:
           requests:
             cpu: 20m


### PR DESCRIPTION
As per title. We used the previous value as a temporary solution for the pr that upgraded the image code, pls check [here](https://github.com/openshift-knative/serverless-operator/pull/1494#issuecomment-1095669897).