### PR TITLE
Run namespaced broker upgrade tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	k8s.io/client-go v0.25.2
 	knative.dev/eventing v0.35.2
 	knative.dev/eventing-kafka v0.35.1
-	knative.dev/eventing-kafka-broker v0.0.0-00010101000000-000000000000
+	knative.dev/eventing-kafka-broker v0.35.5
 	knative.dev/hack v0.0.0-20221010154335-3fdc50b9c24a
 	knative.dev/networking v0.0.0-20220818010248-e51df7cdf571
 	knative.dev/operator v0.34.2
@@ -173,7 +173,7 @@ replace (
 	// Knative forks.
 	knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20221223194634-91b1cee5fce4
 	knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc
-	knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20221226093937-630a33d847c3
+	knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd
 	knative.dev/serving => github.com/openshift-knative/serving v0.10.1-0.20221227111603-f612214ac3df
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1446,8 +1446,8 @@ github.com/openshift-knative/eventing v0.99.1-0.20221223194634-91b1cee5fce4 h1:0
 github.com/openshift-knative/eventing v0.99.1-0.20221223194634-91b1cee5fce4/go.mod h1:6UnNnPrEUNAM9PfCpf7L8N7G/1vq+HQlpOjzndY6ryw=
 github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc h1:avIbZM/BPZV7PYTgwkxZj9bauRehrSFRPcANeAtRxSE=
 github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc/go.mod h1:RZ/b/xO0sEPL0it4Xm0kSbrhATdsND1WVQq5AcHi7ro=
-github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20221226093937-630a33d847c3 h1:HcSsUw27PQayl8TGoUghW8JxLVI448DCrvU0xD5DoJ8=
-github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20221226093937-630a33d847c3/go.mod h1:Kod8wexuKfcKm6le7W7ZgSUnvL4AvQuls8c/TWksOXE=
+github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd h1:HR6u4bFngzrZt6dTHqVo5gelfI+oCJTG7Tv/pKQPJPg=
+github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd/go.mod h1:Kod8wexuKfcKm6le7W7ZgSUnvL4AvQuls8c/TWksOXE=
 github.com/openshift-knative/serving v0.10.1-0.20221227111603-f612214ac3df h1:CQEQZMvPYuhNHNObXYzFKjCekrtSBA5ds0aY3B8fQ+g=
 github.com/openshift-knative/serving v0.10.1-0.20221227111603-f612214ac3df/go.mod h1:iT5JrONKyOhhcKy2Xn8Ihqoq1Wlc0MfrUXUgVhfusWg=
 github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=

--- a/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
@@ -9,10 +9,13 @@ import (
 	"time"
 
 	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
+	corev1 "k8s.io/api/core/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	kafka "knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
+	kafkatestpkg "knative.dev/eventing-kafka-broker/test/pkg"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
@@ -23,26 +26,57 @@ const (
 	nativeKafkaBrokerName = "smoke-test-native-kafka-broker"
 )
 
-var (
-	nativeKafkaBroker = &eventingv1.Broker{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        nativeKafkaBrokerName,
-			Namespace:   test.Namespace,
-			Annotations: map[string]string{"eventing.knative.dev/broker.class": "Kafka"},
-		},
-		Spec: eventingv1.BrokerSpec{
-			Config: &duckv1.KReference{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-				Name:       "kafka-broker-config",
-				Namespace:  "knative-eventing",
-			},
-		},
-	}
-)
+func TestSourceToNativeKafkaBrokerToKnativeService(t *testing.T) {
+	eventinge2e.KnativeSourceBrokerTriggerKnativeService(t, createBrokerFunc(t, kafka.BrokerClass))
+}
 
-func TestSourceToNativeKafkaBasedBrokerToKnativeService(t *testing.T) {
-	eventinge2e.KnativeSourceBrokerTriggerKnativeService(t, func(client *test.Context) *eventingv1.Broker {
+func TestSourceToNamespacedKafkaBrokerToKnativeService(t *testing.T) {
+	eventinge2e.KnativeSourceBrokerTriggerKnativeService(t, createBrokerFunc(t, kafka.NamespacedBrokerClass))
+}
+
+func createBrokerFunc(t *testing.T, brokerClass string) func(client *test.Context) *eventingv1.Broker {
+	return func(client *test.Context) *eventingv1.Broker {
+		kafkaBrokerConfigName := "kafka-broker-config"
+		kafkaBrokerConfigNamespace := "knative-eventing"
+		var brokerConfigMap *corev1.ConfigMap
+		if brokerClass == kafka.NamespacedBrokerClass {
+			kafkaBrokerConfigNamespace = test.Namespace
+			brokerConfigMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kafkaBrokerConfigName,
+					Namespace: kafkaBrokerConfigNamespace,
+				},
+				Data: map[string]string{
+					kafka.BootstrapServersConfigMapKey:              kafkatestpkg.BootstrapServersPlaintext,
+					kafka.DefaultTopicNumPartitionConfigMapKey:      fmt.Sprintf("%d", kafkatestpkg.NumPartitions),
+					kafka.DefaultTopicReplicationFactorConfigMapKey: fmt.Sprintf("%d", kafkatestpkg.ReplicationFactor),
+				},
+			}
+		}
+		nativeKafkaBroker := &eventingv1.Broker{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        nativeKafkaBrokerName,
+				Namespace:   test.Namespace,
+				Annotations: map[string]string{"eventing.knative.dev/broker.class": brokerClass},
+			},
+			Spec: eventingv1.BrokerSpec{
+				Config: &duckv1.KReference{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Name:       kafkaBrokerConfigName,
+					Namespace:  kafkaBrokerConfigNamespace,
+				},
+			},
+		}
+
+		// Create Kafka Broker ConfigMap for Namespaced broker only
+		if brokerClass == kafka.NamespacedBrokerClass {
+			_, err := client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Create(context.Background(), brokerConfigMap, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatal("Unable to create KafkaBroker ConfigMap: ", err)
+			}
+		}
+
 		// Create the (native) Kafka Broker
 		broker, err := client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Create(context.Background(), nativeKafkaBroker, metav1.CreateOptions{})
 		if err != nil {
@@ -64,19 +98,23 @@ func TestSourceToNativeKafkaBasedBrokerToKnativeService(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			cmName := nativeKafkaBroker.Spec.Config.Name
-			cmNamepace := nativeKafkaBroker.Spec.Config.Namespace
-			cm, err := client.Clients.Kube.
-				CoreV1().
-				ConfigMaps(cmNamepace).
-				Get(ctx, cmName, metav1.GetOptions{})
-			if err != nil {
-				t.Fatalf("Failed to get ConfigMap")
-			}
-			for _, f := range cm.GetFinalizers() {
-				if strings.Contains(f, nativeKafkaBrokerName) && strings.Contains(f, test.Namespace) {
-					cmBytes, _ := json.MarshalIndent(cm, "", " ")
-					t.Fatalf("ConfigMap still contains the finalizer %s\n%s\n", f, string(cmBytes))
+			if brokerClass == kafka.NamespacedBrokerClass {
+				if err := client.Clients.Kube.CoreV1().ConfigMaps(test.Namespace).Delete(ctx, kafkaBrokerConfigName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+					t.Errorf("Failed to delete ConfigMap %s/%s: %v", test.Namespace, kafkaBrokerConfigName, err)
+				}
+			} else {
+				cm, err := client.Clients.Kube.
+					CoreV1().
+					ConfigMaps(nativeKafkaBroker.Spec.Config.Namespace).
+					Get(ctx, nativeKafkaBroker.Spec.Config.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Failed to get ConfigMap")
+				}
+				for _, f := range cm.GetFinalizers() {
+					if strings.Contains(f, nativeKafkaBrokerName) && strings.Contains(f, test.Namespace) {
+						cmBytes, _ := json.MarshalIndent(cm, "", " ")
+						t.Fatalf("ConfigMap still contains the finalizer %s\n%s\n", f, string(cmBytes))
+					}
 				}
 			}
 
@@ -84,7 +122,7 @@ func TestSourceToNativeKafkaBasedBrokerToKnativeService(t *testing.T) {
 		})
 
 		return broker
-	})
+	}
 }
 
 func waitForBrokerDeletion(ctx context.Context, client *test.Context, t *testing.T) wait.ConditionFunc {

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -45,9 +45,9 @@ func TestServerlessUpgradePrePost(t *testing.T) {
 	cfg := newUpgradeConfig(t)
 	suite := pkgupgrade.Suite{
 		Tests: pkgupgrade.Tests{
-			PreUpgrade:    preUpgradeTests(),
-			PostUpgrade:   postUpgradeTests(ctx, true),
-			PostDowngrade: postDowngradeTests(),
+			PreUpgrade:  preUpgradeTests(),
+			PostUpgrade: postUpgradeTests(ctx, true),
+			//PostDowngrade: postDowngradeTests(),
 		},
 		Installations: pkgupgrade.Installations{
 			UpgradeWith: []pkgupgrade.Operation{
@@ -57,7 +57,7 @@ func TestServerlessUpgradePrePost(t *testing.T) {
 					}
 				}),
 			},
-			DowngradeWith: downgrade(ctx),
+			//DowngradeWith: downgrade(ctx),
 		},
 	}
 	suite.Execute(cfg)

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -180,7 +180,6 @@ func postDowngradeTests() []pkgupgrade.Operation {
 		kafkaupgrade.ChannelPostDowngradeTest(),
 		kafkaupgrade.SourcePostDowngradeTest(),
 		kafkabrokerupgrade.BrokerPostDowngradeTest(),
-		kafkabrokerupgrade.NamespacedBrokerPostDowngradeTest(),
 		kafkabrokerupgrade.SinkPostDowngradeTest(),
 	)
 	return tests

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -77,6 +77,7 @@ func TestServerlessUpgradeContinual(t *testing.T) {
 				},
 				kafkaupgrade.ChannelContinualTests(continual.ChannelTestOptions{}),
 				kafkabrokerupgrade.BrokerContinualTests(),
+				kafkabrokerupgrade.NamespacedBrokerContinualTests(),
 				kafkabrokerupgrade.SinkContinualTests(),
 			),
 		},
