### PR TITLE
Replace community image with OpenShift's

### DIFF
--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	image                 = "gcr.io/knative-samples/helloworld-go"
+	image                 = "quay.io/openshift-knative/hello-openshift"
 	helloworldService     = "helloworld-go"
 	helloworldService2    = "helloworld-go2"
 	kubeHelloworldService = "kube-helloworld-go"

--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -16,7 +16,7 @@ const (
 	helloworldService     = "helloworld-go"
 	helloworldService2    = "helloworld-go2"
 	kubeHelloworldService = "kube-helloworld-go"
-	helloworldText        = "Hello World!"
+	helloworldText        = "Hello OpenShift!"
 )
 
 func WaitForRouteServingText(t *testing.T, caCtx *test.Context, routeURL *url.URL, expectedText string) {

--- a/test/servinge2e/kourier/custom_route_test.go
+++ b/test/servinge2e/kourier/custom_route_test.go
@@ -158,8 +158,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error polling custom domain: %v", err)
 	}
-	const expectedResponse = "Hello World!"
-	if resp.StatusCode != 200 || strings.TrimSpace(string(resp.Body)) != expectedResponse {
-		t.Fatalf("Expecting a HTTP 200 response with %q, got %d: %s", expectedResponse, resp.StatusCode, string(resp.Body))
+	if resp.StatusCode != 200 || strings.TrimSpace(string(resp.Body)) != helloworldText {
+		t.Fatalf("Expecting a HTTP 200 response with %q, got %d: %s", helloworldText, resp.StatusCode, string(resp.Body))
 	}
 }

--- a/test/servinge2e/kourier/helpers.go
+++ b/test/servinge2e/kourier/helpers.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	image          = "quay.io/openshift-knative/hello-openshift"
-	helloworldText = "Hello World!"
+	helloworldText = "Hello OpenShift!"
 )
 
 func withServiceReadyOrFail(ctx *test.Context, service *servingv1.Service) *servingv1.Service {

--- a/test/servinge2e/kourier/helpers.go
+++ b/test/servinge2e/kourier/helpers.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	image          = "gcr.io/knative-samples/helloworld-go"
+	image          = "quay.io/openshift-knative/hello-openshift"
 	helloworldText = "Hello World!"
 )
 


### PR DESCRIPTION
This patch replaces community image with OpenShift's.

CI sometimes fails due to timeout with `ContainerCreating` as ([log](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/1530/pull-ci-openshift-knative-serverless-operator-main-4.10-operator-e2e-aws-ocp-410/1518842222026428416)):

```
serverless-tests2                                  kube-helloworld-go-5d86cf49cd-fh77q                               0/1     ContainerCreating   0             8m7s    <none>         ip-10-0-136-64.ec2.internal    <none>           <none>
```

The CI log did not say the exact reason why it took so long to start the container but the failed pod always uses community image which is larger.

(community image) https://console.cloud.google.com/gcr/images/knative-samples/global/helloworld-go
(openshift image) https://quay.io/repository/openshift-knative/hello-openshift?tab=tags

So it is worth to use OpenShift image.

Also, I think we should use OpenShift image rather than community image.
