### PR TITLE
make eventinge2e verify the events were received

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test-e2e-with-kafka-testonly:
 test-e2e-with-kafka:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	./hack/tracing.sh
-	INSTALL_KAFKA="true" ENABLE_TRACING=true ./hack/install.sh
+	SCALE_UP=4 INSTALL_KAFKA="true" ENABLE_TRACING=true ./hack/install.sh
 	TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
 	./hack/teardown.sh
 

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -89,11 +89,11 @@ export SAMPLE_RATE="${SAMPLE_RATE:-"1.0"}"
 export ZIPKIN_DEDICATED_NODE="${ZIPKIN_DEDICATED_NODE:-false}"
 DEFAULT_IMAGE_TEMPLATE=$(
   cat <<-EOF
-quay.io/{{- with .Name }}
-{{- if eq . "httpproxy" }}openshift-knative-serving-test/{{.}}:v1.3
-{{- else if eq . "recordevents" }}openshift-knative/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
-{{- else if eq . "wathola-forwarder" }}openshift-knative/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
-{{- else                }}openshift-knative/{{.}}:multiarch{{end -}}
+quay.io/openshift-knative/{{- with .Name }}
+{{- if eq . "httpproxy" }}serving/{{.}}:v$(echo "${KNATIVE_SERVING_VERSION#v}" | awk -F \. '{printf "%d.%d", $1, $2}')
+{{- else if eq . "recordevents" }}eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
+{{- else if eq . "wathola-forwarder" }}eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
+{{- else }}{{.}}:multiarch{{end -}}
 {{end -}}
 EOF
 )

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -91,6 +91,8 @@ DEFAULT_IMAGE_TEMPLATE=$(
   cat <<-EOF
 quay.io/{{- with .Name }}
 {{- if eq . "httpproxy" }}openshift-knative-serving-test/{{.}}:v1.3
+{{- else if eq . "recordevents" }}openshift-knative/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
+{{- else if eq . "wathola-forwarder" }}openshift-knative/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
 {{- else                }}openshift-knative/{{.}}:multiarch{{end -}}
 {{end -}}
 EOF

--- a/test/eventinge2e/eventing_to_ksvc_utils.go
+++ b/test/eventinge2e/eventing_to_ksvc_utils.go
@@ -34,7 +34,7 @@ const (
 func DeployKsvcWithEventInfoStoreOrFail(ctx *test.Context, t *testing.T, namespace string, name string) (*recordevents.EventInfoStore, *servingv1.Service) {
 	libclient, err := lib.NewClient(namespace, t)
 	if err != nil {
-		t.Fatal("error creating testlib client", err)
+		t.Fatal("Error creating testlib client", err)
 	}
 
 	lib.CreateRBACPodsGetEventsAll(libclient, namespace)

--- a/test/eventinge2e/eventing_to_ksvc_utils.go
+++ b/test/eventinge2e/eventing_to_ksvc_utils.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	pingSourceName = "smoke-test-ping"
-	pingSourceData = "{\"message\":\"Hello, world!\"}"
+	PingSourceData = "{\"message\":\"Hello, world!\"}"
 
 	triggerName       = "smoke-test-trigger"
 	cmName            = "smoke-test-br-cm"
@@ -95,8 +95,8 @@ func AssertPingSourceDataReceivedAtLeastOnce(eventStore *recordevents.EventInfoS
 		if info.Event == nil {
 			return fmt.Errorf("event body nil")
 		}
-		if string(info.Event.Data()) != pingSourceData {
-			return fmt.Errorf("event body %q does not match %q", info.Event.Data(), pingSourceData)
+		if string(info.Event.Data()) != PingSourceData {
+			return fmt.Errorf("event body %q does not match %q", info.Event.Data(), PingSourceData)
 		}
 		return nil
 	})

--- a/test/eventinge2e/eventing_to_ksvc_utils.go
+++ b/test/eventinge2e/eventing_to_ksvc_utils.go
@@ -1,0 +1,102 @@
+package eventinge2e
+
+import (
+	"context"
+	"fmt"
+	"github.com/openshift-knative/serverless-operator/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/test/lib"
+	"knative.dev/eventing/test/lib/recordevents"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
+	serving "knative.dev/serving/pkg/apis/serving/v1"
+	"testing"
+)
+
+const (
+	pingSourceName = "smoke-test-ping"
+	pingSourceData = "{\"message\":\"Hello, world!\"}"
+
+	triggerName       = "smoke-test-trigger"
+	cmName            = "smoke-test-br-cm"
+	ksvcAPIVersion    = "serving.knative.dev/v1"
+	ksvcKind          = "Service"
+	helloWorldService = "helloworld-go"
+	brokerAPIVersion  = "eventing.knative.dev/v1"
+	brokerKind        = "Broker"
+
+	subscriptionName = "smoke-test-subscription"
+)
+
+// DeployKsvcWithEventInfoStoreOrFail deploys a wathola-forwarder ksvc forwarding events to a recordevents receiver
+func DeployKsvcWithEventInfoStoreOrFail(ctx *test.Context, t *testing.T, namespace string, name string) (*recordevents.EventInfoStore, *serving.Service) {
+	libclient, err := lib.NewClient(namespace, t)
+	if err != nil {
+		t.Fatal("error creating testlib client", err)
+	}
+
+	lib.CreateRBACPodsGetEventsAll(libclient, namespace)
+	lib.CreateRBACPodsEventsGetListWatch(libclient, namespace)
+
+	// have a random suffix for the recordevents name,
+	// so we can safely re-run the same tests and not get conflicts with Event names
+	recordeventsname := helpers.AppendRandomString(name + "-re")
+
+	eventStore, _ := recordevents.StartEventRecordOrFail(context.Background(), libclient, recordeventsname)
+
+	ctx.AddToCleanup(func() error {
+		return libclient.Tracker.Clean(true)
+	})
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name + "-config",
+		},
+		Data: map[string]string{
+			"config.toml": "[forwarder]\ntarget = \"http://" + recordeventsname + "\"\n",
+		},
+	}
+	_, err = ctx.Clients.Kube.CoreV1().ConfigMaps(namespace).Create(context.Background(), cm, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal("Error creating ConfigMap", cm.Name, err)
+	}
+	ctx.AddToCleanup(func() error {
+		return ctx.Clients.Kube.CoreV1().ConfigMaps(namespace).Delete(context.Background(), name+"-config", metav1.DeleteOptions{})
+	})
+
+	// Setup a knative service for the wathola-forwarder
+	ksvc, err := test.WithServiceReady(ctx, name, namespace, pkgTest.ImagePath(test.WatholaForwarderImg), func(service *serving.Service) {
+		service.Spec.Template.Spec.Volumes = []corev1.Volume{
+			{Name: "config", VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: name + "-config",
+					},
+				},
+			}},
+		}
+
+		service.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+			{Name: "config", ReadOnly: true, MountPath: "/.config/wathola/"},
+		}
+	})
+
+	if err != nil {
+		t.Fatalf("%s does not become Ready: %v", name, err)
+	}
+
+	return eventStore, ksvc
+}
+
+func AssertPingSourceDataReceivedAtLeastOnce(eventStore *recordevents.EventInfoStore) {
+	eventStore.AssertAtLeast(1, func(info recordevents.EventInfo) error {
+		if info.Event == nil {
+			return fmt.Errorf("event body nil")
+		}
+		if string(info.Event.Data()) != pingSourceData {
+			return fmt.Errorf("event body %q does not match %q", info.Event.Data(), pingSourceData)
+		}
+		return nil
+	})
+}

