### PR TITLE
[SRVKE-1388] Namespaced Broker deletion hangs with foreground propagation policy

### DIFF
--- a/knative-operator/pkg/monitoring/monitoring_kafka.go
+++ b/knative-operator/pkg/monitoring/monitoring_kafka.go
@@ -28,7 +28,7 @@ func AdditionalResourcesForNamespacedBroker() (string, error) {
 	// - Create a `ServiceMonitor` that makes Prometheus scrape our dataplane pods.
 	//   It also sets up certificates for the RBAC proxy mentioned above.
 	//
-	// - Create a `ClusterRoleBinding` of the `rbac-proxy-reviews-prom` `ClusterRole` for the
+	// - Create a `RoleBinding` of the `rbac-proxy-reviews-prom` `ClusterRole` for the
 	//  `knative-kafka-broker-data-plane` `ServiceAccount` in the broker namespace. Otherwise, RBAC proxy cannot
 	//   authorize itself.
 	//
@@ -43,7 +43,7 @@ func AdditionalResourcesForNamespacedBroker() (string, error) {
 		serviceMonitor("dispatcher"),
 		service("receiver"),
 		service("dispatcher"),
-		clusterRoleBinding(),
+		roleBinding(),
 		namespace(),
 	)
 	if err != nil {
@@ -80,14 +80,15 @@ func namespace() *corev1.Namespace {
 	}
 }
 
-func clusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
+func roleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
-			Kind:       "ClusterRoleBinding",
+			Kind:       "RoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "rbac-proxy-reviews-prom-rb-knative-kafka-broker-data-plane-{{.Namespace}}",
+			Name:      "rbac-proxy-reviews-prom-rb-knative-kafka-broker-data-plane",
+			Namespace: "{{.Namespace}}",
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",

--- a/knative-operator/pkg/monitoring/monitoring_kafka_test.go
+++ b/knative-operator/pkg/monitoring/monitoring_kafka_test.go
@@ -103,10 +103,11 @@ func ExampleAdditionalResourcesForNamespacedBroker() {
 	//   status:
 	//     loadBalancer: {}
 	// - apiVersion: rbac.authorization.k8s.io/v1
-	//   kind: ClusterRoleBinding
+	//   kind: RoleBinding
 	//   metadata:
 	//     creationTimestamp: null
-	//     name: rbac-proxy-reviews-prom-rb-knative-kafka-broker-data-plane-{{.Namespace}}
+	//     name: rbac-proxy-reviews-prom-rb-knative-kafka-broker-data-plane
+	//     namespace: '{{.Namespace}}'
 	//   roleRef:
 	//     apiGroup: rbac.authorization.k8s.io
 	//     kind: ClusterRole

--- a/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	kafka "knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	kafkatestpkg "knative.dev/eventing-kafka-broker/test/pkg"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -88,7 +89,10 @@ func createBrokerFunc(t *testing.T, brokerClass string) func(client *test.Contex
 			ctx, cancel := context.WithTimeout(ctx, 4*time.Minute)
 			defer cancel()
 
-			err := client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Delete(context.Background(), nativeKafkaBrokerName, metav1.DeleteOptions{})
+			pp := metav1.DeletePropagationForeground
+			err := client.Clients.Eventing.EventingV1().Brokers(test.Namespace).Delete(context.Background(), nativeKafkaBrokerName, metav1.DeleteOptions{
+				PropagationPolicy: &pp,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Fixes JIRA SRVKE-1388

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
