### PR TITLE
Change unavailablePeriodSeconds for upgrade tests

### DIFF
--- a/test/upgrade/continual/channel-config.toml
+++ b/test/upgrade/continual/channel-config.toml
@@ -7,3 +7,8 @@ interval = {{ .Config.Interval.Nanoseconds }}
 
 [forwarder]
 target = '{{- .ForwarderTarget -}}'
+
+[receiver]
+  [receiver.errors]
+    # Value in nanoseconds
+    unavailablePeriodToReport = 10000000000

--- a/test/upgrade/continual/channel-config.toml
+++ b/test/upgrade/continual/channel-config.toml
@@ -11,4 +11,4 @@ target = '{{- .ForwarderTarget -}}'
 [receiver]
   [receiver.errors]
     # Value in nanoseconds
-    unavailablePeriodToReport = 10000000000
+    unavailablePeriodToReport = 90000000000

--- a/test/upgrade/continual/kafka-broker-config.toml
+++ b/test/upgrade/continual/kafka-broker-config.toml
@@ -7,3 +7,8 @@ interval = {{ .Config.Interval.Nanoseconds }}
 
 [forwarder]
 target = '{{- .ForwarderTarget -}}'
+
+[receiver]
+  [receiver.errors]
+    # Value in nanoseconds
+    unavailablePeriodToReport = 10000000000

--- a/test/upgrade/continual/kafka-broker-config.toml
+++ b/test/upgrade/continual/kafka-broker-config.toml
@@ -11,4 +11,4 @@ target = '{{- .ForwarderTarget -}}'
 [receiver]
   [receiver.errors]
     # Value in nanoseconds
-    unavailablePeriodToReport = 10000000000
+    unavailablePeriodToReport = 90000000000

--- a/test/upgrade/continual/kafka-sink-source-config.toml
+++ b/test/upgrade/continual/kafka-sink-source-config.toml
@@ -7,3 +7,8 @@ interval = {{ .Config.Interval.Nanoseconds }}
 
 [forwarder]
 target = '{{- .ForwarderTarget -}}'
+
+[receiver]
+  [receiver.errors]
+    # Value in nanoseconds
+    unavailablePeriodToReport = 10000000000

--- a/test/upgrade/continual/kafka-sink-source-config.toml
+++ b/test/upgrade/continual/kafka-sink-source-config.toml
@@ -11,4 +11,4 @@ target = '{{- .ForwarderTarget -}}'
 [receiver]
   [receiver.errors]
     # Value in nanoseconds
-    unavailablePeriodToReport = 10000000000
+    unavailablePeriodToReport = 90000000000


### PR DESCRIPTION
Fixes the problem in upgrade tests such as this one:
```
actual unavailable period 1m0.322977758s is over down time limit of 1m0s
```
Like in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/1574/pull-ci-openshift-knative-serverless-operator-main-4.10-upgrade-tests-aws-ocp-410/1529113432580689920

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Change unavailablePeriodSeconds from 60 to 90 seconds and give room to the KafkaChannel migration to be finished properly
- We can revert this back with the next release when we're already on the new impl. Edit: I've changed the target branch to release-1.23 only. So, no action needed for the next release.
