### PR TITLE
Using new config map keys for channel-template-spec

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -279,7 +279,7 @@ function ensure_kafka_channel_default {
         "default-ch-config": "'"${defaultChConfig//$'\n'/\\n}"'"
       },
       "config-br-default-channel": {
-        "channelTemplateSpec": "'"${channelTemplateSpec//$'\n'/\\n}"'"
+        "channel-template-spec": "'"${channelTemplateSpec//$'\n'/\\n}"'"
       }
     }
   }

--- a/test/eventinge2e/source_broker_ksvc_test.go
+++ b/test/eventinge2e/source_broker_ksvc_test.go
@@ -46,7 +46,7 @@ func TestKnativeSourceBrokerTriggerKnativeService(t *testing.T) {
 			Name: cmName,
 		},
 		Data: map[string]string{
-			"channelTemplateSpec": fmt.Sprintf(`
+			"channel-template-spec": fmt.Sprintf(`
 apiVersion: %q
 kind: %q`, channelAPIVersion, channelKind),
 		},

--- a/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
@@ -30,7 +30,7 @@ var (
 			Name: kafkaChannelTemplateConfigMapName,
 		},
 		Data: map[string]string{
-			"channelTemplateSpec": fmt.Sprintf(`
+			"channel-template-spec": fmt.Sprintf(`
 apiVersion: %q
 kind: %q`, channelAPIVersion, kafkaChannelKind),
 		},

--- a/test/kitchensinke2e/brokerconfig/config.yaml
+++ b/test/kitchensinke2e/brokerconfig/config.yaml
@@ -10,7 +10,7 @@ data:
   default.topic.replication.factor: "{{ .kafkaBroker.replicationFactor }}"
   {{ end }}
   {{ if .kafkaChannel }}
-  channelTemplateSpec: |
+  channel-template-spec: |
     apiVersion: messaging.knative.dev/{{ .kafkaChannel.version }}
     kind: KafkaChannel
     spec:
@@ -18,7 +18,7 @@ data:
       replicationFactor: {{ .kafkaChannel.replicationFactor }}
   {{ end }}
   {{ if .inMemoryChannel }}
-  channelTemplateSpec: |
+  channel-template-spec: |
     apiVersion: messaging.knative.dev/{{ .inMemoryChannel.version }}
     kind: InMemoryChannel
   {{ end}}


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

The `channelTemplateSpec` is deprecated and replaced by `channel-template-spec`....