### PR TITLE
[WIP][TEST_ONLY][SRVKS-953] Set runAsNonRoot to false on Kourier Gateway

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/ingress/1.4/0-kourier.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/1.4/0-kourier.yaml
@@ -427,7 +427,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
-            runAsNonRoot: false
+            runAsNonRoot: true
             capabilities:
               drop:
                 - all


### PR DESCRIPTION
This patch sets runAsNonRoot to false.

As per https://github.com/knative-sandbox/net-kourier/pull/272,

the setting was necessary as:
- the envoy image wants to run as root.
- the envoy needs write access to the filesystem.

For write access, I could produce the error if I changed readOnlyRootFilesystem to `false`. 

```
[2022-08-22 07:08:29.879][1][critical][main] [external/envoy/source/server/server.cc:108] error initializing configuration '/tmp/config/envoy-bootstrap.yaml': cannot bind '/tmp/envoy.admin': Read-only file system
[2022-08-22 07:08:29.879][1][info][main] [external/envoy/source/server/server.cc:790] exiting
```

However, `runAsNonRoot` could be false without any isssue. Let's see the CI as well.