### PR TITLE
Use new multiarch variant for helloworld-go and hello-openshift images

### DIFF
--- a/test/eventinge2e/source_to_ksvc_test.go
+++ b/test/eventinge2e/source_to_ksvc_test.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	pingSourceName    = "smoke-test-ping"
-	image             = "quay.io/openshift-knative/helloworld-go"
+	image             = "quay.io/openshift-knative/helloworld-go:multiarch"
 	helloWorldService = "helloworld-go"
 	helloWorldText    = "Hello World!"
 	ksvcAPIVersion    = "serving.knative.dev/v1"

--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -28,7 +28,7 @@ const (
 	kafkaSourceName     = "smoke-ks"
 	kafkaTopicName      = "smoke-topic"
 	kafkaConsumerGroup  = "smoke-cg"
-	image               = "quay.io/openshift-knative/helloworld-go"
+	image               = "quay.io/openshift-knative/helloworld-go:multiarch"
 	helloWorldService   = "helloworld-go"
 	ksvcAPIVersion      = "serving.knative.dev/v1"
 	ksvcKind            = "Service"

--- a/test/kitchensinke2e/ksvc/ksvc.go
+++ b/test/kitchensinke2e/ksvc/ksvc.go
@@ -15,7 +15,7 @@ import (
 //go:embed *.yaml
 var yaml embed.FS
 
-const defaultImage = "quay.io/openshift-knative/helloworld-go"
+const defaultImage = "quay.io/openshift-knative/helloworld-go:multiarch"
 
 func GVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1", Resource: "services"}

--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	image                 = "quay.io/openshift-knative/helloworld-go"
+	image                 = "quay.io/openshift-knative/helloworld-go:multiarch"
 	helloworldService     = "helloworld-go"
 	helloworldService2    = "helloworld-go2"
 	kubeHelloworldService = "kube-helloworld-go"

--- a/test/servinge2e/kourier/helpers.go
+++ b/test/servinge2e/kourier/helpers.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	image          = "quay.io/openshift-knative/helloworld-go"
+	image          = "quay.io/openshift-knative/helloworld-go:multiarch"
 	helloworldText = "Hello World!"
 )
 

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -335,7 +335,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 		// istio-pilot caches the JWKS content if a new Policy has the same jwksUri as some old policy.
 		// Rerunning this test would fail if we kept the jwksUri constant across invocations then,
 		// hence the random suffix for the jwks ksvc.
-		jwksKsvc := test.Service(helpers.AppendRandomString("jwks"), test.Namespace, "quay.io/openshift-knative/hello-openshift", nil)
+		jwksKsvc := test.Service(helpers.AppendRandomString("jwks"), test.Namespace, "quay.io/openshift-knative/hello-openshift:multiarch", nil)
 		jwksKsvc.Spec.Template.Spec.Containers[0].Env = append(jwksKsvc.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 			Name:  "RESPONSE",
 			Value: jwks,


### PR DESCRIPTION
This is part of the work for P/Z. The two images 
`quay.io/openshift-knative-serving-test/hello-openshift:latest` and `quay.io/openshift-knative-client-test/helloworld:v1.3` were pushed to their new locations:
```
quay.io/openshift-knative/hello-openshift:multiarch
quay.io/openshift-knative/helloworld-go:multiarch
```
They're multiarch images including amd64,arm64,ppc64le, s390x.


Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
