### PR TITLE
Use an amd64 tag for the opm image

### DIFF
--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -1,6 +1,6 @@
 FROM openshift/origin-base as builder
 
-COPY --from=quay.io/operator-framework/opm:latest /bin/opm /bin/opm
+COPY --from=quay.io/operator-framework/opm:v1.23.2 /bin/opm /bin/opm
 
 # Copy declarative config root into image at /configs
 COPY configs /configs
@@ -11,7 +11,7 @@ RUN /bin/opm --skip-tls-verify render -o yaml registry.ci.openshift.org/knative/
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM quay.io/operator-framework/opm:latest
+FROM quay.io/operator-framework/opm:v1.23.2
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -1,6 +1,6 @@
 FROM openshift/origin-base as builder
 
-COPY --from=quay.io/operator-framework/opm:latest /bin/opm /bin/opm
+COPY --from=quay.io/operator-framework/opm:v1.23.2 /bin/opm /bin/opm
 
 # Copy declarative config root into image at /configs
 COPY configs /configs
@@ -11,7 +11,7 @@ RUN /bin/opm --skip-tls-verify render -o yaml registry.ci.openshift.org/knative/
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM quay.io/operator-framework/opm:latest
+FROM quay.io/operator-framework/opm:v1.23.2
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Facing the issue [here](https://github.com/openshift/knative-serving/pull/1169#issuecomment-1182599769). Our jobs use `amd64` afaik. The image changed a few hours ago and things broke.
- `opm:latest` is derived from an arm64 arch check [here](https://quay.io/repository/operator-framework/opm?tab=tags).
- Discussion on slack [here](https://coreos.slack.com/archives/C3VS0LV41/p1657671513007229).
