### PR TITLE
increase kitchensink-e2e go test timeout

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -177,7 +177,7 @@ function downstream_kitchensink_e2e_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  go_test_e2e -failfast -timeout=60m -parallel=8 ./test/kitchensinke2e "$@"
+  go_test_e2e -failfast -timeout=120m -parallel=8 ./test/kitchensinke2e "$@"
 }
 
 # == Upgrade testing


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.10-e2e-kitchensink-ocp-410-continuous/1534626523200360448

failed on 
```
 panic: test timed out after 1h0m0s 
```

- :broom: Increase kitchensink-e2e go test timeout