### PR TITLE
Setup quick API deprecation alerts for upstream tests

### DIFF
--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -20,6 +20,8 @@ if [[ $FULL_MESH != true ]]; then
   trust_router_ca
 fi
 
+[ -n "$OPENSHIFT_CI" ] && setup_quick_api_deprecation_alerts
+
 # Run upgrade tests
 if [[ $TEST_KNATIVE_UPGRADE == true ]]; then
   # Set KafkaChannel as default for upgrade tests.


### PR DESCRIPTION
* Similar to what we have in e2e-tests.sh
* The goal is for the alerts to be fired more quickly. The default "for"
clause in the PrometheusRule is 1h so the alerts will be fired after 1h.
We're setting the timeout to be 1 minute.