### PR TITLE
[WIP] Disable downgrades to get logs from operator pod on upgrade

### DIFF
--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -45,9 +45,12 @@ func TestServerlessUpgrade(t *testing.T) {
 	cfg := newUpgradeConfig(t)
 	suite := pkgupgrade.Suite{
 		Tests: pkgupgrade.Tests{
-			PreUpgrade:    preUpgradeTests(),
-			PostUpgrade:   postUpgradeTests(ctx),
-			PostDowngrade: postDowngradeTests(),
+			PreUpgrade:  preUpgradeTests(),
+			PostUpgrade: postUpgradeTests(ctx),
+			PostDowngrade: []pkgupgrade.Operation{
+				// Ensure cleanup through PostDowngradeTest.
+				servingupgrade.ServicePostDowngradeTest(),
+			},
 			Continual: merge(
 				[]pkgupgrade.BackgroundOperation{
 					servingupgrade.ProbeTest(),
@@ -67,7 +70,6 @@ func TestServerlessUpgrade(t *testing.T) {
 					}
 				}),
 			},
-			DowngradeWith: downgrade(ctx),
 		},
 	}
 	suite.Execute(cfg)


### PR DESCRIPTION
Disabling downgrades to reproduce https://issues.redhat.com/browse/SRVKS-954 (which seems to be related to upgrades) and get logs from operator pods during upgrade. When downgrades are enabled the operator pods are replaced with older version again and logs from upgrades are lost.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
