### PR TITLE
Add istio label to knative-local-gateway service

### DIFF
--- a/hack/lib/mesh_resources/gateway.yaml
+++ b/hack/lib/mesh_resources/gateway.yaml
@@ -38,6 +38,8 @@ kind: Service
 metadata:
   name: knative-local-gateway
   namespace: istio-system
+  labels:
+    experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
Partly fixes JIRA https://issues.redhat.com/browse/SRVKS-992

The label is used in the docs for the OpenShift Service Mesh integration, but not present in the e2e test resources.

## Proposed Changes
- :broom: Add `experimental.istio.io/disable-gateway-port-translation: "true"` label to  `knative-local-gateway` servic

/cc @nak3 