### PR TITLE
[SRVKS-876] Use http-protocol instead of httpOption

### DIFF
--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
+	"knative.dev/networking/pkg/apis/networking"
 	pkgTest "knative.dev/pkg/test"
 )
 
@@ -16,7 +17,7 @@ func TestKnativeServiceHTTPRedirect(t *testing.T) {
 	defer test.CleanupAll(t, caCtx)
 
 	ksvc := test.Service("redirect-service", test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg), nil)
-	ksvc.ObjectMeta.Annotations = map[string]string{"networking.knative.dev/httpOption": "redirected"}
+	ksvc.ObjectMeta.Annotations = map[string]string{networking.HTTPProtocolAnnotationKey: "redirected"}
 	ksvc = test.WithServiceReadyOrFail(caCtx, ksvc)
 
 	// Implicitly checks that HTTPS works.


### PR DESCRIPTION
This is a tiny change which uses an updated annotation key.
The key is available since upstream v1.1.