### PR TITLE
Revert legacy config removal because of downgrades

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,12 +33,10 @@ require (
 	knative.dev/pkg v0.0.0-20220223180940-4fcbc1bc12e8
 	knative.dev/serving v0.29.2
 	sigs.k8s.io/controller-runtime v0.9.7
+	sigs.k8s.io/yaml v1.3.0
 )
 
-require (
-	k8s.io/klog v1.0.0 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
-)
+require k8s.io/klog v1.0.0 // indirect
 
 require (
 	cloud.google.com/go v0.99.0 // indirect

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -277,6 +277,7 @@ func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *serve
 			common.KafkaOwnerNamespace: instance.Namespace,
 		}),
 		setKafkaDeployments(instance.Spec.HighAvailability.Replicas),
+		configureLegacyEventingKafka(instance.Spec.Channel),
 		operatorcommon.ConfigMapTransform(instance.Spec.Config, logging.FromContext(context.TODO())),
 		configureEventingKafka(instance.Spec),
 		ImageTransform(common.BuildImageOverrideMapFromEnviron(os.Environ(), "KAFKA_IMAGE_")),
@@ -508,6 +509,35 @@ func (r *ReconcileKnativeKafka) buildManifest(instance *serverlessoperatorv1alph
 
 func enableControlPlaneManifest(spec serverlessoperatorv1alpha1.KnativeKafkaSpec) bool {
 	return spec.Broker.Enabled || spec.Sink.Enabled || spec.Source.Enabled || spec.Channel.Enabled
+}
+
+func configureLegacyEventingKafka(kafkachannel serverlessoperatorv1alpha1.Channel) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() == "ConfigMap" && u.GetName() == "config-kafka" {
+
+			// set the values from our operator
+			kafkacfg := EventingKafkaConfig{
+				Kafka: kafkaconfig.EKKafkaConfig{
+					Brokers:             kafkachannel.BootstrapServers,
+					AuthSecretName:      kafkachannel.AuthSecretName,
+					AuthSecretNamespace: kafkachannel.AuthSecretNamespace,
+				},
+			}
+
+			// write to yaml
+			configBytes, err := yaml.Marshal(kafkacfg)
+			if err != nil {
+				return err
+			}
+
+			// update the config map data
+			log.Info("Found ConfigMap config-kafka, updating it with broker and auth info from spec")
+			if err := unstructured.SetNestedField(u.Object, string(configBytes), "data", "eventing-kafka"); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 }
 
 // configureEventingKafka configures the new Knative Eventing components for Apache Kafka

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -33,10 +33,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	kafkaconfig "knative.dev/eventing-kafka/pkg/common/config"
+	"sigs.k8s.io/yaml"
+
 	serverlessoperatorv1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring"
-	kafkaconfig "knative.dev/eventing-kafka/pkg/common/config"
 )
 
 const (

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -7,25 +7,27 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/yaml"
+
 	"github.com/google/go-cmp/cmp"
 	mf "github.com/manifestival/manifestival"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
@@ -586,6 +588,11 @@ func makeEventingKafkaDeployment(t *testing.T) *unstructured.Unstructured {
 	}
 
 	return result
+}
+
+func marshalEventingKafkaConfig(kafka EventingKafkaConfig) string {
+	configBytes, _ := yaml.Marshal(kafka)
+	return string(configBytes)
 }
 
 func makeCr(mods ...func(*v1alpha1.KnativeKafka)) *v1alpha1.KnativeKafka {

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
+	kafkaconfig "knative.dev/eventing-kafka/pkg/common/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/yaml"
@@ -194,6 +195,200 @@ func TestKnativeKafkaReconcile(t *testing.T) {
 				if err != nil {
 					t.Fatalf("get: (%v)", err)
 				}
+			}
+		})
+	}
+}
+
+func TestUpdateEventingKafka(t *testing.T) {
+	tests := []struct {
+		name         string
+		obj          *unstructured.Unstructured
+		kafkaChannel v1alpha1.Channel
+		expect       *unstructured.Unstructured
+	}{{
+		name: "Update config-kafka with all arguments",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+			},
+		},
+		kafkaChannel: v1alpha1.Channel{
+			AuthSecretName:      "my-secret",
+			BootstrapServers:    "example.com:1234",
+			AuthSecretNamespace: "my-ns",
+		},
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+				"data": map[string]interface{}{
+					"eventing-kafka": "kafka:\n  authSecretName: my-secret\n  authSecretNamespace: my-ns\n  brokers: example.com:1234\n",
+				},
+			},
+		},
+	}, {
+		name: "Update config-kafka with only brokers",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+			},
+		},
+		kafkaChannel: v1alpha1.Channel{
+			BootstrapServers: "example.com:1234",
+		},
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+				"data": map[string]interface{}{
+					"eventing-kafka": "kafka:\n  brokers: example.com:1234\n",
+				},
+			},
+		},
+	}, {
+		name: "Update config-kafka - overwrite all arguments",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+				"data": map[string]interface{}{
+					"eventing-kafka": marshalEventingKafkaConfig(EventingKafkaConfig{
+						Kafka: kafkaconfig.EKKafkaConfig{
+							Brokers:             "TO_BE_OVERWRITTEN",
+							AuthSecretName:      "TO_BE_OVERWRITTEN",
+							AuthSecretNamespace: "TO_BE_OVERWRITTEN",
+						},
+					}),
+				},
+			},
+		},
+		kafkaChannel: v1alpha1.Channel{
+			BootstrapServers:    "example.com:1234",
+			AuthSecretName:      "my-secret",
+			AuthSecretNamespace: "my-ns",
+		},
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+				"data": map[string]interface{}{
+					"eventing-kafka": "kafka:\n  authSecretName: my-secret\n  authSecretNamespace: my-ns\n  brokers: example.com:1234\n",
+				},
+			},
+		},
+	}, {
+		name: "Update config-kafka - overwrite only brokers",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+				"data": map[string]interface{}{
+					"eventing-kafka": marshalEventingKafkaConfig(EventingKafkaConfig{
+						Kafka: kafkaconfig.EKKafkaConfig{
+							Brokers: "TO_BE_OVERWRITTEN",
+						},
+					}),
+				},
+			},
+		},
+		kafkaChannel: v1alpha1.Channel{
+			BootstrapServers: "example.com:1234",
+		},
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+				"data": map[string]interface{}{
+					"eventing-kafka": "kafka:\n  brokers: example.com:1234\n",
+				},
+			},
+		},
+	}, {
+		name: "Do not update other configmaps",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-foo",
+				},
+			},
+		},
+		kafkaChannel: v1alpha1.Channel{
+			AuthSecretName:      "my-secret",
+			AuthSecretNamespace: "my-ns",
+		},
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-foo",
+				},
+			},
+		},
+	}, {
+		name: "Do not update other resources",
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+			},
+		},
+		kafkaChannel: v1alpha1.Channel{
+			AuthSecretName:      "my-secret",
+			AuthSecretNamespace: "my-ns",
+		},
+		expect: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "config-kafka",
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := configureLegacyEventingKafka(test.kafkaChannel)(test.obj)
+			if err != nil {
+				t.Fatalf("setAuthSecretNamespace/setAuthSecretName: (%v)", err)
+			}
+
+			if !cmp.Equal(test.expect, test.obj) {
+				t.Fatalf("Resource wasn't what we expected, diff: %s", cmp.Diff(test.obj, test.expect))
 			}
 		})
 	}


### PR DESCRIPTION
Reverting a bit of #1564 and we keep the `legacy` Eventing Kafka transformer around for now

