### PR TITLE
[main] Set memory requests to 10Gi when on dedicated node

### DIFF
--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -2,7 +2,6 @@
 
 function install_tracing {
   if [[ "${TRACING_BACKEND}" == "zipkin" ]]; then
-    ZIPKIN_MEMORY_REQUESTS="256Mi"
     if [[ "$ZIPKIN_DEDICATED_NODE" == "true" ]]; then
       dedicate_node_to_zipkin
       ZIPKIN_MEMORY_REQUESTS="10Gi"
@@ -29,6 +28,7 @@ function dedicate_node_to_zipkin {
 function install_zipkin_tracing {
   logger.info "Installing Zipkin in namespace ${TRACING_NAMESPACE}"
   local nodeAffinity=""
+  local memory_requests=${ZIPKIN_MEMORY_REQUESTS:-"256Mi"}
   if [[ "$ZIPKIN_DEDICATED_NODE" == "true" ]]; then
   nodeAffinity=$(cat <<-EOF
       affinity:
@@ -92,7 +92,7 @@ spec:
           limits:
             memory: 10Gi
           requests:
-            memory: ${ZIPKIN_MEMORY_REQUESTS}
+            memory: ${memory_requests}
       tolerations:
       - key: zipkin
         operator: Exists

--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -2,8 +2,10 @@
 
 function install_tracing {
   if [[ "${TRACING_BACKEND}" == "zipkin" ]]; then
+    ZIPKIN_MEMORY_REQUESTS="256Mi"
     if [[ "$ZIPKIN_DEDICATED_NODE" == "true" ]]; then
       dedicate_node_to_zipkin
+      ZIPKIN_MEMORY_REQUESTS="10Gi"
     fi
     install_zipkin_tracing
   else
@@ -90,7 +92,7 @@ spec:
           limits:
             memory: 10Gi
           requests:
-            memory: 256Mi
+            memory: ${ZIPKIN_MEMORY_REQUESTS}
       tolerations:
       - key: zipkin
         operator: Exists


### PR DESCRIPTION
The Zipkin pod was recently evicted and traces for events lost:
```
istio-system                   18m         Warning   Evicted                                      pod/zipkin-58fcd685d-shtj4                                         The node was low on resource: memory. Container zipkin was using 8725020Ki, which exceeds its request of 256Mi.
```
This PR should minimizes the chance of evicting the Pod.
Related discussion: https://coreos.slack.com/archives/CLUCMK7R6/p1663832224355229
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
