### PR TITLE
Place Zipkin pod on a dedicated node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,8 @@ test-upstream-upgrade-testonly:
 	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
 test-upstream-upgrade:
+	TRACING_BACKEND=zipkin ZIPKIN_DEDICATED_NODE=true ./hack/tracing.sh
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
-	TRACING_BACKEND=zipkin ./hack/tracing.sh
 	INSTALL_PREVIOUS_VERSION="true" INSTALL_KAFKA="true" TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=6 SAMPLE_RATE="0.3" ./hack/install.sh
 	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -76,3 +76,4 @@ export FULL_MESH="${FULL_MESH:-false}"
 export ENABLE_TRACING="${ENABLE_TRACING:-false}"
 # Define sample-rate for tracing.
 export SAMPLE_RATE="${SAMPLE_RATE:-"1.0"}"
+export ZIPKIN_DEDICATED_NODE="${ZIPKIN_DEDICATED_NODE:-false}"


### PR DESCRIPTION
This is a follow up on https://github.com/openshift-knative/serverless-operator/pull/1611
Fixes https://issues.redhat.com/browse/SRVCOM-1908

If the Zipkin is placed on the same node as Kafka and collect a lot of traces, there might be all kinds of intermittent errors in tests. The nodes can stop reacting if the memory reaches limits.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Label one node for Zipkin and also place a taint on it
- Force placing the Zipkin pod on the node via nodeAffinity
- Prevent other pods from running on the same node
- Do the setup before installing other components so that they're placed on different nodes
- Place Zipkin pod on a dedicated node only for upgrade tests where we gather a lot of traces, for other test suites it's not a problem
