### PR TITLE
[release-1.25] Fix massive kafka-controller restarts after toggling KnativeKafka components

### DIFF
--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"sort"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,7 +34,7 @@ func (m StringMap) StringValues() string {
 	for _, v := range m {
 		values = append(values, v)
 	}
-
+	sort.Strings(values)
 	return strings.Join(values, ",")
 }
 

--- a/knative-operator/pkg/common/util_test.go
+++ b/knative-operator/pkg/common/util_test.go
@@ -123,17 +123,59 @@ func environFromMap(envMap map[string]string) []string {
 }
 
 func TestStringMap(t *testing.T) {
-	disabledKafkaControllers := common.StringMap{
-		"broker": "broker-controller,trigger-controller",
-		"sink":   "sink-controller",
+	cases := []struct {
+		name   string
+		remove string
+		remain string
+		size   int
+	}{
+		{
+			name:   "All controllers",
+			remove: "",
+			remain: "broker-controller,trigger-controller,channel-controller,sink-controller,source-controller",
+			size:   4,
+		},
+		{
+			name:   "Remove Broker",
+			remove: "BROKER",
+			remain: "channel-controller,sink-controller,source-controller",
+			size:   3,
+		},
+		{
+			name:   "Remove Sink",
+			remove: "SINK",
+			remain: "channel-controller,source-controller",
+			size:   2,
+		},
+		{
+			name:   "Remove Channel",
+			remove: "CHANNEL",
+			remain: "source-controller",
+			size:   1,
+		},
+		{
+			name:   "Remove Source",
+			remove: "SOURCE",
+			remain: "",
+			size:   0,
+		},
 	}
-	disabledKafkaControllers.Remove("broker")
-	assert.Equal(t, len(disabledKafkaControllers), 1)
-	assert.NotEmpty(t, disabledKafkaControllers)
 
-	disabledKafkaControllers.Remove("sink")
-	assert.Equal(t, len(disabledKafkaControllers), 0)
-	assert.Empty(t, disabledKafkaControllers)
+	disabledKafkaControllers := common.StringMap{
+		"BROKER":  "broker-controller,trigger-controller",
+		"SINK":    "sink-controller",
+		"SOURCE":  "source-controller",
+		"CHANNEL": "channel-controller",
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			disabledKafkaControllers.Remove(tc.remove)
+			assert.Equal(t, tc.remain, disabledKafkaControllers.StringValues())
+			assert.Equal(t, tc.size, len(disabledKafkaControllers))
+		})
+	}
 }
 
 func TestSetAnnotations(t *testing.T) {

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -592,9 +592,12 @@ func configureEventingKafka(spec serverlessoperatorv1alpha1.KnativeKafkaSpec) mf
 				disabledKafkaControllers.Remove(channelController)
 			}
 
-			// render the actual argument
-			// todo: if we have no disabled controllers left we should filter for the proper argument and remove just that!
-			deployment.Spec.Template.Spec.Containers[0].Args = []string{"--disable-controllers=" + disabledKafkaControllers.StringValues()}
+			// render the actual argument, if any
+			if len(disabledKafkaControllers) == 0 {
+				deployment.Spec.Template.Spec.Containers[0].Args = nil
+			} else {
+				deployment.Spec.Template.Spec.Containers[0].Args = []string{"--disable-controllers=" + disabledKafkaControllers.StringValues()}
+			}
 
 			return scheme.Scheme.Convert(deployment, u, nil)
 		}


### PR DESCRIPTION
Fixes JIRA #1320

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- adding a sort by values, so we have an expected ordering of the strings that call out the controllers that are disabled
- only render the `args` if we have controllers that are disabled, otherwise do not render the `args` 