@@ -137,6 +138,7 @@ func preUpgradeTests() []pkgupgrade.Operation {
 		kafkaupgrade.ChannelPreUpgradeTest(),
 		kafkaupgrade.SourcePreUpgradeTest(),
 		kafkabrokerupgrade.BrokerPreUpgradeTest(),
+		kafkabrokerupgrade.NamespacedBrokerPreUpgradeTest(),
 		kafkabrokerupgrade.SinkPreUpgradeTest(),
 	}
 	// We might want to skip pre-upgrade test if we want to re-use the services
@@ -164,6 +166,7 @@ func postUpgradeTests(ctx *test.Context, failOnNoJobs bool) []pkgupgrade.Operati
 		kafkaupgrade.ChannelPostUpgradeTest(),
 		kafkaupgrade.SourcePostUpgradeTest(),
 		kafkabrokerupgrade.BrokerPostUpgradeTest(),
+		kafkabrokerupgrade.NamespacedBrokerPostUpgradeTest(),
 		kafkabrokerupgrade.SinkPostUpgradeTest(),
 	)
 	tests = append(tests, servingupgrade.ServingPostUpgradeTests()...)
@@ -179,6 +182,7 @@ func postDowngradeTests() []pkgupgrade.Operation {
 		kafkaupgrade.ChannelPostDowngradeTest(),
 		kafkaupgrade.SourcePostDowngradeTest(),
 		kafkabrokerupgrade.BrokerPostDowngradeTest(),
+		kafkabrokerupgrade.NamespacedBrokerPostDowngradeTest(),
 		kafkabrokerupgrade.SinkPostDowngradeTest(),
 	)
 	return tests

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -45,9 +45,9 @@ func TestServerlessUpgradePrePost(t *testing.T) {
 	cfg := newUpgradeConfig(t)
 	suite := pkgupgrade.Suite{
 		Tests: pkgupgrade.Tests{
-			PreUpgrade:  preUpgradeTests(),
-			PostUpgrade: postUpgradeTests(ctx, true),
-			//PostDowngrade: postDowngradeTests(),
+			PreUpgrade:    preUpgradeTests(),
+			PostUpgrade:   postUpgradeTests(ctx, true),
+			PostDowngrade: postDowngradeTests(),
 		},
 		Installations: pkgupgrade.Installations{
 			UpgradeWith: []pkgupgrade.Operation{
@@ -57,7 +57,7 @@ func TestServerlessUpgradePrePost(t *testing.T) {
 					}
 				}),
 			},
-			//DowngradeWith: downgrade(ctx),
+			DowngradeWith: downgrade(ctx),
 		},
 	}
 	suite.Execute(cfg)

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -77,7 +77,6 @@ func TestServerlessUpgradeContinual(t *testing.T) {
 				},
 				kafkaupgrade.ChannelContinualTests(continual.ChannelTestOptions{}),
 				kafkabrokerupgrade.BrokerContinualTests(),
