### PR TITLE
[WIP] [release-1.23] Test Serverless downgrades

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -15,10 +15,13 @@ export STRIMZI_VERSION=0.28.0
 
 # Adjust these when upgrading the knative versions.
 export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v$(metadata.get dependencies.serving)}"
+export KNATIVE_SERVING_VERSION_PREVIOUS="${KNATIVE_SERVING_VERSION_PREVIOUS:-v$(metadata.get dependencies.previous.serving)}"
 export KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v$(metadata.get dependencies.eventing)}"
+export KNATIVE_EVENTING_VERSION_PREVIOUS="${KNATIVE_EVENTING_VERSION_PREVIOUS:-v$(metadata.get dependencies.previous.eventing)}"
 # TODO(matzew): SRVKE-1076 remove this when kafka e2e tests have been migrated
 export KNATIVE_EVENTING_KAFKA_VERSION="${KNATIVE_EVENTING_KAFKA_VERSION:-v$(metadata.get dependencies.eventing_kafka)}"
 export KNATIVE_EVENTING_KAFKA_BROKER_VERSION="${KNATIVE_EVENTING_KAFKA_BROKER_VERSION:-v$(metadata.get dependencies.eventing_kafka_broker)}"
+export KNATIVE_EVENTING_KAFKA_BROKER_VERSION_PREVIOUS="${KNATIVE_EVENTING_KAFKA_BROKER_VERSION_PREVIOUS:-v$(metadata.get dependencies.previous.eventing_kafka_broker)}"
 
 CURRENT_VERSION="$(metadata.get project.version)"
 PREVIOUS_VERSION="$(metadata.get olm.replaces)"

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -20,6 +20,7 @@ export KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v$(metadata.get dep
 export KNATIVE_EVENTING_VERSION_PREVIOUS="${KNATIVE_EVENTING_VERSION_PREVIOUS:-v$(metadata.get dependencies.previous.eventing)}"
 # TODO(matzew): SRVKE-1076 remove this when kafka e2e tests have been migrated
 export KNATIVE_EVENTING_KAFKA_VERSION="${KNATIVE_EVENTING_KAFKA_VERSION:-v$(metadata.get dependencies.eventing_kafka)}"
+export KNATIVE_EVENTING_KAFKA_VERSION_PREVIOUS="${KNATIVE_EVENTING_KAFKA_VERSION_PREVIOUS:-v$(metadata.get dependencies.previous.eventing_kafka)}"
 export KNATIVE_EVENTING_KAFKA_BROKER_VERSION="${KNATIVE_EVENTING_KAFKA_BROKER_VERSION:-v$(metadata.get dependencies.eventing_kafka_broker)}"
 export KNATIVE_EVENTING_KAFKA_BROKER_VERSION_PREVIOUS="${KNATIVE_EVENTING_KAFKA_BROKER_VERSION_PREVIOUS:-v$(metadata.get dependencies.previous.eventing_kafka_broker)}"
 

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -39,4 +39,5 @@ dependencies:
   previous:
     serving: 1.1.2
     eventing: 1.1.0
+    eventing_kafka: 1.1.0
     eventing_kafka_broker: 1.1.3

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -35,3 +35,8 @@ dependencies:
   eventing_kafka_broker_artifacts_branch: release-v1.2
   cli: 1.2.0
   operator: 1.2.2
+  # Previous versions required for downgrade testing
+  previous:
+    serving: 1.1.2
+    eventing: 1.1.0
+    eventing_kafka_broker: 1.1.3

--- a/test/flags.go
+++ b/test/flags.go
@@ -18,18 +18,22 @@ var Flags = initializeFlags()
 
 // FlagsStruct is struct that defines testing options
 type FlagsStruct struct {
-	Kubeconfigs           string // Path to .kube/config
-	CatalogSource         string // CatalogSource in the openshift-marketplace namespace for the Serverless operator Subscription
-	Channel               string // Serverless operator Subscription channel
-	Subscription          string // Serverless operator Subscription name
-	UpgradeChannel        string // Target OLM channel for upgrades
-	CSV                   string // Target CSV for upgrades
-	ServingVersion        string // Target Serving version for upgrades
-	EventingVersion       string // Target Eventing version for upgrades
-	KafkaVersion          string // Target Kafka version for upgrades
-	OpenShiftImage        string // Target OpenShift image for upgrades
-	UpgradeOpenShift      bool   // Whether to upgrade the OpenShift cluster
-	SkipServingPreUpgrade bool   // Whether to skip Serving pre-upgrade tests
+	Kubeconfigs             string // Path to .kube/config
+	CatalogSource           string // CatalogSource in the openshift-marketplace namespace for the Serverless operator Subscription
+	Channel                 string // Serverless operator Subscription channel
+	Subscription            string // Serverless operator Subscription name
+	UpgradeChannel          string // Target OLM channel for upgrades
+	CSV                     string // Target CSV for upgrades
+	CSVPrevious             string // Previous CSV for downgrades
+	ServingVersion          string // Target Serving version for upgrades
+	EventingVersion         string // Target Eventing version for upgrades
+	KafkaVersion            string // Target Kafka version for upgrades
+	ServingVersionPrevious  string // Target Serving version for downgrades
+	EventingVersionPrevious string // Target Eventing version for downgrades
+	KafkaVersionPrevious    string // Target Kafka version for downgrades
+	OpenShiftImage          string // Target OpenShift image for upgrades
+	UpgradeOpenShift        bool   // Whether to upgrade the OpenShift cluster
+	SkipServingPreUpgrade   bool   // Whether to skip Serving pre-upgrade tests
 }
 
 func initializeFlags() *FlagsStruct {
@@ -51,12 +55,20 @@ func initializeFlags() *FlagsStruct {
 		"OLM channel to be used during upgrades, empty by default.")
 	flag.StringVar(&f.CSV, "csv", "",
 		"Target ClusterServiceVersion for upgrade tests, empty by default.")
+	flag.StringVar(&f.CSVPrevious, "csvprevious", "",
+		"Target ClusterServiceVersion for upgrade tests, empty by default.")
 	flag.StringVar(&f.ServingVersion, "servingversion", "",
 		"Target Serving version for upgrade tests, empty by default.")
+	flag.StringVar(&f.ServingVersionPrevious, "servingversionprevious", "",
+		"Target Serving version for downgrade tests, empty by default.")
 	flag.StringVar(&f.EventingVersion, "eventingversion", "",
 		"Target Eventing version for upgrade tests, empty by default.")
+	flag.StringVar(&f.EventingVersionPrevious, "eventingversionprevious", "",
+		"Target Eventing version for downgrade tests, empty by default.")
 	flag.StringVar(&f.KafkaVersion, "kafkaversion", "",
 		"Target Kafka version for upgrade tests, empty by default.")
+	flag.StringVar(&f.KafkaVersionPrevious, "kafkaversionprevious", "",
+		"Target Kafka version for downgrade tests, empty by default.")
 	flag.StringVar(&f.OpenShiftImage, "openshiftimage", "",
 		"Target OpenShift image for cluster upgrades, empty by default.")
 	flag.BoolVar(&f.UpgradeOpenShift, "upgradeopenshift", false,

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -207,9 +207,13 @@ function run_rolling_upgrade_tests {
     "--catalogsource=${OLM_SOURCE}" \
     "--upgradechannel=${OLM_UPGRADE_CHANNEL}" \
     "--csv=${CURRENT_CSV}" \
+    "--csvprevious=${PREVIOUS_CSV}" \
     "--servingversion=${KNATIVE_SERVING_VERSION}" \
     "--eventingversion=${KNATIVE_EVENTING_VERSION}" \
     "--kafkaversion=${KNATIVE_EVENTING_KAFKA_BROKER_VERSION}" \
+    "--servingversionprevious=${KNATIVE_SERVING_VERSION_PREVIOUS}" \
+    "--eventingversionprevious=${KNATIVE_EVENTING_VERSION_PREVIOUS}" \
+    "--kafkaversionprevious=${KNATIVE_EVENTING_KAFKA_BROKER_VERSION_PREVIOUS}" \
     --resolvabledomain \
     --https)
 

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -213,7 +213,7 @@ function run_rolling_upgrade_tests {
     "--kafkaversion=${KNATIVE_EVENTING_KAFKA_BROKER_VERSION}" \
     "--servingversionprevious=${KNATIVE_SERVING_VERSION_PREVIOUS}" \
     "--eventingversionprevious=${KNATIVE_EVENTING_VERSION_PREVIOUS}" \
-    "--kafkaversionprevious=${KNATIVE_EVENTING_KAFKA_BROKER_VERSION_PREVIOUS}" \
+    "--kafkaversionprevious=${KNATIVE_EVENTING_KAFKA_VERSION_PREVIOUS}" \
     --resolvabledomain \
     --https)
 

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -222,7 +222,7 @@ function run_rolling_upgrade_tests {
     if ! oc get namespace serving-tests &>/dev/null; then
       oc create namespace serving-tests
     fi
-    go_test_e2e -run=TestServerlessUpgrade -timeout=90m "${common_opts[@]}"
+    go_test_e2e -run=TestServerlessUpgrade -timeout=120m "${common_opts[@]}"
   fi
 
   # For reuse in downstream test executions. Might be run after Serverless
@@ -232,7 +232,7 @@ function run_rolling_upgrade_tests {
       oc delete namespace serving-tests
     fi
     oc create namespace serving-tests
-    go_test_e2e -run=TestClusterUpgrade -timeout=190m "${common_opts[@]}" \
+    go_test_e2e -run=TestClusterUpgrade -timeout=220m "${common_opts[@]}" \
       --openshiftimage="${UPGRADE_OCP_IMAGE}" \
       --upgradeopenshift
   fi

--- a/test/subscription.go
+++ b/test/subscription.go
@@ -70,8 +70,7 @@ func Subscription(subscriptionName string) *operatorsv1alpha1.Subscription {
 			Package:                ServerlessOperatorPackage,
 			Channel:                Flags.Channel,
 			InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
-			//TODO: Pass this as a flag, similar to --csv=serverless-operator.v1.23.0
-			StartingCSV: "serverless-operator.v1.22.0",
+			StartingCSV:            Flags.CSVPrevious,
 		},
 	}
 }
@@ -81,27 +80,5 @@ func CreateSubscription(ctx *Context, name string) (*operatorsv1alpha1.Subscript
 	if err != nil {
 		return nil, err
 	}
-	//ctx.AddToCleanup(func() error {
-	//	ctx.T.Logf("Cleaning up Subscription '%s/%s'", subs.Namespace, subs.Name)
-	//	return ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(subs.Namespace).Delete(context.Background(), subs.Name, metav1.DeleteOptions{})
-	//})
 	return subs, nil
 }
-
-//func WaitForSubscriptionState(ctx *Context, name, namespace string, inState func(s *operatorsv1alpha1.Subscription, err error) (bool, error)) (*operatorsv1alpha1.Subscription, error) {
-//	var lastState *operatorsv1alpha1.Subscription
-//	var err error
-//	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
-//		lastState, err = ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(namespace).Get(context.Background(), name, metav1.GetOptions{})
-//		return inState(lastState, err)
-//	})
-//
-//	if waitErr != nil {
-//		return lastState, fmt.Errorf("subscription %s is not in desired state, got: %+v: %w", name, lastState, waitErr)
-//	}
-//	return lastState, nil
-//}
-//
-//func IsSubscriptionInstalledCSVPresent(s *operatorsv1alpha1.Subscription, err error) (bool, error) {
-//	return s.Status.InstalledCSV != "" && s.Status.InstalledCSV != "<none>", err
-//}

--- a/test/subscription.go
+++ b/test/subscription.go
@@ -50,11 +50,15 @@ func IsCSVSucceeded(c *operatorsv1alpha1.ClusterServiceVersion, err error) (bool
 	return c.Status.Phase == "Succeeded", err
 }
 
+func DeleteClusterServiceVersion(ctx *Context, name, namespace string) error {
+	return ctx.Clients.OLM.OperatorsV1alpha1().ClusterServiceVersions(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
 func DeleteSubscription(ctx *Context, name, namespace string) error {
 	return ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
 }
 
-func Subscription(subscriptionName string) *operatorsv1alpha1.Subscription {
+func Subscription(subscriptionName, startingCSV string) *operatorsv1alpha1.Subscription {
 	return &operatorsv1alpha1.Subscription{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       operatorsv1alpha1.SubscriptionKind,
@@ -70,13 +74,13 @@ func Subscription(subscriptionName string) *operatorsv1alpha1.Subscription {
 			Package:                ServerlessOperatorPackage,
 			Channel:                Flags.Channel,
 			InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
-			StartingCSV:            Flags.CSVPrevious,
+			StartingCSV:            startingCSV,
 		},
 	}
 }
 
-func CreateSubscription(ctx *Context, name string) (*operatorsv1alpha1.Subscription, error) {
-	subs, err := ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(OperatorsNamespace).Create(context.Background(), Subscription(name), metav1.CreateOptions{})
+func CreateSubscription(ctx *Context, name, startingCSV string) (*operatorsv1alpha1.Subscription, error) {
+	subs, err := ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(OperatorsNamespace).Create(context.Background(), Subscription(name, startingCSV), metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/test/subscription.go
+++ b/test/subscription.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,8 +17,10 @@ const (
 	// Interval specifies the time between two polls.
 	Interval = 10 * time.Second
 	// Timeout specifies the timeout for the function PollImmediate to reach a certain status.
-	Timeout            = 5 * time.Minute
-	OperatorsNamespace = "openshift-serverless"
+	Timeout                   = 5 * time.Minute
+	OperatorsNamespace        = "openshift-serverless"
+	OLMNamespace              = "openshift-marketplace"
+	ServerlessOperatorPackage = "serverless-operator"
 )
 
 func UpdateSubscriptionChannelSource(ctx *Context, name, channel, source string) (*operatorsv1alpha1.Subscription, error) {
@@ -48,3 +49,59 @@ func IsCSVSucceeded(c *operatorsv1alpha1.ClusterServiceVersion, err error) (bool
 	}
 	return c.Status.Phase == "Succeeded", err
 }
+
+func DeleteSubscription(ctx *Context, name, namespace string) error {
+	return ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
+func Subscription(subscriptionName string) *operatorsv1alpha1.Subscription {
+	return &operatorsv1alpha1.Subscription{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       operatorsv1alpha1.SubscriptionKind,
+			APIVersion: operatorsv1alpha1.SubscriptionCRDAPIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: OperatorsNamespace,
+			Name:      subscriptionName,
+		},
+		Spec: &operatorsv1alpha1.SubscriptionSpec{
+			CatalogSource:          Flags.CatalogSource,
+			CatalogSourceNamespace: OLMNamespace,
+			Package:                ServerlessOperatorPackage,
+			Channel:                Flags.Channel,
+			InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+			//TODO: Pass this as a flag, similar to --csv=serverless-operator.v1.23.0
+			StartingCSV: "serverless-operator.v1.22.0",
+		},
+	}
+}
+
+func CreateSubscription(ctx *Context, name string) (*operatorsv1alpha1.Subscription, error) {
+	subs, err := ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(OperatorsNamespace).Create(context.Background(), Subscription(name), metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	//ctx.AddToCleanup(func() error {
+	//	ctx.T.Logf("Cleaning up Subscription '%s/%s'", subs.Namespace, subs.Name)
+	//	return ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(subs.Namespace).Delete(context.Background(), subs.Name, metav1.DeleteOptions{})
+	//})
+	return subs, nil
+}
+
+//func WaitForSubscriptionState(ctx *Context, name, namespace string, inState func(s *operatorsv1alpha1.Subscription, err error) (bool, error)) (*operatorsv1alpha1.Subscription, error) {
+//	var lastState *operatorsv1alpha1.Subscription
+//	var err error
+//	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
+//		lastState, err = ctx.Clients.OLM.OperatorsV1alpha1().Subscriptions(namespace).Get(context.Background(), name, metav1.GetOptions{})
+//		return inState(lastState, err)
+//	})
+//
+//	if waitErr != nil {
+//		return lastState, fmt.Errorf("subscription %s is not in desired state, got: %+v: %w", name, lastState, waitErr)
+//	}
+//	return lastState, nil
+//}
+//
+//func IsSubscriptionInstalledCSVPresent(s *operatorsv1alpha1.Subscription, err error) (bool, error) {
+//	return s.Status.InstalledCSV != "" && s.Status.InstalledCSV != "<none>", err
+//}

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -69,7 +69,7 @@ func DowngradeServerless(ctx *test.Context) error {
 		return err
 	}
 
-	installPlan, err := test.WaitForInstallPlan(ctx, test.OperatorsNamespace, "serverless-operator.v1.22.0" /*test.Flags.CSV*/, test.Flags.CatalogSource)
+	installPlan, err := test.WaitForInstallPlan(ctx, test.OperatorsNamespace, test.Flags.CSVPrevious, test.Flags.CatalogSource)
 	if err != nil {
 		return err
 	}
@@ -78,35 +78,34 @@ func DowngradeServerless(ctx *test.Context) error {
 		return err
 	}
 
-	if _, err := test.WaitForClusterServiceVersionState(ctx, "serverless-operator.v1.22.0" /*test.Flags.CSV*/, test.OperatorsNamespace, test.IsCSVSucceeded); err != nil {
+	if _, err := test.WaitForClusterServiceVersionState(ctx, test.Flags.CSVPrevious, test.OperatorsNamespace, test.IsCSVSucceeded); err != nil {
 		return err
 	}
 
-	//TODO: Pass correct Serving, Eventing, Kafka version through flags, refactor
 	knativeServing := "knative-serving"
 	if _, err := v1a1test.WaitForKnativeServingState(ctx,
 		knativeServing,
 		knativeServing,
-		v1a1test.IsKnativeServingWithVersionReady(strings.TrimPrefix(test.Flags.ServingVersion, "v")),
+		v1a1test.IsKnativeServingWithVersionReady(strings.TrimPrefix(test.Flags.ServingVersionPrevious, "v")),
 	); err != nil {
-		return fmt.Errorf("serving upgrade failed: %w", err)
+		return fmt.Errorf("serving downgrade failed: %w", err)
 	}
 
 	knativeEventing := "knative-eventing"
 	if _, err := v1a1test.WaitForKnativeEventingState(ctx,
 		knativeEventing,
 		knativeEventing,
-		v1a1test.IsKnativeEventingWithVersionReady(strings.TrimPrefix(test.Flags.EventingVersion, "v")),
+		v1a1test.IsKnativeEventingWithVersionReady(strings.TrimPrefix(test.Flags.EventingVersionPrevious, "v")),
 	); err != nil {
-		return fmt.Errorf("eventing upgrade failed: %w", err)
+		return fmt.Errorf("eventing downgrade failed: %w", err)
 	}
 
 	if _, err := v1a1test.WaitForKnativeKafkaState(ctx,
 		"knative-kafka",
 		knativeEventing,
-		v1a1test.IsKnativeKafkaWithVersionReady(strings.TrimPrefix(test.Flags.KafkaVersion, "v")),
+		v1a1test.IsKnativeKafkaWithVersionReady(strings.TrimPrefix(test.Flags.KafkaVersionPrevious, "v")),
 	); err != nil {
-		return fmt.Errorf("knative kafka upgrade failed: %w", err)
+		return fmt.Errorf("knative kafka downgrade failed: %w", err)
 	}
 
 	return nil

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -61,11 +61,15 @@ func DowngradeServerless(ctx *test.Context) error {
 		return err
 	}
 
+	if err := test.DeleteClusterServiceVersion(ctx, test.Flags.CSV, test.OperatorsNamespace); err != nil {
+		return err
+	}
+
 	if err := test.WaitForServerlessOperatorsDeleted(ctx); err != nil {
 		return err
 	}
 
-	if _, err := test.CreateSubscription(ctx, subscription); err != nil {
+	if _, err := test.CreateSubscription(ctx, subscription, test.Flags.CSVPrevious); err != nil {
 		return err
 	}
 

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -152,10 +152,17 @@ func postUpgradeTests(ctx *test.Context) []pkgupgrade.Operation {
 }
 
 func postDowngradeTests() []pkgupgrade.Operation {
-	return []pkgupgrade.Operation{
-		// Ensure cleanup through PostDowngradeTest.
-		servingupgrade.ServicePostDowngradeTest(),
-	}
+	tests := servingupgrade.ServingPostDowngradeTests()
+	tests = append(tests,
+		servingupgrade.CRDStoredVersionPostUpgradeTest(), // Check if CRD Stored version check works with downgrades.
+		eventingupgrade.PostDowngradeTest(),
+		eventingupgrade.CRDPostUpgradeTest(), // Check if CRD Stored version check works with downgrades.
+		kafkaupgrade.ChannelPostDowngradeTest(),
+		kafkaupgrade.SourcePostDowngradeTest(),
+		kafkabrokerupgrade.BrokerPostDowngradeTest(),
+		kafkabrokerupgrade.SinkPostDowngradeTest(),
+	)
+	return tests
 }
 
 func waitForServicesReady(ctx *test.Context) pkgupgrade.Operation {

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -67,6 +67,13 @@ func TestServerlessUpgrade(t *testing.T) {
 					}
 				}),
 			},
+			DowngradeWith: []pkgupgrade.Operation{
+				pkgupgrade.NewOperation("DowngradeServerless", func(c pkgupgrade.Context) {
+					if err := installation.DowngradeServerless(ctx); err != nil {
+						c.T.Error("Serverless downgrade failed:", err)
+					}
+				}),
+			},
 		},
 	}
 	suite.Execute(cfg)


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVCOM-1863

I plan to send this to "main" as well but currently, "main" is being upgraded to 1.24 and the upgrade from 1.23->1.24 doesn't include kafka-channel-migration. That's why I'm testing it here first.