### PR TITLE
Do not use wathola-forwarder in Eventing upgrade tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ test-upstream-upgrade-testonly:
 test-upstream-upgrade:
 	TRACING_BACKEND=zipkin ZIPKIN_DEDICATED_NODE=true ./hack/tracing.sh
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
-	INSTALL_PREVIOUS_VERSION="true" INSTALL_KAFKA="true" TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=4 SAMPLE_RATE="0.3" ./hack/install.sh
+	INSTALL_PREVIOUS_VERSION="true" INSTALL_KAFKA="true" TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=5 SAMPLE_RATE="0.3" ./hack/install.sh
 	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
 # Alias.

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -232,7 +232,7 @@ EOF
   # Test configuration. See https://github.com/knative/eventing/tree/main/test/upgrade#probe-test-configuration
   # TODO(ksuszyns): remove EVENTING_UPGRADE_TESTS_SERVING_SCALETOZERO when knative/operator#297 is fixed.
   export EVENTING_UPGRADE_TESTS_SERVING_SCALETOZERO=false
-  export EVENTING_UPGRADE_TESTS_SERVING_USE=true
+  export EVENTING_UPGRADE_TESTS_SERVING_USE=false
   export EVENTING_UPGRADE_TESTS_CONFIGMOUNTPOINT=/.config/wathola
   export GATEWAY_OVERRIDE="kourier"
   export GATEWAY_NAMESPACE_OVERRIDE="${INGRESS_NAMESPACE}"

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -232,6 +232,7 @@ EOF
   # Test configuration. See https://github.com/knative/eventing/tree/main/test/upgrade#probe-test-configuration
   # TODO(ksuszyns): remove EVENTING_UPGRADE_TESTS_SERVING_SCALETOZERO when knative/operator#297 is fixed.
   export EVENTING_UPGRADE_TESTS_SERVING_SCALETOZERO=false
+  # Review this line as part of SRVCOM-2176
   export EVENTING_UPGRADE_TESTS_SERVING_USE=false
   export EVENTING_UPGRADE_TESTS_CONFIGMOUNTPOINT=/.config/wathola
   export GATEWAY_OVERRIDE="kourier"


### PR DESCRIPTION

See [Slack discussion](https://coreos.slack.com/archives/CEXRYS5QC/p1668777165819389?thread_ts=1668499127.372969&cid=CEXRYS5QC).

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Do not use wathola-forwarder in Eventing upgrade tests and use only Eventing components. The forwarder is a Knative Service and Knative Serving shows flakiness in its own tests during upgrades so it probably affects Eventing tests as well if the forwarder component is included.
- Exclude us-east-1e from scale-up, see the comment in code for more details.

