### PR TITLE
[TEST ONLY] Logstream for upgrade test namespace

### DIFF
--- a/vendor/knative.dev/pkg/test/logstream/null.go
+++ b/vendor/knative.dev/pkg/test/logstream/null.go
@@ -16,12 +16,16 @@ limitations under the License.
 
 package logstream
 
+import (
+	logstreamv2 "knative.dev/pkg/test/logstream/v2"
+)
+
 type null struct{}
 
 var _ streamer = (*null)(nil)
 
 // Start implements streamer
-func (*null) Start(t ti) Canceler {
+func (*null) Start(t ti, callback logstreamv2.Callback) Canceler {
 	t.Log("logstream was requested, but SYSTEM_NAMESPACE was unset.")
 	return func() {}
 }

--- a/vendor/knative.dev/serving/test/upgrade/probe.go
+++ b/vendor/knative.dev/serving/test/upgrade/probe.go
@@ -35,11 +35,12 @@ func ProbeTest() pkgupgrade.BackgroundOperation {
 	var clients *test.Clients
 	var names *test.ResourceNames
 	var prober test.Prober
-	var cancel logstream.Canceler
+	var cancel, sysCancel logstream.Canceler
 	return pkgupgrade.NewBackgroundVerification("ProbeTest",
 		func(c pkgupgrade.Context) {
 			// Setup
 			clients = e2e.Setup(c.T)
+			sysCancel = logstream.Start(c.T)
 			cancel = logstream.StartForNamespaces(c.T, c.Log.Infof, "serving-tests")
 			names = &test.ResourceNames{
 				Service: "upgrade-probe",
@@ -61,6 +62,7 @@ func ProbeTest() pkgupgrade.BackgroundOperation {
 			test.EnsureTearDown(c.T, clients, names)
 			test.AssertProberSLO(c.T, prober, *successFraction)
 			c.T.Cleanup(cancel)
+			c.T.Cleanup(sysCancel)
 			c.T.Fail()
 		},
 	)


### PR DESCRIPTION
Trying an updated logstream for Pods in the test namespace. Enabling this for Prober test in upgrade test suite.

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