--- a/test/eventinge2e/eventing_to_ksvc_utils.go
+++ b/test/eventinge2e/eventing_to_ksvc_utils.go
@@ -3,6 +3,8 @@ package eventinge2e
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/openshift-knative/serverless-operator/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,7 +13,6 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/helpers"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
-	"testing"
 )
 
 const (

--- a/test/eventinge2e/eventing_to_ksvc_utils.go
+++ b/test/eventinge2e/eventing_to_ksvc_utils.go
@@ -10,7 +10,7 @@ import (
 	"knative.dev/eventing/test/lib/recordevents"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/helpers"
-	serving "knative.dev/serving/pkg/apis/serving/v1"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"testing"
 )
 
@@ -30,7 +30,7 @@ const (
 )
 
 // DeployKsvcWithEventInfoStoreOrFail deploys a wathola-forwarder ksvc forwarding events to a recordevents receiver
-func DeployKsvcWithEventInfoStoreOrFail(ctx *test.Context, t *testing.T, namespace string, name string) (*recordevents.EventInfoStore, *serving.Service) {
+func DeployKsvcWithEventInfoStoreOrFail(ctx *test.Context, t *testing.T, namespace string, name string) (*recordevents.EventInfoStore, *servingv1.Service) {
 	libclient, err := lib.NewClient(namespace, t)
 	if err != nil {
 		t.Fatal("error creating testlib client", err)
@@ -66,7 +66,7 @@ func DeployKsvcWithEventInfoStoreOrFail(ctx *test.Context, t *testing.T, namespa
 	})
 
 	// Setup a knative service for the wathola-forwarder
-	ksvc, err := test.WithServiceReady(ctx, name, namespace, pkgTest.ImagePath(test.WatholaForwarderImg), func(service *serving.Service) {
+	ksvc, err := test.WithServiceReady(ctx, name, namespace, pkgTest.ImagePath(test.WatholaForwarderImg), func(service *servingv1.Service) {
 		service.Spec.Template.Spec.Volumes = []corev1.Volume{
 			{Name: "config", VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{

--- a/test/eventinge2e/source_broker_ksvc.go
+++ b/test/eventinge2e/source_broker_ksvc.go
@@ -2,12 +2,13 @@ package eventinge2e
 
 import (
 	"context"
+	"testing"
+
 	"github.com/openshift-knative/serverless-operator/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"testing"
 )
 
 func KnativeSourceBrokerTriggerKnativeService(t *testing.T, createBrokerOrFail func(*test.Context) *eventingv1.Broker) {

--- a/test/eventinge2e/source_broker_ksvc.go
+++ b/test/eventinge2e/source_broker_ksvc.go
@@ -1,0 +1,73 @@
+package eventinge2e
+
+import (
+	"context"
+	"github.com/openshift-knative/serverless-operator/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"testing"
+)
+
+func KnativeSourceBrokerTriggerKnativeService(t *testing.T, createBrokerOrFail func(*test.Context) *eventingv1.Broker) {
+	client := test.SetupClusterAdmin(t)
+	cleanup := func() {
+		test.CleanupAll(t, client)
+		client.Clients.Eventing.EventingV1().Triggers(test.Namespace).Delete(context.Background(), triggerName, metav1.DeleteOptions{})
+		client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
+		client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Delete(context.Background(), cmName, metav1.DeleteOptions{})
+	}
+	test.CleanupOnInterrupt(t, cleanup)
+	defer cleanup()
+
+	eventStore, ksvc := DeployKsvcWithEventInfoStoreOrFail(client, t, test.Namespace, helloWorldService)
+
+	broker := createBrokerOrFail(client)
+
+	tr := &eventingv1.Trigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      triggerName,
+			Namespace: test.Namespace,
+		},
+		Spec: eventingv1.TriggerSpec{
+			Broker: broker.Name,
+			Subscriber: duckv1.Destination{
+				Ref: &duckv1.KReference{
+					APIVersion: ksvcAPIVersion,
+					Kind:       ksvcKind,
+					Name:       ksvc.Name,
+				},
+			},
+		},
+	}
+	_, err := client.Clients.Eventing.EventingV1().Triggers(test.Namespace).Create(context.Background(), tr, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal("Unable to create trigger: ", err)
+	}
+
+	ps := &sourcesv1.PingSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pingSourceName,
+			Namespace: test.Namespace,
+		},
+		Spec: sourcesv1.PingSourceSpec{
+			Data: pingSourceData,
+			SourceSpec: duckv1.SourceSpec{
+				Sink: duckv1.Destination{
+					Ref: &duckv1.KReference{
+						APIVersion: brokerAPIVersion,
+						Kind:       brokerKind,
+						Name:       broker.Name,
+					},
+				},
+			},
+		},
+	}
+	_, err = client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), ps, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal("Knative PingSource not created: %+V", err)
+	}
+
+	AssertPingSourceDataReceivedAtLeastOnce(eventStore)
+}

--- a/test/eventinge2e/source_broker_ksvc.go
+++ b/test/eventinge2e/source_broker_ksvc.go
@@ -53,7 +53,7 @@ func KnativeSourceBrokerTriggerKnativeService(t *testing.T, createBrokerOrFail f
 			Namespace: test.Namespace,
 		},
 		Spec: sourcesv1.PingSourceSpec{
-			Data: pingSourceData,
+			Data: PingSourceData,
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{
 					Ref: &duckv1.KReference{

--- a/test/eventinge2e/source_broker_ksvc_test.go
+++ b/test/eventinge2e/source_broker_ksvc_test.go
@@ -6,116 +6,59 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
-	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pkgTest "knative.dev/pkg/test"
-
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
-	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 const (
-	brokerName       = "smoke-test-broker"
-	triggerName      = "smoke-test-trigger"
-	cmName           = "smoke-test-br-cm"
-	brokerAPIVersion = "eventing.knative.dev/v1"
-	brokerKind       = "Broker"
+	brokerName = "smoke-test-broker"
 )
 
 func TestKnativeSourceBrokerTriggerKnativeService(t *testing.T) {
-	client := test.SetupClusterAdmin(t)
-	cleanup := func() {
-		test.CleanupAll(t, client)
-		client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Delete(context.Background(), brokerName, metav1.DeleteOptions{})
-		client.Clients.Eventing.EventingV1().Triggers(test.Namespace).Delete(context.Background(), triggerName, metav1.DeleteOptions{})
-		client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
-		client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Delete(context.Background(), cmName, metav1.DeleteOptions{})
-	}
-	test.CleanupOnInterrupt(t, cleanup)
-	defer cleanup()
-
-	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
-	if err != nil {
-		t.Fatal("Knative Service not ready", err)
-	}
-
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: cmName,
-		},
-		Data: map[string]string{
-			"channel-template-spec": fmt.Sprintf(`
+	KnativeSourceBrokerTriggerKnativeService(t, func(client *test.Context) *eventingv1.Broker {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cmName,
+			},
+			Data: map[string]string{
+				"channel-template-spec": fmt.Sprintf(`
 apiVersion: %q
 kind: %q`, channelAPIVersion, channelKind),
-		},
-	}
-	configMap, err := client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Create(context.Background(), cm, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create ConfigMap: ", err)
-	}
-	br := &eventingv1.Broker{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      brokerName,
-			Namespace: test.Namespace,
-		},
-		Spec: eventingv1.BrokerSpec{
-			Config: &duckv1.KReference{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-				Name:       configMap.Name,
 			},
-		},
-	}
-	broker, err := client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Create(context.Background(), br, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create broker: ", err)
-	}
-	tr := &eventingv1.Trigger{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      triggerName,
-			Namespace: test.Namespace,
-		},
-		Spec: eventingv1.TriggerSpec{
-			Broker: broker.Name,
-			Subscriber: duckv1.Destination{
-				Ref: &duckv1.KReference{
-					APIVersion: ksvcAPIVersion,
-					Kind:       ksvcKind,
-					Name:       helloWorldService,
+		}
+		configMap, err := client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Create(context.Background(), cm, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal("Unable to create ConfigMap: ", err)
+		}
+
+		client.AddToCleanup(func() error {
+			return client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Delete(context.Background(), cmName, metav1.DeleteOptions{})
+		})
+
+		br := &eventingv1.Broker{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      brokerName,
+				Namespace: test.Namespace,
+			},
+			Spec: eventingv1.BrokerSpec{
+				Config: &duckv1.KReference{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Name:       configMap.Name,
 				},
 			},
-		},
-	}
-	_, err = client.Clients.Eventing.EventingV1().Triggers(test.Namespace).Create(context.Background(), tr, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create trigger: ", err)
-	}
+		}
+		broker, err := client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Create(context.Background(), br, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal("Unable to create broker: ", err)
+		}
 
-	ps := &sourcesv1.PingSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pingSourceName,
-			Namespace: test.Namespace,
-		},
-		Spec: sourcesv1.PingSourceSpec{
-			Data: helloWorldText,
-			SourceSpec: duckv1.SourceSpec{
-				Sink: duckv1.Destination{
-					Ref: &duckv1.KReference{
-						APIVersion: brokerAPIVersion,
-						Kind:       brokerKind,
-						Name:       broker.Name,
-					},
-				},
-			},
-		},
-	}
-	_, err = client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), ps, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Knative PingSource not created: %+V", err)
-	}
-	servinge2e.WaitForRouteServingText(t, client, ksvc.Status.URL.URL(), helloWorldText)
+		client.AddToCleanup(func() error {
+			return client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Delete(context.Background(), brokerName, metav1.DeleteOptions{})
+		})
 
+		return broker
+	})
 }

--- a/test/eventinge2e/source_channel_ksvc.go
+++ b/test/eventinge2e/source_channel_ksvc.go
@@ -2,12 +2,13 @@ package eventinge2e
 
 import (
 	"context"
+	"testing"
+
 	"github.com/openshift-knative/serverless-operator/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"testing"
 )
 
 func KnativeSourceChannelKnativeService(t *testing.T, createChannelOrFail func(*test.Context) duckv1.KReference) {

--- a/test/eventinge2e/source_channel_ksvc.go
+++ b/test/eventinge2e/source_channel_ksvc.go
@@ -51,7 +51,7 @@ func KnativeSourceChannelKnativeService(t *testing.T, createChannelOrFail func(*
 			Namespace: test.Namespace,
 		},
 		Spec: sourcesv1.PingSourceSpec{
-			Data: pingSourceData,
+			Data: PingSourceData,
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{
 					Ref: &channelRef,

--- a/test/eventinge2e/source_channel_ksvc.go
+++ b/test/eventinge2e/source_channel_ksvc.go
@@ -1,0 +1,67 @@
+package eventinge2e
+
+import (
+	"context"
+	"github.com/openshift-knative/serverless-operator/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"testing"
+)
+
+func KnativeSourceChannelKnativeService(t *testing.T, createChannelOrFail func(*test.Context) duckv1.KReference) {
+	client := test.SetupClusterAdmin(t)
+	cleanup := func() {
+		test.CleanupAll(t, client)
+		client.Clients.Eventing.MessagingV1().Subscriptions(test.Namespace).Delete(context.Background(), subscriptionName, metav1.DeleteOptions{})
+		client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
+	}
+	test.CleanupOnInterrupt(t, cleanup)
+	defer cleanup()
+
+	eventStore, ksvc := DeployKsvcWithEventInfoStoreOrFail(client, t, test.Namespace, helloWorldService)
+
+	channelRef := createChannelOrFail(client)
+
+	subscription := &messagingv1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      subscriptionName,
+			Namespace: test.Namespace,
+		},
+		Spec: messagingv1.SubscriptionSpec{
+			Channel: channelRef,
+			Subscriber: &duckv1.Destination{
+				Ref: &duckv1.KReference{
+					APIVersion: ksvcAPIVersion,
+					Kind:       ksvcKind,
+					Name:       ksvc.Name,
+				},
+			},
+		},
+	}
+	_, err := client.Clients.Eventing.MessagingV1().Subscriptions(test.Namespace).Create(context.Background(), subscription, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal("Unable to create Subscription: ", err)
+	}
+	ps := &sourcesv1.PingSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pingSourceName,
+			Namespace: test.Namespace,
+		},
+		Spec: sourcesv1.PingSourceSpec{
+			Data: pingSourceData,
+			SourceSpec: duckv1.SourceSpec{
+				Sink: duckv1.Destination{
+					Ref: &channelRef,
+				},
+			},
+		},
+	}
+	_, err = client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), ps, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal("Knative PingSource not created: %+V", err)
+	}
+
+	AssertPingSourceDataReceivedAtLeastOnce(eventStore)
+}

--- a/test/eventinge2e/source_channel_ksvc_test.go
+++ b/test/eventinge2e/source_channel_ksvc_test.go
@@ -5,94 +5,38 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
-	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pkgTest "knative.dev/pkg/test"
-
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
-	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 const (
 	channelName       = "smoke-test-channel"
-	subscriptionName  = "smoke-test-subscription"
 	channelAPIVersion = "messaging.knative.dev/v1"
 	channelKind       = "Channel"
 )
 
 func TestKnativeSourceChannelKnativeService(t *testing.T) {
-	client := test.SetupClusterAdmin(t)
-	cleanup := func() {
-		test.CleanupAll(t, client)
-		client.Clients.Eventing.MessagingV1().Subscriptions(test.Namespace).Delete(context.Background(), subscriptionName, metav1.DeleteOptions{})
-		client.Clients.Eventing.MessagingV1().Channels(test.Namespace).Delete(context.Background(), channelName, metav1.DeleteOptions{})
-		client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
-	}
-	test.CleanupOnInterrupt(t, cleanup)
-	defer cleanup()
+	KnativeSourceChannelKnativeService(t, func(client *test.Context) duckv1.KReference {
+		imc := &messagingv1.Channel{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      channelName,
+				Namespace: test.Namespace,
+			},
+		}
+		channel, err := client.Clients.Eventing.MessagingV1().Channels(test.Namespace).Create(context.Background(), imc, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal("Unable to create Channel: ", err)
+		}
 
-	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
-	if err != nil {
-		t.Fatal("Knative Service not ready", err)
-	}
+		client.AddToCleanup(func() error {
+			return client.Clients.Eventing.MessagingV1().Channels(test.Namespace).Delete(context.Background(), channelName, metav1.DeleteOptions{})
+		})
 
-	imc := &messagingv1.Channel{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      channelName,
-			Namespace: test.Namespace,
-		},
-	}
-	channel, err := client.Clients.Eventing.MessagingV1().Channels(test.Namespace).Create(context.Background(), imc, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create Channel: ", err)
-	}
-	subscription := &messagingv1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      subscriptionName,
-			Namespace: test.Namespace,
-		},
-		Spec: messagingv1.SubscriptionSpec{
-			Channel: duckv1.KReference{
-				APIVersion: channelAPIVersion,
-				Kind:       channelKind,
-				Name:       channel.Name,
-			},
-			Subscriber: &duckv1.Destination{
-				Ref: &duckv1.KReference{
-					APIVersion: ksvcAPIVersion,
-					Kind:       ksvcKind,
-					Name:       helloWorldService,
-				},
-			},
-		},
-	}
-	_, err = client.Clients.Eventing.MessagingV1().Subscriptions(test.Namespace).Create(context.Background(), subscription, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create Subscription: ", err)
-	}
-	ps := &sourcesv1.PingSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pingSourceName,
-			Namespace: test.Namespace,
-		},
-		Spec: sourcesv1.PingSourceSpec{
-			Data: helloWorldText,
-			SourceSpec: duckv1.SourceSpec{
-				Sink: duckv1.Destination{
-					Ref: &duckv1.KReference{
-						APIVersion: channelAPIVersion,
-						Kind:       channelKind,
-						Name:       channel.Name,
-					},
-				},
-			},
-		},
-	}
-	_, err = client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), ps, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Knative PingSource not created: %+V", err)
-	}
-	servinge2e.WaitForRouteServingText(t, client, ksvc.Status.URL.URL(), helloWorldText)
+		return duckv1.KReference{
+			APIVersion: channelAPIVersion,
+			Kind:       channelKind,
+			Name:       channel.Name,
+		}
+	})
 }

--- a/test/eventinge2e/source_to_ksvc_test.go
+++ b/test/eventinge2e/source_to_ksvc_test.go
@@ -27,7 +27,7 @@ func TestKnativeSourceToKnativeService(t *testing.T) {
 			Namespace: test.Namespace,
 		},
 		Spec: sourcesv1.PingSourceSpec{
-			Data: pingSourceData,
+			Data: PingSourceData,
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{
 					Ref: &duckv1.KReference{

--- a/test/eventinge2e/source_to_ksvc_test.go
+++ b/test/eventinge2e/source_to_ksvc_test.go
@@ -5,20 +5,9 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
-	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pkgTest "knative.dev/pkg/test"
-
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-)
-
-const (
-	pingSourceName    = "smoke-test-ping"
-	helloWorldService = "helloworld-go"
-	helloWorldText    = "Hello World!"
-	ksvcAPIVersion    = "serving.knative.dev/v1"
-	ksvcKind          = "Service"
 )
 
 func TestKnativeSourceToKnativeService(t *testing.T) {
@@ -30,11 +19,7 @@ func TestKnativeSourceToKnativeService(t *testing.T) {
 	test.CleanupOnInterrupt(t, cleanup)
 	defer cleanup()
 
-	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
-	if err != nil {
-		t.Fatal("Knative Service not ready", err)
-	}
+	eventStore, ksvc := DeployKsvcWithEventInfoStoreOrFail(client, t, test.Namespace, helloWorldService)
 
 	ps := &sourcesv1.PingSource{
 		ObjectMeta: metav1.ObjectMeta{
@@ -42,7 +27,7 @@ func TestKnativeSourceToKnativeService(t *testing.T) {
 			Namespace: test.Namespace,
 		},
 		Spec: sourcesv1.PingSourceSpec{
-			Data: helloWorldText,
+			Data: pingSourceData,
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{
 					Ref: &duckv1.KReference{
@@ -54,9 +39,10 @@ func TestKnativeSourceToKnativeService(t *testing.T) {
 			},
 		},
 	}
-	_, err = client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), ps, metav1.CreateOptions{})
+	_, err := client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), ps, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("Knative PingSource not created: %+V", err)
 	}
-	servinge2e.WaitForRouteServingText(t, client, ksvc.Status.URL.URL(), helloWorldText)
+
+	AssertPingSourceDataReceivedAtLeastOnce(eventStore)
 }

--- a/test/extensione2e/kafka/kafka_channel_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_channel_ksvc_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	pingSourceName    = "smoke-test-pingsource"
 	helloWorldText    = "Hello World!"
 	kafkaChannelName  = "smoke-kc"
 	channelAPIVersion = "messaging.knative.dev/v1beta1"

--- a/test/extensione2e/kafka/kafka_channel_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_channel_ksvc_test.go
@@ -2,8 +2,9 @@ package knativekafkae2e
 
 import (
 	"context"
-	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 	"testing"
+
+	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 
 	"github.com/openshift-knative/serverless-operator/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/extensione2e/kafka/kafka_channel_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_channel_ksvc_test.go
@@ -2,17 +2,13 @@ package knativekafkae2e
 
 import (
 	"context"
+	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 	"testing"
 
+	"github.com/openshift-knative/serverless-operator/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kafkachannelv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
-	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
-	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	pkgTest "knative.dev/pkg/test"
-
-	"github.com/openshift-knative/serverless-operator/test"
-	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 )
 
 const (
@@ -21,7 +17,6 @@ const (
 	kafkaChannelName  = "smoke-kc"
 	channelAPIVersion = "messaging.knative.dev/v1beta1"
 	kafkaChannelKind  = "KafkaChannel"
-	subscriptionName  = "smoke-test-kafka-subscription"
 	serviceAccount    = "default"
 )
 
@@ -36,82 +31,23 @@ var (
 			ReplicationFactor: 1,
 		},
 	}
-
-	subscription = &messagingv1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      subscriptionName,
-			Namespace: test.Namespace,
-		},
-		Spec: messagingv1.SubscriptionSpec{
-			Channel: duckv1.KReference{
-				APIVersion: channelAPIVersion,
-				Kind:       kafkaChannelKind,
-				Name:       kafkaChannelName,
-			},
-			Subscriber: &duckv1.Destination{
-				Ref: &duckv1.KReference{
-					APIVersion: ksvcAPIVersion,
-					Kind:       ksvcKind,
-					Name:       helloWorldService,
-				},
-			},
-		},
-	}
-
-	ps = &sourcesv1.PingSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pingSourceName,
-			Namespace: test.Namespace,
-		},
-		Spec: sourcesv1.PingSourceSpec{
-			Data: helloWorldText,
-			SourceSpec: duckv1.SourceSpec{
-				Sink: duckv1.Destination{
-					Ref: &duckv1.KReference{
-						APIVersion: channelAPIVersion,
-						Kind:       kafkaChannelKind,
-						Name:       kafkaChannelName,
-					},
-				},
-			},
-		},
-	}
 )
 
 func TestSourceToKafkaChanelToKnativeService(t *testing.T) {
-	client := test.SetupClusterAdmin(t)
-	cleanup := func() {
-		test.CleanupAll(t, client)
-		client.Clients.Kafka.MessagingV1beta1().KafkaChannels(test.Namespace).Delete(context.Background(), kafkaChannelName, metav1.DeleteOptions{})
-		client.Clients.Eventing.MessagingV1().Subscriptions(test.Namespace).Delete(context.Background(), subscriptionName, metav1.DeleteOptions{})
-		client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
-	}
-	test.CleanupOnInterrupt(t, cleanup)
-	defer cleanup()
+	eventinge2e.KnativeSourceChannelKnativeService(t, func(client *test.Context) duckv1.KReference {
+		channel, err := client.Clients.Kafka.MessagingV1beta1().KafkaChannels(test.Namespace).Create(context.Background(), &kafkaChannel, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal("Unable to create Channel: ", err)
+		}
 
-	// Setup a knative service
-	ksvc, err := test.WithServiceReady(client, helloWorldService, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
-	if err != nil {
-		t.Fatal("Knative Service not ready", err)
-	}
+		client.AddToCleanup(func() error {
+			return client.Clients.Kafka.MessagingV1beta1().KafkaChannels(test.Namespace).Delete(context.Background(), kafkaChannelName, metav1.DeleteOptions{})
+		})
 
-	// Create kafka channel
-	_, err = client.Clients.Kafka.MessagingV1beta1().KafkaChannels(test.Namespace).Create(context.Background(), &kafkaChannel, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create KafkaChannel: ", err)
-	}
-
-	// Create subscription (from channel to service)
-	_, err = client.Clients.Eventing.MessagingV1().Subscriptions(test.Namespace).Create(context.Background(), subscription, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create Subscription: ", err)
-	}
-
-	// Create source (channel as sink)
-	_, err = client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), ps, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Knative PingSource not created: ", err)
-	}
-
-	servinge2e.WaitForRouteServingText(t, client, ksvc.Status.URL.URL(), helloWorldText)
+		return duckv1.KReference{
+			APIVersion: channelAPIVersion,
+			Kind:       kafkaChannelKind,
+			Name:       channel.Name,
+		}
+	})
 }

--- a/test/extensione2e/kafka/kafka_channel_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_channel_ksvc_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	helloWorldText    = "Hello World!"
 	kafkaChannelName  = "smoke-kc"
 	channelAPIVersion = "messaging.knative.dev/v1beta1"
 	kafkaChannelKind  = "KafkaChannel"

--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -3,10 +3,11 @@ package knativekafkae2e
 import (
 	"context"
 	"fmt"
-	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"

--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -66,7 +66,7 @@ func createCronJobObjV1Beta1(name, topic, server string) *batchv1beta1.CronJob {
 								{
 									Name:    "kafka-message-test",
 									Image:   "strimzi/kafka:0.16.2-kafka-2.4.0",
-									Command: []string{"sh", "-c", fmt.Sprintf(`echo "%s" | bin/kafka-console-producer.sh --broker-list %s --topic %s`, helloWorldText, server, topic)},
+									Command: []string{"sh", "-c", fmt.Sprintf(`echo '%s' | bin/kafka-console-producer.sh --broker-list %s --topic %s`, eventinge2e.PingSourceData, server, topic)},
 								},
 							},
 							RestartPolicy: corev1.RestartPolicyOnFailure,
@@ -94,7 +94,7 @@ func createCronJobObjV1(name, topic, server string) *batchv1.CronJob {
 								{
 									Name:    "kafka-message-test",
 									Image:   "strimzi/kafka:0.16.2-kafka-2.4.0",
-									Command: []string{"sh", "-c", fmt.Sprintf(`echo "%s" | bin/kafka-console-producer.sh --broker-list %s --topic %s`, helloWorldText, server, topic)},
+									Command: []string{"sh", "-c", fmt.Sprintf(`echo '%s' | bin/kafka-console-producer.sh --broker-list %s --topic %s`, eventinge2e.PingSourceData, server, topic)},
 								},
 							},
 							RestartPolicy: corev1.RestartPolicyOnFailure,

--- a/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
@@ -17,8 +17,6 @@ import (
 const (
 	kafkaChannelBrokerName            = "smoke-test-kafka-kafka-channel-broker"
 	kafkaChannelTemplateConfigMapName = "smoke-test-br-cm"
-	brokerAPIVersion                  = "eventing.knative.dev/v1"
-	brokerKind                        = "Broker"
 )
 
 var (

--- a/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
@@ -3,23 +3,19 @@ package knativekafkae2e
 import (
 	"context"
 	"fmt"
+	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pkgTest "knative.dev/pkg/test"
-
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
-	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/openshift-knative/serverless-operator/test"
-	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 )
 
 const (
 	kafkaChannelBrokerName            = "smoke-test-kafka-kafka-channel-broker"
-	kafkatriggerName                  = "smoke-test-trigger"
 	kafkaChannelTemplateConfigMapName = "smoke-test-br-cm"
 	brokerAPIVersion                  = "eventing.knative.dev/v1"
 	brokerKind                        = "Broker"
@@ -50,85 +46,30 @@ kind: %q`, channelAPIVersion, kafkaChannelKind),
 			},
 		},
 	}
-
-	trigger = &eventingv1.Trigger{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kafkatriggerName,
-			Namespace: test.Namespace,
-		},
-		Spec: eventingv1.TriggerSpec{
-			Broker: kafkaChannelBrokerName,
-			Subscriber: duckv1.Destination{
-				Ref: &duckv1.KReference{
-					APIVersion: ksvcAPIVersion,
-					Kind:       ksvcKind,
-					Name:       helloWorldService + "-kafka-channel-broker",
-				},
-			},
-		},
-	}
-
-	brokerPingSource = &sourcesv1.PingSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pingSourceName,
-			Namespace: test.Namespace,
-		},
-		Spec: sourcesv1.PingSourceSpec{
-			Data: helloWorldText,
-			SourceSpec: duckv1.SourceSpec{
-				Sink: duckv1.Destination{
-					Ref: &duckv1.KReference{
-						APIVersion: brokerAPIVersion,
-						Kind:       brokerKind,
-						Name:       kafkaChannelBrokerName,
-					},
-				},
-			},
-		},
-	}
 )
 
 func TestSourceToKafkaChannelBasedBrokerToKnativeService(t *testing.T) {
-	client := test.SetupClusterAdmin(t)
-	cleanup := func() {
-		test.CleanupAll(t, client)
-		client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Delete(context.Background(), kafkaChannelBrokerName, metav1.DeleteOptions{})
-		client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Delete(context.Background(), pingSourceName, metav1.DeleteOptions{})
-		client.Clients.Eventing.EventingV1().Triggers(test.Namespace).Delete(context.Background(), kafkatriggerName, metav1.DeleteOptions{})
-		client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Delete(context.Background(), kafkaChannelTemplateConfigMapName, metav1.DeleteOptions{})
-	}
-	test.CleanupOnInterrupt(t, cleanup)
-	defer cleanup()
+	eventinge2e.KnativeSourceBrokerTriggerKnativeService(t, func(client *test.Context) *eventingv1.Broker {
+		// Create the KafkaChannel template ConfigMap for the Broker
+		_, err := client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Create(context.Background(), kafkaChannelTemplateConfigMap, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal("Unable to create ConfigMap: ", err)
+		}
 
-	ksvc, err := test.WithServiceReady(client, helloWorldService+"-kafka-channel-broker", test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
-	if err != nil {
-		t.Fatal("Knative Service not ready", err)
-	}
+		client.AddToCleanup(func() error {
+			return client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Delete(context.Background(), kafkaChannelTemplateConfigMapName, metav1.DeleteOptions{})
+		})
 
-	// Create the configmap
-	_, err = client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Create(context.Background(), kafkaChannelTemplateConfigMap, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create Channel Template ConfigMap: ", err)
-	}
+		// Create the (kafka backed) kafkaChannelBroker
+		broker, err := client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Create(context.Background(), kafkaChannelBroker, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal("Unable to create Kafka Backed Broker: ", err)
+		}
 
-	// Create the (kafka backed) kafkaChannelBroker
-	_, err = client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Create(context.Background(), kafkaChannelBroker, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create Kafka Backed Broker: ", err)
-	}
+		client.AddToCleanup(func() error {
+			return client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Delete(context.Background(), kafkaChannelBrokerName, metav1.DeleteOptions{})
+		})
 
-	// Create the Trigger
-	_, err = client.Clients.Eventing.EventingV1().Triggers(test.Namespace).Create(context.Background(), trigger, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create trigger: ", err)
-	}
-
-	// Create the source
-	_, err = client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), brokerPingSource, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create pingsource: ", err)
-	}
-
-	// Wait for text in kservice
-	servinge2e.WaitForRouteServingText(t, client, ksvc.Status.URL.URL(), helloWorldText)
+		return broker
+	})
 }

--- a/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_kafka_broker_ksvc_test.go
@@ -3,8 +3,9 @@ package knativekafkae2e
 import (
 	"context"
 	"fmt"
-	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 	"testing"
+
+	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 	"strings"
 	"testing"
 	"time"
@@ -11,20 +12,15 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	pkgTest "knative.dev/pkg/test"
-
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
-	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/openshift-knative/serverless-operator/test"
-	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 )
 
 const (
 	nativeKafkaBrokerName = "smoke-test-native-kafka-broker"
 	kafkaTriggerName      = "smoke-test-kafka-trigger"
-	kafkaTriggerKsvcName  = helloWorldService + "-" + kafkaTriggerName
 )
 
 var (
@@ -43,118 +39,47 @@ var (
 			},
 		},
 	}
