### PR TITLE
add failfast to kitchensink test execution

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -177,7 +177,7 @@ function downstream_kitchensink_e2e_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  go_test_e2e -timeout=60m -parallel=8 ./test/kitchensinke2e "$@"
+  go_test_e2e -failfast -timeout=60m -parallel=8 ./test/kitchensinke2e "$@"
 }
 
 # == Upgrade testing


### PR DESCRIPTION
Add -failfast to kitchensink test execution, to make it consistent with the other tests, and to help debugging (by not polluting logs with subsequent tests after failure)