### PR TITLE
[RELEASE-1.27] Add example for v1alpha1 to avoid scorecard warnings

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -17,7 +17,25 @@ metadata:
           }
         },
         {
+          "apiVersion": "operator.knative.dev/v1alpha1",
+          "kind": "KnativeServing",
+          "metadata": {
+            "name": "knative-serving"
+          },
+          "spec": {
+          }
+        },
+        {
           "apiVersion": "operator.knative.dev/v1beta1",
+          "kind": "KnativeEventing",
+          "metadata": {
+            "name": "knative-eventing"
+          },
+          "spec": {
+          }
+        },
+        {
+          "apiVersion": "operator.knative.dev/v1alpha1",
           "kind": "KnativeEventing",
           "metadata": {
             "name": "knative-eventing"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -17,7 +17,25 @@ metadata:
           }
         },
         {
+          "apiVersion": "operator.knative.dev/v1alpha1",
+          "kind": "KnativeServing",
+          "metadata": {
+            "name": "knative-serving"
+          },
+          "spec": {
+          }
+        },
+        {
           "apiVersion": "operator.knative.dev/v1beta1",
+          "kind": "KnativeEventing",
+          "metadata": {
+            "name": "knative-eventing"
+          },
+          "spec": {
+          }
+        },
+        {
+          "apiVersion": "operator.knative.dev/v1alpha1",
           "kind": "KnativeEventing",
           "metadata": {
             "name": "knative-eventing"


### PR DESCRIPTION
- Fixes the warning scorecard:

```
    		Warning: Value operator.knative.dev/v1alpha1, Kind=KnativeEventing: provided API should have an example annotation
    		Warning: Value operator.knative.dev/v1alpha1, Kind=KnativeServing: provided API should have an example annotation
```

Test comparison here: https://gist.github.com/skonto/a97365a2d8176b3b4c58346fa7529315

Used:

 ```
kind: Configuration
apiversion: scorecard.operatorframework.io/v1alpha3
metadata:
  name: config
stages:
- parallel: true
  tests:
  - image: quay.io/operator-framework/scorecard-test:latest
    entrypoint:
    - scorecard-test
    - basic-check-spec
    labels:
      suite: basic
      test: basic-check-spec-test
  - image: quay.io/operator-framework/scorecard-test:latest
    entrypoint:
    - scorecard-test
    - olm-bundle-validation
    labels:
      suite: olm
      test: olm-bundle-validation-test
```
for the tests.
