### PR TITLE
Print traces for missed events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -156,9 +156,9 @@ require (
 
 replace (
 	// Knative forks.
-	knative.dev/eventing => github.com/openshift/knative-eventing v0.99.1-0.20220408065219-104a546bc063
+	knative.dev/eventing => github.com/openshift/knative-eventing v0.99.1-0.20220421094847-2f5934a57f07
 	knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20220331121128-d72948ffaf32
-	knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20220415152823-78c569154a7d
+	knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20220421085255-bd4340fb17e9
 	knative.dev/serving => github.com/openshift/knative-serving v0.10.1-0.20220413035834-cc8e56c905aa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1230,8 +1230,8 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openshift-knative/eventing-kafka v0.19.1-0.20220331121128-d72948ffaf32 h1:Bh8XRFANNSJCj4uB1hBqR7D4jukrX5rHUFcpDD265H0=
 github.com/openshift-knative/eventing-kafka v0.19.1-0.20220331121128-d72948ffaf32/go.mod h1:Y9+hHdaYCmD46PPOU2pAfWCUXJyIfgJOnkWZwsBAEoU=
-github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20220415152823-78c569154a7d h1:ocYH4ZN2xEkRGusvpCopYHQbJ4H9tOCLbHH0tZSBQl4=
-github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20220415152823-78c569154a7d/go.mod h1:9yLPTwiEKPfg0n3t0gCTHjXHAxO2zoCPMg6BMUFl7XQ=
+github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20220421085255-bd4340fb17e9 h1:iWiA+mOgAnRMLDcU2JJo0xJgEUtPpEOWRCTLbxd52yY=
+github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20220421085255-bd4340fb17e9/go.mod h1:ok+AdFFpC6IpnD+Onp3Iipz4MdGNcjm4i0NFHabmQHk=
 github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
 github.com/openshift/api v0.0.0-20200331152225-585af27e34fd/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
 github.com/openshift/api v0.0.0-20210105115604-44119421ec6b/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
@@ -1242,8 +1242,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mo
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
 github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47 h1:+TEY29DK0XhqB7HFC9OfV8qf3wffSyi7MWv3AP28DGQ=
 github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47/go.mod h1:u7NRAjtYVAKokiI9LouzTv4mhds8P4S1TwdVAfbjKSk=
-github.com/openshift/knative-eventing v0.99.1-0.20220408065219-104a546bc063 h1:XjM3kOFYkVtXTbO2QRPdnqBFwWlKj5Lf7CpQbk2rP0Q=
-github.com/openshift/knative-eventing v0.99.1-0.20220408065219-104a546bc063/go.mod h1:u5T5NZTDUsLR7yJwp5MDnBnDX5MhywD3yK3Rq+7gTtI=
+github.com/openshift/knative-eventing v0.99.1-0.20220421094847-2f5934a57f07 h1:HhNCXurHzuzIBQ8lCNdM3TMx0MLgTDI5jB/yZUsZQY0=
+github.com/openshift/knative-eventing v0.99.1-0.20220421094847-2f5934a57f07/go.mod h1:u5T5NZTDUsLR7yJwp5MDnBnDX5MhywD3yK3Rq+7gTtI=
 github.com/openshift/knative-serving v0.10.1-0.20220413035834-cc8e56c905aa h1:gIN69zijtlCdssoyKI69Zz53CLfWrds8uhr3exjZBP0=
 github.com/openshift/knative-serving v0.10.1-0.20220413035834-cc8e56c905aa/go.mod h1:8Ay9QjyTcqoJE+2PietSmT5/VMdSQHe5aIBhsAFOCjM=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=

--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -52,9 +52,13 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: JAVA_OPTS
+          value: '-Xms128m -Xmx5G -XX:+ExitOnOutOfMemoryError'
+        - name: MEM_MAX_SPANS
+          value: '10000000'
         resources:
           limits:
-            memory: 1000Mi
+            memory: 6Gi
           requests:
             memory: 256Mi
 ---

--- a/test/upgrade/continual/channel-config.toml
+++ b/test/upgrade/continual/channel-config.toml
@@ -1,1 +1,9 @@
-../../../vendor/knative.dev/eventing-kafka/test/upgrade/continual/channel-config.toml
+# Copy of https://github.com/knative-sandbox/eventing-kafka/blob/main/test/upgrade/continual/channel-config.toml
+# logLevel = 'DEBUG'
+tracingConfig = '{{- .TracingConfig -}}'
+[sender]
+address = '{{- .Endpoint -}}'
+interval = {{ .Config.Interval.Nanoseconds }}
+
+[forwarder]
+target = '{{- .ForwarderTarget -}}'

--- a/test/upgrade/continual/kafka-broker-config.toml
+++ b/test/upgrade/continual/kafka-broker-config.toml
@@ -1,1 +1,9 @@
-../../../vendor/knative.dev/eventing-kafka-broker/test/upgrade/continual/kafka-broker-config.toml
+# Copy of https://github.com/knative-sandbox/eventing-kafka-broker/blob/main/test/upgrade/continual/kafka-broker-config.toml
+# logLevel = 'DEBUG'
+tracingConfig = '{{- .TracingConfig -}}'
+[sender]
+address = '{{- .Endpoint -}}'
+interval = {{ .Config.Interval.Nanoseconds }}
+
+[forwarder]
+target = '{{- .ForwarderTarget -}}'

--- a/test/upgrade/continual/kafka-sink-source-config.toml
+++ b/test/upgrade/continual/kafka-sink-source-config.toml
@@ -1,1 +1,9 @@
-../../../vendor/knative.dev/eventing-kafka-broker/test/upgrade/continual/kafka-sink-source-config.toml
+# Copy of https://github.com/knative-sandbox/eventing-kafka-broker/blob/main/test/upgrade/continual/kafka-sink-source-config.toml
+# logLevel = 'DEBUG'
+tracingConfig = '{{- .TracingConfig -}}'
+[sender]
+address = '{{- .Endpoint -}}'
+interval = {{ .Config.Interval.Nanoseconds }}
+
+[forwarder]
+target = '{{- .ForwarderTarget -}}'

--- a/vendor/knative.dev/eventing/test/lib/client.go
+++ b/vendor/knative.dev/eventing/test/lib/client.go
@@ -42,7 +42,6 @@ import (
 
 	eventing "knative.dev/eventing/pkg/client/clientset/versioned"
 	"knative.dev/eventing/test/lib/duck"
-	ti "knative.dev/eventing/test/test_images"
 )
 
 // Client holds instances of interfaces for making requests to Knative.
@@ -61,8 +60,8 @@ type Client struct {
 
 	podsCreated []string
 
-	tracingEnv corev1.EnvVar
-	loggingEnv *corev1.EnvVar
+	TracingCfg string
+	loggingCfg string
 
 	cleanup func()
 }
@@ -105,12 +104,12 @@ func NewClient(namespace string, t *testing.T) (*Client, error) {
 	client.EventListener = NewEventListener(client.Kube, client.Namespace, client.T.Logf)
 	client.Cleanup(client.EventListener.Stop)
 
-	client.tracingEnv, err = getTracingConfig(client.Kube)
+	client.TracingCfg, err = getTracingConfig(client.Kube)
 	if err != nil {
 		return nil, err
 	}
 
-	client.loggingEnv, err = getLoggingConfig(client.Kube)
+	client.loggingCfg, err = getLoggingConfig(client.Kube)
 	if err != nil {
 		t.Log("Cannot retrieve the logging config map: ", err)
 	}
@@ -161,40 +160,40 @@ func getGenericResource(tm metav1.TypeMeta) runtime.Object {
 	return &duckv1.KResource{}
 }
 
-func getTracingConfig(c kubernetes.Interface) (corev1.EnvVar, error) {
+func getTracingConfig(c kubernetes.Interface) (string, error) {
 	cm, err := c.CoreV1().ConfigMaps(system.Namespace()).Get(context.Background(), configtracing.ConfigName, metav1.GetOptions{})
 	if err != nil {
-		return corev1.EnvVar{}, fmt.Errorf("error while retrieving the %s config map: %+v", configtracing.ConfigName, errors.WithStack(err))
+		return "", fmt.Errorf("error while retrieving the %s config map: %+v", configtracing.ConfigName, errors.WithStack(err))
 	}
 
 	config, err := configtracing.NewTracingConfigFromConfigMap(cm)
 	if err != nil {
-		return corev1.EnvVar{}, fmt.Errorf("error while parsing the %s config map: %+v", configtracing.ConfigName, errors.WithStack(err))
+		return "", fmt.Errorf("error while parsing the %s config map: %+v", configtracing.ConfigName, errors.WithStack(err))
 	}
 
 	configSerialized, err := configtracing.TracingConfigToJSON(config)
 	if err != nil {
-		return corev1.EnvVar{}, fmt.Errorf("error while serializing the %s config map: %+v", configtracing.ConfigName, errors.WithStack(err))
+		return "", fmt.Errorf("error while serializing the %s config map: %+v", configtracing.ConfigName, errors.WithStack(err))
 	}
 
-	return corev1.EnvVar{Name: ti.ConfigTracingEnv, Value: configSerialized}, nil
+	return configSerialized, nil
 }
 
-func getLoggingConfig(c kubernetes.Interface) (*corev1.EnvVar, error) {
+func getLoggingConfig(c kubernetes.Interface) (string, error) {
 	cm, err := c.CoreV1().ConfigMaps(system.Namespace()).Get(context.Background(), logging.ConfigMapName(), metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error while retrieving the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
+		return "", fmt.Errorf("error while retrieving the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
 	}
 
 	config, err := logging.NewConfigFromMap(cm.Data)
 	if err != nil {
-		return nil, fmt.Errorf("error while parsing the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
+		return "", fmt.Errorf("error while parsing the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
 	}
 
 	configSerialized, err := logging.ConfigToJSON(config)
 	if err != nil {
-		return nil, fmt.Errorf("error while serializing the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
+		return "", fmt.Errorf("error while serializing the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
 	}
 
-	return &corev1.EnvVar{Name: ti.ConfigLoggingEnv, Value: configSerialized}, nil
+	return configSerialized, nil
 }

--- a/vendor/knative.dev/eventing/test/lib/creation.go
+++ b/vendor/knative.dev/eventing/test/lib/creation.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/eventing/pkg/utils"
 	"knative.dev/eventing/test/lib/duck"
 	"knative.dev/eventing/test/lib/resources"
+	ti "knative.dev/eventing/test/test_images"
 )
 
 // TODO(chizhg): break this file into multiple files when it grows too large.
@@ -566,9 +567,9 @@ func (c *Client) CreateClusterRoleBindingOrFail(saName, crName, crbName string) 
 
 func (c *Client) applyAdditionalEnv(pod *corev1.PodSpec) {
 	for i := 0; i < len(pod.Containers); i++ {
-		pod.Containers[i].Env = append(pod.Containers[i].Env, c.tracingEnv)
-		if c.loggingEnv != nil {
-			pod.Containers[i].Env = append(pod.Containers[i].Env, *c.loggingEnv)
+		pod.Containers[i].Env = append(pod.Containers[i].Env, corev1.EnvVar{Name: ti.ConfigTracingEnv, Value: c.TracingCfg})
+		if c.loggingCfg != "" {
+			pod.Containers[i].Env = append(pod.Containers[i].Env, corev1.EnvVar{Name: ti.ConfigLoggingEnv, Value: c.loggingCfg})
 		}
 	}
 }

--- a/vendor/knative.dev/eventing/test/test_images/utils.go
+++ b/vendor/knative.dev/eventing/test/test_images/utils.go
@@ -56,23 +56,17 @@ const (
 	ConfigLoggingEnv = "K_CONFIG_LOGGING"
 )
 
-// ConfigureTracing can be used in test-images to configure tracing
+// ConfigureTracing can be used in test-images to configure tracing.
 func ConfigureTracing(logger *zap.SugaredLogger, serviceName string) error {
 	tracingEnv := os.Getenv(ConfigTracingEnv)
-
-	if tracingEnv == "" {
-		return tracing.SetupStaticPublishing(logger, serviceName, config.NoopConfig())
-	}
-
 	conf, err := config.JSONToTracingConfig(tracingEnv)
 	if err != nil {
-		return err
+		logger.Warn("Error while trying to read the tracing config, using NoopConfig: ", err)
 	}
-
 	return tracing.SetupStaticPublishing(logger, serviceName, conf)
 }
 
-// ConfigureTracing can be used in test-images to configure tracing
+// ConfigureLogging can be used in test-images to configure logging.
 func ConfigureLogging(ctx context.Context, name string) context.Context {
 	loggingEnv := os.Getenv(ConfigLoggingEnv)
 	conf, err := logging.JSONToConfig(loggingEnv)

--- a/vendor/knative.dev/eventing/test/upgrade/README.md
+++ b/vendor/knative.dev/eventing/test/upgrade/README.md
@@ -119,3 +119,24 @@ struct can be influenced, by using `EVENTING_UPGRADE_TESTS_XXXXX` environmental
 variable prefix (using
 [kelseyhightower/envconfig](https://github.com/kelseyhightower/envconfig#usage)
 usage).
+
+#### Inspecting Zipkin traces for undelivered events
+
+When tracing is enabled in the `config-tracing` config map in the system namespace
+the prober collects traces for undelivered events. The traces are exported as json files
+under the artifacts dir. Traces for each event are stored in a separate file.
+Step event traces are stored as `$ARTIFACTS/traces/missed-events/step-<step_number>.json`
+The finished event traces are stored as `$ARTIFACTS/traces/missed-events/finished.json`
+
+Traces can be viewed as follows:
+- Start a Zipkin container on localhost:
+   ```
+   $ docker run -d -p 9411:9411 ghcr.io/openzipkin/zipkin:2
+   ```
+- Send traces to the Zipkin endpoint:
+   ```
+   $ curl -v -X POST localhost:9411/api/v2/spans \
+     -H 'Content-Type: application/json' \
+     -d @$ARTIFACTS/traces/missed-events/step-<step_number>.json
+   ```
+- View traces in Zipkin UI at `http://localhost:9411/zipkin`

--- a/vendor/knative.dev/eventing/test/upgrade/prober/config.toml
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/config.toml
@@ -1,6 +1,7 @@
 # logLevel = 'DEBUG'
+tracingConfig = '{{- .TracingConfig -}}'
 [sender]
 address = '{{- .Endpoint -}}'
 interval = {{ .Config.Interval.Nanoseconds }}
 [forwarder]
-target = 'http://wathola-receiver.{{- .Namespace -}}.svc.cluster.local'
+target = '{{- .ForwarderTarget -}}'

--- a/vendor/knative.dev/eventing/test/upgrade/prober/configuration.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/configuration.go
@@ -18,7 +18,6 @@ package prober
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -27,8 +26,11 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
+	"github.com/pkg/errors"
 	"knative.dev/eventing/test/lib/resources"
 	"knative.dev/eventing/test/upgrade/prober/sut"
+	"knative.dev/eventing/test/upgrade/prober/wathola/forwarder"
+	"knative.dev/eventing/test/upgrade/prober/wathola/receiver"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	pkgTest "knative.dev/pkg/test"
 	pkgupgrade "knative.dev/pkg/test/upgrade"
@@ -49,6 +51,8 @@ const (
 	Error DuplicateAction = "error"
 
 	prefix = "eventing_upgrade_tests"
+
+	forwarderTargetFmt = "http://" + receiver.Name + ".%s.svc.cluster.local"
 )
 
 var (
@@ -141,9 +145,9 @@ func (p *prober) deployConfiguration() {
 		Log:    p.log,
 		Client: p.client,
 	}
-	ref := resources.KnativeRefForService(receiverName, p.client.Namespace)
+	ref := resources.KnativeRefForService(receiver.Name, p.client.Namespace)
 	if p.config.Serving.Use {
-		ref = resources.KnativeRefForKservice(forwarderName, p.client.Namespace)
+		ref = resources.KnativeRefForKservice(forwarder.Name, p.client.Namespace)
 	}
 	dest := duckv1.Destination{Ref: ref}
 	s := p.config.SystemUnderTest
@@ -153,19 +157,20 @@ func (p *prober) deployConfiguration() {
 			tr.Teardown(sc)
 		}
 	})
+
 	p.deployConfigToml(endpoint)
 }
 
 func (p *prober) deployConfigToml(endpoint interface{}) {
 	name := p.config.ConfigMapName
 	p.log.Infof("Deploying config map: \"%s/%s\"", p.client.Namespace, name)
-	configData := p.compileTemplate(p.config.ConfigTemplate, endpoint)
+	configData := p.compileTemplate(p.config.ConfigTemplate, endpoint, p.client.TracingCfg)
 	p.client.CreateConfigMapOrFail(name, p.client.Namespace, map[string]string{
 		p.config.ConfigFilename: configData,
 	})
 }
 
-func (p *prober) compileTemplate(templateName string, endpoint interface{}) string {
+func (p *prober) compileTemplate(templateName string, endpoint interface{}, tracingConfig string) string {
 	_, filename, _, _ := runtime.Caller(0)
 	templateFilepath := path.Join(path.Dir(filename), templateName)
 	templateBytes, err := ioutil.ReadFile(templateFilepath)
@@ -175,15 +180,20 @@ func (p *prober) compileTemplate(templateName string, endpoint interface{}) stri
 	var buff bytes.Buffer
 	data := struct {
 		*Config
+		// Deprecated: use ForwarderTarget
 		Namespace string
 		// Deprecated: use Endpoint
-		BrokerURL string
-		Endpoint  interface{}
+		BrokerURL       string
+		Endpoint        interface{}
+		TracingConfig   string
+		ForwarderTarget string
 	}{
 		p.config,
 		p.client.Namespace,
 		fmt.Sprintf("%v", endpoint),
 		endpoint,
+		tracingConfig,
+		fmt.Sprintf(forwarderTargetFmt, p.client.Namespace),
 	}
 	p.ensureNoError(tmpl.Execute(&buff, data))
 	return buff.String()

--- a/vendor/knative.dev/eventing/test/upgrade/prober/receiver.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/receiver.go
@@ -22,13 +22,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	pkgTest "knative.dev/pkg/test"
+
 	testlib "knative.dev/eventing/test/lib"
 	watholaconfig "knative.dev/eventing/test/upgrade/prober/wathola/config"
-	pkgTest "knative.dev/pkg/test"
-)
-
-var (
-	receiverName = "wathola-receiver"
+	"knative.dev/eventing/test/upgrade/prober/wathola/receiver"
 )
 
 func (p *prober) deployReceiver() {
@@ -37,22 +35,22 @@ func (p *prober) deployReceiver() {
 }
 
 func (p *prober) deployReceiverDeployment() {
-	p.log.Info("Deploy of receiver deployment: ", receiverName)
+	p.log.Info("Deploy of receiver deployment: ", receiver.Name)
 	deployment := p.createReceiverDeployment()
 	p.client.CreateDeploymentOrFail(deployment)
 
-	testlib.WaitFor(fmt.Sprint("receiver deployment be ready: ", receiverName), func() error {
+	testlib.WaitFor(fmt.Sprint("receiver deployment be ready: ", receiver.Name), func() error {
 		return pkgTest.WaitForDeploymentScale(
-			p.config.Ctx, p.client.Kube, receiverName, p.client.Namespace, 1,
+			p.config.Ctx, p.client.Kube, receiver.Name, p.client.Namespace, 1,
 		)
 	})
 }
 
 func (p *prober) deployReceiverService() {
-	p.log.Infof("Deploy of receiver service: %v", receiverName)
+	p.log.Infof("Deploy of receiver service: %v", receiver.Name)
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      receiverName,
+			Name:      receiver.Name,
 			Namespace: p.client.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
@@ -68,7 +66,7 @@ func (p *prober) deployReceiverService() {
 				},
 			},
 			Selector: map[string]string{
-				"app": receiverName,
+				"app": receiver.Name,
 			},
 			Type: corev1.ServiceTypeClusterIP,
 		},
@@ -80,20 +78,20 @@ func (p *prober) createReceiverDeployment() *appsv1.Deployment {
 	var replicas int32 = 1
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      receiverName,
+			Name:      receiver.Name,
 			Namespace: p.client.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": receiverName,
+					"app": receiver.Name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": receiverName,
+						"app": receiver.Name,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -109,7 +107,7 @@ func (p *prober) createReceiverDeployment() *appsv1.Deployment {
 					}},
 					Containers: []corev1.Container{{
 						Name:  "receiver",
-						Image: p.config.ImageResolver(receiverName),
+						Image: p.config.ImageResolver(receiver.Name),
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      p.config.ConfigMapName,
 							ReadOnly:  true,

--- a/vendor/knative.dev/eventing/test/upgrade/prober/verify.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/verify.go
@@ -20,6 +20,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
 	"time"
 
 	"go.uber.org/zap"
@@ -28,27 +31,49 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"knative.dev/eventing/test/upgrade/prober/wathola/event"
 	"knative.dev/eventing/test/upgrade/prober/wathola/fetcher"
 	"knative.dev/eventing/test/upgrade/prober/wathola/receiver"
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 	"knative.dev/pkg/test/logging"
+	"knative.dev/pkg/test/prow"
+	"knative.dev/pkg/test/zipkin"
 )
 
 const (
-	fetcherName     = "wathola-fetcher"
-	jobWaitInterval = time.Second
-	jobWaitTimeout  = 10 * time.Minute
+	fetcherName         = "wathola-fetcher"
+	jobWaitInterval     = time.Second
+	jobWaitTimeout      = 10 * time.Minute
+	stepEventMsgPattern = "event #([0-9]+).*"
+	exportTraceLimit    = 1000
 )
 
 // Verify will verify prober state after finished has been sent.
 func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 	var report *receiver.Report
+	// Enable port-forwarding for Zipkin endpoint.
+	if err := zipkin.SetupZipkinTracingFromConfigTracing(p.config.Ctx,
+		p.client.Kube, p.client.T.Logf, system.Namespace()); err != nil {
+		p.log.Warnf("Failed to setup Zipkin tracing. Traces for events won't be available.")
+	} else {
+		// Required for proper cleanup.
+		zipkin.ZipkinTracingEnabled = true
+	}
 	p.log.Info("Waiting for complete report from receiver...")
 	start := time.Now()
 	if err := wait.PollImmediate(jobWaitInterval, jobWaitTimeout, func() (bool, error) {
-		report = p.fetchReport()
-		return report.State != "active", nil
+		var err error
+		report, err = p.fetchReport()
+		if err != nil {
+			return false, err
+		}
+		return report != nil && report.State != "active", nil
 	}); err != nil {
+		if err := p.exportTrace(p.getTraceForFinishedEvent(), "finished.json"); err != nil {
+			p.log.Warnf("Failed to export trace for Finished event: %v", err)
+		}
 		p.client.T.Fatalf("Error fetching complete/inactive report: %v\nReport: %+v", err, report)
 	}
 	elapsed := time.Since(start)
@@ -60,8 +85,15 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 		elapsed, report.EventsSent, report.State)
 	p.log.Infof("Availability: %.3f%%, Requests sent: %d.",
 		availRate, report.TotalRequests)
-	for _, t := range report.Thrown.Missing {
+	for i, t := range report.Thrown.Missing {
 		eventErrs = append(eventErrs, errors.New(t))
+		if i > exportTraceLimit {
+			continue
+		}
+		stepNo := p.getStepNoFromMsg(t)
+		if err := p.exportTrace(p.getTraceForStepEvent(stepNo), fmt.Sprintf("step-%s.json", stepNo)); err != nil {
+			p.log.Warnf("Failed to export trace for Step event #%s: %v", stepNo, err)
+		}
 	}
 	for _, t := range report.Thrown.Unexpected {
 		eventErrs = append(eventErrs, errors.New(t))
@@ -69,11 +101,18 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 	for _, t := range report.Thrown.Unavailable {
 		eventErrs = append(eventErrs, errors.New(t))
 	}
-	for _, t := range report.Thrown.Duplicated {
+	for i, t := range report.Thrown.Duplicated {
 		if p.config.OnDuplicate == Warn {
 			p.log.Warn("Duplicate events: ", t)
 		} else if p.config.OnDuplicate == Error {
 			eventErrs = append(eventErrs, errors.New(t))
+		}
+		if i > exportTraceLimit {
+			continue
+		}
+		stepNo := p.getStepNoFromMsg(t)
+		if err := p.exportTrace(p.getTraceForStepEvent(stepNo), fmt.Sprintf("step-%s.json", stepNo)); err != nil {
+			p.log.Warnf("Failed to export trace for Step event #%s: %v", stepNo, err)
 		}
 	}
 	return eventErrs, report.EventsSent
@@ -84,10 +123,63 @@ func (p *prober) Finish() {
 	p.removeSender()
 }
 
-func (p *prober) fetchReport() *receiver.Report {
-	exec := p.fetchExecution()
+func (p *prober) getStepNoFromMsg(message string) string {
+	r, _ := regexp.Compile(stepEventMsgPattern)
+	matches := r.FindStringSubmatch(message)
+	if len(matches) != 2 {
+		p.log.Warnf("message does not match pattern %s: %s", stepEventMsgPattern, message)
+	}
+	return matches[1]
+}
+
+func (p *prober) getTraceForStepEvent(eventNo string) []byte {
+	p.log.Infof("Fetching trace for Step event #%s", eventNo)
+	query := fmt.Sprintf("step=%s and cloudevents.type=%s and target=%s",
+		eventNo, event.StepType, fmt.Sprintf(forwarderTargetFmt, p.client.Namespace))
+	trace, err := event.FindTrace(query)
+	if err != nil {
+		p.log.Warn(err)
+	}
+	return trace
+}
+
+func (p *prober) getTraceForFinishedEvent() []byte {
+	p.log.Info("Fetching trace for Finished event")
+	query := fmt.Sprintf("cloudevents.type=%s and target=%s",
+		event.FinishedType, fmt.Sprintf(forwarderTargetFmt, p.client.Namespace))
+	trace, err := event.FindTrace(query)
+	if err != nil {
+		p.log.Warn(err)
+	}
+	return trace
+}
+
+func (p *prober) exportTrace(trace []byte, fileName string) error {
+	tracesDir := filepath.Join(prow.GetLocalArtifactsDir(), "traces", "events")
+	if err := helpers.CreateDir(tracesDir); err != nil {
+		return fmt.Errorf("error creating directory %q: %w", tracesDir, err)
+	}
+	fp := filepath.Join(tracesDir, fileName)
+	p.log.Infof("Exporting trace into %s", fp)
+	f, err := os.Create(fp)
+	if err != nil {
+		return fmt.Errorf("error creating file %q: %w", fp, err)
+	}
+	defer f.Close()
+	_, err = f.Write(trace)
+	if err != nil {
+		return fmt.Errorf("error writing trace into file %q: %w", fp, err)
+	}
+	return nil
+}
+
+func (p *prober) fetchReport() (*receiver.Report, error) {
+	exec, err := p.fetchExecution()
+	if err != nil {
+		return nil, err
+	}
 	replayLogs(p.log, exec)
-	return exec.Report
+	return exec.Report, nil
 }
 
 func replayLogs(log *zap.SugaredLogger, exec *fetcher.Execution) {
@@ -105,14 +197,18 @@ func replayLogs(log *zap.SugaredLogger, exec *fetcher.Execution) {
 	}
 }
 
-func (p *prober) fetchExecution() *fetcher.Execution {
+func (p *prober) fetchExecution() (*fetcher.Execution, error) {
 	ns := p.client.Namespace
 	job := p.deployFetcher()
 	defer p.deleteFetcher(job.Name)
 	pod, err := p.findSucceededPod(job)
-	p.ensureNoError(err)
+	if err != nil {
+		return nil, err
+	}
 	bytes, err := pkgTest.PodLogs(p.config.Ctx, p.client.Kube, pod.Name, fetcherName, ns)
-	p.ensureNoError(err)
+	if err != nil {
+		return nil, err
+	}
 	ex := &fetcher.Execution{
 		Logs: []fetcher.LogEntry{},
 		Report: &receiver.Report{
@@ -128,8 +224,7 @@ func (p *prober) fetchExecution() *fetcher.Execution {
 		},
 	}
 	err = json.Unmarshal(bytes, ex)
-	p.ensureNoError(err)
-	return ex
+	return ex, err
 }
 
 func (p *prober) deployFetcher() *batchv1.Job {

--- a/vendor/knative.dev/eventing/test/upgrade/prober/verify.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/verify.go
@@ -85,10 +85,6 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 		elapsed, report.EventsSent, report.State)
 	p.log.Infof("Availability: %.3f%%, Requests sent: %d.",
 		availRate, report.TotalRequests)
-	stepNo := "10" // Try getting trace for event #10
-	if err := p.exportTrace(p.getTraceForStepEvent(stepNo), fmt.Sprintf("step-%s.json", stepNo)); err != nil {
-		p.log.Warnf("Failed to export trace for Step event #%s: %v", stepNo, err)
-	}
 	for i, t := range report.Thrown.Missing {
 		eventErrs = append(eventErrs, errors.New(t))
 		if i > exportTraceLimit {

--- a/vendor/knative.dev/eventing/test/upgrade/prober/verify.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/verify.go
@@ -85,6 +85,10 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 		elapsed, report.EventsSent, report.State)
 	p.log.Infof("Availability: %.3f%%, Requests sent: %d.",
 		availRate, report.TotalRequests)
+	stepNo := "10" // Try getting trace for event #10
+	if err := p.exportTrace(p.getTraceForStepEvent(stepNo), fmt.Sprintf("step-%s.json", stepNo)); err != nil {
+		p.log.Warnf("Failed to export trace for Step event #%s: %v", stepNo, err)
+	}
 	for i, t := range report.Thrown.Missing {
 		eventErrs = append(eventErrs, errors.New(t))
 		if i > exportTraceLimit {

--- a/vendor/knative.dev/eventing/test/upgrade/prober/wathola/config/defaults.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/wathola/config/defaults.go
@@ -79,6 +79,7 @@ func defaultValues() *Config {
 			Message: "OK",
 			Status:  nethttp.StatusOK,
 		},
-		LogLevel: zap.InfoLevel.String(),
+		LogLevel:      zap.InfoLevel.String(),
+		TracingConfig: `{"backend":"none","debug":"false","sample-rate":"0.1"}`,
 	}
 }

--- a/vendor/knative.dev/eventing/test/upgrade/prober/wathola/config/structure.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/wathola/config/structure.go
@@ -65,9 +65,10 @@ type ReadinessConfig struct {
 
 // Config hold complete configuration
 type Config struct {
-	Sender    SenderConfig
-	Forwarder ForwarderConfig
-	Receiver  ReceiverConfig
-	Readiness ReadinessConfig
-	LogLevel  string
+	Sender        SenderConfig
+	Forwarder     ForwarderConfig
+	Receiver      ReceiverConfig
+	Readiness     ReadinessConfig
+	LogLevel      string
+	TracingConfig string
 }

--- a/vendor/knative.dev/eventing/test/upgrade/prober/wathola/config/tracing.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/wathola/config/tracing.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"go.uber.org/zap"
+	"knative.dev/pkg/tracing"
+	tracingconfig "knative.dev/pkg/tracing/config"
+)
+
+func SetupTracing() {
+	config, err := tracingconfig.JSONToTracingConfig(Instance.TracingConfig)
+	if err != nil {
+		Log.Warn("Tracing configuration is invalid, using the no-op default", zap.Error(err))
+	}
+	if err = tracing.SetupStaticPublishing(Log, "", config); err != nil {
+		Log.Fatal("Error setting up trace publishing", zap.Error(err))
+	}
+}

--- a/vendor/knative.dev/eventing/test/upgrade/prober/wathola/event/services.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/wathola/event/services.go
@@ -159,10 +159,7 @@ func asStrings(errThrown []thrown) []string {
 func (f *finishedStore) reportViolations(finished *Finished) {
 	steps := f.steps.(*stepStore)
 	for eventNo := 1; eventNo <= finished.EventsSent; eventNo++ {
-		times, ok := steps.store[eventNo]
-		if !ok {
-			times = 0
-		}
+		times := steps.store[eventNo]
 		if times != 1 {
 			throwMethod := f.errors.throwMissing
 			if times > 1 {

--- a/vendor/knative.dev/eventing/test/upgrade/prober/wathola/event/tracing.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/wathola/event/tracing.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/openzipkin/zipkin-go/model"
+)
+
+const ZipkinTracesEndpoint = "http://localhost:9411/api/v2/traces"
+
+// FindTrace fetches tracing endpoint and retrieves Zipkin traces matching the annotation query.
+func FindTrace(annotationQuery string) ([]byte, error) {
+	trace := []byte("<unavailable>")
+	spanModelsAll, err := SendTraceQuery(ZipkinTracesEndpoint, annotationQuery)
+	if err != nil {
+		return trace, fmt.Errorf("failed to send trace query %q: %w", annotationQuery, err)
+	}
+	if len(spanModelsAll) == 0 {
+		return trace, fmt.Errorf("no traces found for query %q", annotationQuery)
+	}
+	var models []model.SpanModel
+	for _, m := range spanModelsAll {
+		models = append(models, m...)
+	}
+	b, err := json.MarshalIndent(models, "", "  ")
+	if err != nil {
+		return trace, fmt.Errorf("failed to marshall span models: %w", err)
+	}
+	return b, nil
+}
+
+// SendTraceQuery sends the query to the tracing endpoint and returns all spans matching the query.
+func SendTraceQuery(endpoint string, annotationQuery string) ([][]model.SpanModel, error) {
+	var empty [][]model.SpanModel
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return empty, err
+	}
+	q := req.URL.Query()
+	q.Add("annotationQuery", annotationQuery)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return empty, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return empty, err
+	}
+
+	var models [][]model.SpanModel
+	err = json.Unmarshal(body, &models)
+	if err != nil {
+		return empty, fmt.Errorf("got an error in unmarshalling JSON %q: %w", body, err)
+	}
+
+	return models, nil
+}

--- a/vendor/knative.dev/eventing/test/upgrade/prober/wathola/forwarder/operations.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/wathola/forwarder/operations.go
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 The Knative Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forwarder
+
+// Forwarder perform waiting and receiving of events and forwarding them to other place
+type Forwarder interface {
+	Forward()
+}

--- a/vendor/knative.dev/eventing/test/upgrade/prober/wathola/forwarder/services.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/wathola/forwarder/services.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 The Knative Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forwarder
+
+import (
+	"context"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"go.opencensus.io/trace"
+	"knative.dev/eventing/test/upgrade/prober/wathola/client"
+	"knative.dev/eventing/test/upgrade/prober/wathola/config"
+	"knative.dev/eventing/test/upgrade/prober/wathola/sender"
+
+	"time"
+)
+
+const (
+	Name = "wathola-forwarder"
+)
+
+var (
+	log                = config.Log
+	lastProgressReport = time.Now()
+	Canceling          = make(chan context.CancelFunc, 1)
+)
+
+// New creates new forwarder
+func New() Forwarder {
+	config.ReadIfPresent()
+	config.SetupTracing()
+	f := &forwarder{
+		count: 0,
+	}
+	return f
+}
+
+func (f *forwarder) Forward() {
+	port := config.Instance.Forwarder.Port
+	client.Receive(port, Canceling, f.forwardEvent)
+}
+
+func (f *forwarder) forwardEvent(ctx context.Context, e cloudevents.Event) {
+	target := config.Instance.Forwarder.Target
+	log.Debugf("Forwarding event %v to %v", e.ID(), target)
+	ctx, span := trace.StartSpan(ctx, Name)
+	defer span.End()
+	err := sender.SendEvent(ctx, e, target)
+	if err != nil {
+		log.Error(err)
+	}
+	f.count++
+	f.reportProgress()
+}
+
+func (f *forwarder) reportProgress() {
+	if lastProgressReport.Add(config.Instance.Receiver.Progress.Duration).Before(time.Now()) {
+		lastProgressReport = time.Now()
+		log.Infof("forwarded %v events", f.count)
+	}
+}
+
+type forwarder struct {
+	count int
+}

--- a/vendor/knative.dev/eventing/test/upgrade/prober/wathola/sender/operations.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/wathola/sender/operations.go
@@ -25,6 +25,7 @@ import (
 // New creates new Sender
 func New() Sender {
 	config.ReadIfPresent()
+	config.SetupTracing()
 	return &sender{
 		eventsSent: 0,
 	}

--- a/vendor/knative.dev/eventing/test/upgrade/prober/wathola/sender/types.go
+++ b/vendor/knative.dev/eventing/test/upgrade/prober/wathola/sender/types.go
@@ -16,18 +16,34 @@ limitations under the License.
 
 package sender
 
-import cloudevents "github.com/cloudevents/sdk-go/v2"
+import (
+	"context"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
 
 // Sender will send messages continuously until process receives a SIGINT
 type Sender interface {
 	SendContinually()
 }
 
-// EventSender will be used to send events to configured endpoint.
-type EventSender interface {
+type EndpointSupporter interface {
 	// Supports will check given endpoint definition and decide if it's valid for
 	// this sender.
 	Supports(endpoint interface{}) bool
+}
+
+// EventSender will be used to send events to configured endpoint.
+// Deprecated. Use EventSenderWithContext.
+type EventSender interface {
+	EndpointSupporter
 	// SendEvent will send event to given endpoint.
 	SendEvent(ce cloudevents.Event, endpoint interface{}) error
+}
+
+// EventSenderWithContext will be used to send events to configured endpoint, passing a context.
+type EventSenderWithContext interface {
+	EndpointSupporter
+	// SendEventWithContext will send event to the given endpoint and pass context.
+	SendEventWithContext(ctx context.Context, ce cloudevents.Event, endpoint interface{}) error
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1259,7 +1259,7 @@ k8s.io/utils/trace
 ## explicit; go 1.15
 knative.dev/caching/pkg/apis/caching
 knative.dev/caching/pkg/apis/caching/v1alpha1
-# knative.dev/eventing v0.29.1 => github.com/openshift/knative-eventing v0.99.1-0.20220408065219-104a546bc063
+# knative.dev/eventing v0.29.1 => github.com/openshift/knative-eventing v0.99.1-0.20220421094847-2f5934a57f07
 ## explicit; go 1.16
 knative.dev/eventing/pkg/apis/config
 knative.dev/eventing/pkg/apis/duck
@@ -1342,6 +1342,7 @@ knative.dev/eventing/test/upgrade/prober/wathola/client
 knative.dev/eventing/test/upgrade/prober/wathola/config
 knative.dev/eventing/test/upgrade/prober/wathola/event
 knative.dev/eventing/test/upgrade/prober/wathola/fetcher
+knative.dev/eventing/test/upgrade/prober/wathola/forwarder
 knative.dev/eventing/test/upgrade/prober/wathola/receiver
 knative.dev/eventing/test/upgrade/prober/wathola/sender
 # knative.dev/eventing-kafka v0.29.1 => github.com/openshift-knative/eventing-kafka v0.19.1-0.20220331121128-d72948ffaf32
@@ -1383,7 +1384,7 @@ knative.dev/eventing-kafka/test/lib/resources
 knative.dev/eventing-kafka/test/upgrade
 knative.dev/eventing-kafka/test/upgrade/continual
 knative.dev/eventing-kafka/test/upgrade/installation
-# knative.dev/eventing-kafka-broker v0.0.0-00010101000000-000000000000 => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20220415152823-78c569154a7d
+# knative.dev/eventing-kafka-broker v0.0.0-00010101000000-000000000000 => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20220421085255-bd4340fb17e9
 ## explicit; go 1.16
 knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing
 knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1
@@ -1608,9 +1609,9 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# knative.dev/eventing => github.com/openshift/knative-eventing v0.99.1-0.20220408065219-104a546bc063
+# knative.dev/eventing => github.com/openshift/knative-eventing v0.99.1-0.20220421094847-2f5934a57f07
 # knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20220331121128-d72948ffaf32
-# knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20220415152823-78c569154a7d
+# knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20220421085255-bd4340fb17e9
 # knative.dev/serving => github.com/openshift/knative-serving v0.10.1-0.20220413035834-cc8e56c905aa
 # github.com/go-logr/logr => github.com/go-logr/logr v0.4.0
 # github.com/go-logr/zapr => github.com/go-logr/zapr v0.4.0


### PR DESCRIPTION
* Update dependencies on openshift/knative-eventing to get the functionality for printing traces
* Remove the symlinks to vendored toml files to prevent excessive backporting of dependencies and rather include a copy of those files.
* Increase memory limits for Zipkin