### PR TITLE
Fix pdb version

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -25,7 +25,7 @@ requirements:
 dependencies:
   serving: 1.4.0
   # serving midstream branch name
-  serving_artifacts_branch: release-v1.4
+  serving_artifacts_branch: fix_pdb_1.4
 
   # versions for networking components
   kourier: 1.4.0

--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/1.4.0/2-serving-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/1.4.0/2-serving-core.yaml
@@ -4873,7 +4873,7 @@ spec:
 # Activator PDB. Currently we permit unavailability of 20% of tasks at the same time.
 # Given the subsetting and that the activators are partially stateful systems, we want
 # a slow rollout of the new versions and slow migration during node upgrades.
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: activator-pdb
@@ -5560,7 +5560,7 @@ spec:
           averageUtilization: 100
 ---
 # Webhook PDB.
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: webhook-pdb

--- a/openshift-knative-operator/hack/update-manifests.sh
+++ b/openshift-knative-operator/hack/update-manifests.sh
@@ -45,7 +45,7 @@ function download_serving {
     target_file="$target_dir/$index-$file"
 
     if [[ ${KNATIVE_SERVING_MANIFESTS_DIR} = "" ]]; then
-      url="https://raw.githubusercontent.com/openshift/knative-serving/${branch}/openshift/release/artifacts/$index-$file"
+      url="https://raw.githubusercontent.com/skonto/serving/${branch}/openshift/release/artifacts/$index-$file"
       wget --no-check-certificate "$url" -O "$target_file"
     else
       cp "${KNATIVE_SERVING_MANIFESTS_DIR}/${file}" "$target_file"


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fixes [failures](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.6-upgrade-tests-aws-ocp-46-continuous/1552806242353680384) on 4.6 due to the unsupported version of pdb. 
- Missed this patch when moving patches to the mid stream repo.
- Midstream PR: https://github.com/openshift/knative-serving/pull/1194 needs to get in first and then we will revert the branches here.
/assign @nak3 
/hold for the midstream PR
