### PR TITLE
Rebase target branch before running validate

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -39,6 +39,21 @@ jobs:
         with:
           path: ./src/github.com/${{ github.repository }}
 
+      - name: Merge upstream
+        if: github.event_name == 'pull_request'
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: |
+          if ! git config user.name > /dev/null; then
+            git config user.name "John Doe"
+          fi
+          if ! git config user.email > /dev/null; then
+            git config user.email "johndoe@localhost"
+          fi
+          git remote add upstream https://github.com/${{ github.repository }}.git
+          git fetch upstream ${{ github.base_ref }}
+          git pull --no-rebase --no-commit upstream ${{ github.base_ref }}
+        shell: bash
+
       - name: Regenerate all generated files
         working-directory: ./src/github.com/${{ github.repository }}
         run: make generated-files

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -51,7 +51,7 @@ jobs:
             git config user.email "johndoe@localhost"
           fi
           git remote add upstream https://github.com/${{ github.repository }}.git
-          git pull upstream ${{ github.base_ref }}
+          git pull --no-rebase upstream ${{ github.base_ref }}
         shell: bash
 
       - name: Regenerate all generated files

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -51,7 +51,6 @@ jobs:
             git config user.email "johndoe@localhost"
           fi
           git remote add upstream https://github.com/${{ github.repository }}.git
-          git fetch upstream ${{ github.base_ref }}
           git pull upstream ${{ github.base_ref }}
         shell: bash
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -52,7 +52,7 @@ jobs:
           fi
           git remote add upstream https://github.com/${{ github.repository }}.git
           git fetch upstream ${{ github.base_ref }}
-          git pull --no-rebase --no-commit upstream ${{ github.base_ref }}
+          git pull upstream ${{ github.base_ref }}
         shell: bash
 
       - name: Regenerate all generated files

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -35,9 +35,10 @@ jobs:
           sudo mv /usr/bin/yq /usr/local/bin/yq
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ./src/github.com/${{ github.repository }}
+          fetch-depth: 0
 
       - name: Merge upstream
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This removes the need to rebase PRs that aren't rebased 
on top of the latest target branch commit.

Copied from https://github.com/knative/actions/blob/2da2b8c17f8f1d4317e1d215e0e80bedf44274e1/.github/workflows/go-test.yaml#L40-L52

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
