### PR TITLE
[release-1.22] Use knative namespace for operator images

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -405,7 +405,7 @@ spec:
                 containers:
                   - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:openshift-knative-operator
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:openshift-knative-operator
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -517,7 +517,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:knative-operator
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -682,7 +682,7 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:knative-openshift-ingress
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:knative-openshift-ingress
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -808,13 +808,13 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:openshift-knative-operator
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:knative-operator
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:knative-openshift-ingress
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:knative-openshift-ingress
     - name: "IMAGE_queue-proxy"
       image: "registry.ci.openshift.org/openshift/knative-v1.1.2:knative-serving-queue"
     - name: "IMAGE_activator"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -413,7 +413,7 @@ spec:
                 containers:
                   - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:openshift-knative-operator
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:openshift-knative-operator
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -475,7 +475,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:knative-operator
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -557,7 +557,7 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:knative-openshift-ingress
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:knative-openshift-ingress
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -685,12 +685,12 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:openshift-knative-operator
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:knative-operator
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/openshift/openshift-serverless-v1.22.1:knative-openshift-ingress
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.22.1:knative-openshift-ingress
   replaces:
   version:


### PR DESCRIPTION
That's the namespace where operator images are promoted now.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

:bug:
- This is same as https://github.com/openshift-knative/serverless-operator/commit/84b6d1a66846d854fe2fbd70fe035cb5313db472 , just for release-1.22 branch.
- This change should not have any effect on the product. This should only help fix CI issues, especially in upgrade tests where we upgrade from 1.22 to a newer version. The serverless-bundle and serverless-stop-bundle must point to correct up-to-date images. So far they were pointing to a little outdated operator images from "openshift" namespace.

