### PR TITLE
Use operator images built by CI only when running within own CI

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -28,8 +28,8 @@ function install_catalogsource {
     mkdir -p "${rootdir}/_output"
     cp "$csv" "${rootdir}/_output/bkp.yaml"
 
-    if [ -n "$OPENSHIFT_CI" ]; then
-      # Image variables supplied by ci-operator.
+    if [ "$OPENSHIFT_BUILD_NAME" = "serverless-operator-src" ]; then
+      # Image variables supplied by ci-operator only when running within serverless-operator's CI.
       sed -i "s,image: .*openshift-serverless-.*:knative-operator,image: ${KNATIVE_OPERATOR}," "$csv"
       sed -i "s,image: .*openshift-serverless-.*:knative-openshift-ingress,image: ${KNATIVE_OPENSHIFT_INGRESS}," "$csv"
       sed -i "s,image: .*openshift-serverless-.*:openshift-knative-operator,image: ${OPENSHIFT_KNATIVE_OPERATOR}," "$csv"


### PR DESCRIPTION
* One can also run this function in CI but for a different repository
(e.g. openshift/knative-serving) in which case the CI-built images are
not available.

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug:  Fix installing the CatalogSource when the function is called from Knative Serving CI. In that case the bundle and index images need to be built but other operator images remain unchanged. The Knative Serving repo would call the installation like this: `ensure_catalogsource_installed` instead of `OPENSHIFT_CI="" ensure_catalogsource_installed`
- The OPENSHIFT_BUILD_NAME variable is named "serverless-operator-src" only in serverless-operator's CI. It will be unset in local runs and in other repo's CI it will have a different value (possibly just "src")
- Overall it works like this:
  - if OPENSHIFT_CI is unset it will run with latest nightly builds (not building any images)
  - if OPENSHIFT_CI is set it will build bundle and index images but not operator images
  - if OPENSHIFT_CI is set and OPENSHIFT_BUILD_NAME==serverless-operator-src , it will use CI's built operator 
 images and it will build bundle/index as well (this is for CI in serverless-operator)
  - DOCKER_REPO_OVERRIDE is independent of the above, when it's set it will build all images (including operator images from scratch, bundle and index images) - this is typical for local development