-
-	triggerForNativeBroker = &eventingv1.Trigger{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kafkaTriggerName,
-			Namespace: test.Namespace,
-		},
-		Spec: eventingv1.TriggerSpec{
-			Broker: nativeKafkaBrokerName,
-			Subscriber: duckv1.Destination{
-				Ref: &duckv1.KReference{
-					APIVersion: ksvcAPIVersion,
-					Kind:       ksvcKind,
-					Name:       helloWorldService + "-native-kafka-channel-broker",
-				},
-			},
-		},
-	}
-
-	nativeKafkaBrokerPingSource = &sourcesv1.PingSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pingSourceName,
-			Namespace: test.Namespace,
-		},
-		Spec: sourcesv1.PingSourceSpec{
-			Data: helloWorldText,
-			SourceSpec: duckv1.SourceSpec{
-				Sink: duckv1.Destination{
-					Ref: &duckv1.KReference{
-						APIVersion: brokerAPIVersion,
-						Kind:       brokerKind,
-						Name:       nativeKafkaBrokerName,
-					},
-				},
-			},
-		},
-	}
 )
 
 func TestSourceToNativeKafkaBasedBrokerToKnativeService(t *testing.T) {
-	ctx := context.Background()
-	client := test.SetupClusterAdmin(t)
-	cleanup := func() {
-		test.CleanupAll(t, client)
-		ctx, cancel := context.WithTimeout(ctx, 4*time.Minute)
-		defer cancel()
-
-		if err := client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Delete(ctx, nativeKafkaBrokerName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			br, _ := client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Get(ctx, nativeKafkaBrokerName, metav1.GetOptions{})
-			brStr, _ := json.Marshal(br)
-			t.Errorf("failed to delete broker %s/%s: %v\n%s\n", test.Namespace, nativeKafkaBrokerName, err, string(brStr))
-		}
-		if err := client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Delete(ctx, pingSourceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			t.Errorf("failed to delete pingsource %s/%s: %v", test.Namespace, pingSourceName, err)
-		}
-		if err := client.Clients.Eventing.EventingV1().Triggers(test.Namespace).Delete(ctx, kafkaTriggerName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			tr, _ := client.Clients.Eventing.EventingV1().Triggers(test.Namespace).Get(ctx, kafkaTriggerName, metav1.GetOptions{})
-			trStr, _ := json.Marshal(tr)
-			t.Errorf("failed to delete trigger %s/%s: %v\n%s\n", test.Namespace, kafkaTriggerName, err, string(trStr))
-		}
-		if err := client.Clients.Serving.ServingV1().Services(test.Namespace).Delete(ctx, kafkaTriggerKsvcName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			t.Errorf("failed to delete ksvc %s/%s: %v", test.Namespace, kafkaTriggerKsvcName, err)
-		}
-
-		err := wait.PollImmediateUntil(2*time.Second, waitForBrokerDeletion(ctx, client, t), ctx.Done())
+	eventinge2e.KnativeSourceBrokerTriggerKnativeService(t, func(client *test.Context) *eventingv1.Broker {
+		// Create the (native) Kafka Broker
+		broker, err := client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Create(context.Background(), nativeKafkaBroker, metav1.CreateOptions{})
 		if err != nil {
-			t.Fatal(err)
+			t.Fatal("Unable to create Kafka Backed Broker: ", err)
 		}
 
-		cmName := nativeKafkaBroker.Spec.Config.Name
-		cmNamepace := nativeKafkaBroker.Spec.Config.Namespace
-		cm, err := client.Clients.Kube.
-			CoreV1().
-			ConfigMaps(cmNamepace).
-			Get(ctx, cmName, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("failed to get ConfigMap")
-		}
-		for _, f := range cm.GetFinalizers() {
-			if strings.Contains(f, nativeKafkaBrokerName) && strings.Contains(f, test.Namespace) {
-				cmBytes, _ := json.MarshalIndent(cm, "", " ")
-				t.Fatalf("ConfigMap still contains the finalizer %s\n%s\n", f, string(cmBytes))
+		client.AddToCleanup(func() error {
+			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(ctx, 4*time.Minute)
+			defer cancel()
+
+			err := wait.PollImmediateUntil(2*time.Second, waitForBrokerDeletion(ctx, client, t), ctx.Done())
+			if err != nil {
+				t.Fatal(err)
 			}
-		}
-	}
-	test.CleanupOnInterrupt(t, cleanup)
-	defer cleanup()
 
-	ksvc, err := test.WithServiceReady(client, kafkaTriggerKsvcName, test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
-	if err != nil {
-		t.Fatal("Knative Service not ready", err)
-	}
+			cmName := nativeKafkaBroker.Spec.Config.Name
+			cmNamepace := nativeKafkaBroker.Spec.Config.Namespace
+			cm, err := client.Clients.Kube.
+				CoreV1().
+				ConfigMaps(cmNamepace).
+				Get(ctx, cmName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get ConfigMap")
+			}
+			for _, f := range cm.GetFinalizers() {
+				if strings.Contains(f, nativeKafkaBrokerName) && strings.Contains(f, test.Namespace) {
+					cmBytes, _ := json.MarshalIndent(cm, "", " ")
+					t.Fatalf("ConfigMap still contains the finalizer %s\n%s\n", f, string(cmBytes))
+				}
+			}
 
-	// Create the (native) Kafka Broker
-	_, err = client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Create(context.Background(), nativeKafkaBroker, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create Kafka Backed Broker: ", err)
-	}
+			return nil
+		})
 
-	// Create the Trigger
-	_, err = client.Clients.Eventing.EventingV1().Triggers(test.Namespace).Create(context.Background(), triggerForNativeBroker, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create trigger: ", err)
-	}
-
-	// Create the source
-	_, err = client.Clients.Eventing.SourcesV1().PingSources(test.Namespace).Create(context.Background(), nativeKafkaBrokerPingSource, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal("Unable to create pingsource: ", err)
-	}
-
-	// Wait for text in kservice
-	servinge2e.WaitForRouteServingText(t, client, ksvc.Status.URL.URL(), helloWorldText)
+		return broker
+	})
 }
 
 func waitForBrokerDeletion(ctx context.Context, client *test.Context, t *testing.T) wait.ConditionFunc {

--- a/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
@@ -54,7 +54,12 @@ func TestSourceToNativeKafkaBasedBrokerToKnativeService(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, 4*time.Minute)
 			defer cancel()
 
-			err := wait.PollImmediateUntil(2*time.Second, waitForBrokerDeletion(ctx, client, t), ctx.Done())
+			err := client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Delete(context.Background(), nativeKafkaBrokerName, metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = wait.PollImmediateUntil(2*time.Second, waitForBrokerDeletion(ctx, client, t), ctx.Done())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
@@ -71,7 +71,7 @@ func TestSourceToNativeKafkaBasedBrokerToKnativeService(t *testing.T) {
 				ConfigMaps(cmNamepace).
 				Get(ctx, cmName, metav1.GetOptions{})
 			if err != nil {
-				t.Fatalf("failed to get ConfigMap")
+				t.Fatalf("Failed to get ConfigMap")
 			}
 			for _, f := range cm.GetFinalizers() {
 				if strings.Contains(f, nativeKafkaBrokerName) && strings.Contains(f, test.Namespace) {

--- a/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	nativeKafkaBrokerName = "smoke-test-native-kafka-broker"
-	kafkaTriggerName      = "smoke-test-kafka-trigger"
 )
 
 var (

--- a/test/images.go
+++ b/test/images.go
@@ -2,7 +2,9 @@ package test
 
 // The list of images used by serverless-operator test suite.
 const (
-	HelloworldGoImg   = "helloworld-go"
-	HelloOpenshiftImg = "hello-openshift"
-	HTTPProxyImg      = "httpproxy"
+	HelloworldGoImg     = "helloworld-go"
+	HelloOpenshiftImg   = "hello-openshift"
+	HTTPProxyImg        = "httpproxy"
+	RecordEventsImg     = "recordevents"
+	WatholaForwarderImg = "wathola-forwarder"
 )

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -138,6 +138,10 @@ function downstream_eventing_e2e_tests {
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
+  # Used by eventing/test/lib
+  SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
+  export SYSTEM_NAMESPACE
+
   go_test_e2e -failfast -timeout=30m -parallel=1 ./test/eventinge2e \
     --kubeconfigs "${kubeconfigs_str}" \
     --imagetemplate "${IMAGE_TEMPLATE}" \
@@ -154,6 +158,10 @@ function downstream_knative_kafka_e2e_tests {
     kubeconfigs+=("$(pwd)/${cfg}")
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
+
+  # Used by eventing/test/lib
+  SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
+  export SYSTEM_NAMESPACE
 
   go_test_e2e -failfast -timeout=30m -parallel=1 ./test/extensione2e/kafka \
     --kubeconfigs "${kubeconfigs_str}" \


### PR DESCRIPTION
Make the eventing smoke tests actually verify the events were received by a ksvc

## Proposed Changes
- refactors the eventing tests to be reusable by the extensione2e kafka tests where possible
- deploy a recordevents pod and make the receiving ksvc a forwarder so the tests can actually verify the ksvc has received the events