### PR TITLE
[RELEASE-1.24] Point to the published v1.24.0 release rather than nightly

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -404,7 +404,7 @@ spec:
                 containers:
                   - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/knative/openshift-serverless-nightly:openshift-knative-operator
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:openshift-knative-operator
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -516,7 +516,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-operator
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -677,7 +677,7 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-openshift-ingress
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:knative-openshift-ingress
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -803,13 +803,13 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/knative/openshift-serverless-nightly:openshift-knative-operator
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-operator
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-openshift-ingress
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:knative-openshift-ingress
     - name: "IMAGE_queue-proxy"
       image: "registry.ci.openshift.org/openshift/knative-v1.3.0:knative-serving-queue"
     - name: "IMAGE_activator"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -412,7 +412,7 @@ spec:
                 containers:
                   - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/knative/openshift-serverless-nightly:openshift-knative-operator
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:openshift-knative-operator
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -474,7 +474,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-operator
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -556,7 +556,7 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-openshift-ingress
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:knative-openshift-ingress
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -684,12 +684,12 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/knative/openshift-serverless-nightly:openshift-knative-operator
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-operator
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-openshift-ingress
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:knative-openshift-ingress
   replaces:
   version:


### PR DESCRIPTION
- The usual as per title.
- Images are now available since https://github.com/openshift/release/pull/30476 has been merged.