-				kafkabrokerupgrade.NamespacedBrokerContinualTests(),
 				kafkabrokerupgrade.SinkContinualTests(),
 			),
 		},
@@ -138,7 +137,6 @@ func preUpgradeTests() []pkgupgrade.Operation {
 		kafkaupgrade.ChannelPreUpgradeTest(),
 		kafkaupgrade.SourcePreUpgradeTest(),
 		kafkabrokerupgrade.BrokerPreUpgradeTest(),
-		kafkabrokerupgrade.NamespacedBrokerPreUpgradeTest(),
 		kafkabrokerupgrade.SinkPreUpgradeTest(),
 	}
 	// We might want to skip pre-upgrade test if we want to re-use the services

--- a/vendor/knative.dev/eventing-kafka-broker/test/upgrade/continual.go
+++ b/vendor/knative.dev/eventing-kafka-broker/test/upgrade/continual.go
@@ -21,11 +21,14 @@ import (
 
 	"knative.dev/eventing-kafka-broker/test/upgrade/continual"
 	eventingkafkacontinual "knative.dev/eventing-kafka/test/upgrade/continual"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 )
 
 // ContinualTests returns all continual tests.
 func ContinualTests() []pkgupgrade.BackgroundOperation {
 	c := BrokerContinualTests()
+	c = append(c, NamespacedBrokerContinualTests()...)
 	c = append(c, ChannelContinualTests()...)
 	c = append(c, SinkContinualTests()...)
 	return c
@@ -36,7 +39,29 @@ func ContinualTests() []pkgupgrade.BackgroundOperation {
 // process asserting that all events are propagated.
 func BrokerContinualTests() []pkgupgrade.BackgroundOperation {
 	return []pkgupgrade.BackgroundOperation{
-		continual.BrokerTest(continual.KafkaBrokerTestOptions{}),
+		continual.BrokerTest(continual.KafkaBrokerTestOptions{
+			Broker: &continual.Broker{
+				Name:  "broker-upgrade",
+				Class: kafka.BrokerClass,
+			},
+			Triggers: &continual.Triggers{
+				Prefix: "trigger-upgrade",
+			},
+		}),
+	}
+}
+
+func NamespacedBrokerContinualTests() []pkgupgrade.BackgroundOperation {
+	return []pkgupgrade.BackgroundOperation{
+		continual.BrokerTest(continual.KafkaBrokerTestOptions{
+			Broker: &continual.Broker{
+				Name:  "namespaced-broker-upgrade",
+				Class: kafka.NamespacedBrokerClass,
+			},
+			Triggers: &continual.Triggers{
+				Prefix: "namespaced-trigger-upgrade",
+			},
+		}),
 	}
 }
 

--- a/vendor/knative.dev/eventing-kafka-broker/test/upgrade/continual/broker.go
+++ b/vendor/knative.dev/eventing-kafka-broker/test/upgrade/continual/broker.go
@@ -60,18 +60,26 @@ func (o *KafkaBrokerTestOptions) setDefaults() {
 	}
 	if o.Broker == nil {
 		o.Broker = &Broker{
-			Name:               "broker-upgrade",
-			ReplicationOptions: defaultReplicationOptions(),
-			RetryOptions:       defaultRetryOptions(),
+			Name:  "broker-upgrade",
+			Class: kafka.BrokerClass,
 		}
+	}
+	if o.Broker.ReplicationOptions == nil {
+		o.Broker.ReplicationOptions = defaultReplicationOptions()
+	}
+	if o.RetryOptions == nil {
+		o.Broker.RetryOptions = defaultRetryOptions()
 	}
 	if o.Triggers == nil {
 		o.Triggers = &Triggers{
-			Prefix: "trigger-upgrade",
-			Triggers: sut.Triggers{
-				Types: eventTypes,
-			},
+			Triggers: sut.Triggers{},
 		}
+	}
+	if o.Triggers.Prefix == "" {
+		o.Triggers.Prefix = "trigger-upgrade"
+	}
+	if o.Triggers.Types == nil {
+		o.Triggers.Types = eventTypes
 	}
 }
 
@@ -140,7 +148,7 @@ func (k kafkaBrokerSut) deployBroker(ctx sut.Context) {
 			Name:       cm.GetName(),
 			APIVersion: "v1",
 		}),
