### PR TITLE
Adding worloadOverride, inherited from upstream, copying over the manifest bits

### DIFF
--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
@@ -37,6 +37,10 @@ type KnativeKafkaSpec struct {
 	// Set logging configuration of the data plane.
 	// +optional
 	Logging *Logging `json:"logging,omitempty"`
+
+	// Workloads overrides workloads configurations such as resources and replicas.
+	// +optional
+	Workloads []base.WorkloadOverride `json:"workloads,omitempty"`
 }
 
 // KnativeKafkaStatus defines the observed state of KnativeKafka

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -336,6 +336,7 @@ func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *serve
 		configureEventingKafka(instance.Spec),
 		ImageTransform(common.BuildImageOverrideMapFromEnviron(os.Environ(), "KAFKA_IMAGE_")),
 		socommon.VersionedJobNameTransform(),
+		operatorcommon.OverridesTransform(instance.Spec.Workloads, logging.FromContext(context.TODO())),
 		socommon.ConfigMapVolumeChecksumTransform(context.Background(), r.client, sets.NewString("config-tracing", "kafka-config-logging")),
 		rbacProxyTranform), socommon.DeprecatedAPIsTranformersFromConfig()...)
 	m, err := manifest.Transform(tfs...)

--- a/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
+++ b/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
@@ -138,6 +138,926 @@ spec:
                     type: string
                     default: INFO
                 type: object
