### PR TITLE
Avoid parsing flags twice in kitchensink tests

### DIFF
--- a/test/kitchensinke2e/main_test.go
+++ b/test/kitchensinke2e/main_test.go
@@ -3,6 +3,7 @@ package kitchensinke2e
 import (
 	"context"
 	"flag"
+	"log"
 	"os"
 	"testing"
 	"time"
@@ -12,6 +13,9 @@ import (
 	"knative.dev/reconciler-test/pkg/knative"
 
 	"knative.dev/pkg/injection"
+	// Make sure to initialize flags from knative.dev/pkg/test before parsing them.
+	pkgTest "knative.dev/pkg/test"
+
 	"knative.dev/reconciler-test/pkg/environment"
 )
 
@@ -43,7 +47,11 @@ func TestMain(m *testing.M) {
 	// testing framework for namespace management, and could be leveraged by
 	// features to pull Kubernetes clients or the test environment out of the
 	// context passed in the features.
-	ctx, startInformers := injection.EnableInjectionOrDie(nil, nil) //nolint
+	cfg, err := pkgTest.Flags.ClientConfig.GetRESTConfig()
+	if err != nil {
+		log.Fatal("Error building client config: ", err)
+	}
+	ctx, startInformers := injection.EnableInjectionOrDie(nil, cfg) //nolint
 	startInformers()
 
 	// global is used to make instances of Environments, NewGlobalEnvironment


### PR DESCRIPTION
Fixes error such as:
```
 /tmp/go-build4002486348/b001/kitchensinke2e.test flag redefined: cluster
panic: /tmp/go-build4002486348/b001/kitchensinke2e.test flag redefined: cluster goroutine 1 [running]:
flag.(*FlagSet).Var(0xc000112180, {0x3066c30, 0xc0000d2180}, {0x2cb8ae1, 0x7}, {0x2cf9d95, 0x2e})
	/usr/local/go/src/flag/flag.go:879 +0x3a5
flag.(*FlagSet).StringVar(...)
	/usr/local/go/src/flag/flag.go:762
knative.dev/pkg/environment.(*ClientConfig).InitFlags(0xc0000d2180, 0xc000112180)
	/go/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/pkg/environment/client_config.go:40 +0x9e
knative.dev/pkg/injection.ParseAndGetRESTConfigOrDie()
	/go/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/pkg/injection/config.go:32 +0x65
knative.dev/pkg/injection.EnableInjectionOrDie({0x0, 0x0}, 0x0)
	/go/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/pkg/injection/injection.go:46 +0xe5
github.com/openshift-knative/serverless-operator/test/kitchensinke2e.TestMain(0x2ba6620)
	/go/src/github.com/openshift-knative/serverless-operator/test/kitchensinke2e/main_test.go:46 +0xb3
main.main()
	_testmain.go:49 +0x265
```
The error can be seen in [nightly job](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.11-e2e-kitchensink-ocp-411-continuous/1595688771330772992)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
