### PR TITLE
[release-1.25] Use httpproxy image from quay

### DIFF
--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -2,7 +2,7 @@ FROM src
 
 COPY oc /usr/bin/oc
 COPY --from=registry.ci.openshift.org/openshift/knative-v1.4.0:knative-serving-src /go/src/knative.dev/serving/ /go/src/knative.dev/serving/
-COPY --from=registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-src /go/src/github.com/openshift/knative-eventing/ /go/src/knative.dev/eventing/
+COPY --from=registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-src /go/src/github.com/openshift-knative/eventing/ /go/src/knative.dev/eventing/
 COPY --from=registry.ci.openshift.org/openshift/knative-v1.1.0:knative-eventing-kafka-src /go/src/knative.dev/eventing-kafka/ /go/src/knative.dev/eventing-kafka/
 COPY --from=registry.ci.openshift.org/openshift/knative-v1.4:eventing-kafka-broker-src /go/src/github.com/openshift-knative/eventing-kafka-broker/ /go/src/knative.dev/eventing-kafka-broker/
 

--- a/templates/test-source-image.Dockerfile
+++ b/templates/test-source-image.Dockerfile
@@ -2,7 +2,7 @@ FROM src
 
 COPY oc /usr/bin/oc
 COPY --from=registry.ci.openshift.org/openshift/knative-v__SERVING_VERSION__:knative-serving-src /go/src/knative.dev/serving/ /go/src/knative.dev/serving/
-COPY --from=registry.ci.openshift.org/openshift/knative-v__EVENTING_VERSION__:knative-eventing-src /go/src/github.com/openshift/knative-eventing/ /go/src/knative.dev/eventing/
+COPY --from=registry.ci.openshift.org/openshift/knative-v__EVENTING_VERSION__:knative-eventing-src /go/src/github.com/openshift-knative/eventing/ /go/src/knative.dev/eventing/
 COPY --from=registry.ci.openshift.org/openshift/knative-v__EVENTING_KAFKA_VERSION__:knative-eventing-kafka-src /go/src/knative.dev/eventing-kafka/ /go/src/knative.dev/eventing-kafka/
 COPY --from=registry.ci.openshift.org/openshift/knative-v__EVENTING_KAFKA_BROKER_VERSION__:eventing-kafka-broker-src /go/src/github.com/openshift-knative/eventing-kafka-broker/ /go/src/knative.dev/eventing-kafka-broker/
 

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -43,7 +43,7 @@ type testCase struct {
 
 const (
 	serviceMeshTestNamespaceName = "serverless-tests-mesh"
-	httpProxyImage               = "registry.ci.openshift.org/openshift/knative-v0.17.3:knative-serving-test-httpproxy"
+	httpProxyImage               = "quay.io/openshift-knative-serving-test/httpproxy:v1.3"
 	istioInjectKey               = "sidecar.istio.io/inject"
 )
 


### PR DESCRIPTION
The knative-v0.17.3 image no longer exists. We now use the multiarch variant of the same image that is available on quay.io.

This image was replaced some time ago on "main" branch as well. We do this to allow running s-o tests after downgrade from 1.26.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
