### PR TITLE
fix panic in TestKafkaSourceToKnativeService

### DIFF
--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -280,7 +280,7 @@ func TestKafkaSourceToKnativeService(t *testing.T) {
 		// Setup a knative service
 		ksvc, err := test.WithServiceReady(client, helloWorldService+"-"+name, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
 		if err != nil {
-			t.Fatalf("Knative Service(%s) not ready: %v", ksvc.GetName(), err)
+			t.Fatalf("Knative Service(%s) not ready: %v", helloWorldService+"-"+name, err)
 		}
 
 		// Create kafkatopic


### PR DESCRIPTION
fix a panic if the ksvc does not become Ready

```
=== RUN   TestKafkaSourceToKnativeService
    service.go:90: Cleaning up Knative Service 'serverless-tests/helloworld-go-sasl'
--- FAIL: TestKafkaSourceToKnativeService (300.20s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x277dd68]

goroutine 52 [running]:
testing.tRunner.func1.2({0x29a1940, 0x4069a50})
	/usr/local/go/src/testing/testing.go:1389 +0x366
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1392 +0x5d2
panic({0x29a1940, 0x4069a50})
	/usr/local/go/src/runtime/panic.go:844 +0x258
github.com/openshift-knative/serverless-operator/test/extensione2e/kafka.TestKafkaSourceToKnativeService(0xc0007d3860)
	/tmp/gopath-HME5NqBD8p/src/github.com/openshift-knative/serverless-operator/test/extensione2e/kafka/kafka_source_to_ksvc_test.go:283 +0x11c8
testing.tRunner(0xc0007d3860, 0x2d68480)
	/usr/local/go/src/testing/testing.go:1439 +0x214
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1486 +0x725
```