-		resources.WithBrokerClassForBroker(kafka.BrokerClass),
+		resources.WithBrokerClassForBroker(k.Broker.Class),
 		resources.WithDeliveryForBroker(&eventingduckv1.DeliverySpec{
 			Retry:         pointer.Int32Ptr(int32(k.RetryCount)),
 			BackoffPolicy: &k.BackoffPolicy,

--- a/vendor/knative.dev/eventing-kafka-broker/test/upgrade/continual/types.go
+++ b/vendor/knative.dev/eventing-kafka-broker/test/upgrade/continual/types.go
@@ -37,7 +37,8 @@ type Triggers struct {
 }
 
 type Broker struct {
-	Name string
+	Name  string
+	Class string
 	*eventingkafkaupgrade.ReplicationOptions
 	*eventingkafkaupgrade.RetryOptions
 }

--- a/vendor/knative.dev/eventing-kafka-broker/test/upgrade/postdowngrade.go
+++ b/vendor/knative.dev/eventing-kafka-broker/test/upgrade/postdowngrade.go
@@ -21,6 +21,7 @@ import (
 	pkgupgrade "knative.dev/pkg/test/upgrade"
 
 	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/test/e2e_sink"
 )
 
@@ -28,7 +29,15 @@ import (
 // downgrade.
 func BrokerPostDowngradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("BrokerPostDowngradeTest", func(c pkgupgrade.Context) {
-		runBrokerSmokeTest(c.T)
+		runBrokerSmokeTest(c.T, kafka.BrokerClass)
+	})
+}
+
+// NamespacedBrokerPostDowngradeTest tests basic namespaced broker operations after
+// downgrade.
+func NamespacedBrokerPostDowngradeTest() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("NamespacedBrokerPostDowngradeTest", func(c pkgupgrade.Context) {
+		runBrokerSmokeTest(c.T, kafka.NamespacedBrokerClass)
 	})
 }
 

--- a/vendor/knative.dev/eventing-kafka-broker/test/upgrade/postupgrade.go
+++ b/vendor/knative.dev/eventing-kafka-broker/test/upgrade/postupgrade.go
@@ -31,6 +31,7 @@ import (
 	pkgupgrade "knative.dev/pkg/test/upgrade"
 
 	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/test/e2e_sink"
 	eventingkafkaupgrade "knative.dev/eventing-kafka/test/upgrade"
 )
@@ -43,7 +44,20 @@ func BrokerPostUpgradeTest() pkgupgrade.Operation {
 			verifyPostInstall(t)
 		})
 		c.T.Run("tests", func(t *testing.T) {
-			runBrokerSmokeTest(t)
+			runBrokerSmokeTest(t, kafka.BrokerClass)
+		})
+	})
+}
+
+// NamespacedBrokerPostUpgradeTest tests channel operations after upgrade.
+func NamespacedBrokerPostUpgradeTest() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("NamespacedBrokerPostUpgradeTest", func(c pkgupgrade.Context) {
+		c.T.Parallel()
+		c.T.Run("Verify post-install", func(t *testing.T) {
+			verifyPostInstall(t)
+		})
+		c.T.Run("tests", func(t *testing.T) {
+			runBrokerSmokeTest(t, kafka.NamespacedBrokerClass)
 		})
 	})
 }

