### PR TITLE
Verify post-install jobs test takes into account longer running jobs

### DIFF
--- a/test/upgrade/verify_jobs.go
+++ b/test/upgrade/verify_jobs.go
@@ -55,7 +55,7 @@ func verifyPostInstallJobs(ctx context.Context, c upgrade.Context, cfg VerifyPos
 		}
 
 		eg.Go(func() error {
-			err := wait.Poll(5*time.Second, 10*time.Minute, func() (done bool, err error) {
+			err := wait.PollUntil(5*time.Second, func() (bool, error) {
 				j, err := kubeClient.
 					BatchV1().
 					Jobs(cfg.Namespace).
@@ -76,7 +76,7 @@ func verifyPostInstallJobs(ctx context.Context, c upgrade.Context, cfg VerifyPos
 				}
 
 				return j.Status.Succeeded > 0, nil
-			})
+			}, ctx.Done())
 			if err != nil {
 				return fmt.Errorf("%w, job:\n%+v", err, j)
 			}


### PR DESCRIPTION
The migration job takes some time to complete and we sometimes get
a timeout since the job is still active [1] (eventing jobs have sleeps
to wait for DNS propagation, etc).

[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/1591/pull-ci-openshift-knative-serverless-operator-main-4.10-upgrade-tests-aws-ocp-410/1533725499665158144

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>