### PR TITLE
Disable/enable namespaced controllers as well, based on KnativeKafka spec.broker.enabled

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -595,7 +595,7 @@ func configureEventingKafka(spec serverlessoperatorv1alpha1.KnativeKafkaSpec) mf
 		if u.GetKind() == "Deployment" && u.GetName() == "kafka-controller" {
 
 			var disabledKafkaControllers = common.StringMap{
-				brokerController:  "broker-controller,trigger-controller",
+				brokerController:  "broker-controller,trigger-controller,namespaced-broker-controller,namespaced-trigger-controller",
 				sinkController:    "sink-controller",
 				sourceController:  "source-controller",
 				channelController: "channel-controller",

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -560,7 +560,7 @@ func TestDisabledControllers(t *testing.T) {
 				Enabled: true,
 			},
 		},
-		expectedDisabledControllers: []string{"broker-controller", "trigger-controller", "source-controller"},
+		expectedDisabledControllers: []string{"broker-controller", "trigger-controller", "namespaced-broker-controller", "namespaced-trigger-controller", "source-controller"},
 	}, {
 		name: "broker and sink",
 		knativeKafka: v1alpha1.KnativeKafkaSpec{
@@ -582,7 +582,7 @@ func TestDisabledControllers(t *testing.T) {
 				Enabled: false,
 			},
 		},
-		expectedDisabledControllers: []string{"broker-controller", "trigger-controller", "sink-controller", "source-controller"},
+		expectedDisabledControllers: []string{"broker-controller", "trigger-controller", "namespaced-broker-controller", "namespaced-trigger-controller", "sink-controller", "source-controller"},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Disable/enable namespaced controllers as well, based on KnativeKafka spec.broker.enabled
- Similar to regular broker controllers
- There's no mechanism at the moment to enable/disable regular and namespaced controllers separately
