### PR TITLE
[SRVCOM-1915] Remove cluster monitoring annotation from csv

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -3,7 +3,6 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     operatorframework.io/suggested-namespace: "openshift-serverless"
-    operatorframework.io/cluster-monitoring: "true"
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     alm-examples: |-

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -3,7 +3,6 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     operatorframework.io/suggested-namespace: "openshift-serverless"
-    operatorframework.io/cluster-monitoring: "true"
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     alm-examples: |-


### PR DESCRIPTION
- As per title, more details about the annotation in the ticket. Currently there is no effect if user enables or disables the cluster monitoring via the ui in the S-O ns.
- Alternative is not enable cluster monitoring by default in the S-O installation ns. See [here](https://github.com/openshift-knative/serverless-operator/compare/main...skonto:disable_cluster_monitoring_default).
