### PR TITLE
[SRVCOM-2118] Install console resources only if related crds are available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect
 	go.opencensus.io v0.23.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/atomic v1.9.0
 	go.uber.org/automaxprocs v1.4.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect

--- a/knative-operator/pkg/apis/addtoscheme_crds_v1.go
+++ b/knative-operator/pkg/apis/addtoscheme_crds_v1.go
@@ -1,0 +1,11 @@
+package apis
+
+import (
+	apisextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func init() {
+	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
+	// Adds schema for k8s crds
+	AddToSchemes = append(AddToSchemes, apisextensionv1.AddToScheme)
+}

--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -4,10 +4,13 @@ import (
 	"sort"
 	"strings"
 
+	"go.uber.org/atomic"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mf "github.com/manifestival/manifestival"
@@ -16,7 +19,10 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var Log = logf.Log.WithName("knative").WithName("openshift")
+var (
+	Log              = logf.Log.WithName("knative").WithName("openshift")
+	ConsoleInstalled = atomic.NewBool(false)
+)
 
 // StringMap is a map which key and value are strings
 type StringMap map[string]string
@@ -132,4 +138,16 @@ func BuildGVKToResourceMap(manifests ...mf.Manifest) map[schema.GroupVersionKind
 	}
 
 	return gvkToResource
+}
+
+type SkipPredicate struct {
+	predicate.Funcs
+}
+
+func (SkipPredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (SkipPredicate) Update(e event.UpdateEvent) bool {
+	return false
 }

--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 	"strings"
 
-	"go.uber.org/atomic"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,10 +18,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var (
-	Log              = logf.Log.WithName("knative").WithName("openshift")
-	ConsoleInstalled = atomic.NewBool(false)
-)
+var Log = logf.Log.WithName("knative").WithName("openshift")
 
 // StringMap is a map which key and value are strings
 type StringMap map[string]string

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -10,7 +10,7 @@ import (
 	socommon "github.com/openshift-knative/serverless-operator/pkg/common"
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	"go.uber.org/atomic"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,21 +25,19 @@ const knCLIDownload = "kn"
 var (
 	operatorNamespace = os.Getenv(common.NamespaceEnvKey)
 	log               = common.Log.WithName("consoleclidownload")
+	ConsoleInstalled  = atomic.NewBool(false)
 )
 
 // Apply installs kn ConsoleCLIDownload and its required resources when applicable
-func Apply(instance *operatorv1beta1.KnativeServing, apiclient client.Client, apiExtensionV1Client apiextensionv1.ApiextensionsV1Interface) error {
+func Apply(instance *operatorv1beta1.KnativeServing, apiclient client.Client) error {
 	// Install the cli download route even if there is no console available to allow fetching the related binaries
 	route, err := reconcileKnConsoleCLIDownloadRoute(apiclient, instance)
 	if err != nil {
 		return err
 	}
-	// Skip installing console cli download resources if there are no related CRDs available eg. cluster is installed without console
-	if _, err = apiExtensionV1Client.CustomResourceDefinitions().Get(context.Background(), "consoleclidownloads.console.openshift.io", metav1.GetOptions{}); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to fetch ConsoleCLIDownload CRDs: %w", err)
+	// If console is not installed skip installing cdd resources
+	if !ConsoleInstalled.Load() {
+		return nil
 	}
 	return reconcileKnConsoleCLIDownload(apiclient, instance, route)
 }

--- a/knative-operator/pkg/controller/knativeserving/consoleutil/util.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleutil/util.go
@@ -1,0 +1,23 @@
+package consoleutil
+
+import (
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleclidownload"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/quickstart"
+)
+
+func SetConsoleCRDInstalled(crd string) {
+	switch crd {
+	case consoleclidownload.CLIDownloadCRDName:
+		consoleclidownload.ConsoleCLIDownloadsCRDInstalled.Store(true)
+	case quickstart.QuickStartsCRDName:
+		quickstart.ConsoleQuickStartsCRDInstalled.Store(true)
+	}
+}
+
+func RequiredConsoleCRDMissing() bool {
+	return !consoleclidownload.ConsoleCLIDownloadsCRDInstalled.Load() || !quickstart.ConsoleQuickStartsCRDInstalled.Load()
+}
+
+func AnyRequiredConsoleCRDAvailable() bool {
+	return consoleclidownload.ConsoleCLIDownloadsCRDInstalled.Load() || quickstart.ConsoleQuickStartsCRDInstalled.Load()
+}

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -331,14 +331,7 @@ func (r *ReconcileKnativeServing) installQuickstarts(instance *operatorv1beta1.K
 
 // installKnConsoleCLIDownload creates CR for kn CLI download link
 func (r *ReconcileKnativeServing) installKnConsoleCLIDownload(instance *operatorv1beta1.KnativeServing) error {
-	// Skip installing console cli download if there are no related CRDs available eg. cluster is installed without console
-	if _, err := r.apiExtensionV1Client.CustomResourceDefinitions().Get(context.Background(), "consoleclidownloads.console.openshift.io", metav1.GetOptions{}); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to fetch ConsoleCLIDownload CRDs: %w", err)
-	}
-	return consoleclidownload.Apply(instance, r.client, r.scheme)
+	return consoleclidownload.Apply(instance, r.client, r.apiExtensionV1Client)
 }
 
 // installDashboard installs dashboard for OpenShift webconsole

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -2,12 +2,12 @@ package knativeserving
 
 import (
 	"context"
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleclidownload"
 	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleclidownload"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/quickstart"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring/dashboards"
 	configv1 "github.com/openshift/api/config/v1"

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleclidownload"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/quickstart"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring/dashboards"
 	configv1 "github.com/openshift/api/config/v1"
@@ -149,7 +149,7 @@ func TestExtraResourcesReconcile(t *testing.T) {
 				}
 			}
 
-			common.ConsoleInstalled.Store(true)
+			consoleclidownload.ConsoleCLIDownloadsCRDInstalled.Store(true)
 			cliDownloadWatchSet.Store(true)
 
 			// Reconcile again

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -2,6 +2,7 @@ package knativeserving
 
 import (
 	"context"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleclidownload"
 	"os"
 	"testing"
 
@@ -13,8 +14,6 @@ import (
 	consolev1 "github.com/openshift/api/console/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apisapiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -126,16 +125,8 @@ func TestExtraResourcesReconcile(t *testing.T) {
 			ns := &dashboardNamespace
 
 			cl := fake.NewClientBuilder().WithObjects(ks, ingress, ns, &servingNamespace).Build()
-
-			cldCrd := &apisapiextensionv1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "consoleclidownloads.console.openshift.io",
-				},
-			}
-
-			apifake := apiextensionfake.NewSimpleClientset().ApiextensionsV1()
-			_, _ = apifake.CustomResourceDefinitions().Create(context.Background(), cldCrd, metav1.CreateOptions{})
-			r := &ReconcileKnativeServing{client: cl, apiExtensionV1Client: apifake, scheme: scheme.Scheme}
+			consoleclidownload.ConsoleInstalled.Store(true)
+			r := &ReconcileKnativeServing{client: cl, scheme: scheme.Scheme}
 
 			// Reconcile to initialize
 			if _, err := r.Reconcile(context.Background(), defaultRequest); err != nil {

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -13,6 +13,8 @@ import (
 	consolev1 "github.com/openshift/api/console/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apisapiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -124,7 +126,16 @@ func TestExtraResourcesReconcile(t *testing.T) {
 			ns := &dashboardNamespace
 
 			cl := fake.NewClientBuilder().WithObjects(ks, ingress, ns, &servingNamespace).Build()
-			r := &ReconcileKnativeServing{client: cl, scheme: scheme.Scheme}
+
+			cldCrd := &apisapiextensionv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "consoleclidownloads.console.openshift.io",
+				},
+			}
+
+			apifake := apiextensionfake.NewSimpleClientset().ApiextensionsV1()
+			_, _ = apifake.CustomResourceDefinitions().Create(context.Background(), cldCrd, metav1.CreateOptions{})
+			r := &ReconcileKnativeServing{client: cl, apiExtensionV1Client: apifake, scheme: scheme.Scheme}
 
 			// Reconcile to initialize
 			if _, err := r.Reconcile(context.Background(), defaultRequest); err != nil {

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleclidownload"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/quickstart"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring/dashboards"
 	configv1 "github.com/openshift/api/config/v1"
@@ -125,7 +125,6 @@ func TestExtraResourcesReconcile(t *testing.T) {
 			ns := &dashboardNamespace
 
 			cl := fake.NewClientBuilder().WithObjects(ks, ingress, ns, &servingNamespace).Build()
-			consoleclidownload.ConsoleInstalled.Store(true)
 			r := &ReconcileKnativeServing{client: cl, scheme: scheme.Scheme}
 
 			// Reconcile to initialize
@@ -136,11 +135,36 @@ func TestExtraResourcesReconcile(t *testing.T) {
 			// Check kn ConsoleCLIDownload CR
 			err := cl.Get(context.TODO(), types.NamespacedName{Name: "kn", Namespace: ""}, ccd)
 			if err != nil {
-				t.Fatalf("get: (%v)", err)
+				if !errors.IsNotFound(err) {
+					t.Fatalf("get: (%v)", err)
+				}
 			}
 
 			// Check if Serving dashboard configmap is available
 			dashboardCM := &corev1.ConfigMap{}
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-serving-resources", Namespace: ns.Name}, dashboardCM)
+			if err != nil {
+				if !errors.IsNotFound(err) {
+					t.Fatalf("get: (%v)", err)
+				}
+			}
+
+			common.ConsoleInstalled.Store(true)
+			cliDownloadWatchSet.Store(true)
+
+			// Reconcile again
+			if _, err = r.Reconcile(context.Background(), defaultRequest); err != nil {
+				t.Fatalf("reconcile: (%v)", err)
+			}
+
+			// Check kn ConsoleCLIDownload CR
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: "kn", Namespace: ""}, ccd)
+			if err != nil {
+				t.Fatalf("get: (%v)", err)
+			}
+
+			// Check if Serving dashboard configmap is available
+			dashboardCM = &corev1.ConfigMap{}
 			err = cl.Get(context.TODO(), types.NamespacedName{Name: "grafana-dashboard-definition-knative-serving-resources", Namespace: ns.Name}, dashboardCM)
 			if err != nil {
 				t.Fatalf("get: (%v)", err)

--- a/knative-operator/pkg/controller/knativeserving/quickstart/quickstart.go
+++ b/knative-operator/pkg/controller/knativeserving/quickstart/quickstart.go
@@ -7,14 +7,21 @@ import (
 	mfc "github.com/manifestival/controller-runtime-client"
 	mf "github.com/manifestival/manifestival"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
+	"go.uber.org/atomic"
 	apierrs "k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// EnvKey is the environment variable that decides which manifest to load
-const EnvKey = "QUICKSTART_MANIFEST_PATH"
+const (
+	// EnvKey is the environment variable that decides which manifest to load
+	EnvKey             = "QUICKSTART_MANIFEST_PATH"
+	QuickStartsCRDName = "consolequickstarts.console.openshift.io"
+)
 
-var log = common.Log.WithName("quickstart")
+var (
+	ConsoleQuickStartsCRDInstalled = atomic.NewBool(false)
+	log                            = common.Log.WithName("quickstart")
+)
 
 // Apply applies Quickstart resources.
 func Apply(api client.Client) error {


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- This is meant for the case where we don't have console available.
- Tested as described [here](https://gist.github.com/skonto/1af0ad93d8a3b7bb1d6f5169f0ab7a72) with 4.12 nightly. We had to patch a few manifests due to SRVKS-934.
[knative-openshift.log](https://github.com/openshift-knative/serverless-operator/files/9727810/os.log), 
[knative-operator-webhook.log](https://github.com/openshift-knative/serverless-operator/files/9727813/opw.log)

Paths tested:

a) no console -> install S-O -> Install Console -> Install Serving/Eventing
b) no console -> install S-O -> install Serving/Eventing ->  Install Console
c)  Install Console -> install S-O -> Install Serving/Eventing
To install console just use:

```
  oc patch clusterversion/version --type merge -p '{"spec":{"capabilities":{"additionalEnabledCapabilities":["Console"]}}}'

```
-  If users have no console installed and they decide to install it later we require the knative-openshift pod to be restarted.
- Fixes the issue with cache sync as described in the ticket: 
```
failed to wait for knativeserving-controller caches to sync: no matches for kind "ConsoleCLIDownload" in version "console.openshift.io/v1"
```
