### PR TITLE
Replicate legacy sugar controller config during tests

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -226,6 +226,17 @@ spec:
       loglevel.kafkachannel-controller: "debug"
       loglevel.inmemorychannel-dispatcher: "debug"
       loglevel.mt-broker-controller: "debug"
+    sugar:
+      namespace-selector: |
+        matchExpressions:
+        - key: "e2e.eventing.knative.dev/injection"
+          operator: "In"
+          values: ["enabled"]
+      trigger-selector: |
+        matchExpressions:
+        - key: "e2e.eventing.knative.dev/injection"
+          operator: "In"
+          values: ["enabled"]
 EOF
 
   if [[ $ENABLE_TRACING == "true" ]]; then


### PR DESCRIPTION
Copied from https://github.com/knative/eventing/blob/main/test/config/configmaps/config-sugar.yaml

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
