### PR TITLE
Enable internal encryption by default in tests

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -152,6 +152,8 @@ function deploy_knativeserving_cr {
 
   if [[ $FULL_MESH == "true" ]]; then
     enable_istio "$serving_cr"
+    # Disable internal encryption.
+    yq delete --inplace "$serving_cr" spec.config.network.internal-encryption
   fi
 
   if [[ $ENABLE_TRACING == "true" ]]; then

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -156,6 +156,14 @@ function deploy_knativeserving_cr {
     yq delete --inplace "$serving_cr" spec.config.network.internal-encryption
   fi
 
+  # When upgrading from 1.24 or older, disable internal TLS. It works since 1.25.
+  if [[ "$INSTALL_PREVIOUS_VERSION" == "true" ]]; then
+    if versions.le "$(versions.major_minor "$PREVIOUS_VERSION")" "1.24"; then
+      logger.warn "Disabling internal encryption. Unsupported version."
+      yq delete --inplace "$serving_cr" spec.config.network.internal-encryption
+    fi
+  fi
+
   if [[ $ENABLE_TRACING == "true" ]]; then
     enable_tracing "$serving_cr"
   fi

--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -1,47 +1,12 @@
 package kourier
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
-	pkgTest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/spoof"
 )
-
-func TestKnativeServiceHTTPS(t *testing.T) {
-
-	caCtx := test.SetupClusterAdmin(t)
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
-	defer test.CleanupAll(t, caCtx)
-
-	ksvc, err := test.WithServiceReady(caCtx, "https-service", test.Namespace, image)
-	if err != nil {
-		t.Fatal("Knative Service not ready", err)
-	}
-
-	// Implicitly checks that HTTPS works.
-	servinge2e.WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
-
-	// Now check that HTTP works.
-	httpURL := ksvc.Status.URL.DeepCopy()
-
-	httpURL.Scheme = "http"
-	if _, err := pkgTest.CheckEndpointState(
-		context.Background(),
-		caCtx.Clients.Kube,
-		t.Logf,
-		httpURL.URL(),
-		spoof.MatchesBody(helloworldText),
-		"WaitForRouteToServeText",
-		true,
-	); err != nil {
-		t.Fatalf("The Route at domain %s didn't serve the expected text %q: %v", httpURL, helloworldText, err)
-	}
-
-}
 
 func TestKnativeServiceHTTPRedirect(t *testing.T) {
 

--- a/test/servinge2e/tracing_test.go
+++ b/test/servinge2e/tracing_test.go
@@ -34,6 +34,7 @@ func TestTraceStartedAtActivator(t *testing.T) {
 }
 
 func TestTraceStartedAtQueueProxy(t *testing.T) {
+	t.Skip("Activator is always on the path. See SRVKS-784")
 	tracingTest(t, false /* activatorInPath */)
 }
 

--- a/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
+++ b/test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
@@ -4,6 +4,8 @@ metadata:
   name: knative-serving
 spec:
   config:
+    network:
+      internal-encryption: "true"
     autoscaler:
       container-concurrency-target-default: "100"
       container-concurrency-target-percentage: "1.0"


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Enable internal encryption by default
- Disable encryption for Service Mesh
- Disable tracing test which doesn't allow Activator in path
- Remove TestKnativeServiceHTTPS: The Route is passthrough with insecureEdgeTerminationPolicy:Redirect. The kourier gateway serves only HTTPS and it requires certificates.
