### PR TITLE
Make WaitForKnativeKafkaState wait longer

### DIFF
--- a/test/v1alpha1/knativekafka.go
+++ b/test/v1alpha1/knativekafka.go
@@ -95,7 +95,7 @@ func WaitForKnativeKafkaState(ctx *test.Context, name, namespace string, inState
 		lastState *kafkav1alpha1.KnativeKafka
 		err       error
 	)
-	waitErr := wait.PollImmediate(test.Interval, test.Timeout, func() (bool, error) {
+	waitErr := wait.PollImmediate(test.Interval, 2*test.Timeout, func() (bool, error) {
 		lastState = &kafkav1alpha1.KnativeKafka{}
 		var u *unstructured.Unstructured
 		u, err = ctx.Clients.Dynamic.Resource(kafkav1alpha1.SchemeGroupVersion.WithResource("knativekafkas")).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})


### PR DESCRIPTION
The original 5 minutes might not be enough in some cases, e.g. during downgrades in downstream.

The problem with short timeout can be seen e.g. here: https://master-jenkins-csb-serverless-qe.apps.ocp-c1.prod.psi.redhat.com/job/functional_tests/job/stream1_25/job/rolling-upgrade-1.25/1, the KnativeKafka pods are started about 5 minutes after other Eventing pods during downgrade. In the end the KnativeKafka CR status gets the right version but it's after the current timeout.

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
