### PR TITLE
Define authorization for Kafka users

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -43,6 +43,10 @@ function install_strimzi_cluster {
             tls: true
             authentication:
               type: scram-sha-512
+        authorization:
+          superUsers:
+            - ANONYMOUS
+          type: simple
         config:
           offsets.topic.replication.factor: 3
           transaction.state.log.replication.factor: 3
@@ -85,6 +89,41 @@ metadata:
 spec:
   authentication:
     type: tls
+  authorization:
+    type: simple
+    acls:
+      # Example ACL rules for consuming from a topic.
+      - resource:
+          type: topic
+          name: "*"
+        operation: Read
+        host: "*"
+      - resource:
+          type: topic
+          name: "*"
+        operation: Describe
+        host: "*"
+      - resource:
+          type: group
+          name: "*"
+        operation: Read
+        host: "*"
+      # Example ACL rules for producing to a topic.
+      - resource:
+          type: topic
+          name: "*"
+        operation: Write
+        host: "*"
+      - resource:
+          type: topic
+          name: "*"
+        operation: Create
+        host: "*"
+      - resource:
+          type: topic
+          name: "*"
+        operation: Describe
+        host: "*"
 EOF
 
   header "Applying Strimzi SASL Admin User"
@@ -99,6 +138,41 @@ metadata:
 spec:
   authentication:
     type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # Example ACL rules for consuming from knative-messaging-kafka using consumer group my-group
+      - resource:
+          type: topic
+          name: "*"
+        operation: Read
+        host: "*"
+      - resource:
+          type: topic
+          name: "*"
+        operation: Describe
+        host: "*"
+      - resource:
+          type: group
+          name: "*"
+        operation: Read
+        host: "*"
+      # Example ACL rules for producing to topic knative-messaging-kafka
+      - resource:
+          type: topic
+          name: "*"
+        operation: Write
+        host: "*"
+      - resource:
+          type: topic
+          name: "*"
+        operation: Create
+        host: "*"
+      - resource:
+          type: topic
+          name: "*"
+        operation: Describe
+        host: "*"
 EOF
 
   header "Waiting for Strimzi admin users to become ready"


### PR DESCRIPTION
Align this with eventing-kafka-broker and make it possible to configure
the Kafka cluster only once and then run both eventing-kafka-broker and
serverless-operator tests for kafka.

The eventing-kafka-broker uses the authorization element on KafkaUsers when setting up tests: https://github.com/knative-sandbox/eventing-kafka-broker/blob/release-1.4/test/kafka/user-sasl-scram-512.yaml#L24
The latest versions of Kafka cluster (3.0.0,3.1.0) then require the authorization element so that users which define authorization are accepted: https://github.com/knative-sandbox/eventing-kafka-broker/blob/main/test/kafka/kafka-ephemeral.yaml#L52

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
