### PR TITLE
[SRVCOM-2209] Support kube rbac proxy overrides

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -321,10 +321,10 @@ func (r *ReconcileKnativeKafka) ensureFinalizers(manifest *mf.Manifest, instance
 func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *serverlessoperatorv1alpha1.KnativeKafka) error {
 	log.Info("Transforming manifest")
 	// If in deletion we don't apply any monitoring transformer to kafka components and transformer will be nil and skipped.
-	var rbacProxyTranform mf.Transformer
+	var rbacProxyTranform []mf.Transformer
 	if instance.GetDeletionTimestamp() == nil {
 		var err error
-		if rbacProxyTranform, err = monitoring.GetRBACProxyInjectTransformer(r.client); err != nil {
+		if rbacProxyTranform, err = monitoring.GetRBACProxyInjectTransformer(instance, r.client); err != nil {
 			return err
 		}
 	}
@@ -343,8 +343,9 @@ func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *serve
 		socommon.InjectCommonEnvironment(),
 		operatorcommon.OverridesTransform(instance.Spec.Workloads, logging.FromContext(context.TODO())),
 		socommon.ConfigMapVolumeChecksumTransform(context.Background(), r.client, sets.NewString("config-tracing", "kafka-config-logging")),
-		injectNamespacedBrokerMonitoring(r.client),
-		rbacProxyTranform), socommon.DeprecatedAPIsTranformersFromConfig()...)
+		injectNamespacedBrokerMonitoring(r.client)), socommon.DeprecatedAPIsTranformersFromConfig()...)
+	tfs = append(tfs, rbacProxyTranform...)
+
 	m, err := manifest.Transform(tfs...)
 	if err != nil {
 		return fmt.Errorf("failed to transform manifest: %w", err)

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -321,10 +321,10 @@ func (r *ReconcileKnativeKafka) ensureFinalizers(manifest *mf.Manifest, instance
 func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *serverlessoperatorv1alpha1.KnativeKafka) error {
 	log.Info("Transforming manifest")
 	// If in deletion we don't apply any monitoring transformer to kafka components and transformer will be nil and skipped.
-	var rbacProxyTranform []mf.Transformer
+	var rbacProxyTranforms []mf.Transformer
 	if instance.GetDeletionTimestamp() == nil {
 		var err error
-		if rbacProxyTranform, err = monitoring.GetRBACProxyInjectTransformer(instance, r.client); err != nil {
+		if rbacProxyTranforms, err = monitoring.GetRBACProxyInjectTransformers(instance, r.client); err != nil {
 			return err
 		}
 	}
@@ -344,7 +344,7 @@ func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *serve
 		operatorcommon.OverridesTransform(instance.Spec.Workloads, logging.FromContext(context.TODO())),
 		socommon.ConfigMapVolumeChecksumTransform(context.Background(), r.client, sets.NewString("config-tracing", "kafka-config-logging")),
 		injectNamespacedBrokerMonitoring(r.client)), socommon.DeprecatedAPIsTranformersFromConfig()...)
-	tfs = append(tfs, rbacProxyTranform...)
+	tfs = append(tfs, rbacProxyTranforms...)
 
 	m, err := manifest.Transform(tfs...)
 	if err != nil {

--- a/knative-operator/pkg/monitoring/kafka_rbacproxy_transforms.go
+++ b/knative-operator/pkg/monitoring/kafka_rbacproxy_transforms.go
@@ -97,7 +97,7 @@ func AddRBACProxyToManifest(instance *serverlessoperatorv1alpha1.KnativeKafka, c
 	return &proxyManifest, nil
 }
 
-func GetRBACProxyInjectTransformer(apiClient client.Client) (mf.Transformer, error) {
+func GetRBACProxyInjectTransformer(instance *serverlessoperatorv1alpha1.KnativeKafka, apiClient client.Client) ([]mf.Transformer, error) {
 	eventingList := &operatorv1beta1.KnativeEventingList{}
 	err := apiClient.List(context.Background(), eventingList)
 	if err != nil {
@@ -107,7 +107,10 @@ func GetRBACProxyInjectTransformer(apiClient client.Client) (mf.Transformer, err
 		return nil, errors.New("eventing instance not found")
 	}
 	if monitoring.ShouldEnableMonitoring(eventingList.Items[0].GetSpec().GetConfig()) {
-		return monitoring.InjectRbacProxyContainer(sets.NewString(deployments...)), nil
+		deps := sets.NewString(deployments...)
+		transformers := []mf.Transformer{monitoring.InjectRbacProxyContainer(deps, instance.Spec.Config)}
+		transformers = append(transformers, monitoring.ExtensionDeploymentOverrides(instance.Spec.Workloads, deps))
+		return transformers, nil
 	}
 	return nil, nil
 }

--- a/knative-operator/pkg/monitoring/kafka_rbacproxy_transforms.go
+++ b/knative-operator/pkg/monitoring/kafka_rbacproxy_transforms.go
@@ -97,7 +97,7 @@ func AddRBACProxyToManifest(instance *serverlessoperatorv1alpha1.KnativeKafka, c
 	return &proxyManifest, nil
 }
 
-func GetRBACProxyInjectTransformer(instance *serverlessoperatorv1alpha1.KnativeKafka, apiClient client.Client) ([]mf.Transformer, error) {
+func GetRBACProxyInjectTransformers(instance *serverlessoperatorv1alpha1.KnativeKafka, apiClient client.Client) ([]mf.Transformer, error) {
 	eventingList := &operatorv1beta1.KnativeEventingList{}
 	err := apiClient.List(context.Background(), eventingList)
 	if err != nil {

--- a/openshift-knative-operator/pkg/monitoring/helpers.go
+++ b/openshift-knative-operator/pkg/monitoring/helpers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	mf "github.com/manifestival/manifestival"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -18,8 +19,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/operator/pkg/apis/operator/base"
 	"knative.dev/pkg/logging"
-
-	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 )
 
 const (

--- a/openshift-knative-operator/pkg/monitoring/monitoring_eventing.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_eventing.go
@@ -22,7 +22,8 @@ func GetEventingTransformers(comp base.KComponent) []mf.Transformer {
 	// When monitoring is off we keep around the required resources, only rbac-proxy is removed
 	transformers := []mf.Transformer{injectNamespaceWithSubject(comp.GetNamespace(), OpenshiftMonitoringNamespace)}
 	if ShouldEnableMonitoring(comp.GetSpec().GetConfig()) {
-		transformers = append(transformers, InjectRbacProxyContainer(eventingDeployments))
+		transformers = append(transformers, InjectRbacProxyContainer(eventingDeployments, comp.GetSpec().GetConfig()))
+		transformers = append(transformers, ExtensionDeploymentOverrides(comp.GetSpec().GetWorkloadOverrides(), eventingDeployments))
 	}
 	return transformers
 }

--- a/openshift-knative-operator/pkg/monitoring/monitoring_serving.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_serving.go
@@ -22,7 +22,8 @@ func GetServingTransformers(comp base.KComponent) []mf.Transformer {
 	// When monitoring is off we keep around the required resources, only rbac-proxy is removed
 	transformers := []mf.Transformer{injectNamespaceWithSubject(comp.GetNamespace(), OpenshiftMonitoringNamespace)}
 	if ShouldEnableMonitoring(comp.GetSpec().GetConfig()) {
-		transformers = append(transformers, InjectRbacProxyContainer(servingDeployments))
+		transformers = append(transformers, InjectRbacProxyContainer(servingDeployments, comp.GetSpec().GetConfig()))
+		transformers = append(transformers, ExtensionDeploymentOverrides(comp.GetSpec().GetWorkloadOverrides(), servingDeployments))
 	}
 	return transformers
 }

--- a/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection_test.go
+++ b/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
+	"knative.dev/operator/pkg/apis/operator/base"
 )
 
 func TestInjectRbacProxyContainerToDeployments(t *testing.T) {
@@ -59,9 +60,18 @@ func TestInjectRbacProxyContainerToDeployments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to construct manifest: %s", err)
 	}
-
-	if manifest, err = manifest.Transform(InjectRbacProxyContainer(sets.NewString(in.Name))); err != nil {
+	cfg := base.ConfigMapData{}
+	cfg["deployment"] = map[string]string{
+		"kube-rbac-proxy-cpu-limit":    "100m",
+		"kube-rbac-proxy-memory-limit": "100Mi",
+	}
+	if manifest, err = manifest.Transform(InjectRbacProxyContainer(sets.NewString(in.Name), cfg)); err != nil {
 		t.Fatalf("Unable to transform test manifest: %s", err)
+	}
+
+	limits := corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("100Mi"),
+		corev1.ResourceCPU:    resource.MustParse("100m"),
 	}
 
 	got := &appsv1.Deployment{}
@@ -106,17 +116,16 @@ func TestInjectRbacProxyContainerToDeployments(t *testing.T) {
 							MountPath: "/foo/bar",
 						}},
 					}, {
-						Name:  rbacContainerName,
+						Name:  RBACContainerName,
 						Image: os.Getenv(rbacProxyImageEnvVar),
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "secret-activator-sm-service-tls",
 							MountPath: "/etc/tls/private",
 						}},
 						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								"memory": resource.MustParse("20Mi"),
-								"cpu":    resource.MustParse("10m"),
-							}},
+							Limits:   limits,
+							Requests: defaultKubeRBACProxyReqeusts,
+						},
 						Args: []string{
 							"--secure-listen-address=0.0.0.0:8444",
 							"--upstream=http://127.0.0.1:9090/",
@@ -130,7 +139,30 @@ func TestInjectRbacProxyContainerToDeployments(t *testing.T) {
 			},
 		},
 	}
