### PR TITLE
use quay mirror of helloworld-go in tests

### DIFF
--- a/test/eventinge2e/source_to_ksvc_test.go
+++ b/test/eventinge2e/source_to_ksvc_test.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	pingSourceName    = "smoke-test-ping"
-	image             = "gcr.io/knative-samples/helloworld-go"
+	image             = "quay.io/openshift-knative/helloworld-go"
 	helloWorldService = "helloworld-go"
 	helloWorldText    = "Hello World!"
 	ksvcAPIVersion    = "serving.knative.dev/v1"

--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -28,7 +28,7 @@ const (
 	kafkaSourceName     = "smoke-ks"
 	kafkaTopicName      = "smoke-topic"
 	kafkaConsumerGroup  = "smoke-cg"
-	image               = "gcr.io/knative-samples/helloworld-go"
+	image               = "quay.io/openshift-knative/helloworld-go"
 	helloWorldService   = "helloworld-go"
 	ksvcAPIVersion      = "serving.knative.dev/v1"
 	ksvcKind            = "Service"

--- a/test/kitchensinke2e/ksvc/ksvc.go
+++ b/test/kitchensinke2e/ksvc/ksvc.go
@@ -15,7 +15,7 @@ import (
 //go:embed *.yaml
 var yaml embed.FS
 
-const defaultImage = "gcr.io/knative-samples/helloworld-go"
+const defaultImage = "quay.io/openshift-knative/helloworld-go"
 
 func GVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1", Resource: "services"}

--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	image                 = "gcr.io/knative-samples/helloworld-go"
+	image                 = "quay.io/openshift-knative/helloworld-go"
 	helloworldService     = "helloworld-go"
 	helloworldService2    = "helloworld-go2"
 	kubeHelloworldService = "kube-helloworld-go"

--- a/test/servinge2e/kourier/helpers.go
+++ b/test/servinge2e/kourier/helpers.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	image          = "gcr.io/knative-samples/helloworld-go"
+	image          = "quay.io/openshift-knative/helloworld-go"
 	helloworldText = "Hello World!"
 )
 


### PR DESCRIPTION
gcr.io seems to be terribly slow today, causing timeouts. We should use quay by default anyway. 