### PR TITLE
increase timeout in kitchensink tests

### DIFF
--- a/test/kitchensinke2e/main_test.go
+++ b/test/kitchensinke2e/main_test.go
@@ -28,7 +28,7 @@ func defaultContext(t *testing.T) (context.Context, environment.Environment) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
-		environment.WithPollTimings(4*time.Second, 320*time.Second),
+		environment.WithPollTimings(4*time.Second, 600*time.Second),
 		environment.Managed(t),
 	)
 }


### PR DESCRIPTION
Some of the kitchensink scenarios create ~64 kafkachannels, with various dependencies between Parallels and Sequences, so it is expected the overall readiness can take some time.

## Proposed Changes
- :broom: Increase kitchensink tests timeouts