### PR TITLE
Add tlsnoauth listener to kafka cluster

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -55,6 +55,11 @@ function install_strimzi_cluster {
             tls: false
             authentication:
               type: scram-sha-512
+          # TLS no auth
+          - name: tlsnoauth
+            port: 9096
+            type: internal
+            tls: true
         authorization:
           superUsers:
             - ANONYMOUS


### PR DESCRIPTION
In https://github.com/openshift-knative/eventing-kafka-broker/pull/472 we added some e2e tests requiring a TLS kafka listener with no auth. This should be added here as well to keep the e2e tests passing.

## Proposed Changes
* :gift: Add an additional listener to the my-cluster Kafka cluster for TLS with no auth 