### PR TITLE
Add annotation to toggle the gRPC/HTTP2 port name

### DIFF
--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -86,6 +86,15 @@ func addKourierEnvValues(ks base.KComponent) mf.Transformer {
 // addKourierAppProtocol adds appProtocol name to the Kourier service.
 // OpenShift Ingress needs to have it to handle gRPC/H2C.
 func addKourierAppProtocol(ks base.KComponent) mf.Transformer {
+	// TODO: revisit after OCP 4.13 (HAProxy 2.4) is available.
+	// As current h2c protocol name breaks websocket on OCP Route, change the port name only when the annotation is added.
+	//
+	// see - https://docs.openshift.com/container-platform/4.11/networking/ingress-operator.html#nw-http2-haproxy_configuring-ingress
+	// > Consequently, if you have an application that is intended to accept WebSocket connections,
+	// > it must not allow negotiating the HTTP/2 protocol or else clients will fail to upgrade to the WebSocket protocol.
+	if _, ok := ks.GetAnnotations()["serverless.openshift.io/default-enable-http2"]; !ok {
+		return nil
+	}
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() != "Service" && u.GetName() != "kourier" {
 			return nil

--- a/openshift-knative-operator/pkg/serving/kourier_test.go
+++ b/openshift-knative-operator/pkg/serving/kourier_test.go
@@ -54,8 +54,9 @@ func TestOverrideKourierNamespace(t *testing.T) {
 func TestKourierServiceAppProtocol(t *testing.T) {
 	ks := &operatorv1beta1.KnativeServing{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "knative-serving",
-			Name:      "test",
+			Namespace:   "knative-serving",
+			Name:        "test",
+			Annotations: map[string]string{"serverless.openshift.io/default-enable-http2": "true"},
 		},
 	}
 

--- a/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
+++ b/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   config:
     network:
-      internal-encryption: "true"
+      # TODO: Re-enable after fixing https://issues.redhat.com/browse/SRVKS-983
+      internal-encryption: "false"
     autoscaler:
       container-concurrency-target-default: "100"
       container-concurrency-target-percentage: "1.0"


### PR DESCRIPTION
This patch introduces `serverless.openshift.io/default-enable-http2` for KnativeServing.

As current h2c protocol name breaks websocket on OCP Route, 
change the port name only when the annotation is added.
Note, this annotation should be able to drop around OCP 4.13.

Reference - https://docs.openshift.com/container-platform/4.11/networking/ingress-operator.html#nw-http2-haproxy_configuring-ingress
> Consequently, if you have an application that is intended to accept WebSocket connections,
>  it must not allow negotiating the HTTP/2 protocol or else clients will fail to upgrade to the WebSocket protocol.
