### PR TITLE
Remove redundant source-config.toml

### DIFF
--- a/test/upgrade/continual/source-config.toml
+++ b/test/upgrade/continual/source-config.toml
@@ -1,1 +1,0 @@
-../../../vendor/knative.dev/eventing-kafka/test/upgrade/continual/source-config.toml


### PR DESCRIPTION
The kafka source tests now use kafka-sink-source-config.toml from the
knative-kafka-broker repo.