### PR TITLE
Use --imagetemplate parameter in s-o E2E tests

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -433,10 +433,12 @@ function dump_subscriptions {
 function gather_knative_state {
   logger.info 'Gather knative state'
   local gather_dir="${ARTIFACT_DIR:-/tmp}/gather-knative"
+  local gatherImageKnative="${MUST_GATHER_IMAGE_KNATIVE:-quay.io/openshift-knative/must-gather}"
+  local gatherImageMesh="${MUST_GATHER_IMAGE_MESH:-registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7}"
   mkdir -p "$gather_dir"
-  IMAGE_OPTION=("--image=quay.io/openshift-knative/must-gather")
+  IMAGE_OPTION=("--image=${gatherImageKnative}")
   if [[ $FULL_MESH == true ]]; then
-    IMAGE_OPTION=("${IMAGE_OPTION[@]}" "--image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7")
+    IMAGE_OPTION=("${IMAGE_OPTION[@]}" "--image=${gatherImageMesh}")
   fi
 
   oc --insecure-skip-tls-verify adm must-gather \

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -87,3 +87,12 @@ export ENABLE_TRACING="${ENABLE_TRACING:-false}"
 # Define sample-rate for tracing.
 export SAMPLE_RATE="${SAMPLE_RATE:-"1.0"}"
 export ZIPKIN_DEDICATED_NODE="${ZIPKIN_DEDICATED_NODE:-false}"
+DEFAULT_IMAGE_TEMPLATE=$(
+  cat <<-EOF
+{{- with .Name }}
+{{- if eq . "knative-serving-test-httpproxy"}}registry.ci.openshift.org/openshift/knative-v0.17.3:{{.}}
+{{- else                                    }}quay.io/openshift-knative/{{.}}:multiarch{{end -}}
+{{end -}}
+EOF
+)
+export IMAGE_TEMPLATE="${IMAGE_TEMPLATE:-"$DEFAULT_IMAGE_TEMPLATE"}"

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -89,9 +89,9 @@ export SAMPLE_RATE="${SAMPLE_RATE:-"1.0"}"
 export ZIPKIN_DEDICATED_NODE="${ZIPKIN_DEDICATED_NODE:-false}"
 DEFAULT_IMAGE_TEMPLATE=$(
   cat <<-EOF
-{{- with .Name }}
-{{- if eq . "knative-serving-test-httpproxy"}}registry.ci.openshift.org/openshift/knative-v0.17.3:{{.}}
-{{- else                                    }}quay.io/openshift-knative/{{.}}:multiarch{{end -}}
+quay.io/{{- with .Name }}
+{{- if eq . "httpproxy" }}openshift-knative-serving-test/{{.}}:v1.3
+{{- else                }}openshift-knative/{{.}}:multiarch{{end -}}
 {{end -}}
 EOF
 )

--- a/test/eventinge2e/source_broker_ksvc_test.go
+++ b/test/eventinge2e/source_broker_ksvc_test.go
@@ -37,7 +37,7 @@ func TestKnativeSourceBrokerTriggerKnativeService(t *testing.T) {
 	defer cleanup()
 
 	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(image))
+	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/eventinge2e/source_broker_ksvc_test.go
+++ b/test/eventinge2e/source_broker_ksvc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgTest "knative.dev/pkg/test"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
@@ -36,7 +37,7 @@ func TestKnativeSourceBrokerTriggerKnativeService(t *testing.T) {
 	defer cleanup()
 
 	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, image)
+	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(image))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/eventinge2e/source_channel_ksvc_test.go
+++ b/test/eventinge2e/source_channel_ksvc_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgTest "knative.dev/pkg/test"
 
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
@@ -32,7 +33,7 @@ func TestKnativeSourceChannelKnativeService(t *testing.T) {
 	defer cleanup()
 
 	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, image)
+	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(image))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/eventinge2e/source_channel_ksvc_test.go
+++ b/test/eventinge2e/source_channel_ksvc_test.go
@@ -33,7 +33,7 @@ func TestKnativeSourceChannelKnativeService(t *testing.T) {
 	defer cleanup()
 
 	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(image))
