### PR TITLE
[SRVCOM-2170] Handle nil logging level on deletion

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -625,7 +625,7 @@ func configureEventingKafka(spec serverlessoperatorv1alpha1.KnativeKafkaSpec) mf
 		if u.GetKind() == "ConfigMap" && u.GetName() == "kafka-config-logging" {
 			log.Info("Found ConfigMap kafka-config-logging, updating it with values from spec")
 
-			if err := unstructured.SetNestedField(u.Object, renderLoggingConfigXML(spec.Logging.Level), "data", "config.xml"); err != nil {
+			if err := unstructured.SetNestedField(u.Object, renderLoggingConfigXML(spec.Logging), "data", "config.xml"); err != nil {
 				return err
 			}
 		}
@@ -688,7 +688,11 @@ func contains(array []string, name string) bool {
 	return false
 }
 
-func renderLoggingConfigXML(loglevel string) string {
+func renderLoggingConfigXML(logging *serverlessoperatorv1alpha1.Logging) string {
+	loglevel := "INFO"
+	if logging != nil {
+		loglevel = logging.Level
+	}
 
 	xmlTemplate := `    <configuration>
       <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -698,11 +698,13 @@ func TestCheckHAComponent(t *testing.T) {
 func TestXmlConfig(t *testing.T) {
 	cases := []struct {
 		name        string
-		logLevel    string
+		logLevel    *v1alpha1.Logging
 		returnedXML string
 	}{{
-		name:     "Set level to INFO",
-		logLevel: "INFO",
+		name: "Set level to INFO",
+		logLevel: &v1alpha1.Logging{
+			Level: "INFO",
+		},
 		returnedXML: `    <configuration>
       <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
@@ -712,8 +714,20 @@ func TestXmlConfig(t *testing.T) {
       </root>
     </configuration>`,
 	}, {
-		name:     "Set level to ERROR",
-		logLevel: "ERROR",
+		name: "Set level to INFO by default",
+		returnedXML: `    <configuration>
+      <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+      </appender>
+      <root level="INFO">
+        <appender-ref ref="jsonConsoleAppender"/>
+      </root>
+    </configuration>`,
+	}, {
+		name: "Set level to ERROR",
+		logLevel: &v1alpha1.Logging{
+			Level: "ERROR",
+		},
 		returnedXML: `    <configuration>
       <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>


### PR DESCRIPTION
As per title, spec.logging can be nil if wasn't reconciled yet by the "new version" of the controller