### PR TITLE
Increase Zipkin to -Xmx9G

### DIFF
--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -53,12 +53,12 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         - name: JAVA_OPTS
-          value: '-Xms128m -Xmx7G -XX:+ExitOnOutOfMemoryError'
+          value: '-Xms128m -Xmx9G -XX:+ExitOnOutOfMemoryError'
         - name: MEM_MAX_SPANS
           value: '10000000'
         resources:
           limits:
-            memory: 8Gi
+            memory: 10Gi
           requests:
             memory: 256Mi
 ---


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Increase the Zipkin Xmx limit to 9G as we're still hitting OOM errors when running upgrade tests and collecting traces as can be seen [here](https://github.com/openshift-knative/serverless-operator/pull/1541). Another option would be to send fewer events. We're now sending events every 10 ms. We could probably set this to 20 ms but first try increasing the memory limits. 

