### PR TITLE
Use queue-sidecar-image instead of queueSidecarImage.

### DIFF
--- a/hack/lib/common.bash
+++ b/hack/lib/common.bash
@@ -68,5 +68,6 @@ function versions.major_minor {
 function yaml.break_image_references {
   sed -i "s,image: .*,image: TO_BE_REPLACED," "$1"
   sed -i "s,value: gcr.io/knative-releases.*,value: TO_BE_REPLACED," "$1"
-  sed -i "s,queueSidecarImage: .*,queueSidecarImage: TO_BE_REPLACED," "$1"
+  # TODO: Replace queueSidecarImage with queue-sidecar-image when upstream v1.8 is used. See: https://github.com/knative/serving/pull/13347.
+  sed -i "s,queueSidecarImage: .*,queue-sidecar-image: TO_BE_REPLACED," "$1"
 }

--- a/openshift-knative-operator/cmd/operator/kodata/knative-serving/1.5.0/2-serving-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-serving/1.5.0/2-serving-core.yaml
@@ -3891,7 +3891,7 @@ data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
   # TODO: switch to 'queue-sidecar-image' after 0.27
-  queueSidecarImage: TO_BE_REPLACED
+  queue-sidecar-image: TO_BE_REPLACED
   _example: |-
     ################################
     #                              #

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -113,7 +113,7 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 	images := common.ImageMapFromEnvironment(os.Environ())
 	ks.Spec.Registry.Override = images
 	ks.Spec.Registry.Default = images["default"]
-	common.Configure(&ks.Spec.CommonSpec, "deployment", "queueSidecarImage", images["queue-proxy"])
+	common.Configure(&ks.Spec.CommonSpec, "deployment", "queue-sidecar-image", images["queue-proxy"])
 
 	// Default to 2 replicas.
 	if ks.Spec.HighAvailability == nil {

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -509,7 +509,7 @@ func ks(mods ...func(*operatorv1beta1.KnativeServing)) *operatorv1beta1.KnativeS
 				},
 				Config: base.ConfigMapData{
 					"deployment": map[string]string{
-						"queueSidecarImage": "baz",
+						"queue-sidecar-image": "baz",
 					},
 					"domain": map[string]string{
 						"routing.example.com": "",


### PR DESCRIPTION
As per title, this patch replaces queueSidecarImage with queue-sidecar-image.

It causes an error in midstream because upstream changed the default as https://github.com/knative/serving/commit/79a45887a7d56b305a714f21a36e736f1b9f5ebe