### PR TITLE
Clean up psp logic

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -99,6 +99,7 @@ func TestKnativeKafkaReconcile(t *testing.T) {
 		},
 	}}
 
+	t.Setenv("TEST_DEPRECATED_APIS_K8S_VERSION", "v1.24.0")
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cl := fake.NewClientBuilder().WithObjects(test.instance, &operatorv1beta1.KnativeEventing{}).Build()

--- a/openshift-knative-operator/pkg/common/api.go
+++ b/openshift-knative-operator/pkg/common/api.go
@@ -195,18 +195,18 @@ func FakeDeprecatedAPIsTranformers(version string) []mf.Transformer {
 	// The policy/v1beta1 API version of PodDisruptionBudget will no longer be served in v1.25.
 	// The autoscaling/v2beta2 API version of HorizontalPodAutoscaler will no longer be served in v1.26
 	// TODO: When we move away from releases that bring v1beta1 we can remove this part
-	if err := CheckMinimumKubeVersion(&dummyVersioner{version: version}, "1.24.0"); err == nil {
+	if err := CheckMinimumKubeVersion(&fakeVersioner{version: version}, "1.24.0"); err == nil {
 		transformers = append(transformers, UpgradePodDisruptionBudget(), UpgradeHorizontalPodAutoscaler(), SetSecurityContextForAdmissionController())
 	}
 	return transformers
 }
 
-type dummyVersioner struct {
+type fakeVersioner struct {
 	version string
 	err     error
 }
 
-func (t *dummyVersioner) ServerVersion() (*version.Info, error) {
+func (t *fakeVersioner) ServerVersion() (*version.Info, error) {
 	return &version.Info{GitVersion: t.version}, t.err
 }
 

--- a/openshift-knative-operator/pkg/common/api_test.go
+++ b/openshift-knative-operator/pkg/common/api_test.go
@@ -70,7 +70,7 @@ func TestVersionCheck(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := CheckMinimumVersion(test.actualVersion, minVersion)
+			err := CheckMinimumKubeVersion(test.actualVersion, minVersion)
 			if err == nil && test.wantError {
 				t.Errorf("Expected an error for minimum: %q, actual: %v", minVersion, test.actualVersion)
 			}

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -127,7 +127,7 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 
 	// Changing service type from LoadBalancer to ClusterIP has a bug https://github.com/kubernetes/kubernetes/pull/95196
 	// Do not apply the default if the version is less than v1.20.0.
-	if err := common.CheckMinimumVersion(e.kubeclient.Discovery(), "1.20.0"); err != nil {
+	if err := common.CheckMinimumKubeVersion(e.kubeclient.Discovery(), "1.20.0"); err != nil {
 		log.Warnf("Could not apply default service type for Kourier Gateway: %v", err)
 	} else {
 		// Apply Kourier gateway service type.

--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -291,7 +291,7 @@ func TestKafkaSourceToKnativeService(t *testing.T) {
 		}
 
 		// send event to kafka topic
-		if err := common.CheckMinimumVersion(client.Clients.Kube.Discovery(), "1.24.0"); err == nil {
+		if err := common.CheckMinimumKubeVersion(client.Clients.Kube.Discovery(), "1.24.0"); err == nil {
 			cj := createCronJobObjV1(cronJobName+"-"+name, kafkaTopicName+"-"+name, kafkaSource.Spec.BootstrapServers[0])
 			_, err = client.Clients.Kube.BatchV1().CronJobs(test.Namespace).Create(context.Background(), cj, metav1.CreateOptions{})
 			if err != nil {


### PR DESCRIPTION


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Cleans up stuff in https://github.com/openshift-knative/serverless-operator/pull/1773
- Address the issue where unit tests fail if no kubeconfig is set. Right now if we run via the IDE or without any kubeconfig locally set, tests fail as follows:
```
--- FAIL: TestKnativeKafkaReconcile (0.01s)
    --- FAIL: TestKnativeKafkaReconcile/Create_CR_with_channel_and_source_enabled (0.01s)
panic: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable [recovered]
	panic: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```
Missed that because the tests on ci have k8s config setup already.
- Adds support for injecting sc in statefulsets.
