### PR TITLE
Use knative namespace for metatdata-webhook image

### DIFF
--- a/serving/metadata-webhook/config/webhook.yaml
+++ b/serving/metadata-webhook/config/webhook.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: controller
       containers:
       - name: webhook
-        image: registry.ci.openshift.org/openshift/openshift-serverless-nightly:metadata-webhook
+        image: registry.ci.openshift.org/knative/openshift-serverless-nightly:metadata-webhook
         resources:
           requests:
             cpu: 20m


### PR DESCRIPTION
As per title, this patch changes to use image in `registry.ci.openshift.org/openshift/openshift-serverless-nightly`.