### PR TITLE
Change sample-rate for tracing in upgrade tests to 0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ test-upstream-upgrade-testonly:
 test-upstream-upgrade:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	TRACING_BACKEND=zipkin ./hack/tracing.sh
-	INSTALL_PREVIOUS_VERSION="true" INSTALL_KAFKA="true" TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=6 ./hack/install.sh
+	INSTALL_PREVIOUS_VERSION="true" INSTALL_KAFKA="true" TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=6 SAMPLE_RATE="0.3" ./hack/install.sh
 	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
 # Alias.

--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -180,14 +180,14 @@ function enable_eventing_tracing {
   logger.info "Configuring tracing for Eventing"
   local endpoint
   endpoint=$(get_tracing_endpoint)
-  oc -n "${EVENTING_NAMESPACE}" patch knativeeventing/knative-eventing --type=merge --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"'"${endpoint}"'", "sample-rate":"0.3"}}}}'
+  oc -n "${EVENTING_NAMESPACE}" patch knativeeventing/knative-eventing --type=merge --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"'"${endpoint}"'", "sample-rate":"'"${SAMPLE_RATE}"'"}}}}'
 }
 
 function enable_serving_tracing {
   logger.info "Configuring tracing for Serving"
   local endpoint
   endpoint=$(get_tracing_endpoint)
-  oc -n "${SERVING_NAMESPACE}" patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"'"${endpoint}"'", "sample-rate":"0.3"}}}}'
+  oc -n "${SERVING_NAMESPACE}" patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"'"${endpoint}"'", "sample-rate":"'"${SAMPLE_RATE}"'"}}}}'
 }
 
 function get_tracing_endpoint {

--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -180,14 +180,14 @@ function enable_eventing_tracing {
   logger.info "Configuring tracing for Eventing"
   local endpoint
   endpoint=$(get_tracing_endpoint)
-  oc -n "${EVENTING_NAMESPACE}" patch knativeeventing/knative-eventing --type=merge --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"'"${endpoint}"'", "debug":"true", "sample-rate":"1.0"}}}}'
+  oc -n "${EVENTING_NAMESPACE}" patch knativeeventing/knative-eventing --type=merge --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"'"${endpoint}"'", "sample-rate":"0.3"}}}}'
 }
 
 function enable_serving_tracing {
   logger.info "Configuring tracing for Serving"
   local endpoint
   endpoint=$(get_tracing_endpoint)
-  oc -n "${SERVING_NAMESPACE}" patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"'"${endpoint}"'", "sample-rate":"1.0"}}}}'
+  oc -n "${SERVING_NAMESPACE}" patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "tracing": {"enable":"true","backend":"zipkin", "zipkin-endpoint":"'"${endpoint}"'", "sample-rate":"0.3"}}}}'
 }
 
 function get_tracing_endpoint {

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -74,3 +74,5 @@ export INSTALL_EVENTING="${INSTALL_EVENTING:-true}"
 export INSTALL_KAFKA="${INSTALL_KAFKA:-false}"
 export FULL_MESH="${FULL_MESH:-false}"
 export ENABLE_TRACING="${ENABLE_TRACING:-false}"
+# Define sample-rate for tracing.
+export SAMPLE_RATE="${SAMPLE_RATE:-"1.0"}"


### PR DESCRIPTION
This is to prevent OOM issues in Zipkin.

Having sample-rate 0.1 produces about 2,106.8 MiB of data in Zipkin. We
currently have -Xmx9G for Zipkin so setting this parameter to 0.3 in
order to have some buffer for cases when the tests take longer and
produce more data.

Fixes https://issues.redhat.com/browse/SRVCOM-1907

:bug:


