### PR TITLE
Add pierDipi and nak3 to OWNER_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,9 +6,10 @@ aliases:
   - lberk
   - matzew
   - mgencur
-  - warrenvw
-  - rhuss
+  - nak3
   - openshift-cherrypick-robot
+  - pierDipi
+  - rhuss
   - skonto
   serverless-reviewers:
   - alanfx
@@ -18,7 +19,7 @@ aliases:
   - lberk
   - matzew
   - mgencur
-  - navidshaikh
+  - nak3
+  - pierDipi
   - rhuss
   - skonto
-  - warrenvw


### PR DESCRIPTION
This patch adds @pierDipi and @nak3 to OWNER_ALIASES as approver.

Without the permission, we cannot merge the automated PR like https://github.com/openshift-knative/serverless-operator/pull/1622.

/assign @matzew @rhuss @mgencur 