### PR TITLE
Support building operator images on cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ need to run `docker login` to be able to push images. Now run
 `make images` and all images in this repository will now be built and
 pushed to your docker repository.
 
+#### Creating the images on cluster
+
+`make images` requires docker or podman to build images, by setting
+`ON_CLUSTER_BUILDS=true` env variable, `make images` will build images
+using OpenShift Build and they will be available at the in-cluster
+registry `image-registry.openshift-image-registry.svc:5000/openshift-marketplace/<image_name>`.
+
+To install the system using those images, use
+`DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace`
+
 ### Installing the system
 
 Use the appropriate make targets or scripts in `hack`:

--- a/hack/images.sh
+++ b/hack/images.sh
@@ -5,18 +5,54 @@
 
 set -Eeuo pipefail
 
+source "$(dirname $0)/lib/__sources__.bash"
+
+root_dir="$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"
+
 if [[ "$#" -ne 1 ]]; then
-    echo "Please ensure DOCKER_REPO_OVERRIDE envvar is set"
-    exit 1
+  echo "Please ensure DOCKER_REPO_OVERRIDE envvar is set"
+  exit 1
 fi
 
 repo=$1
 
-docker build -t "$repo/openshift-knative-operator" -f openshift-knative-operator/Dockerfile .
-docker push "$repo/openshift-knative-operator"
+on_cluster_builds=${ON_CLUSTER_BUILDS:-false}
+echo "On cluster builds: ${on_cluster_builds}"
 
-docker build -t "$repo/knative-operator" -f knative-operator/Dockerfile .
-docker push "$repo/knative-operator"
+function build_image() {
+  name=${1:?Pass a name of image to be built as arg[1]}
+  dockerfile_path=${2:?Pass dockerfile path}
 
-docker build -t "$repo/knative-openshift-ingress" -f serving/ingress/Dockerfile .
-docker push "$repo/knative-openshift-ingress"
+  if ! oc get buildconfigs "$name" -n "$OLM_NAMESPACE" >/dev/null 2>&1; then
+    logger.info "Create an image build for ${name}"
+    oc -n "${OLM_NAMESPACE}" new-build \
+      --strategy=docker --name "$name" --dockerfile "$(cat "${dockerfile_path}")"
+  else
+    logger.info "${name} image build is already created"
+  fi
+
+  logger.info 'Build the image in the cluster-internal registry.'
+  oc -n "${OLM_NAMESPACE}" start-build "${name}" --from-dir "${root_dir}" -F
+}
+
+if [[ $on_cluster_builds = true ]]; then
+  #  image-registry.openshift-image-registry.svc:5000/openshift-marketplace/openshift-knative-operator:latest
+  build_image "openshift-knative-operator" "${root_dir}/openshift-knative-operator/Dockerfile" || exit 1
+  #  image-registry.openshift-image-registry.svc:5000/openshift-marketplace/knative-operator:latest
+  build_image "knative-operator" "${root_dir}/knative-operator/Dockerfile" || exit 1
+  #  image-registry.openshift-image-registry.svc:5000/openshift-marketplace/knative-openshift-ingress:latest
+  build_image "knative-openshift-ingress" "${root_dir}/serving/ingress/Dockerfile" || exit 1
+
+  logger.info 'Images build'
+
+else
+  docker build -t "$repo/openshift-knative-operator" -f openshift-knative-operator/Dockerfile .
+  docker push "$repo/openshift-knative-operator"
+
+  docker build -t "$repo/knative-operator" -f knative-operator/Dockerfile .
+  docker push "$repo/knative-operator"
+
+  docker build -t "$repo/knative-openshift-ingress" -f serving/ingress/Dockerfile .
+  docker push "$repo/knative-openshift-ingress"
+
+fi

--- a/hack/images.sh
+++ b/hack/images.sh
@@ -5,7 +5,8 @@
 
 set -Eeuo pipefail
 
-source "$(dirname $0)/lib/__sources__.bash"
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/lib/__sources__.bash"
 
 root_dir="$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"
 

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -19,5 +19,10 @@ dump_state.setup
 scale_up_workers
 create_namespaces "${SYSTEM_NAMESPACES[@]}"
 
+export ON_CLUSTER_BUILDS=true
+export DOCKER_REPO_OVERRIDE="image-registry.openshift-image-registry.svc:5000/openshift-marketplace"
+
+make images
+
 ensure_catalogsource_installed
 ensure_serverless_installed "${INSTALL_PREVIOUS_VERSION}"

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -19,10 +19,5 @@ dump_state.setup
 scale_up_workers
 create_namespaces "${SYSTEM_NAMESPACES[@]}"
 
-export ON_CLUSTER_BUILDS=true
-export DOCKER_REPO_OVERRIDE="image-registry.openshift-image-registry.svc:5000/openshift-marketplace"
-
-make images
-
 ensure_catalogsource_installed
 ensure_serverless_installed "${INSTALL_PREVIOUS_VERSION}"


### PR DESCRIPTION
For midstream testing using serverless operator we need
to rebuild these images to inject the newly generated
artifacts and there isn't docker available in CI.

Tested in https://github.com/openshift-knative/serverless-operator/pull/1657/commits/b2cd9dedcde172d97cc5c6726a5a1fe01786dbbd as well as locally

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
