### PR TITLE
Create automated PRs only on selected events and use variable branch name

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -50,12 +50,12 @@ jobs:
       #   when it's manually triggered or a scheduled run, create a PR
       #   when there are changes detected.
       - name: Create Pull Request
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
         uses: peter-evans/create-pull-request@v4
         with:
           path: ./src/github.com/${{ github.repository }}
-          branch: auto/update-generated-files
-          title: "Run make generated-files"
+          branch: auto/update-generated-files-${{ github.ref }}
+          title: "[${{ github.ref }}] Run make generated-files"
           commit-message: "Run make generated-files"
           delete-branch: true
           body: |


### PR DESCRIPTION
Fix PR  like [1] created and closed without merge.

[1] https://github.com/openshift-knative/serverless-operator/pull/1629

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add target branch name to generated PR branch name to not clash branch name across multiple branches
- Create a PR only on schedule or manual trigger event