### PR TITLE
Inject `SERVING_NAMESPACE` env value to kourier controller

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -71,7 +71,7 @@ func (e *extension) Transformers(ks operatorv1alpha1.KComponent) []mf.Transforme
 			corev1.EnvVar{Name: "NO_PROXY", Value: os.Getenv("NO_PROXY")},
 		),
 		overrideKourierNamespace(ks),
-		addHTTPOptionDisabledEnvValue(),
+		addKourierEnvValues(),
 		enableSecretInformerFiltering(ks),
 	}, monitoring.GetServingTransformers(ks)...)
 }

--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -44,8 +44,9 @@ func kourierNamespace(servingNs string) string {
 	return servingNs + "-ingress"
 }
 
-func addHTTPOptionDisabledEnvValue() mf.Transformer {
+func addKourierEnvValues() mf.Transformer {
 	return common.InjectEnvironmentIntoDeployment("net-kourier-controller", "controller",
 		corev1.EnvVar{Name: "KOURIER_HTTPOPTION_DISABLED", Value: "true"},
+		corev1.EnvVar{Name: "SERVING_NAMESPACE", Value: "knative-serving"},
 	)
 }

--- a/openshift-knative-operator/pkg/serving/kourier_test.go
+++ b/openshift-knative-operator/pkg/serving/kourier_test.go
@@ -78,7 +78,7 @@ func TestAddHTTPOptionDisabledEnvValue(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name: "controller",
-						Env:  []corev1.EnvVar{{Name: "a", Value: "b"}, {Name: "KOURIER_HTTPOPTION_DISABLED", Value: "true"}},
+						Env:  []corev1.EnvVar{{Name: "a", Value: "b"}, {Name: "KOURIER_HTTPOPTION_DISABLED", Value: "true"}, {Name: "SERVING_NAMESPACE", Value: "knative-serving"}},
 					}},
 				},
 			},
@@ -95,7 +95,7 @@ func TestAddHTTPOptionDisabledEnvValue(t *testing.T) {
 		t.Fatal("Failed to convert deployment to unstructured", err)
 	}
 
-	addHTTPOptionDisabledEnvValue()(got)
+	addKourierEnvValues()(got)
 
 	if !cmp.Equal(got, want) {
 		t.Errorf("Resource was not as expected:\n%s", cmp.Diff(got, want))


### PR DESCRIPTION
Since https://github.com/knative-sandbox/net-kourier/pull/855, kourier
controller supports SERVING_NAMESPACE env value to specify the serving
namespace.

/cc @skonto 