### PR TITLE
Being explicit about authorization for our test kafkausers

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -43,6 +43,8 @@ function install_strimzi_cluster {
             tls: true
             authentication:
               type: scram-sha-512
+        authorization:
+          type: simple
         config:
           offsets.topic.replication.factor: 3
           transaction.state.log.replication.factor: 3


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

- Being explicit about authorization for our test kafkausers. Because: In newer versions of (like 0.27+) Strimzi changed the approach from silently ignoring it to rejecting `KafkaUser` with `Authorization` when the cluster has it (Authorization) disabled.
