### PR TITLE
Allow openshift-serverless namespace to pull images from openshift-marketplace

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -53,6 +53,10 @@ function install_catalogsource {
     # Allow OPM to pull the serverless-bundle from openshift-marketplace ns from internal registry.
     oc adm policy add-role-to-group system:image-puller system:unauthenticated --namespace openshift-marketplace
 
+    # export ON_CLUSTER_BUILDS=true; make images
+    # will push images to ${OLM_NAMESPACE} namespace, allow the ${OPERATORS_NAMESPACE} namespace to pull those images.
+    oc adm policy add-role-to-group system:image-puller system:serviceaccounts:"${OPERATORS_NAMESPACE}" --namespace "${OLM_NAMESPACE}"
+
     local index_build_dir=${rootdir}/olm-catalog/serverless-operator/index
 
     logger.debug "Create a backup of the index Dockerfile."


### PR DESCRIPTION
When using `ON_CLUSTER_BUILDS` for `make images` I'm getting
```
Failed to pull image "image-registry.openshift-image-registry.svc:5000/openshift-marketplace/knative-operator": rpc error: code = Unknown desc = reading manifest latest in image-registry.openshift-image-registry.svc:5000/openshift-marketplace/knative-operator: unauthorized: authentication required
```

We need to allow `openshift-serverless` namespace to pull images
from the namespace `openshift-marketplace` as documented in
https://docs.openshift.com/container-platform/4.7/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-across-projects_using-image-pull-secrets

Apparently, the command that we already (pasted below) run is not
enough for this case:
```
oc adm policy add-role-to-group system:image-puller system:unauthenticated --namespace openshift-marketplace
```

This is blocking https://github.com/openshift/knative-eventing/pull/1822, see also the same error here:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_knative-eventing/1822/pull-ci-openshift-knative-eventing-release-v1.4-46-test-e2e-aws-ocp-46/1553039593392050176/artifacts/test-e2e-aws-ocp-46/gather-extra/artifacts/pods.json, grep for `Back-off pulling image \"image-registry.openshift-image-registry.svc:5000/openshift-marketplace/knative-operator\"`

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
