### PR TITLE
Add job GeneratedName transformer to eventing, serving

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -190,6 +190,9 @@ done
 add_downstream_operator_deployment_env "$target" "CURRENT_VERSION" "$(metadata.get project.version)"
 add_downstream_operator_deployment_env "$target" "KNATIVE_EVENTING_KAFKA_BROKER_VERSION" "$(metadata.get dependencies.eventing_kafka_broker)"
 
+# Add Serverless version to be used for naming storage jobs for Serving, Eventing
+add_upstream_operator_deployment_env "$target" "CURRENT_VERSION" "$(metadata.get project.version)"
+
 # Override the image for the CLI artifact deployment
 yq write --inplace "$target" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.initContainers(name==cli-artifacts).image" "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
 

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -484,6 +484,8 @@ spec:
                         value: "registry.ci.openshift.org/origin/4.7:kube-rbac-proxy"
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
                         value: "registry.ci.openshift.org/knative/release-1.3:client-plugin-event-sender"
+                      - name: "CURRENT_VERSION"
+                        value: "1.24.0"
                     securityContext:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: true

--- a/openshift-knative-operator/pkg/eventing/extension.go
+++ b/openshift-knative-operator/pkg/eventing/extension.go
@@ -34,7 +34,7 @@ func (e *extension) Manifests(ke operatorv1alpha1.KComponent) ([]mf.Manifest, er
 }
 
 func (e *extension) Transformers(ke operatorv1alpha1.KComponent) []mf.Transformer {
-	return append([]mf.Transformer{common.InjectCommonLabelIntoNamespace()},
+	return append([]mf.Transformer{common.InjectCommonLabelIntoNamespace(), common.VersionedJobNameTransform()},
 		monitoring.GetEventingTransformers(ke)...)
 }
 

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -73,6 +73,7 @@ func (e *extension) Transformers(ks operatorv1alpha1.KComponent) []mf.Transforme
 		overrideKourierNamespace(ks),
 		addKourierEnvValues(),
 		enableSecretInformerFiltering(ks),
+		common.VersionedJobNameTransform(),
 	}, monitoring.GetServingTransformers(ks)...)
 }
 

