### PR TITLE
[SRVCOM-2118] Install console resources only if the related clusteroperator is available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect
 	go.opencensus.io v0.23.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/atomic v1.9.0
 	go.uber.org/automaxprocs v1.4.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect

--- a/knative-operator/pkg/common/util.go
+++ b/knative-operator/pkg/common/util.go
@@ -7,7 +7,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mf "github.com/manifestival/manifestival"
@@ -132,4 +134,12 @@ func BuildGVKToResourceMap(manifests ...mf.Manifest) map[schema.GroupVersionKind
 	}
 
 	return gvkToResource
+}
+
+type SkipPredicate struct {
+	predicate.Funcs
+}
+
+func (SkipPredicate) Delete(e event.DeleteEvent) bool {
+	return false
 }

--- a/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/knative-operator/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleutil"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring/dashboards/health"
+	configv1 "github.com/openshift/api/config/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -70,6 +73,39 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	c, err := controller.New("knativeeventing-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
+	}
+
+	if !consoleutil.IsConsoleInstalled() {
+		enqueueRequests := handler.MapFunc(func(obj client.Object) []reconcile.Request {
+			if obj.GetName() == consoleutil.ConsoleClusterOperatorName {
+				log.Info("Eventing, processing crd request", "name", obj.GetName())
+				co := &configv1.ClusterOperator{}
+				if err = r.(*ReconcileKnativeEventing).client.Get(context.Background(), client.ObjectKey{Namespace: "", Name: consoleutil.ConsoleClusterOperatorName}, co); err != nil {
+					return nil
+				}
+				if !consoleutil.IsClusterOperatorAvailable(co.Status) {
+					return nil
+				}
+				consoleutil.SetConsoleToInstalledStatus()
+				_ = health.InstallHealthDashboard(r.(*ReconcileKnativeEventing).client)
+				list := &operatorv1beta1.KnativeEventingList{}
+				// At this point we know that console is available and try to find if there is an Eventing instance installed
+				// and trigger a reconciliation. If there is no instance do nothing as from now on reconciliation loop will do what is needed
+				// when a new instance is created. In case an instance is deleted we do nothing. We read from cache so the call is cheap.
+				if err = r.(*ReconcileKnativeEventing).client.List(context.Background(), list); err != nil {
+					return nil
+				}
+				if len(list.Items) > 0 {
+					return []reconcile.Request{{
+						NamespacedName: types.NamespacedName{Namespace: list.Items[0].Namespace, Name: list.Items[0].Name},
+					}}
+				}
+			}
+			return nil
+		})
+		if err = c.Watch(&source.Kind{Type: &configv1.ClusterOperator{}}, handler.EnqueueRequestsFromMapFunc(enqueueRequests), common.SkipPredicate{}); err != nil {
+			return err
+		}
 	}
 
 	// Watch for changes to primary resource KnativeEventing
