### PR TITLE
Making a more generic contains function

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -647,8 +647,8 @@ func configureEventingKafka(spec serverlessoperatorv1alpha1.KnativeKafkaSpec) mf
 	}
 }
 
-func checkHAComponent(name string) bool {
-	for _, component := range KafkaHAComponents {
+func contains(array []string, name string) bool {
+	for _, component := range array {
 		if name == component {
 			return true
 		}
@@ -658,7 +658,7 @@ func checkHAComponent(name string) bool {
 
 func setKafkaDeployments(replicas int32) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
-		if u.GetKind() == "Deployment" && checkHAComponent(u.GetName()) {
+		if u.GetKind() == "Deployment" && contains(KafkaHAComponents, u.GetName()) {
 			log.Info("Setting Kafka HA component", "deployment", u.GetName(), "replicas", replicas)
 			if err := unstructured.SetNestedField(u.Object, int64(replicas), "spec", "replicas"); err != nil {
 				return err

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -651,7 +651,7 @@ func TestCheckHAComponent(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := checkHAComponent(tc.deploymentName)
+			result := contains(KafkaHAComponents, tc.deploymentName)
 			if result == tc.shouldFail {
 				t.Errorf("Got: %v, want: %v\n", result, tc.shouldFail)
 			}


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Refactoring the `checkHAComponent` to a more generic `contains` function, so it is usful for similar checks (e.g. a possible check of allowed/valid log-levels) 
