### PR TITLE
Disable internal encryption to work around SRVKS-983

### DIFF
--- a/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
+++ b/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   config:
     network:
-      internal-encryption: "true"
+      # TODO: Re-enable after fixing https://issues.redhat.com/browse/SRVKS-983
+      internal-encryption: "false"
     autoscaler:
       container-concurrency-target-default: "100"
       container-concurrency-target-percentage: "1.0"


### PR DESCRIPTION
Workaround for SRVKS-983

Internal encryption is still Tech.Preview and this PR will unblock CI.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Comment out internal encryption from KnativeServing config
-
-
