### PR TITLE
Pull the previous bundle image from a new namespace "knative"

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -58,7 +58,7 @@ function install_catalogsource {
     cp "${index_build_dir}/Dockerfile" "${rootdir}/_output/bkp.Dockerfile"
 
     # Replace the nightly bundle reference with the previously built bundle
-    sed -i "s_\(.*\)\(registry.ci.openshift.org/openshift/openshift-serverless-nightly:serverless-bundle\)\(.*\)_\1image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle:latest\3_" "${index_build_dir}/Dockerfile"
+    sed -i "s_\(.*\)\(registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-bundle\)\(.*\)_\1image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle:latest\3_" "${index_build_dir}/Dockerfile"
 
     build_image "serverless-index" "${index_build_dir}"
 

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -7,7 +7,7 @@ COPY configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
 RUN /bin/opm --skip-tls-verify render -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.22.0:serverless-stop-bundle \
-  registry.ci.openshift.org/openshift/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
+  registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -6,7 +6,7 @@ COPY --from=quay.io/operator-framework/opm:latest /bin/opm /bin/opm
 COPY configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
-RUN /bin/opm --skip-tls-verify render -o yaml registry.ci.openshift.org/openshift/openshift-serverless-v1.22.0:serverless-stop-bundle \
+RUN /bin/opm --skip-tls-verify render -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.22.0:serverless-stop-bundle \
   registry.ci.openshift.org/openshift/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
 
 # The base image is expected to contain

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -6,7 +6,7 @@ COPY --from=quay.io/operator-framework/opm:latest /bin/opm /bin/opm
 COPY configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
-RUN /bin/opm --skip-tls-verify render -o yaml registry.ci.openshift.org/openshift/openshift-serverless-v__PREVIOUS_VERSION__:serverless-stop-bundle \
+RUN /bin/opm --skip-tls-verify render -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_VERSION__:serverless-stop-bundle \
   registry.ci.openshift.org/openshift/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
 
 # The base image is expected to contain

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -7,7 +7,7 @@ COPY configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
 RUN /bin/opm --skip-tls-verify render -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_VERSION__:serverless-stop-bundle \
-  registry.ci.openshift.org/openshift/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
+  registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe


### PR DESCRIPTION
This is the namespace where images are now promoted since release-1.22

This PR depends on another one: The namespace was changed in https://github.com/openshift/release/pull/28552 because the old namespace openshift is no longer allowed.

When this PR is merged the serverless-index image will be built in CI and published. Then `make install` without DOCKER_REPO_OVERRIDE should work seemlessly.