### PR TITLE
[release-1.26] Do not use wathola-forwarder in Eventing upgrade tests

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -232,7 +232,7 @@ EOF
   # Test configuration. See https://github.com/knative/eventing/tree/main/test/upgrade#probe-test-configuration
   # TODO(ksuszyns): remove EVENTING_UPGRADE_TESTS_SERVING_SCALETOZERO when knative/operator#297 is fixed.
   export EVENTING_UPGRADE_TESTS_SERVING_SCALETOZERO=false
-  export EVENTING_UPGRADE_TESTS_SERVING_USE=true
+  export EVENTING_UPGRADE_TESTS_SERVING_USE=false
   export EVENTING_UPGRADE_TESTS_CONFIGMOUNTPOINT=/.config/wathola
   export GATEWAY_OVERRIDE="kourier"
   export GATEWAY_NAMESPACE_OVERRIDE="${INGRESS_NAMESPACE}"


### PR DESCRIPTION

See [Slack discussion](https://coreos.slack.com/archives/CEXRYS5QC/p1668777165819389?thread_ts=1668499127.372969&cid=CEXRYS5QC).

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Do not use wathola-forwarder in Eventing upgrade tests and use only Eventing components. The forwarder is a Knative Service and Knative Serving shows flakiness in its own tests during upgrades so it probably affects Eventing tests as well if the forwarder component is included.
- Exclude us-east-1e from scale-up, see the comment in code for more details.


