### PR TITLE
Add timeout option and verbose flag to golangci-lint action

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -115,6 +115,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.45.2
+          args: --timeout=10m0s --verbose
           working-directory: ./src/github.com/${{ github.repository }}
 
       # This is mostly copied from https://github.com/get-woke/woke-action-reviewdog/blob/main/entrypoint.sh


### PR DESCRIPTION
For more check [here](https://github.com/openshift-knative/serverless-operator/pull/1546#issuecomment-1117174138).
Default time out is 1m. Setting it to 10m, a bit generous to cover slow runs (but should take less). 