### PR TITLE
NIT: Fixing wrong repo location URL

### DIFF
--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -42,7 +42,7 @@ function download_serving {
     target_file="$target_dir/$index-$file"
 
     if [[ ${KNATIVE_SERVING_MANIFESTS_DIR} = "" ]]; then
-      url="https://raw.githubusercontent.com/openshift/serving/${branch}/openshift/release/artifacts/$index-$file"
+      url="https://raw.githubusercontent.com/openshift/knative-serving/${branch}/openshift/release/artifacts/$index-$file"
       wget --no-check-certificate "$url" -O "$target_file"
     else
       cp "${KNATIVE_SERVING_MANIFESTS_DIR}/${file}" "$target_file"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

There is no `openshift/serving` repo