### PR TITLE
Link global pull secret to test namespaces

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,6 +23,7 @@ logger.success '🚀 Cluster prepared for testing.'
 
 # Run serverless-operator specific tests.
 create_namespaces "${TEST_NAMESPACES[@]}"
+link_global_pullsecret_to_namespaces "${TEST_NAMESPACES[@]}"
 create_htpasswd_users && add_roles
 serverless_operator_e2e_tests
 if [[ $TEST_KNATIVE_KAFKA == true ]]; then

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -45,7 +44,7 @@ func LinkGlobalPullSecretToNamespace(ctx *Context, ns string) error {
 	// Link global pull secrets for accessing private registries, see https://issues.redhat.com/browse/SRVKS-833
 	_, err := utils.CopySecret(ctx.Clients.Kube.CoreV1(),
 		"openshift-config", "pull-secret", ns, "default")
-	if err != nil && !apierrs.IsNotFound(err) {
+	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("error copying secret into ns %s: %w", ns, err)
 	}
 	return nil

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2,10 +2,15 @@ package test
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/eventing/pkg/utils"
 )
 
 func IsServiceMeshInstalled(ctx *Context) bool {
@@ -24,4 +29,24 @@ func IsServiceMeshInstalled(ctx *Context) bool {
 	}
 
 	return false
+}
+
+func LinkGlobalPullSecretToNamespace(ctx *Context, ns string) error {
+	// Wait for the default ServiceAccount to exist.
+	if err := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {
+		sas := ctx.Clients.Kube.CoreV1().ServiceAccounts(ns)
+		if _, err := sas.Get(context.Background(), "default", metav1.GetOptions{}); err == nil {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("default ServiceAccount was not created for namespace %s: %w", ns, err)
+	}
+	// Link global pull secrets for accessing private registries, see https://issues.redhat.com/browse/SRVKS-833
+	_, err := utils.CopySecret(ctx.Clients.Kube.CoreV1(),
+		"openshift-config", "pull-secret", ns, "default")
+	if err != nil && !apierrs.IsNotFound(err) {
+		return fmt.Errorf("error copying secret into ns %s: %w", ns, err)
+	}
+	return nil
 }

--- a/test/servinge2e/kourier/verify_route_conflict_test.go
+++ b/test/servinge2e/kourier/verify_route_conflict_test.go
@@ -32,6 +32,9 @@ func TestRouteConflictBehavior(t *testing.T) {
 		}, metav1.CreateOptions{}); err != nil && !apierrs.IsAlreadyExists(err) {
 			t.Fatalf("Failed to create namespace %s: %v", ns, err)
 		}
+		if err := test.LinkGlobalPullSecretToNamespace(caCtx, ns); err != nil {
+			t.Fatalf("Unable to link global pull secret to namespace %s: %v", ns, err)
+		}
 		defer caCtx.Clients.Kube.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
 	}
 


### PR DESCRIPTION
This is related to https://github.com/openshift-knative/serverless-operator/pull/1771 and allows for testing disconnected environments which have the internal mirror registry secured.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Copy global pull secret to the test namespace
- Link the pull secret with the default ServiceAccount which is used to run Knative services
- Some tests create test namespaces themselves so the pull secret needs to be set up in Golang as well
