### PR TITLE
Bump SO to 1.28 

### DIFF
--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.bundle.channels.v1="stable"
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
       name="openshift-serverless-1/serverless-operator-bundle" \
-      version="1.27.0" \
+      version="1.28.0" \
       summary="Red Hat OpenShift Serverless Bundle" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -8,9 +8,9 @@ COPY --from=opm /bin/opm /bin/opm
 COPY configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
-RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.26.0:serverless-stop-bundle \
-      registry.ci.openshift.org/knative/openshift-serverless-v1.27.0:serverless-bundle >> /configs/index.yaml || \
-    /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.26.0:serverless-stop-bundle \
+RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.27.0:serverless-stop-bundle \
+      registry.ci.openshift.org/knative/openshift-serverless-v1.28.0:serverless-bundle >> /configs/index.yaml || \
+    /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.27.0:serverless-stop-bundle \
       registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
 
 # The base image is expected to contain

--- a/olm-catalog/serverless-operator/index/configs/index.yaml
+++ b/olm-catalog/serverless-operator/index/configs/index.yaml
@@ -2,7 +2,7 @@ schema: olm.channel
 name: stable
 package: serverless-operator
 entries:
-  - name: "serverless-operator.v1.26.0"
   - name: "serverless-operator.v1.27.0"
-    replaces: serverless-operator.v1.26.0
-    skipRange: ">=1.26.0 <1.27.0"
+  - name: "serverless-operator.v1.28.0"
+    replaces: serverless-operator.v1.27.0
+    skipRange: ">=1.27.0 <1.28.0"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -61,12 +61,12 @@ metadata:
       Deploy and manage event-driven serverless applications and functions using Knative.
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
-    olm.skipRange: '>=1.26.0 <1.27.0'
+    olm.skipRange: '>=1.27.0 <1.28.0'
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: serverless-operator.v1.27.0
+  name: serverless-operator.v1.28.0
   namespace: placeholder
 spec:
   # User-facing metadata
@@ -526,7 +526,7 @@ spec:
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
                         value: "registry.ci.openshift.org/knative/release-1.4:client-plugin-event-sender"
                       - name: "CURRENT_VERSION"
-                        value: "1.27.0"
+                        value: "1.28.0"
                     securityContext:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: true
@@ -697,7 +697,7 @@ spec:
                       - name: "KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate"
                         value: "registry.ci.openshift.org/openshift/knative-eventing-storage-version-migration:knative-v1.6"
                       - name: "CURRENT_VERSION"
-                        value: "1.27.0"
+                        value: "1.28.0"
                       - name: "KNATIVE_EVENTING_KAFKA_BROKER_VERSION"
                         value: "1.6"
                     securityContext:
@@ -957,5 +957,5 @@ spec:
       image: "registry.ci.openshift.org/openshift/knative-eventing-kafka-broker-post-install:knative-v1.6"
     - name: "KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate"
       image: "registry.ci.openshift.org/openshift/knative-eventing-storage-version-migration:knative-v1.6"
-  replaces: serverless-operator.v1.26.0
-  version: 1.27.0
+  replaces: serverless-operator.v1.27.0
+  version: 1.28.0

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -2,11 +2,11 @@
 project:
   name: serverless-operator
   # For minor and major version bumps, bump all `dependencies.previous` to whatever `dependencies` has set.
-  version: 1.27.0
+  version: 1.28.0
 
 olm:
-  replaces: 1.26.0
-  skipRange: '>=1.26.0 <1.27.0'
+  replaces: 1.27.0
+  skipRange: '>=1.27.0 <1.28.0'
   channels:
     default: 'stable'
     list:

--- a/olm-catalog/serverless-operator/stopbundle.Dockerfile
+++ b/olm-catalog/serverless-operator/stopbundle.Dockerfile
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.bundle.channels.v1="stable"
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
       name="openshift-serverless-1/serverless-operator-bundle" \
-      version="1.27.0" \
+      version="1.28.0" \
       summary="Red Hat OpenShift Serverless Bundle" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

DO NOT YET MERGE: MISSING 1.27 branch for SO

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- bumping just SO version to 1.28, keeping the operands intentionally untouched
