### PR TITLE
Define default BROKER_CLASS

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -36,6 +36,7 @@ export KNATIVE_SERVING_HOME="${GOPATH}/src/knative.dev/serving"
 export KNATIVE_EVENTING_HOME="${GOPATH}/src/knative.dev/eventing"
 export KNATIVE_EVENTING_KAFKA_HOME="${GOPATH}/src/knative.dev/eventing-kafka"
 export KNATIVE_EVENTING_KAFKA_BROKER_HOME="${GOPATH}/src/knative.dev/eventing-kafka-broker"
+export BROKER_CLASS=${BROKER_CLASS:-"Kafka"}
 
 export DOCKER_REPO_OVERRIDE="${DOCKER_REPO_OVERRIDE:-}"
 export INTERACTIVE="${INTERACTIVE:-$(test -z "${GDMSESSION}"; echo $?)}"


### PR DESCRIPTION
Test failing with:

```
            --- FAIL: TestServerlessUpgrade/PreUpgradeTests/BrokerPreUpgradeTest/1 (2.86s)
panic: error getting KafkaBroker class from env 'unable to determine KafkaBroker class. Specify 'BROKER_CLASS' env var' [recovered]
	panic: error getting KafkaBroker class from env 'unable to determine KafkaBroker class. Specify 'BROKER_CLASS' env var'
```
