### PR TITLE
Add path to the repository in the generate files periodic flow

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -53,6 +53,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v4
         with:
+          path: ./src/github.com/${{ github.repository }}
           branch: auto/update-generated-files
           title: "Run make generated-files"
           commit-message: "Run make generated-files"


### PR DESCRIPTION
We checkout the repository in a different location, so we need
to specify the path.

see https://github.com/openshift-knative/serverless-operator/runs/6422167407?check_suite_focus=true

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>