### PR TITLE
Separate target for Kafka Broker upstream tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,24 +118,33 @@ test-operator: test-unit test-e2e
 # Run upstream E2E tests with net-istio and sidecar.
 # TODO: Enable upgrade tests once upstream fixed the issue https://github.com/knative/serving/issues/11535.
 test-upstream-e2e-mesh-testonly:
-	FULL_MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	FULL_MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
 test-upstream-e2e-mesh:
 	FULL_MESH="true" UNINSTALL_MESH="false" ./hack/mesh.sh
 	TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ./hack/tracing.sh
 	FULL_MESH=true TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ENABLE_TRACING=true ./hack/install.sh
 	FULL_MESH=true ./test/e2e-tests.sh
-	FULL_MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	FULL_MESH=true TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
 # Run upstream E2E tests without upgrades.
 test-upstream-e2e-no-upgrade-testonly:
-	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+
+test-upstream-e2e-kafka-no-upgrade-testonly:
+	TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
 test-upstream-e2e-no-upgrade:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	TRACING_BACKEND=zipkin ./hack/tracing.sh
 	INSTALL_KAFKA="true" TRACING_BACKEND=zipkin ENABLE_TRACING=true ./hack/install.sh
-	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=true TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+
+test-upstream-e2e-kafka-no-upgrade:
+	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
+	TRACING_BACKEND=zipkin ./hack/tracing.sh
+	INSTALL_KAFKA="true" TRACING_BACKEND=zipkin ENABLE_TRACING=true ./hack/install.sh
+	TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
 # Run only upstream upgrade tests.
 test-upstream-upgrade-testonly:

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -73,6 +73,7 @@ export OLM_SOURCE="${OLM_SOURCE:-"$OPERATOR"}"
 export TEST_KNATIVE_UPGRADE="${TEST_KNATIVE_UPGRADE:-true}"
 export TEST_KNATIVE_E2E="${TEST_KNATIVE_E2E:-true}"
 export TEST_KNATIVE_KAFKA="${TEST_KNATIVE_KAFKA:-false}"
+export TEST_KNATIVE_KAFKA_BROKER="${TEST_KNATIVE_KAFKA_BROKER:-false}"
 
 # Makefile triggers for modular install
 export INSTALL_SERVING="${INSTALL_SERVING:-true}"

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -37,8 +37,16 @@ if [[ $TEST_KNATIVE_E2E == true ]]; then
   if [[ $TEST_KNATIVE_KAFKA == true ]]; then
     upstream_knative_eventing_kafka_e2e
   fi
-  upstream_knative_serving_e2e_and_conformance_tests
-  upstream_knative_eventing_e2e
+  if [[ $TEST_KNATIVE_KAFKA_BROKER == true ]]; then
+    upstream_knative_eventing_kafka_broker_e2e
+  fi
+  if [[ $TEST_KNATIVE_SERVING == true ]]; then
+    upstream_knative_serving_e2e_and_conformance_tests
+  fi
+  if [[ $TEST_KNATIVE_EVENTING == true ]]; then
+    upstream_knative_eventing_e2e
+  fi
+
 fi
 
 [ -n "$OPENSHIFT_CI" ] && check_serverless_alerts


### PR DESCRIPTION
Current upstream tests in addition to the Kafka Broker tests
take too long to complete, see https://github.com/openshift-knative/serverless-operator/pull/1674

The target `test-upstream-e2e-kafka-no-upgrade` (or the variant `-testonly`)
can be used to run upstream ekb tests once https://github.com/openshift-knative/serverless-operator/pull/1674 is in.

The function `upstream_knative_eventing_kafka_broker_e2e` doesn't exist yet,
it will be added in https://github.com/openshift-knative/serverless-operator/pull/1674,
I separated this commit for easier review.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>