### PR TITLE
[SRVKS-900] Inject net-istio secret informer filtering env var

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -72,6 +72,7 @@ func (e *extension) Transformers(ks operatorv1alpha1.KComponent) []mf.Transforme
 		),
 		overrideKourierNamespace(ks),
 		addHTTPOptionDisabledEnvValue(),
+		enableSecretInformerFiltering(ks),
 	}, monitoring.GetServingTransformers(ks)...)
 }
 

--- a/openshift-knative-operator/pkg/serving/istio.go
+++ b/openshift-knative-operator/pkg/serving/istio.go
@@ -1,0 +1,16 @@
+package serving
+
+import (
+	mf "github.com/manifestival/manifestival"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	operatorv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
+
+func enableSecretInformerFiltering(ks operatorv1alpha1.KComponent) mf.Transformer {
+	if v, ok := ks.GetAnnotations()["knative.dev/enable-secret-informer-filtering-by-cert-uid"]; ok {
+		return common.InjectEnvironmentIntoDeployment("net-istio-controller", "controller",
+			corev1.EnvVar{Name: "ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID", Value: v})
+	}
+	return nil
+}

--- a/openshift-knative-operator/pkg/serving/istio.go
+++ b/openshift-knative-operator/pkg/serving/istio.go
@@ -8,7 +8,7 @@ import (
 )
 
 func enableSecretInformerFiltering(ks operatorv1alpha1.KComponent) mf.Transformer {
-	if v, ok := ks.GetAnnotations()["knative.dev/enable-secret-informer-filtering-by-cert-uid"]; ok {
+	if v, ok := ks.GetAnnotations()["serverless.openshift.io/enable-secret-informer-filtering"]; ok {
 		return common.InjectEnvironmentIntoDeployment("net-istio-controller", "controller",
 			corev1.EnvVar{Name: "ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID", Value: v})
 	}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Follows https://github.com/knative/operator/pull/1083. Didn't backport tests as we dont test all trivial injections.
- Lighter than #1614 
- It can be used for net-kourier too.
- Tested as #1614 using [these steps](https://gist.github.com/skonto/6010c0da420b044dd768927408f9472b) but with the following CR instead:
```
apiVersion: operator.knative.dev/v1alpha1
kind: KnativeServing
metadata:
  name: knative-serving
  namespace: knative-serving
  annotations:
    knative.dev/enable-secret-informer-filtering-by-cert-uid: "true"
spec:
  ingress:
    istio:
      enabled: true
  deployments:
    - annotations:
        sidecar.istio.io/inject: "true"
        sidecar.istio.io/rewriteAppHTTPProbers: "true"
      name: activator
    - annotations:
        sidecar.istio.io/inject: "true"
        sidecar.istio.io/rewriteAppHTTPProbers: "true"
      name: autoscaler

$  oc get pods  net-istio-controller-5ff74848fd-8xssd -n knative-serving -o jsonpath='{.spec.containers[].env}' | jq .
[
  {
    "name": "SYSTEM_NAMESPACE",
    "valueFrom": {
      "fieldRef": {
        "apiVersion": "v1",
        "fieldPath": "metadata.namespace"
      }
    }
  },
  {
    "name": "CONFIG_LOGGING_NAME",
    "value": "config-logging"
  },
  {
    "name": "CONFIG_OBSERVABILITY_NAME",
    "value": "config-observability"
  },
  {
    "name": "METRICS_DOMAIN",
    "value": "knative.dev/net-istio"
  },
  {
    "name": "ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID",
    "value": "true"
  }
]

```
