### PR TITLE
Upgrade golang linter

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -166,7 +166,7 @@ jobs:
       - name: Go Lint - knative-operator
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.50.1
           args: --timeout=10m0s --verbose
           working-directory: ./src/github.com/${{ github.repository }}
 

--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
@@ -134,7 +135,8 @@ func main() {
 		// signal handling so the process can just tear it down with it.
 		log.Info("Serving CLI artifacts on :8080")
 		http.Handle("/", http.FileServer(http.Dir("/cli-artifacts")))
-		if err := http.ListenAndServe(":8080", nil); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		server := http.Server{Addr: ":8080", ReadHeaderTimeout: time.Minute}
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Error(err, "Failed to launch CLI artifact server")
 		}
 	}()


### PR DESCRIPTION
- Updates go linter to latest (v1.50.1)
- Fixes lint issue:
```
knative-operator/cmd/manager/main.go:137:13: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
		if err := http.ListenAndServe(":8080", nil); err != nil && !errors.Is(err, http.ErrServerClosed) {
```

