### PR TITLE
Remove redundant ContinualTest from knative/eventing

### DIFF
--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -53,7 +53,6 @@ func TestServerlessUpgrade(t *testing.T) {
 					servingupgrade.ProbeTest(),
 					servingupgrade.AutoscaleSustainingWithTBCTest(),
 					servingupgrade.AutoscaleSustainingTest(),
-					eventingupgrade.ContinualTest(),
 				},
 				kafkaupgrade.ChannelContinualTests(continual.ChannelTestOptions{}),
 				kafkabrokerupgrade.BrokerContinualTests(),


### PR DESCRIPTION
The test is identical to BrokerBackedByChannelTest because in
serverless-operator repo we set up KafkaChannel as the default channel
before the test suite. Both tests deploy Broker and Trigger and use
KafkaChannel in the background. The tests are vendored from different
repositories and due to the settings we have they test the same
configuration.