### PR TITLE
[TEST_ONLY] Add port name "appProtocol: h2c" to Kourier by default

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/ingress/1.5/0-kourier.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/1.5/0-kourier.yaml
@@ -467,6 +467,7 @@ metadata:
 spec:
   ports:
     - name: http2
+      appProtocol: h2c
       port: 80
       protocol: TCP
       targetPort: 8080


### PR DESCRIPTION
This is part of https://issues.redhat.com/browse/SRVKS-211.

To enable gRPC service needs to have the port name `appProtocol: h2c`.

This PR just verifies if the change will not break current functions or not.
If no break, it should be added in upstream or via operator.