### PR TITLE
Apache Kafka 3.2 bump

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -24,7 +24,7 @@ function install_strimzi_cluster {
       namespace: kafka
     spec:
       kafka:
-        version: 3.1.0
+        version: 3.2.0
         replicas: 3
         listeners:
           - name: plain
@@ -51,7 +51,7 @@ function install_strimzi_cluster {
           offsets.topic.replication.factor: 3
           transaction.state.log.replication.factor: 3
           transaction.state.log.min.isr: 2
-          inter.broker.protocol.version: "3.1"
+          inter.broker.protocol.version: "3.2"
           auto.create.topics.enable: "false"
         storage:
           type: jbod


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Since 0.30 the Strimzi team has no support for Apache Kafka 3.0.x, only for 3.1 and 3.2, see [here](https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.30.0). Here we bump kafka from 3.1 to 3.2, since we are already on Strimzi 0.30 operator: https://github.com/openshift-knative/serverless-operator/pull/1693 
