### PR TITLE
Allow for skipping downgrade tests

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -56,6 +56,7 @@ SYSTEM_NAMESPACES=("${TRACING_NAMESPACE}" "${OPERATORS_NAMESPACE}")
 export SYSTEM_NAMESPACES
 export UPGRADE_SERVERLESS="${UPGRADE_SERVERLESS:-"true"}"
 export UPGRADE_CLUSTER="${UPGRADE_CLUSTER:-"false"}"
+export SKIP_DOWNGRADE="${SKIP_DOWNGRADE:-"false"}"
 # Change this when forcing the upgrade to an image that is not yet available via upgrade channel
 export UPGRADE_OCP_IMAGE="${UPGRADE_OCP_IMAGE:-}"
 

--- a/test/flags.go
+++ b/test/flags.go
@@ -34,7 +34,7 @@ type FlagsStruct struct {
 	OpenShiftImage          string // Target OpenShift image for upgrades
 	UpgradeOpenShift        bool   // Whether to upgrade the OpenShift cluster
 	SkipServingPreUpgrade   bool   // Whether to skip Serving pre-upgrade tests
-	SkipDowngrade           bool   // Whether to skip post-downgrade tests.
+	SkipDowngrade           bool   // Whether to skip post-downgrade tests
 }
 
 func initializeFlags() *FlagsStruct {

--- a/test/flags.go
+++ b/test/flags.go
@@ -34,6 +34,7 @@ type FlagsStruct struct {
 	OpenShiftImage          string // Target OpenShift image for upgrades
 	UpgradeOpenShift        bool   // Whether to upgrade the OpenShift cluster
 	SkipServingPreUpgrade   bool   // Whether to skip Serving pre-upgrade tests
+	SkipDowngrade           bool   // Whether to skip post-downgrade tests.
 }
 
 func initializeFlags() *FlagsStruct {
@@ -75,6 +76,8 @@ func initializeFlags() *FlagsStruct {
 		"Whether to upgrade OpenShift cluster during upgrade tests.")
 	flag.BoolVar(&f.SkipServingPreUpgrade, "skipservingpreupgrade", false,
 		"Whether to skip Serving pre-upgrade tests during upgrade tests.")
+	flag.BoolVar(&f.SkipDowngrade, "skipdowngrade", false,
+		"Whether to skip Serverless downgrade and post-downgrade tests.")
 
 	return &f
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -242,6 +242,7 @@ EOF
     "--servingversionprevious=${KNATIVE_SERVING_VERSION_PREVIOUS}" \
     "--eventingversionprevious=${KNATIVE_EVENTING_VERSION_PREVIOUS}" \
     "--kafkaversionprevious=${KNATIVE_EVENTING_KAFKA_BROKER_VERSION_PREVIOUS}" \
+    "--skipdowngrade=${SKIP_DOWNGRADE}" \
     --resolvabledomain \
     --https)
 

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -147,7 +147,7 @@ func postUpgradeTests(ctx *test.Context) []pkgupgrade.Operation {
 
 func postDowngradeTests() []pkgupgrade.Operation {
 	if test.Flags.SkipDowngrade {
-		return []pkgupgrade.Operation{}
+		return nil
 	}
 	tests := servingupgrade.ServingPostDowngradeTests()
 	tests = append(tests,
@@ -164,7 +164,7 @@ func postDowngradeTests() []pkgupgrade.Operation {
 
 func downgrade(ctx *test.Context) []pkgupgrade.Operation {
 	if test.Flags.SkipDowngrade {
-		return []pkgupgrade.Operation{}
+		return nil
 	}
 	return []pkgupgrade.Operation{
 		pkgupgrade.NewOperation("DowngradeServerless", func(c pkgupgrade.Context) {

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -67,13 +67,7 @@ func TestServerlessUpgrade(t *testing.T) {
 					}
 				}),
 			},
-			DowngradeWith: []pkgupgrade.Operation{
-				pkgupgrade.NewOperation("DowngradeServerless", func(c pkgupgrade.Context) {
-					if err := installation.DowngradeServerless(ctx); err != nil {
-						c.T.Error("Serverless downgrade failed:", err)
-					}
-				}),
-			},
+			DowngradeWith: downgrade(ctx),
 		},
 	}
 	suite.Execute(cfg)
@@ -152,6 +146,9 @@ func postUpgradeTests(ctx *test.Context) []pkgupgrade.Operation {
 }
 
 func postDowngradeTests() []pkgupgrade.Operation {
+	if test.Flags.SkipDowngrade {
+		return []pkgupgrade.Operation{}
+	}
 	tests := servingupgrade.ServingPostDowngradeTests()
 	tests = append(tests,
 		servingupgrade.CRDStoredVersionPostUpgradeTest(), // Check if CRD Stored version check works with downgrades.
@@ -163,6 +160,19 @@ func postDowngradeTests() []pkgupgrade.Operation {
 		kafkabrokerupgrade.SinkPostDowngradeTest(),
 	)
 	return tests
+}
+
+func downgrade(ctx *test.Context) []pkgupgrade.Operation {
+	if test.Flags.SkipDowngrade {
+		return []pkgupgrade.Operation{}
+	}
+	return []pkgupgrade.Operation{
+		pkgupgrade.NewOperation("DowngradeServerless", func(c pkgupgrade.Context) {
+			if err := installation.DowngradeServerless(ctx); err != nil {
+				c.T.Error("Serverless downgrade failed:", err)
+			}
+		}),
+	}
 }
 
 func waitForServicesReady(ctx *test.Context) pkgupgrade.Operation {


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Introduce flag `--skipdowngrade` that will allow for skipping Serverless downgrade and post-downgrade tests
- Run downgrade tests by default unless skipped
- Make the tests reusable downstream and allow for skipping downgrade tests in scenarios such as upgrading Serverless followed by upgrading OCP