+              workloads:
+                description: A mapping of deployment or statefulset name to override
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      description: The name of the deployment
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels overrides labels for the deployment and its template.
+                      type: object
+                    livenessProbes:
+                      description: LivenessProbes overrides liveness probes for the
+                        containers.
+                      items:
+                        description: ProbesRequirementsOverride enables the user to
+                          override any container's env vars.
+                        properties:
+                          container:
+                            description: The container name
+                            type: string
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and
+                              the time when the processes are forcibly halted with
+                              a kill signal. Set this value longer than the expected
+                              cleanup time for your process. If this value is nil,
+                              the pod's terminationGracePeriodSeconds will be used.
+                              Otherwise, this value overrides the value provided by
+                              the pod spec. Value must be non-negative integer. The
+                              value zero indicates stop immediately via the kill signal
+                              (no opportunity to shut down). This is a beta field
+                              and requires enabling ProbeTerminationGracePeriod feature
+                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                              is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                            times out. Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        required:
+                          - container
+                        type: object
+                      type: array
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations overrides labels for the deployment and its template.
+                      type: object
+                    env:
+                      description: Env overrides env vars for the containers.
+                      items:
+                        properties:
+                          container:
+                            description: The container name
+                            type: string
+                          envVars:
+                            description: The desired EnvVarRequirements
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                  type: object
+                              required:
+                                - name
+                              type: object
+                            type: array
+                        required:
+                          - container
+                        type: object
+                      type: array
+                    replicas:
+                      description: The number of replicas that HA parts of the control plane will be scaled to
+                      type: integer
+                      minimum: 0
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector overrides nodeSelector for the deployment.
+                      type: object
+                    readinessProbes:
+                      description: ReadinessProbes overrides readiness probes for
+                        the containers.
+                      items:
+                        description: ProbesRequirementsOverride enables the user to
+                          override any container's env vars.
+                        properties:
+                          container:
+                            description: The container name
+                            type: string
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and
+                              the time when the processes are forcibly halted with
+                              a kill signal. Set this value longer than the expected
+                              cleanup time for your process. If this value is nil,
+                              the pod's terminationGracePeriodSeconds will be used.
+                              Otherwise, this value overrides the value provided by
+                              the pod spec. Value must be non-negative integer. The
+                              value zero indicates stop immediately via the kill signal
+                              (no opportunity to shut down). This is a beta field
+                              and requires enabling ProbeTerminationGracePeriod feature
+                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                              is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                            times out. Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        required:
+                          - container
+                        type: object
+                      type: array
+                    tolerations:
+                      description: If specified, the pod's tolerations.
+                      items:
+                        description: The pod this Toleration is attached to tolerates any
+                          taint that matches the triple <key,value,effect> using the matching
+                          operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty
+                              means match all taint effects. When specified, allowed values
+                              are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty, operator
+                              must be Exists; this combination means to match all values and
+                              all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value.
+                              Valid operators are Exists and Equal. Defaults to Equal. Exists
+                              is equivalent to wildcard for value, so that a pod can tolerate
+                              all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the
+                              toleration (which must be of effect NoExecute, otherwise this
+                              field is ignored) tolerates the taint. By default, it is not
+                              set, which means tolerate the taint forever (do not evict).
+                              Zero and negative values will be treated as 0 (evict immediately)
+                              by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise
+                              just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    affinity:
+                      description: If specified, the pod's scheduling constraints.
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes
+                                that satisfy the affinity expressions specified by this field,
+                                but it may choose a node that violates one or more of the
+                                expressions. The node that is most preferred is the one with
+                                the greatest sum of weights, i.e. for each node that meets
+                                all of the scheduling requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating through
+                                the elements of this field and adding "weight" to the sum
+                                if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches all
+                                  objects with implicit weight 0 (i.e. it's a no-op). A null
+                                  preferred scheduling term matches no objects (i.e. is also
+                                  a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated with the
+                                      corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the corresponding
+                                      nodeSelectorTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by this
+                                field are not met at scheduling time, the pod will not be
+                                scheduled onto the node. If the affinity requirements specified
+                                by this field cease to be met at some point during pod execution
+                                (e.g. due to an update), the system may or may not try to
+                                eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms. The
+                                    terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term matches
+                                      no objects. The requirements of them are ANDed. The
+                                      TopologySelectorTerm type implements a subset of the
+                                      NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g. co-locate
+                            this pod in the same node, zone, etc. as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes
+                                that satisfy the affinity expressions specified by this field,
+                                but it may choose a node that violates one or more of the
+                                expressions. The node that is most preferred is the one with
+                                the greatest sum of weights, i.e. for each node that meets
+                                all of the scheduling requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating through
+                                the elements of this field and adding "weight" to the sum
+                                if the node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label
+                                              selector requirements. The requirements are
+                                              ANDed.
+                                            items:
+                                              description: A label selector requirement is
+                                                a selector that contains values, a key, and
+                                                an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the
+                                                    selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's
+                                                    relationship to a set of values. Valid
+                                                    operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string
+                                                    values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If
+                                                    the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array
+                                                    is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator is "In",
+                                              and the values array contains only "value".
+                                              The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the pods
+                                          matching the labelSelector in the specified namespaces,
+                                          where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches
+                                          that of any node on which any of the selected pods
+                                          is running. Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the corresponding
+                                      podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by this
+                                field are not met at scheduling time, the pod will not be
+                                scheduled onto the node. If the affinity requirements specified
+                                by this field cease to be met at some point during pod execution
+                                (e.g. due to a pod label update), the system may or may not
+                                try to eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding to
+                                each podAffinityTerm are intersected, i.e. all terms must
+                                be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s)) that
+                                  this pod should be co-located (affinity) or not co-located
+                                  (anti-affinity) with, where co-located is defined as running
+                                  on a node whose value of the label with key <topologyKey>
+                                  matches that of any node on which a pod of the set of pods
+                                  is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in
+                                      this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector
+                                          requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values.
+                                                If the operator is In or NotIn, the values
+                                                array must be non-empty. If the operator is
+                                                Exists or DoesNotExist, the values array must
+                                                be empty. This array is replaced during a
+                                                strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs.
+                                          A single {key,value} in the matchLabels map is equivalent
+                                          to an element of matchExpressions, whose key field
+                                          is "key", the operator is "In", and the values array
+                                          contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the
+                                      labelSelector applies to (matches against); null or
+                                      empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where
+                                      co-located is defined as running on a node whose value
+                                      of the label with key topologyKey matches that of any
+                                      node on which any of the selected pods is running. Empty
+                                      topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules (e.g.
+                            avoid putting this pod in the same node, zone, etc. as some other
+                            pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes
+                                that satisfy the anti-affinity expressions specified by this
+                                field, but it may choose a node that violates one or more
+                                of the expressions. The node that is most preferred is the
+                                one with the greatest sum of weights, i.e. for each node that
+                                meets all of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field
+                                and adding "weight" to the sum if the node has pods which
+                                matches the corresponding podAffinityTerm; the node(s) with
+                                the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label
+                                              selector requirements. The requirements are
+                                              ANDed.
+                                            items:
+                                              description: A label selector requirement is
+                                                a selector that contains values, a key, and
+                                                an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the
+                                                    selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's
+                                                    relationship to a set of values. Valid
+                                                    operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string
+                                                    values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If
+                                                    the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array
+                                                    is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator is "In",
+                                              and the values array contains only "value".
+                                              The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the pods
+                                          matching the labelSelector in the specified namespaces,
+                                          where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches
+                                          that of any node on which any of the selected pods
+                                          is running. Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the corresponding
+                                      podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified by
+                                this field are not met at scheduling time, the pod will not
+                                be scheduled onto the node. If the anti-affinity requirements
+                                specified by this field cease to be met at some point during
+                                pod execution (e.g. due to a pod label update), the system
+                                may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all terms must
+                                be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s)) that
+                                  this pod should be co-located (affinity) or not co-located
+                                  (anti-affinity) with, where co-located is defined as running
+                                  on a node whose value of the label with key <topologyKey>
+                                  matches that of any node on which a pod of the set of pods
+                                  is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in
+                                      this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector
+                                          requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values.
+                                                If the operator is In or NotIn, the values
+                                                array must be non-empty. If the operator is
+                                                Exists or DoesNotExist, the values array must
+                                                be empty. This array is replaced during a
+                                                strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs.
+                                          A single {key,value} in the matchLabels map is equivalent
+                                          to an element of matchExpressions, whose key field
+                                          is "key", the operator is "In", and the values array
+                                          contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the
+                                      labelSelector applies to (matches against); null or
+                                      empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where
+                                      co-located is defined as running on a node whose value
+                                      of the label with key topologyKey matches that of any
+                                      node on which any of the selected pods is running. Empty
+                                      topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    resources:
+                      description: If specified, the container's resources.
+                      items:
+                        description: The pod this Resource is used to specify the requests and limits for
+                          a certain container based on the name.
+                        properties:
+                          container:
+                            description: The name of the container
+                            type: string
+                          limits:
+                            properties:
+                              cpu:
+                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                type: string
+                              memory:
+                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                type: string
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                type: string
+                              memory:
+                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                type: string
+                            type: object
+                        type: object
+                      type: array
           status:
             type: object
             description: 'KnativeKafkaStatus defines the observed state of KnativeKafka (from the controller).'


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes JIRA SRVKE-1205

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- adding the `workloads override` from upstream to `KnativeKafka` 
