### PR TITLE
use new "/knative/" instead of "/openshift/" index image by default

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -14,7 +14,7 @@ function install_catalogsource {
 
   local rootdir csv index_image
 
-  index_image=registry.ci.openshift.org/openshift/openshift-serverless-nightly:serverless-index
+  index_image=registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-index
 
   # Build bundle and index images only when running in CI or when DOCKER_REPO_OVERRIDE is defined.
   # Otherwise the latest nightly build will be used for CatalogSource.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
The default nightly index image has been moved to "knative" namespace.

## Proposed Changes
- :bug: Use proper index image since it was renamed to "knative" namespace