### PR TITLE
SRVCOM-1981 Use origin-operator-registry that includes opm binary

### DIFF
--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -1,17 +1,17 @@
 FROM openshift/origin-base as builder
 
-COPY --from=quay.io/operator-framework/opm:v1.23.2 /bin/opm /bin/opm
+COPY --from=quay.io/openshift/origin-operator-registry:4.11 /bin/opm /bin/opm
 
 # Copy declarative config root into image at /configs
 COPY configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
-RUN /bin/opm --skip-tls-verify render -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.23.0:serverless-stop-bundle \
+RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.23.0:serverless-stop-bundle \
   registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM quay.io/operator-framework/opm:v1.23.2
+FROM quay.io/openshift/origin-operator-registry:4.11
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -1,17 +1,17 @@
 FROM openshift/origin-base as builder
 
-COPY --from=quay.io/operator-framework/opm:v1.23.2 /bin/opm /bin/opm
+COPY --from=quay.io/openshift/origin-operator-registry:4.11 /bin/opm /bin/opm
 
 # Copy declarative config root into image at /configs
 COPY configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
-RUN /bin/opm --skip-tls-verify render -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_VERSION__:serverless-stop-bundle \
+RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_VERSION__:serverless-stop-bundle \
   registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM quay.io/operator-framework/opm:v1.23.2
+FROM quay.io/openshift/origin-operator-registry:4.11
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVCOM-1981

* Use specific version of the downstream origin-operator-registry image that includes OPM binary instead of "upstream latest" version which might change.

Related Slack discussion: https://coreos.slack.com/archives/C3VS0LV41/p1657876220715119


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