-
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error("Unexpected Deployment diff (-want +got): ", diff)
+	}
+	limits = corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("200Mi"),
+		corev1.ResourceCPU:    resource.MustParse("200m"),
+	}
+	overrides := []base.WorkloadOverride{{
+		Name: "activator",
+		Resources: []base.ResourceRequirementsOverride{{
+			Container: RBACContainerName,
+			ResourceRequirements: corev1.ResourceRequirements{
+				Limits: limits,
+			},
+		}},
+	}}
+	if manifest, err = manifest.Transform(ExtensionDeploymentOverrides(overrides, servingDeployments)); err != nil {
+		t.Fatalf("Unable to transform test manifest: %s", err)
+	}
+	got = &appsv1.Deployment{}
+	if err := scheme.Scheme.Convert(&manifest.Resources()[0], got, nil); err != nil {
+		t.Fatalf("Unable to convert Unstructured to Deployment: %s", err)
+	}
+	want.Spec.Template.Spec.Containers[1].Resources.Limits = limits
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Error("Unexpected Deployment diff (-want +got): ", diff)
 	}


### PR DESCRIPTION
- Allows to override kube-rbac-proxy container attributes eg. resources 
- Can't be done via a normal deployment override without this patch because knative operator applies deployment [overrides before we inject kube-rbac-proxy](https://github.com/knative/operator/blob/6f94c4f029e102e753ea4786a4780acc0ceff42e/pkg/reconciler/common/transformers.go#L49) container at the extension side. Followed the same approach for Kafka for consistency.