--- a/vendor/knative.dev/eventing-kafka-broker/test/upgrade/preupgrade.go
+++ b/vendor/knative.dev/eventing-kafka-broker/test/upgrade/preupgrade.go
@@ -20,6 +20,7 @@ import (
 	pkgupgrade "knative.dev/pkg/test/upgrade"
 
 	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/test/e2e_sink"
 	eventingkafkaupgrade "knative.dev/eventing-kafka/test/upgrade"
 )
@@ -27,7 +28,14 @@ import (
 // BrokerPreUpgradeTest tests broker basic operations before upgrade.
 func BrokerPreUpgradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("BrokerPreUpgradeTest", func(c pkgupgrade.Context) {
-		runBrokerSmokeTest(c.T)
+		runBrokerSmokeTest(c.T, kafka.BrokerClass)
+	})
+}
+
+// NamespacedBrokerPreUpgradeTest tests broker basic operations before upgrade.
+func NamespacedBrokerPreUpgradeTest() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("NamespacedBrokerPreUpgradeTest", func(c pkgupgrade.Context) {
+		runBrokerSmokeTest(c.T, kafka.NamespacedBrokerClass)
 	})
 }
 

--- a/vendor/knative.dev/eventing-kafka-broker/test/upgrade/smoke.go
+++ b/vendor/knative.dev/eventing-kafka-broker/test/upgrade/smoke.go
@@ -26,14 +26,14 @@ import (
 	testbroker "knative.dev/eventing-kafka-broker/test/pkg/broker"
 )
 
