### PR TITLE
Remove ServiceMeshControlPlane V1 from tests

### DIFF
--- a/test/servicemesh.go
+++ b/test/servicemesh.go
@@ -10,22 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func ServiceMeshControlPlaneV1(name, namespace string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "maistra.io/v1",
-			"kind":       "ServiceMeshControlPlane",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
-			},
-			"spec": map[string]interface{}{
-				"version": "v1.1",
-			},
-		},
-	}
-}
-
 func ServiceMeshControlPlaneV2(name, namespace string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -58,30 +42,12 @@ func ServiceMeshMemberRollV1(name, namespace string, members ...string) *unstruc
 	}
 }
 
-func serviceMeshControlPlaneV1Schema() schema.GroupVersionResource {
-	return schema.GroupVersionResource{
-		Group:    "maistra.io",
-		Version:  "v1",
-		Resource: "servicemeshcontrolplanes",
-	}
-}
-
 func serviceMeshControlPlaneV2Schema() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    "maistra.io",
 		Version:  "v2",
 		Resource: "servicemeshcontrolplanes",
 	}
-}
-
-func CreateServiceMeshControlPlaneV1(ctx *Context, smcp *unstructured.Unstructured) *unstructured.Unstructured {
-	// When cleaning-up SMCP, wait until it doesn't exist, as it takes a while, which would break subsequent tests
-	ctx.AddToCleanup(func() error {
-		ctx.T.Logf("Waiting for ServiceMeshControlPlane %q to not exist", smcp.GetName())
-		_, err := WaitForUnstructuredState(ctx, serviceMeshControlPlaneV1Schema(), smcp.GetName(), smcp.GetNamespace(), DoesUnstructuredNotExist)
-		return err
-	})
-	return CreateUnstructured(ctx, serviceMeshControlPlaneV1Schema(), smcp)
 }
 
 func CreateServiceMeshControlPlaneV2(ctx *Context, smcp *unstructured.Unstructured) *unstructured.Unstructured {

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -63,13 +63,6 @@ func runTestForAllServiceMeshVersions(t *testing.T, testFunc func(ctx *test.Cont
 
 	versions := []serviceMeshVersion{
 		{
-			name: "v1",
-			smcpCreationFunc: func(ctx *test.Context) {
-				smcp := test.ServiceMeshControlPlaneV1(smcpName, serviceMeshTestNamespaceName)
-				test.CreateServiceMeshControlPlaneV1(ctx, smcp)
-			},
-		},
-		{
 			name: "v2",
 			smcpCreationFunc: func(ctx *test.Context) {
 				smcp := test.ServiceMeshControlPlaneV2(smcpName, serviceMeshTestNamespaceName)


### PR DESCRIPTION
* This version is not supported since Serverless 1.24 (see supported configurations [page](https://access.redhat.com/articles/4912821)) and cannot be used with the newest Service Mesh operator v2.3 that is available live on operatorhub.
* Service Mesh operator v2.3 only supports ServiceMeshControlPlane [v2.0 v2.1 v2.2 v2.3]

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
