### PR TITLE
Use golangci/golangci-lint-action@v3

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -133,7 +133,7 @@ jobs:
                 -level="error"
 
       - name: Go Lint - knative-operator
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.45.2
           args: --timeout=10m0s --verbose


### PR DESCRIPTION
As per title, this patch updates golangci/golangci-lint-action to v3.

Current `golangci-lint-action@v2` action always fails due to `golangci-lint exit with code 137`.