### PR TITLE
Upgrade eventing-kafka version to latest midstream 1.1 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -172,7 +172,7 @@ require (
 replace (
 	// Knative forks.
 	knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20221215170220-da8c25a653e7
-	knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221109100552-26eea5293bca
+	knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc
 	knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20221222095110-de26fc249c4f
 	knative.dev/serving => github.com/openshift-knative/serving v0.10.1-0.20221222141647-1ffb9825d2c0
 )

--- a/go.sum
+++ b/go.sum
@@ -1444,8 +1444,8 @@ github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xA
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/openshift-knative/eventing v0.99.1-0.20221215170220-da8c25a653e7 h1:SzFXMET99T/Ju15TmDSwjJ3OXEJJ457KHW653fTNWLU=
 github.com/openshift-knative/eventing v0.99.1-0.20221215170220-da8c25a653e7/go.mod h1:rxI/ijzHbAYenRZpGapYlJHwGEfdUcWjJh4N1bP9+zQ=
-github.com/openshift-knative/eventing-kafka v0.19.1-0.20221109100552-26eea5293bca h1:yXBHJxnGSpuE2EmpmEhEOwQFw5cJmgbW/o0zIfZMKb4=
-github.com/openshift-knative/eventing-kafka v0.19.1-0.20221109100552-26eea5293bca/go.mod h1:RZ/b/xO0sEPL0it4Xm0kSbrhATdsND1WVQq5AcHi7ro=
+github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc h1:avIbZM/BPZV7PYTgwkxZj9bauRehrSFRPcANeAtRxSE=
+github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc/go.mod h1:RZ/b/xO0sEPL0it4Xm0kSbrhATdsND1WVQq5AcHi7ro=
 github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20221222095110-de26fc249c4f h1:Yi+zSzuXLjTQ4+PrP+uOfVKnbjZtq5Tz/d3yknMr8Vs=
 github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20221222095110-de26fc249c4f/go.mod h1:rys0PzhSowUTpW4dw6eTZOmBLdDLZF8cUdXokwzCEFY=
 github.com/openshift-knative/serving v0.10.1-0.20221222141647-1ffb9825d2c0 h1:7Rx9niu1OHwlFPxDAjqd9njxLTPEPgt04gXQUk9cN0g=

--- a/vendor/knative.dev/eventing-kafka/test/e2e-common.sh
+++ b/vendor/knative.dev/eventing-kafka/test/e2e-common.sh
@@ -480,7 +480,8 @@ function create_tls_secrets() {
   kubectl create secret --namespace "${SYSTEM_NAMESPACE}" generic strimzi-tls-secret \
     --from-literal=ca.crt="$STRIMZI_CRT" \
     --from-literal=user.crt="$TLSUSER_CRT" \
-    --from-literal=user.key="$TLSUSER_KEY"
+    --from-literal=user.key="$TLSUSER_KEY" \
+    --dry-run=client -o yaml | kubectl apply -n "${SYSTEM_NAMESPACE}" -f -
 }
 
 function create_sasl_secrets() {
@@ -492,7 +493,8 @@ function create_sasl_secrets() {
     --from-literal=ca.crt="$STRIMZI_CRT" \
     --from-literal=password="$SASL_PASSWD" \
     --from-literal=saslType="SCRAM-SHA-512" \
-    --from-literal=user="my-sasl-user"
+    --from-literal=user="my-sasl-user" \
+    --dry-run=client -o yaml | kubectl apply -n "${SYSTEM_NAMESPACE}" -f -
 }
 
 # Installs the resources necessary to test the consolidated channel, runs those tests, and then cleans up those resources

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1360,7 +1360,7 @@ knative.dev/eventing/test/upgrade/prober/wathola/fetcher
 knative.dev/eventing/test/upgrade/prober/wathola/forwarder
 knative.dev/eventing/test/upgrade/prober/wathola/receiver
 knative.dev/eventing/test/upgrade/prober/wathola/sender
-# knative.dev/eventing-kafka v0.35.1 => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221109100552-26eea5293bca
+# knative.dev/eventing-kafka v0.35.1 => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc
 ## explicit; go 1.16
 knative.dev/eventing-kafka/pkg/apis/bindings
 knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1
@@ -1656,7 +1656,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20221215170220-da8c25a653e7
-# knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221109100552-26eea5293bca
+# knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc
 # knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20221222095110-de26fc249c4f
 # knative.dev/serving => github.com/openshift-knative/serving v0.10.1-0.20221222141647-1ffb9825d2c0
 # github.com/antlr/antlr4/runtime/Go/antlr => github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20211221011931-643d94fcab96


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

(edited by @matzew)

- Upgrade eventing-kafka legacy version to our latest 1.1 midstream to contain `SRC` change made to that branch (see: https://github.com/openshift-knative/eventing-kafka/commit/81b8c0ceb5408ff1d75f016fdd8e9f455b17ad4c)