### PR TITLE
[SRVKE-1324] Avoid reconciliation loops

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-kit/log v0.2.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
-	github.com/go-logr/logr v1.2.2 // indirect
+	github.com/go-logr/logr v1.2.2
 	github.com/go-logr/zapr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect

--- a/knative-operator/deploy/resources/knativekafka/controller/eventing-kafka-controller.yaml
+++ b/knative-operator/deploy/resources/knativekafka/controller/eventing-kafka-controller.yaml
@@ -1648,7 +1648,6 @@ webhooks:
     reinvocationPolicy: IfNeeded
     matchPolicy: Equivalent
     namespaceSelector:
-      matchExpressions: [ ]
       matchLabels:
         app.kubernetes.io/name: knative-eventing
     objectSelector:

--- a/openshift-knative-operator/pkg/monitoring/helpers.go
+++ b/openshift-knative-operator/pkg/monitoring/helpers.go
@@ -13,6 +13,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/operator/pkg/apis/operator/base"
@@ -192,8 +193,9 @@ func createServiceMonitorService(component string, ns string) corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name: "https",
-				Port: 8444,
+				Name:       "https",
+				Port:       8444,
+				TargetPort: intstr.FromInt(8444),
 			}},
 			Selector: getSelectorLabels(component),
 		}}


### PR DESCRIPTION
This is a  fix for SRVKE-1324

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- set creation timestamp to 0 on every resource
- global resync only when some config maps change (config-tracing and kafka-config-logging)
- remove match expression from webhook definition since it is changed by Knative webhook logic