-func runBrokerSmokeTest(t *testing.T) {
+func runBrokerSmokeTest(t *testing.T, class string) {
 	pkgtesting.RunMultiple(t, func(t *testing.T) {
 		helpers.EventTransformationForTriggerTestHelper(
 			context.Background(),
 			t,
 			/* broker version */ "v1",
 			/* trigger version */ "v1",
-			testbroker.Creator,
+			testbroker.CreatorForClass(class),
 		)
 	})
 }

--- a/vendor/knative.dev/eventing-kafka-broker/test/upgrade/suite.go
+++ b/vendor/knative.dev/eventing-kafka-broker/test/upgrade/suite.go
@@ -28,16 +28,19 @@ func Suite() pkgupgrade.Suite {
 		Tests: pkgupgrade.Tests{
 			PreUpgrade: []pkgupgrade.Operation{
 				BrokerPreUpgradeTest(),
+				NamespacedBrokerPreUpgradeTest(),
 				ChannelPreUpgradeTest(),
 				SinkPreUpgradeTest(),
 			},
 			PostUpgrade: []pkgupgrade.Operation{
 				BrokerPostUpgradeTest(),
+				NamespacedBrokerPostUpgradeTest(),
 				ChannelPostUpgradeTest(),
 				SinkPostUpgradeTest(),
 			},
 			PostDowngrade: []pkgupgrade.Operation{
 				BrokerPostDowngradeTest(),
+				NamespacedBrokerPostDowngradeTest(),
 				ChannelPostDowngradeTest(),
 				SinkPostDowngradeTest(),
 			},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1407,7 +1407,7 @@ knative.dev/eventing-kafka/test/rekt/resources/kafkachannel
 knative.dev/eventing-kafka/test/upgrade
 knative.dev/eventing-kafka/test/upgrade/continual
 knative.dev/eventing-kafka/test/upgrade/installation
-# knative.dev/eventing-kafka-broker v0.0.0-00010101000000-000000000000 => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20221226093937-630a33d847c3
+# knative.dev/eventing-kafka-broker v0.35.5 => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd
 ## explicit; go 1.18
 knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing
 knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1
@@ -1668,7 +1668,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20221223194634-91b1cee5fce4
 # knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc
-# knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20221226093937-630a33d847c3
+# knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd
 # knative.dev/serving => github.com/openshift-knative/serving v0.10.1-0.20221227111603-f612214ac3df
 # github.com/antlr/antlr4/runtime/Go/antlr => github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20211221011931-643d94fcab96
 # github.com/go-logr/logr => github.com/go-logr/logr v0.4.0


### PR DESCRIPTION
* Get dependencies via ./hack/update-deps.sh

Only adding NamespacedBrokerPostUpgradeTest as this is a new feature so it would not work for "continual" test or pre-ugprade-post/downgrade.

Fixes https://issues.redhat.com/browse/SRVCOM-2265

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