+	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/eventinge2e/source_to_ksvc_test.go
+++ b/test/eventinge2e/source_to_ksvc_test.go
@@ -31,7 +31,7 @@ func TestKnativeSourceToKnativeService(t *testing.T) {
 	defer cleanup()
 
 	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(image))
+	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/eventinge2e/source_to_ksvc_test.go
+++ b/test/eventinge2e/source_to_ksvc_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgTest "knative.dev/pkg/test"
 
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -14,7 +15,6 @@ import (
 
 const (
 	pingSourceName    = "smoke-test-ping"
-	image             = "quay.io/openshift-knative/helloworld-go:multiarch"
 	helloWorldService = "helloworld-go"
 	helloWorldText    = "Hello World!"
 	ksvcAPIVersion    = "serving.knative.dev/v1"
@@ -31,7 +31,7 @@ func TestKnativeSourceToKnativeService(t *testing.T) {
 	defer cleanup()
 
 	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, image)
+	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(image))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/extensione2e/kafka/kafka_channel_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_channel_ksvc_test.go
@@ -9,6 +9,7 @@ import (
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	pkgTest "knative.dev/pkg/test"
 
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
@@ -89,7 +90,7 @@ func TestSourceToKafkaChanelToKnativeService(t *testing.T) {
 	defer cleanup()
 
 	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, image)
+	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(image))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/extensione2e/kafka/kafka_channel_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_channel_ksvc_test.go
@@ -90,7 +90,7 @@ func TestSourceToKafkaChanelToKnativeService(t *testing.T) {
 	defer cleanup()
 
 	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(image))
+	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -271,7 +271,7 @@ func TestKafkaSourceToKnativeService(t *testing.T) {
 	for name, tc := range tests {
 		name := name
 		// Setup a knative service
-		ksvc, err := test.WithServiceReady(client, helloWorldService+"-"+name, test.Namespace, pkgTest.ImagePath(image))
+		ksvc, err := test.WithServiceReady(client, helloWorldService+"-"+name, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
 		if err != nil {
 			t.Fatalf("Knative Service(%s) not ready: %v", ksvc.GetName(), err)
 		}

--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
+	pkgTest "knative.dev/pkg/test"
 
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -29,7 +30,6 @@ const (
 	kafkaSourceName     = "smoke-ks"
 	kafkaTopicName      = "smoke-topic"
 	kafkaConsumerGroup  = "smoke-cg"
-	image               = "quay.io/openshift-knative/helloworld-go:multiarch"
 	helloWorldService   = "helloworld-go"
 	ksvcAPIVersion      = "serving.knative.dev/v1"
 	ksvcKind            = "Service"
@@ -271,7 +271,7 @@ func TestKafkaSourceToKnativeService(t *testing.T) {
 	for name, tc := range tests {
 		name := name
 		// Setup a knative service
-		ksvc, err := test.WithServiceReady(client, helloWorldService+"-"+name, test.Namespace, image)
+		ksvc, err := test.WithServiceReady(client, helloWorldService+"-"+name, test.Namespace, pkgTest.ImagePath(image))
 		if err != nil {
 			t.Fatalf("Knative Service(%s) not ready: %v", ksvc.GetName(), err)
 		}

--- a/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
@@ -100,7 +100,7 @@ func TestSourceToKafkaChannelBasedBrokerToKnativeService(t *testing.T) {
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()
 
-	ksvc, err := test.WithServiceReady(client, helloWorldService+"-kafka-channel-broker", test.Namespace, pkgTest.ImagePath(image))
+	ksvc, err := test.WithServiceReady(client, helloWorldService+"-kafka-channel-broker", test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgTest "knative.dev/pkg/test"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
@@ -99,7 +100,7 @@ func TestSourceToKafkaChannelBasedBrokerToKnativeService(t *testing.T) {
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()
 
-	ksvc, err := test.WithServiceReady(client, helloWorldService+"-kafka-channel-broker", test.Namespace, image)
+	ksvc, err := test.WithServiceReady(client, helloWorldService+"-kafka-channel-broker", test.Namespace, pkgTest.ImagePath(image))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	pkgTest "knative.dev/pkg/test"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
@@ -129,7 +130,7 @@ func TestSourceToNativeKafkaBasedBrokerToKnativeService(t *testing.T) {
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()
 
-	ksvc, err := test.WithServiceReady(client, kafkaTriggerKsvcName, test.Namespace, image)
+	ksvc, err := test.WithServiceReady(client, kafkaTriggerKsvcName, test.Namespace, pkgTest.ImagePath(image))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
@@ -130,7 +130,7 @@ func TestSourceToNativeKafkaBasedBrokerToKnativeService(t *testing.T) {
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()
 
-	ksvc, err := test.WithServiceReady(client, kafkaTriggerKsvcName, test.Namespace, pkgTest.ImagePath(image))
+	ksvc, err := test.WithServiceReady(client, kafkaTriggerKsvcName, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}

--- a/test/flags.go
+++ b/test/flags.go
@@ -6,6 +6,9 @@ import (
 	"os/user"
 	"path"
 	"testing"
+
+	// Make sure to initialize flags from knative.dev/pkg/test before parsing them.
+	_ "knative.dev/pkg/test"
 )
 
 const (

--- a/test/images.go
+++ b/test/images.go
@@ -4,6 +4,5 @@ package test
 const (
 	HelloworldGoImg   = "helloworld-go"
 	HelloOpenshiftImg = "hello-openshift"
-	// registry.ci.openshift.org/openshift/knative-v0.17.3:knative-serving-test-httpproxy
-	HTTPProxyImg = "knative-serving-test-httpproxy"
+	HTTPProxyImg      = "httpproxy"
 )

--- a/test/images.go
+++ b/test/images.go
@@ -5,5 +5,5 @@ const (
 	HelloworldGoImg   = "helloworld-go"
 	HelloOpenshiftImg = "hello-openshift"
 	// registry.ci.openshift.org/openshift/knative-v0.17.3:knative-serving-test-httpproxy
-	HttpProxyImg = "knative-serving-test-httpproxy"
+	HTTPProxyImg = "knative-serving-test-httpproxy"
 )

--- a/test/images.go
+++ b/test/images.go
@@ -1,0 +1,9 @@
+package test
+
+// The list of images used by serverless-operator test suite.
+const (
+	HelloworldGoImg   = "helloworld-go"
+	HelloOpenshiftImg = "hello-openshift"
+	// registry.ci.openshift.org/openshift/knative-v0.17.3:knative-serving-test-httpproxy
+	HttpProxyImg = "knative-serving-test-httpproxy"
+)

--- a/test/kitchensinke2e/ksvc/ksvc.go
+++ b/test/kitchensinke2e/ksvc/ksvc.go
@@ -5,8 +5,10 @@ import (
 	"embed"
 	"time"
 
+	"github.com/openshift-knative/serverless-operator/test"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
@@ -14,8 +16,6 @@ import (
 
 //go:embed *.yaml
 var yaml embed.FS
-
-const defaultImage = "quay.io/openshift-knative/helloworld-go:multiarch"
 
 func GVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1", Resource: "services"}
@@ -26,7 +26,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 	cfg := map[string]interface{}{
 		"name":    name,
 		"version": GVR().Version,
-		"image":   defaultImage,
+		"image":   pkgTest.ImagePath(test.HelloworldGoImg),
 	}
 	for _, fn := range opts {
 		fn(cfg)

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -2,7 +2,8 @@
 
 # == Overrides & test related
 
-# shellcheck disable=SC1091,SC1090
+# shellcheck disable=SC1091,SC1090,SC2153
+# See https://github.com/koalaman/shellcheck/issues/518
 source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/hack/lib/__sources__.bash"
 
 readonly TEARDOWN="${TEARDOWN:-on_exit}"

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -79,6 +79,7 @@ function serverless_operator_e2e_tests {
   go_test_e2e -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2e \
     --channel "$OLM_CHANNEL" \
     --kubeconfigs "${kubeconfigs_str}" \
+    --imagetemplate "${IMAGE_TEMPLATE}" \
     "$@"
 }
 
@@ -96,6 +97,7 @@ function serverless_operator_kafka_e2e_tests {
   go_test_e2e -failfast -tags=e2e -timeout=30m -parallel=1 ./test/e2ekafka \
     --channel "$OLM_CHANNEL" \
     --kubeconfigs "${kubeconfigs_str}" \
+    --imagetemplate "${IMAGE_TEMPLATE}" \
     "$@"
 }
 
@@ -114,10 +116,12 @@ function downstream_serving_e2e_tests {
     export GODEBUG="x509ignoreCN=0"
     go_test_e2e -failfast -timeout=60m -parallel=1 ./test/servinge2e/ \
       --kubeconfigs "${kubeconfigs_str}" \
+      --imagetemplate "${IMAGE_TEMPLATE}" \
       "$@"
   else
     go_test_e2e -failfast -timeout=60m -parallel=1 ./test/servinge2e/... \
       --kubeconfigs "${kubeconfigs_str}" \
+      --imagetemplate "${IMAGE_TEMPLATE}" \
       "$@"
   fi
 }
@@ -135,6 +139,7 @@ function downstream_eventing_e2e_tests {
 
   go_test_e2e -failfast -timeout=30m -parallel=1 ./test/eventinge2e \
     --kubeconfigs "${kubeconfigs_str}" \
+    --imagetemplate "${IMAGE_TEMPLATE}" \
     "$@"
 }
 
@@ -151,6 +156,7 @@ function downstream_knative_kafka_e2e_tests {
 
   go_test_e2e -failfast -timeout=30m -parallel=1 ./test/extensione2e/kafka \
     --kubeconfigs "${kubeconfigs_str}" \
+    --imagetemplate "${IMAGE_TEMPLATE}" \
     "$@"
 }
 
@@ -167,6 +173,7 @@ function downstream_monitoring_e2e_tests {
 
   go_test_e2e -failfast -timeout=30m -parallel=1 ./test/monitoringe2e \
     --kubeconfigs "${kubeconfigs_str}" \
+    --imagetemplate "${IMAGE_TEMPLATE}" \
     "$@"
 }
 
@@ -177,7 +184,9 @@ function downstream_kitchensink_e2e_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  go_test_e2e -failfast -timeout=120m -parallel=8 ./test/kitchensinke2e "$@"
+  go_test_e2e -failfast -timeout=120m -parallel=8 ./test/kitchensinke2e \
+  --imagetemplate "${IMAGE_TEMPLATE}" \
+  "$@"
 }
 
 # == Upgrade testing

--- a/test/servinge2e/deploy_kn_k8s_svc_in_same_namespace_test.go
+++ b/test/servinge2e/deploy_kn_k8s_svc_in_same_namespace_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	pkgTest "knative.dev/pkg/test"
 )
 
 func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
@@ -19,7 +20,7 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	defer test.CleanupAll(t, caCtx)
 
 	//Create deployment
-	err := test.CreateDeployment(caCtx, kubeHelloworldService, test.Namespace2, image)
+	err := test.CreateDeployment(caCtx, kubeHelloworldService, test.Namespace2, pkgTest.ImagePath(image))
 	if err != nil {
 		t.Fatal("Deployment not created", err)
 	}
@@ -41,7 +42,7 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, kubeServiceURL, helloworldText)
 
 	// Deploy Knative service in the same namespace
-	ksvc, err := test.WithServiceReady(caCtx, helloworldService, test.Namespace2, image)
+	ksvc, err := test.WithServiceReady(caCtx, helloworldService, test.Namespace2, pkgTest.ImagePath(image))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}
@@ -70,7 +71,7 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	}
 
 	// Deploy Knative service in the namespace first
-	ksvc, err = test.WithServiceReady(caCtx, helloworldService2, test.Namespace2, image)
+	ksvc, err = test.WithServiceReady(caCtx, helloworldService2, test.Namespace2, pkgTest.ImagePath(image))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}
@@ -79,7 +80,7 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
 
 	//Create deployment
-	err = test.CreateDeployment(caCtx, kubeHelloworldService, test.Namespace2, image)
+	err = test.CreateDeployment(caCtx, kubeHelloworldService, test.Namespace2, pkgTest.ImagePath(image))
 	if err != nil {
 		t.Fatal("Deployment not created", err)
 	}

--- a/test/servinge2e/deploy_kn_k8s_svc_in_same_namespace_test.go
+++ b/test/servinge2e/deploy_kn_k8s_svc_in_same_namespace_test.go
@@ -20,7 +20,7 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	defer test.CleanupAll(t, caCtx)
 
 	//Create deployment
-	err := test.CreateDeployment(caCtx, kubeHelloworldService, test.Namespace2, pkgTest.ImagePath(image))
+	err := test.CreateDeployment(caCtx, kubeHelloworldService, test.Namespace2, pkgTest.ImagePath(test.HelloworldGoImg))
 	if err != nil {
 		t.Fatal("Deployment not created", err)
 	}
@@ -42,7 +42,7 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, kubeServiceURL, helloworldText)
 
 	// Deploy Knative service in the same namespace
-	ksvc, err := test.WithServiceReady(caCtx, helloworldService, test.Namespace2, pkgTest.ImagePath(image))
+	ksvc, err := test.WithServiceReady(caCtx, helloworldService, test.Namespace2, pkgTest.ImagePath(test.HelloworldGoImg))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}
@@ -71,7 +71,7 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	}
 
 	// Deploy Knative service in the namespace first
-	ksvc, err = test.WithServiceReady(caCtx, helloworldService2, test.Namespace2, pkgTest.ImagePath(image))
+	ksvc, err = test.WithServiceReady(caCtx, helloworldService2, test.Namespace2, pkgTest.ImagePath(test.HelloworldGoImg))
 	if err != nil {
 		t.Fatal("Knative Service not ready", err)
 	}
@@ -80,7 +80,7 @@ func TestKnativeVersusKubeServicesInOneNamespace(t *testing.T) {
 	WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
 
 	//Create deployment
-	err = test.CreateDeployment(caCtx, kubeHelloworldService, test.Namespace2, pkgTest.ImagePath(image))
+	err = test.CreateDeployment(caCtx, kubeHelloworldService, test.Namespace2, pkgTest.ImagePath(test.HelloworldGoImg))
 	if err != nil {
 		t.Fatal("Deployment not created", err)
 	}

--- a/test/servinge2e/helpers.go
+++ b/test/servinge2e/helpers.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	image                 = "quay.io/openshift-knative/helloworld-go:multiarch"
 	helloworldService     = "helloworld-go"
 	helloworldService2    = "helloworld-go2"
 	kubeHelloworldService = "kube-helloworld-go"

--- a/test/servinge2e/kourier/custom_route_test.go
+++ b/test/servinge2e/kourier/custom_route_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
 	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
@@ -38,7 +39,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	defer test.CleanupAll(t, caCtx)
 
 	// Create Kservice with disable Annotation.
-	ksvc := test.Service(serviceName, test.Namespace, image, nil)
+	ksvc := test.Service(serviceName, test.Namespace, pkgTest.ImagePath(image), nil)
 	ksvc.ObjectMeta.Annotations = map[string]string{resources.DisableRouteAnnotation: "true"}
 	ksvc = test.WithServiceReadyOrFail(caCtx, ksvc)
 

--- a/test/servinge2e/kourier/custom_route_test.go
+++ b/test/servinge2e/kourier/custom_route_test.go
@@ -39,7 +39,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	defer test.CleanupAll(t, caCtx)
 
 	// Create Kservice with disable Annotation.
-	ksvc := test.Service(serviceName, test.Namespace, pkgTest.ImagePath(image), nil)
+	ksvc := test.Service(serviceName, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg), nil)
 	ksvc.ObjectMeta.Annotations = map[string]string{resources.DisableRouteAnnotation: "true"}
 	ksvc = test.WithServiceReadyOrFail(caCtx, ksvc)
 

--- a/test/servinge2e/kourier/helpers.go
+++ b/test/servinge2e/kourier/helpers.go
@@ -9,7 +9,6 @@ import (
 )
 
 const (
-	image          = "quay.io/openshift-knative/helloworld-go:multiarch"
 	helloworldText = "Hello World!"
 )
 

--- a/test/servinge2e/kourier/service_to_service_test.go
+++ b/test/servinge2e/kourier/service_to_service_test.go
@@ -64,7 +64,7 @@ func TestServiceToServiceCalls(t *testing.T) {
 
 func testServiceToService(t *testing.T, ctx *test.Context, namespace string, tc testCase) {
 	// Create a ksvc with the specified annotations and labels
-	service := test.Service(tc.name, namespace, pkgTest.ImagePath(image), tc.annotations)
+	service := test.Service(tc.name, namespace, pkgTest.ImagePath(test.HelloworldGoImg), tc.annotations)
 	service.ObjectMeta.Labels = tc.labels
 
 	service = test.WithServiceReadyOrFail(ctx, service)

--- a/test/servinge2e/kourier/service_to_service_test.go
+++ b/test/servinge2e/kourier/service_to_service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/networking/pkg/apis/networking"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
 )
@@ -63,7 +64,7 @@ func TestServiceToServiceCalls(t *testing.T) {
 
 func testServiceToService(t *testing.T, ctx *test.Context, namespace string, tc testCase) {
 	// Create a ksvc with the specified annotations and labels
-	service := test.Service(tc.name, namespace, image, tc.annotations)
+	service := test.Service(tc.name, namespace, pkgTest.ImagePath(image), tc.annotations)
 	service.ObjectMeta.Labels = tc.labels
 
 	service = test.WithServiceReadyOrFail(ctx, service)

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -43,7 +43,6 @@ type testCase struct {
 
 const (
 	serviceMeshTestNamespaceName = "serverless-tests-mesh"
-	httpProxyImage               = "registry.ci.openshift.org/openshift/knative-v0.17.3:knative-serving-test-httpproxy"
 	istioInjectKey               = "sidecar.istio.io/inject"
 )
 
@@ -105,7 +104,7 @@ func runTestForAllServiceMeshVersions(t *testing.T, testFunc func(ctx *test.Cont
 
 // A knative service acting as an "http proxy", redirects requests towards a given "host". Used to test cluster-local services
 func httpProxyService(name, namespace, host string) *servingv1.Service {
-	proxy := test.Service(name, namespace, httpProxyImage, nil)
+	proxy := test.Service(name, namespace, pkgTest.ImagePath(test.HttpProxyImg), nil)
 	proxy.Spec.Template.Spec.Containers[0].Env = append(proxy.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 		Name:  "TARGET_HOST",
 		Value: host,

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -104,7 +104,7 @@ func runTestForAllServiceMeshVersions(t *testing.T, testFunc func(ctx *test.Cont
 
 // A knative service acting as an "http proxy", redirects requests towards a given "host". Used to test cluster-local services
 func httpProxyService(name, namespace, host string) *servingv1.Service {
-	proxy := test.Service(name, namespace, pkgTest.ImagePath(test.HttpProxyImg), nil)
+	proxy := test.Service(name, namespace, pkgTest.ImagePath(test.HTTPProxyImg), nil)
 	proxy.Spec.Template.Spec.Containers[0].Env = append(proxy.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 		Name:  "TARGET_HOST",
 		Value: host,

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -335,7 +335,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 		// istio-pilot caches the JWKS content if a new Policy has the same jwksUri as some old policy.
 		// Rerunning this test would fail if we kept the jwksUri constant across invocations then,
 		// hence the random suffix for the jwks ksvc.
-		jwksKsvc := test.Service(helpers.AppendRandomString("jwks"), test.Namespace, "quay.io/openshift-knative/hello-openshift:multiarch", nil)
+		jwksKsvc := test.Service(helpers.AppendRandomString("jwks"), test.Namespace, pkgTest.ImagePath(test.HelloOpenshiftImg), nil)
 		jwksKsvc.Spec.Template.Spec.Containers[0].Env = append(jwksKsvc.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 			Name:  "RESPONSE",
 			Value: jwks,
@@ -486,7 +486,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 		}
 
 		// Create a test ksvc, should be accessible only via proper JWT token
-		testKsvc := test.Service("jwt-test", test.Namespace, image, map[string]string{
+		testKsvc := test.Service("jwt-test", test.Namespace, pkgTest.ImagePath(image), map[string]string{
 			"sidecar.istio.io/inject":                "true",
 			"sidecar.istio.io/rewriteAppHTTPProbers": "true",
 		})
@@ -636,7 +636,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 
 func lookupOpenShiftRouterIP(ctx *test.Context) net.IP {
 	// Deploy an auxiliary ksvc accessible via an OpenShift route, so that we have a route hostname that we can resolve
-	aux := test.Service("aux", test.Namespace, image, nil)
+	aux := test.Service("aux", test.Namespace, pkgTest.ImagePath(image), nil)
 	aux = test.WithServiceReadyOrFail(ctx, aux)
 
 	ips, err := net.LookupIP(aux.Status.URL.Host)

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -485,7 +485,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 		}
 
 		// Create a test ksvc, should be accessible only via proper JWT token
-		testKsvc := test.Service("jwt-test", test.Namespace, pkgTest.ImagePath(image), map[string]string{
+		testKsvc := test.Service("jwt-test", test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg), map[string]string{
 			"sidecar.istio.io/inject":                "true",
 			"sidecar.istio.io/rewriteAppHTTPProbers": "true",
 		})
@@ -635,7 +635,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 
 func lookupOpenShiftRouterIP(ctx *test.Context) net.IP {
 	// Deploy an auxiliary ksvc accessible via an OpenShift route, so that we have a route hostname that we can resolve
-	aux := test.Service("aux", test.Namespace, pkgTest.ImagePath(image), nil)
+	aux := test.Service("aux", test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg), nil)
 	aux = test.WithServiceReadyOrFail(ctx, aux)
 
 	ips, err := net.LookupIP(aux.Status.URL.Host)

--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -15,7 +15,7 @@ func TestKnativeServiceHTTPRedirect(t *testing.T) {
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
 	defer test.CleanupAll(t, caCtx)
 
-	ksvc := test.Service("redirect-service", test.Namespace, pkgTest.ImagePath(image), nil)
+	ksvc := test.Service("redirect-service", test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg), nil)
 	ksvc.ObjectMeta.Annotations = map[string]string{"networking.knative.dev/httpOption": "redirected"}
 	ksvc = test.WithServiceReadyOrFail(caCtx, ksvc)
 

--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
+	pkgTest "knative.dev/pkg/test"
 )
 
 func TestKnativeServiceHTTPRedirect(t *testing.T) {
@@ -14,7 +15,7 @@ func TestKnativeServiceHTTPRedirect(t *testing.T) {
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
 	defer test.CleanupAll(t, caCtx)
 
-	ksvc := test.Service("redirect-service", test.Namespace, image, nil)
+	ksvc := test.Service("redirect-service", test.Namespace, pkgTest.ImagePath(image), nil)
 	ksvc.ObjectMeta.Annotations = map[string]string{"networking.knative.dev/httpOption": "redirected"}
 	ksvc = test.WithServiceReadyOrFail(caCtx, ksvc)
 

--- a/test/servinge2e/kourier/verify_route_conflict_test.go
+++ b/test/servinge2e/kourier/verify_route_conflict_test.go
@@ -10,6 +10,7 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	pkgTest "knative.dev/pkg/test"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -45,14 +46,14 @@ func TestRouteConflictBehavior(t *testing.T) {
 
 		t.Logf("older: %v, newer: %v", older, newer)
 
-		olderSvc, err := test.WithServiceReady(caCtx, older.Name, older.Namespace, image)
+		olderSvc, err := test.WithServiceReady(caCtx, older.Name, older.Namespace, pkgTest.ImagePath(image))
 		if err != nil {
 			t.Fatal("Knative Service not ready", err)
 		}
 
 		servinge2e.WaitForRouteServingText(t, caCtx, olderSvc.Status.URL.URL(), helloworldText)
 
-		_, err = test.CreateService(caCtx, newer.Name, newer.Namespace, image)
+		_, err = test.CreateService(caCtx, newer.Name, newer.Namespace, pkgTest.ImagePath(image))
 		if err != nil {
 			t.Fatal("Failed to create conflicting Knative Service", err)
 		}

--- a/test/servinge2e/kourier/verify_route_conflict_test.go
+++ b/test/servinge2e/kourier/verify_route_conflict_test.go
@@ -46,14 +46,14 @@ func TestRouteConflictBehavior(t *testing.T) {
 
 		t.Logf("older: %v, newer: %v", older, newer)
 
-		olderSvc, err := test.WithServiceReady(caCtx, older.Name, older.Namespace, pkgTest.ImagePath(image))
+		olderSvc, err := test.WithServiceReady(caCtx, older.Name, older.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
 		if err != nil {
 			t.Fatal("Knative Service not ready", err)
 		}
 
 		servinge2e.WaitForRouteServingText(t, caCtx, olderSvc.Status.URL.URL(), helloworldText)
 
-		_, err = test.CreateService(caCtx, newer.Name, newer.Namespace, pkgTest.ImagePath(image))
+		_, err = test.CreateService(caCtx, newer.Name, newer.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
 		if err != nil {
 			t.Fatal("Failed to create conflicting Knative Service", err)
 		}

--- a/test/servinge2e/tracing_test.go
+++ b/test/servinge2e/tracing_test.go
@@ -54,7 +54,7 @@ func tracingTest(t *testing.T, activatorInPath bool) {
 	if activatorInPath {
 		annotations = nil
 	}
-	ksvc := test.WithServiceReadyOrFail(ctx, test.Service(name, testNamespace, pkgTest.ImagePath(image), annotations))
+	ksvc := test.WithServiceReadyOrFail(ctx, test.Service(name, testNamespace, pkgTest.ImagePath(test.HelloworldGoImg), annotations))
 
 	WaitForRouteServingText(t, ctx, ksvc.Status.URL.URL(), helloworldText)
 

--- a/test/servinge2e/tracing_test.go
+++ b/test/servinge2e/tracing_test.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
 )
 
@@ -53,7 +54,7 @@ func tracingTest(t *testing.T, activatorInPath bool) {
 	if activatorInPath {
 		annotations = nil
 	}
-	ksvc := test.WithServiceReadyOrFail(ctx, test.Service(name, testNamespace, image, annotations))
+	ksvc := test.WithServiceReadyOrFail(ctx, test.Service(name, testNamespace, pkgTest.ImagePath(image), annotations))
 
 	WaitForRouteServingText(t, ctx, ksvc.Status.URL.URL(), helloworldText)
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVCOM-2136

This will allow for testing multiple architectures and disconnected install with just passing a different IMAGE_TEMPLATE. Image for different platforms and disconnected environment might be in different locations and IMAGE_TEMPLATE allows for referencing them.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Move image names into a common location (images.go)
- Introduce `-imagetemplate` argument through knative.dev/pkg/test
- Provide a default template that currently covers all images from the s-o test suite
