### PR TITLE
[RELEASE-1.25][SRVCOM-2106] Remove seccomprofile from CSV deployments

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -493,8 +493,6 @@ spec:
                       capabilities:
                         drop:
                           - ALL
-                      seccompProfile:
-                        type: RuntimeDefault
         # Openshift specific extensions in the "old" operator format. Ships KnativeKafka and
         # other Openshift specifica that have not yet been moved to the operator above.
         - name: knative-openshift
@@ -523,8 +521,6 @@ spec:
                       capabilities:
                         drop:
                           - ALL
-                      seccompProfile:
-                        type: RuntimeDefault
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
@@ -668,8 +664,6 @@ spec:
                       capabilities:
                         drop:
                           - ALL
-                      seccompProfile:
-                        type: RuntimeDefault
                 volumes:
                   - name: cli-artifacts
                     emptyDir: {}
@@ -716,8 +710,6 @@ spec:
                       capabilities:
                         drop:
                           - ALL
-                      seccompProfile:
-                        type: RuntimeDefault
   webhookdefinitions:
     - generateName: validating.knativeeventings.operator.serverless.openshift.io
       type: ValidatingAdmissionWebhook

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -445,8 +445,6 @@ spec:
                       capabilities:
                         drop:
                           - ALL
-                      seccompProfile:
-                        type: RuntimeDefault
         # Openshift specific extensions in the "old" operator format. Ships KnativeKafka and
         # other Openshift specifica that have not yet been moved to the operator above.
         - name: knative-openshift
@@ -480,8 +478,6 @@ spec:
                       capabilities:
                         drop:
                           - ALL
-                      seccompProfile:
-                        type: RuntimeDefault
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
@@ -547,8 +543,6 @@ spec:
                       capabilities:
                         drop:
                           - ALL
-                      seccompProfile:
-                        type: RuntimeDefault
                 volumes:
                   - name: cli-artifacts
                     emptyDir: {}
@@ -596,8 +590,6 @@ spec:
                       capabilities:
                         drop:
                           - ALL
-                      seccompProfile:
-                        type: RuntimeDefault
 
   webhookdefinitions:
     - generateName: validating.knativeeventings.operator.serverless.openshift.io


### PR DESCRIPTION
- #1710 makes S-O fail on 4.7,...,4.10
- Unfortunately we didnt catch this earlier as 4.6 was passing.
- Downside is S-O namespace pods will not be able to deploy under the `restricted` profile if administrator wants to (https://connect.redhat.com/en/blog/important-openshift-changes-pod-security-standards).