--- a/test/e2e/knative_eventing_test.go
+++ b/test/e2e/knative_eventing_test.go
@@ -55,7 +55,7 @@ func TestKnativeEventing(t *testing.T) {
 	})
 
 	t.Run("Verify job succeeded", func(t *testing.T) {
-		upgrade.VerifyPostInstallJobs(upgrade.VerifyPostJobsConfig{
+		upgrade.VerifyPostInstallJobs(caCtx, upgrade.VerifyPostJobsConfig{
 			Namespace:    eventingNamespace,
 			FailOnNoJobs: true,
 		})

--- a/test/e2ekafka/knative_kafka_test.go
+++ b/test/e2ekafka/knative_kafka_test.go
@@ -127,7 +127,7 @@ func TestKnativeKafka(t *testing.T) {
 	})
 
 	t.Run("Verify job succeeded", func(t *testing.T) {
-		upgrade.VerifyPostInstallJobs(upgrade.VerifyPostJobsConfig{
+		upgrade.VerifyPostInstallJobs(caCtx, upgrade.VerifyPostJobsConfig{
 			Namespace:    knativeKafkaNamespace,
 			FailOnNoJobs: true,
 		})

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -130,15 +130,14 @@ func preUpgradeTests() []pkgupgrade.Operation {
 
 func postUpgradeTests(ctx *test.Context) []pkgupgrade.Operation {
 	tests := []pkgupgrade.Operation{waitForServicesReady(ctx)}
-	tests = append(tests, upgrade.VerifyPostInstallServingJobs(ctx, upgrade.VerifyPostJobsConfig{
+	tests = append(tests, upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
 		Namespace:    "knative-serving",
 		FailOnNoJobs: true,
 	}))
-	tests = append(tests, upgrade.VerifyPostInstallJobs(upgrade.VerifyPostJobsConfig{
+	tests = append(tests, upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
 		Namespace:    "knative-eventing",
 		FailOnNoJobs: true,
 	}))
-
 	tests = append(tests, eventingupgrade.PostUpgradeTests()...)
 	tests = append(tests,
 		kafkaupgrade.ChannelPostUpgradeTest(),

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -142,6 +142,10 @@ func postUpgradeTests(ctx *test.Context) []pkgupgrade.Operation {
 		FailOnNoJobs: true,
 	}))
 	tests = append(tests, servingupgrade.ServingPostUpgradeTests()...)
+	tests = append(tests, upgrade.VerifyPostInstallJobs(upgrade.VerifyPostJobsConfig{
+		Namespace:    "knative-serving",
+		FailOnNoJobs: true,
+	}))
 	return tests
 }
 

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -130,6 +130,15 @@ func preUpgradeTests() []pkgupgrade.Operation {
 
 func postUpgradeTests(ctx *test.Context) []pkgupgrade.Operation {
 	tests := []pkgupgrade.Operation{waitForServicesReady(ctx)}
+	tests = append(tests, upgrade.VerifyPostInstallServingJobs(ctx, upgrade.VerifyPostJobsConfig{
+		Namespace:    "knative-serving",
+		FailOnNoJobs: true,
+	}))
+	tests = append(tests, upgrade.VerifyPostInstallJobs(upgrade.VerifyPostJobsConfig{
+		Namespace:    "knative-eventing",
+		FailOnNoJobs: true,
+	}))
+
 	tests = append(tests, eventingupgrade.PostUpgradeTests()...)
 	tests = append(tests,
 		kafkaupgrade.ChannelPostUpgradeTest(),
@@ -137,15 +146,7 @@ func postUpgradeTests(ctx *test.Context) []pkgupgrade.Operation {
 		kafkabrokerupgrade.BrokerPostUpgradeTest(),
 		kafkabrokerupgrade.SinkPostUpgradeTest(),
 	)
-	tests = append(tests, upgrade.VerifyPostInstallJobs(upgrade.VerifyPostJobsConfig{
-		Namespace:    "knative-eventing",
-		FailOnNoJobs: true,
-	}))
 	tests = append(tests, servingupgrade.ServingPostUpgradeTests()...)
-	tests = append(tests, upgrade.VerifyPostInstallJobs(upgrade.VerifyPostJobsConfig{
-		Namespace:    "knative-serving",
-		FailOnNoJobs: true,
-	}))
 	return tests
 }
 

--- a/test/upgrade/verify_jobs.go
+++ b/test/upgrade/verify_jobs.go
@@ -10,7 +10,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/pkg/test/upgrade"
 )
 
@@ -19,23 +18,15 @@ type VerifyPostJobsConfig struct {
 	FailOnNoJobs bool
 }
 
-func VerifyPostInstallJobs(cfg VerifyPostJobsConfig) upgrade.Operation {
+func VerifyPostInstallJobs(ctx *test.Context, cfg VerifyPostJobsConfig) upgrade.Operation {
 	return upgrade.NewOperation("Verify jobs in "+cfg.Namespace, func(c upgrade.Context) {
-		if err := verifyPostInstallJobs(context.Background(), c, cfg); err != nil {
+		if err := verifyPostInstallJobs(context.Background(), ctx, c, cfg); err != nil {
 			c.T.Error(err)
 		}
 	})
 }
 
-func VerifyPostInstallServingJobs(ctx *test.Context, cfg VerifyPostJobsConfig) upgrade.Operation {
-	return upgrade.NewOperation("Verify jobs in "+cfg.Namespace, func(c upgrade.Context) {
-		if err := verifyPostInstallServingJobs(context.Background(), ctx, c, cfg); err != nil {
-			c.T.Error(err)
-		}
-	})
-}
-
-func verifyPostInstallServingJobs(ctx context.Context, testCtx *test.Context, c upgrade.Context, cfg VerifyPostJobsConfig) error {
+func verifyPostInstallJobs(ctx context.Context, testCtx *test.Context, c upgrade.Context, cfg VerifyPostJobsConfig) error {
 	jobs, err := testCtx.Clients.Kube.
 		BatchV1().
 		Jobs(cfg.Namespace).
@@ -48,68 +39,6 @@ func verifyPostInstallServingJobs(ctx context.Context, testCtx *test.Context, c 
 		return fmt.Errorf("no jobs found in namespace %s", cfg.Namespace)
 	}
 	kubeClient := testCtx.Clients.Kube
-
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, j := range jobs.Items {
-		j := j
-
-		if j.Status.Succeeded > 0 {
-			// We don't need to wait for a job that is already succeeded.
-			// In addition, an already succeeded job might go away due to the job's TTL.
-			continue
-		}
-		eg.Go(func() error {
-			err := wait.PollUntil(5*time.Second, func() (bool, error) {
-				j, err := kubeClient.
-					BatchV1().
-					Jobs(cfg.Namespace).
-					Get(ctx, j.Name, metav1.GetOptions{})
-				if apierrors.IsNotFound(err) {
-					return true, nil
-				}
-				if err != nil {
-					return false, err
-				}
-
-				if j.Status.Failed > 0 {
-					c.T.Logf("Job %s/%s failed %d times", j.Namespace, j.Name, j.Status.Failed)
-				}
-
-				if j.Status.Failed == *j.Spec.BackoffLimit {
-					return false, fmt.Errorf("job %s/%s failed: %+v", j.Namespace, j.Name, j.Status)
-				}
-
-				return j.Status.Succeeded > 0, nil
-			}, ctx.Done())
-			if err != nil {
-				return fmt.Errorf("%w, job:\n%+v", err, j)
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return fmt.Errorf("jobs in %s didn't run successfully: %w", cfg.Namespace, err)
-	}
-	return nil
-}
-
-func verifyPostInstallJobs(ctx context.Context, c upgrade.Context, cfg VerifyPostJobsConfig) error {
-	client := testlib.Setup(c.T, false)
-	defer testlib.TearDown(client)
-
-	jobs, err := client.Kube.
-		BatchV1().
-		Jobs(cfg.Namespace).
-		List(ctx, metav1.ListOptions{Limit: 500 /* Use a very large number to avoid handling pagination */})
-	if err != nil {
-		return fmt.Errorf("failed to list jobs in namespace %s: %w", cfg.Namespace, err)
-	}
-
-	if len(jobs.Items) == 0 && cfg.FailOnNoJobs {
-		return fmt.Errorf("no jobs found in namespace %s", cfg.Namespace)
-	}
-
-	kubeClient := client.Kube
 
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, j := range jobs.Items {

--- a/test/upgrade/verify_jobs.go
+++ b/test/upgrade/verify_jobs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift-knative/serverless-operator/test"
 	"golang.org/x/sync/errgroup"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +25,72 @@ func VerifyPostInstallJobs(cfg VerifyPostJobsConfig) upgrade.Operation {
 			c.T.Error(err)
 		}
 	})
+}
+
+func VerifyPostInstallServingJobs(ctx *test.Context, cfg VerifyPostJobsConfig) upgrade.Operation {
+	return upgrade.NewOperation("Verify jobs in "+cfg.Namespace, func(c upgrade.Context) {
+		if err := verifyPostInstallServingJobs(context.Background(), ctx, c, cfg); err != nil {
+			c.T.Error(err)
+		}
+	})
+}
+
+func verifyPostInstallServingJobs(ctx context.Context, testCtx *test.Context, c upgrade.Context, cfg VerifyPostJobsConfig) error {
+	jobs, err := testCtx.Clients.Kube.
+		BatchV1().
+		Jobs(cfg.Namespace).
+		List(ctx, metav1.ListOptions{Limit: 500 /* Use a very large number to avoid handling pagination */})
+	if err != nil {
+		return fmt.Errorf("failed to list jobs in namespace %s: %w", cfg.Namespace, err)
+	}
+
+	if len(jobs.Items) == 0 && cfg.FailOnNoJobs {
+		return fmt.Errorf("no jobs found in namespace %s", cfg.Namespace)
+	}
+	kubeClient := testCtx.Clients.Kube
+
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, j := range jobs.Items {
+		j := j
+
+		if j.Status.Succeeded > 0 {
+			// We don't need to wait for a job that is already succeeded.
+			// In addition, an already succeeded job might go away due to the job's TTL.
+			continue
+		}
+		eg.Go(func() error {
+			err := wait.PollUntil(5*time.Second, func() (bool, error) {
+				j, err := kubeClient.
+					BatchV1().
+					Jobs(cfg.Namespace).
+					Get(ctx, j.Name, metav1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				if err != nil {
+					return false, err
+				}
+
+				if j.Status.Failed > 0 {
+					c.T.Logf("Job %s/%s failed %d times", j.Namespace, j.Name, j.Status.Failed)
+				}
+
+				if j.Status.Failed == *j.Spec.BackoffLimit {
+					return false, fmt.Errorf("job %s/%s failed: %+v", j.Namespace, j.Name, j.Status)
+				}
+
+				return j.Status.Succeeded > 0, nil
+			}, ctx.Done())
+			if err != nil {
+				return fmt.Errorf("%w, job:\n%+v", err, j)
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return fmt.Errorf("jobs in %s didn't run successfully: %w", cfg.Namespace, err)
+	}
+	return nil
 }
 
 func verifyPostInstallJobs(ctx context.Context, c upgrade.Context, cfg VerifyPostJobsConfig) error {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Even if we have a different release suffix for the job name in the next few releases let's create unique names per S-O version.
- Hit a related issue here: https://github.com/openshift-knative/serverless-operator/pull/1647

