### PR TITLE
[SRVKE-1180] Remove the eventing NS from MT bits as well

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.2.1/3-in-memory-channel.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.2.1/3-in-memory-channel.yaml
@@ -1,26 +1,3 @@
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: knative-eventing
-  labels:
-    eventing.knative.dev/release: "v1.2.1"
-    app.kubernetes.io/version: "1.2.1"
-    app.kubernetes.io/name: knative-eventing
-
 ---
 # Copyright 2021 The Knative Authors
 #

--- a/openshift-knative-operator/hack/001-eventing-namespace-deletion.patch
+++ b/openshift-knative-operator/hack/001-eventing-namespace-deletion.patch
@@ -32,3 +32,34 @@ index 813f9bece..c5b131005 100644
  
  apiVersion: v1
  kind: ServiceAccount
+diff --git a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.2.1/3-in-memory-channel.yaml b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.2.1/3-in-memory-channel.yaml
+index d50b8ee02..b160d60ae 100644
+--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.2.1/3-in-memory-channel.yaml
++++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.2.1/3-in-memory-channel.yaml
+@@ -1,26 +1,3 @@
+-# Copyright 2021 The Knative Authors
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     http://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-
+-apiVersion: v1
+-kind: Namespace
+-metadata:
+-  name: knative-eventing
+-  labels:
+-    eventing.knative.dev/release: "v1.2.1"
+-    app.kubernetes.io/version: "1.2.1"
+-    app.kubernetes.io/name: knative-eventing
+-
+ ---
+ # Copyright 2021 The Knative Authors
+ #


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Removing the `knative-eventing` `kind: Namespace` from the MT bundle

https://issues.redhat.com/browse/SRVKE-1180