### PR TITLE
Get some fresh manifest from midstream

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/broker/eventing-kafka-broker.yaml
+++ b/knative-operator/deploy/resources/knativekafka/broker/eventing-kafka-broker.yaml
@@ -325,7 +325,9 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)
@@ -492,7 +494,9 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/knative-operator/deploy/resources/knativekafka/channel/eventing-kafka-channel.yaml
+++ b/knative-operator/deploy/resources/knativekafka/channel/eventing-kafka-channel.yaml
@@ -324,7 +324,9 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)
@@ -491,7 +493,9 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/knative-operator/deploy/resources/knativekafka/sink/eventing-kafka-sink.yaml
+++ b/knative-operator/deploy/resources/knativekafka/sink/eventing-kafka-sink.yaml
@@ -261,7 +261,9 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/knative-operator/deploy/resources/knativekafka/source/eventing-kafka-source.yaml
+++ b/knative-operator/deploy/resources/knativekafka/source/eventing-kafka-source.yaml
@@ -325,7 +325,9 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Midstream had two backports for manifests:
* OOM exit
* fips disabled