@@ -157,8 +193,11 @@ func (r *ReconcileKnativeEventing) ensureFinalizers(instance *operatorv1beta1.Kn
 
 // installDashboard installs dashboard for OpenShift webconsole
 func (r *ReconcileKnativeEventing) installDashboards(instance *operatorv1beta1.KnativeEventing) error {
-	log.Info("Installing Eventing Dashboards")
-	return dashboards.Apply("eventing", instance, r.client)
+	if consoleutil.IsConsoleInstalled() {
+		log.Info("Installing Eventing Dashboards")
+		return dashboards.Apply("eventing", instance, r.client)
+	}
+	return nil
 }
 
 // general clean-up, mostly resources in different namespaces from eventingv1alpha1.KnativeEventing.
@@ -171,9 +210,11 @@ func (r *ReconcileKnativeEventing) delete(instance *operatorv1beta1.KnativeEvent
 		return nil
 	}
 	log.Info("Running cleanup logic")
-	log.Info("Deleting eventing dashboards")
-	if err := dashboards.Delete("eventing", instance, r.client); err != nil {
-		return fmt.Errorf("failed to delete resource dashboard configmaps: %w", err)
+	if consoleutil.IsConsoleInstalled() {
+		log.Info("Deleting eventing dashboards")
+		if err := dashboards.Delete("eventing", instance, r.client); err != nil {
+			return fmt.Errorf("failed to delete resource dashboard configmaps: %w", err)
+		}
 	}
 	// The above might take a while, so we refetch the resource again in case it has changed.
 	refetched := &operatorv1beta1.KnativeEventing{}

--- a/knative-operator/pkg/controller/knativeserving/consoleutil/util.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleutil/util.go
@@ -1,0 +1,32 @@
+package consoleutil
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"go.uber.org/atomic"
+)
+
+const ConsoleClusterOperatorName = "console"
+
+var ConsoleInstalled = atomic.NewBool(false)
+
+// SetConsoleToInstalledStatus updates to true the detected status of the console capability.
+// Once a capability is installed it cannot be uninstalled.
+func SetConsoleToInstalledStatus() {
+	ConsoleInstalled.Store(true)
+}
+
+// IsConsoleInstalled checks the detected status of the console capability.
+func IsConsoleInstalled() bool {
+	return ConsoleInstalled.Load()
+}
+
+// IsClusterOperatorAvailable iterates over conditions of the related resource
+// and checks if it is available.
+func IsClusterOperatorAvailable(status configv1.ClusterOperatorStatus) bool {
+	for _, cond := range status.Conditions {
+		if cond.Type == configv1.OperatorAvailable && cond.Status == configv1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -343,7 +343,9 @@ spec:
                 - clusteroperators
                 - clusteroperators/status
               verbs:
-                - "*"
+                - "get"
+                - "watch"
+                - "list"
             - apiGroups:
                 - route.openshift.io
               resources:

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -338,6 +338,13 @@ spec:
               verbs:
                 - "*"
             - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusteroperators
+                - clusteroperators/status
+              verbs:
+                - "*"
+            - apiGroups:
                 - route.openshift.io
               resources:
                 - routes

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -341,6 +341,13 @@ spec:
               verbs:
                 - "*"
             - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusteroperators
+                - clusteroperators/status
+              verbs:
+                - "*"
+            - apiGroups:
                 - route.openshift.io
               resources:
                 - routes

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -346,7 +346,9 @@ spec:
                 - clusteroperators
                 - clusteroperators/status
               verbs:
-                - "*"
+                - "get"
+                - "watch"
+                - "list"
             - apiGroups:
                 - route.openshift.io
               resources:


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Aims to replace #1757
- Uses the clusteroperator resource instead of crds so we can extend easily in the future for other capabilities like: monitoring and ingress operators which will become optional. As a side note clusterversion is also not that useful since it gets no update [about when the capability is ready](https://gist.github.com/skonto/3ebf91dc178db4b2aa0c856f978f4e64).  
The clusteroperator object has the following form: 
```
        {
            "apiVersion": "config.openshift.io/v1",
            "kind": "ClusterOperator",
            "metadata": {
                "annotations": {
                    "capability.openshift.io/name": "Console",
                    "include.release.openshift.io/ibm-cloud-managed": "true",
                    "include.release.openshift.io/self-managed-high-availability": "true",
                    "include.release.openshift.io/single-node-developer": "true"
                },
                "creationTimestamp": "2022-11-03T21:02:23Z",
                "generation": 1,
                "name": "console",
                "ownerReferences": [
                    {
                        "apiVersion": "config.openshift.io/v1",
                        "kind": "ClusterVersion",
                        "name": "version",
                        "uid": "dd22e3e6-e668-4608-8b67-7dcf9590a649"
                    }
                ],
                "resourceVersion": "43097",
                "uid": "8a989891-890e-42bc-a247-e15fc7c1966e"
            },
            "spec": {},
            "status": {
                "conditions": [
                    {
                        "lastTransitionTime": "2022-11-03T21:02:46Z",
                        "message": "All is well",
                        "reason": "AsExpected",
                        "status": "False",
                        "type": "Degraded"
                    },
                    {
                        "lastTransitionTime": "2022-11-03T21:03:08Z",
                        "message": "All is well",
                        "reason": "AsExpected",
                        "status": "False",
                        "type": "Progressing"
                    },
                    {
                        "lastTransitionTime": "2022-11-03T21:03:07Z",
                        "message": "All is well",
                        "reason": "AsExpected",
                        "status": "True",
                        "type": "Available"
                    },
                    {
                        "lastTransitionTime": "2022-11-03T21:02:46Z",
                        "message": "All is well",
                        "reason": "AsExpected",
                        "status": "True",
                        "type": "Upgradeable"
                    }
                ],
...
```
- Tested in all scenarios as described in #1757 with [4.12.0-ec.4](https://amd64.ocp.releases.ci.openshift.org/releasestream/4-dev-preview/release/4.12.0-ec.4)
Paths tested:

a) no console -> install S-O -> Install Console -> Install Serving/Eventing
b) no console -> install S-O -> install Serving/Eventing -> Install Console
c) Install Console -> install S-O -> Install Serving/Eventing
- More about post-install configuration [here](https://docs.openshift.com/container-platform/4.11/post_installation_configuration/cluster-capabilities.html#setting_additional_enabled_capabilities_cluster-capabilities). Capabilities cannot be uninstalled and this PR is based on this assumption.
