### PR TITLE
[release-1.23] fix prometheus-k8s sa token fetching (#1606)

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/broker/eventing-kafka-broker.yaml
+++ b/knative-operator/deploy/resources/knativekafka/broker/eventing-kafka-broker.yaml
@@ -39,7 +39,7 @@ data:
     max.request.size=1048576
     partitioner.class=org.apache.kafka.clients.producer.internals.DefaultPartitioner
     receive.buffer.bytes=-1
-    request.timeout.ms=30000
+    request.timeout.ms=2000
     enable.idempotence=false
     max.in.flight.requests.per.connection=5
     metadata.max.age.ms=300000
@@ -68,7 +68,7 @@ data:
     auto.offset.reset=earliest
     client.dns.lookup=use_all_dns_ips
     connections.max.idle.ms=540000
-    default.api.timeout.ms=60000
+    default.api.timeout.ms=2000
     enable.auto.commit=false
     exclude.internal.topics=true
     fetch.max.bytes=52428800
@@ -77,7 +77,7 @@ data:
     max.poll.records=500
     # partition.assignment.strategy=org.apache.kafka.clients.consumer.CooperativeStickyAssignor
     receive.buffer.bytes=65536
-    request.timeout.ms=30000
+    request.timeout.ms=2000
     # sasl.client.callback.handler.class=
     # sasl.jaas.config=
     # sasl.kerberos.service.name=

--- a/knative-operator/deploy/resources/knativekafka/channel/eventing-kafka-channel.yaml
+++ b/knative-operator/deploy/resources/knativekafka/channel/eventing-kafka-channel.yaml
@@ -39,7 +39,7 @@ data:
     max.request.size=1048576
     partitioner.class=org.apache.kafka.clients.producer.internals.DefaultPartitioner
     receive.buffer.bytes=-1
-    request.timeout.ms=30000
+    request.timeout.ms=2000
     enable.idempotence=false
     max.in.flight.requests.per.connection=5
     metadata.max.age.ms=300000
@@ -67,7 +67,7 @@ data:
     allow.auto.create.topics=true
     client.dns.lookup=use_all_dns_ips
     connections.max.idle.ms=540000
-    default.api.timeout.ms=60000
+    default.api.timeout.ms=2000
     enable.auto.commit=false
     exclude.internal.topics=true
     fetch.max.bytes=52428800
@@ -76,7 +76,7 @@ data:
     max.poll.records=500
     # partition.assignment.strategy=org.apache.kafka.clients.consumer.CooperativeStickyAssignor
     receive.buffer.bytes=65536
-    request.timeout.ms=30000
+    request.timeout.ms=2000
     # sasl.client.callback.handler.class=
     # sasl.jaas.config=
     # sasl.kerberos.service.name=

--- a/knative-operator/deploy/resources/knativekafka/sink/eventing-kafka-sink.yaml
+++ b/knative-operator/deploy/resources/knativekafka/sink/eventing-kafka-sink.yaml
@@ -39,7 +39,7 @@ data:
     max.request.size=1048576
     partitioner.class=org.apache.kafka.clients.producer.internals.DefaultPartitioner
     receive.buffer.bytes=-1
-    request.timeout.ms=30000
+    request.timeout.ms=2000
     enable.idempotence=false
     max.in.flight.requests.per.connection=5
     metadata.max.age.ms=300000

--- a/knative-operator/deploy/resources/knativekafka/source/eventing-kafka-source.yaml
+++ b/knative-operator/deploy/resources/knativekafka/source/eventing-kafka-source.yaml
@@ -39,7 +39,7 @@ data:
     max.request.size=1048576
     partitioner.class=org.apache.kafka.clients.producer.internals.DefaultPartitioner
     receive.buffer.bytes=-1
-    request.timeout.ms=30000
+    request.timeout.ms=2000
     enable.idempotence=false
     max.in.flight.requests.per.connection=5
     metadata.max.age.ms=300000
@@ -70,7 +70,7 @@ data:
     auto.offset.reset=earliest
     client.dns.lookup=use_all_dns_ips
     connections.max.idle.ms=540000
-    default.api.timeout.ms=60000
+    default.api.timeout.ms=2000
     enable.auto.commit=false
     exclude.internal.topics=true
     fetch.max.bytes=52428800
@@ -79,7 +79,7 @@ data:
     max.poll.records=500
     # partition.assignment.strategy=org.apache.kafka.clients.consumer.CooperativeStickyAssignor
     receive.buffer.bytes=65536
-    request.timeout.ms=30000
+    request.timeout.ms=2000
     # sasl.client.callback.handler.class=
     # sasl.jaas.config=
     # sasl.kerberos.service.name=


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVCOM-1906
(this is a cherry-pick of https://github.com/openshift-knative/serverless-operator/pull/1606 and https://github.com/openshift-knative/serverless-operator/pull/1622)

We need to backport it to release-1.23 because it breaks our interoperability tests with OCP 4.11 and we'd be hitting this issue until 1.24.