### PR TITLE
Create eventing namespace if it doesn't exist in install strimzi

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -232,7 +232,7 @@ EOF
 
   logger.info "Deleting existing Kafka user secrets"
 
-  oc create namespace "${EVENTING_NAMESPACE}" --dry-run=client -o yaml | oc apply -f
+  oc create namespace "${EVENTING_NAMESPACE}" --dry-run=client -o yaml | oc apply -f -
 
   oc delete secret -n default my-tls-secret --ignore-not-found
   oc delete secret -n default my-sasl-secret --ignore-not-found

--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -232,6 +232,8 @@ EOF
 
   logger.info "Deleting existing Kafka user secrets"
 
+  oc create namespace "${EVENTING_NAMESPACE}" --dry-run=client -o yaml | oc apply -f
+
   oc delete secret -n default my-tls-secret --ignore-not-found
   oc delete secret -n default my-sasl-secret --ignore-not-found
   oc delete secret -n "${EVENTING_NAMESPACE}" strimzi-tls-secret --ignore-not-found


### PR DESCRIPTION
With the recent changes in [1], we're installing components in parallel which means that by the time we're trying to create Strimzi secrets in the eventing namespace, eventing is not installed, therefore there is no eventing namespace present.

[1] https://github.com/openshift-knative/serverless-operator/commit/db6b80685e4236e6de5dded74730a5106cceb781

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>