### PR TITLE
Include workflow_dispatch to set current version

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -55,7 +55,7 @@ jobs:
         shell: bash
 
       - name: Set CURRENT_VERSION_IMAGES on push
-        if: github.event_name == 'push' && github.ref_name != 'main'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name != 'main'
         run: |
           branch="${{ github.ref_name }}.0" # example output: "release-1.26.0"
           # Replace "release-" with "v", so that the final variable is like "v1.27.0"


### PR DESCRIPTION
Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Maybe fix for https://github.com/openshift-knative/serverless-operator/pull/1917