### PR TITLE
Specify base image for Index build precisely

### DIFF
--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -1,6 +1,8 @@
-FROM openshift/origin-base as builder
+FROM quay.io/openshift/origin-operator-registry:4.11 AS opm
 
-COPY --from=quay.io/openshift/origin-operator-registry:4.11 /bin/opm /bin/opm
+FROM quay.io/openshift/origin-base:4.11 as builder
+
+COPY --from=opm /bin/opm /bin/opm
 
 # Copy declarative config root into image at /configs
 COPY configs /configs
@@ -11,7 +13,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM quay.io/openshift/origin-operator-registry:4.11
+FROM opm
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -1,6 +1,8 @@
-FROM openshift/origin-base as builder
+FROM quay.io/openshift/origin-operator-registry:4.11 AS opm
 
-COPY --from=quay.io/openshift/origin-operator-registry:4.11 /bin/opm /bin/opm
+FROM quay.io/openshift/origin-base:4.11 as builder
+
+COPY --from=opm /bin/opm /bin/opm
 
 # Copy declarative config root into image at /configs
 COPY configs /configs
@@ -11,7 +13,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM quay.io/openshift/origin-operator-registry:4.11
+FROM opm
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs


### PR DESCRIPTION
* Prevent pulling the openshift/origin-base from docker.io where the
image is outdated.

Fixes failures such as https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.9-e2e-aws-ocp-49-continuous/1549907236153724928

Slack discussion: https://coreos.slack.com/archives/CD87JDUB0/p1658365691127509


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
