### PR TITLE
Do not fail post upgrade tests on no post-jobs after cluster upgrade

### DIFF
--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -46,7 +46,7 @@ func TestServerlessUpgrade(t *testing.T) {
 	suite := pkgupgrade.Suite{
 		Tests: pkgupgrade.Tests{
 			PreUpgrade:  preUpgradeTests(),
-			PostUpgrade: postUpgradeTests(ctx),
+			PostUpgrade: postUpgradeTests(ctx, true),
 			Continual: merge(
 				[]pkgupgrade.BackgroundOperation{
 					servingupgrade.ProbeTest(),
@@ -105,7 +105,7 @@ func TestClusterUpgrade(t *testing.T) {
 	suite := pkgupgrade.Suite{
 		Tests: pkgupgrade.Tests{
 			PreUpgrade:  preUpgradeTests(),
-			PostUpgrade: postUpgradeTests(ctx),
+			PostUpgrade: postUpgradeTests(ctx, false),
 			// Do not include continual tests as they're failing across cluster upgrades.
 		},
 		Installations: pkgupgrade.Installations{
@@ -151,15 +151,15 @@ func preUpgradeTests() []pkgupgrade.Operation {
 	return append(tests, servingupgrade.ServingPreUpgradeTests()...)
 }
 
-func postUpgradeTests(ctx *test.Context) []pkgupgrade.Operation {
+func postUpgradeTests(ctx *test.Context, failOnNoJobs bool) []pkgupgrade.Operation {
 	tests := []pkgupgrade.Operation{waitForServicesReady(ctx)}
 	tests = append(tests, upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
 		Namespace:    "knative-serving",
-		FailOnNoJobs: true,
+		FailOnNoJobs: failOnNoJobs,
 	}))
 	tests = append(tests, upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
 		Namespace:    "knative-eventing",
-		FailOnNoJobs: true,
+		FailOnNoJobs: failOnNoJobs,
 	}))
 	tests = append(tests, eventingupgrade.PostUpgradeTests()...)
 	tests = append(tests,


### PR DESCRIPTION
The cluster upgrade takes more than one hour and the jobs are no longer there.

Fixes an error like this one during cluster upgrades:
```
=== RUN   TestClusterUpgrade/PostUpgradeTests/Verify_jobs_in_knative-serving
    verify_jobs.go:24: no jobs found in namespace knative-serving
2022-12-01T11:59:04.372-0500	ERROR	upgrade/functions.go:48	💣🤬💔️ Upgrade suite have failed!
knative.dev/pkg/test/upgrade.(*Suite).Execute
	/tmp/gopath-No9WDqKn1W/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/pkg/test/upgrade/functions.go:48
github.com/openshift-knative/serverless-operator/test/upgrade_test.TestClusterUpgrade
	/tmp/gopath-No9WDqKn1W/src/github.com/openshift-knative/serverless-operator/test/upgrade/upgrade_test.go:121
testing.tRunner
	/usr/local/go/src/testing/testing.go:1439
        --- FAIL: TestClusterUpgrade/PostUpgradeTests/Verify_jobs_in_knative-serving (0.01s)
```
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
