### PR TITLE
Add appProtocol name to the Kourier service

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -71,6 +71,7 @@ func (e *extension) Transformers(ks base.KComponent) []mf.Transformer {
 		),
 		overrideKourierNamespace(ks),
 		addKourierEnvValues(ks),
+		addKourierAppProtocol(ks),
 		enableSecretInformerFiltering(ks),
 		common.VersionedJobNameTransform(),
 	}


### PR DESCRIPTION
This patch adds appProtocol name to the Kourier service.
OpenShift Ingress needs to have it to handle gRPC/H2C.

#### Alternative consideration:
I considered to add this to Kourier's manifest in upstream but it is necessary for OCP Route only
and might be a breaking change for upstream users.