### PR TITLE
Increase receiver teardown to 10 seconds

### DIFF
--- a/test/upgrade/continual/channel-config.toml
+++ b/test/upgrade/continual/channel-config.toml
@@ -7,3 +7,7 @@ interval = {{ .Config.Interval.Nanoseconds }}
 
 [forwarder]
 target = '{{- .ForwarderTarget -}}'
+
+[receiver]
+[receiver.teardown]
+duration = 10000000000

--- a/test/upgrade/continual/kafka-broker-config.toml
+++ b/test/upgrade/continual/kafka-broker-config.toml
@@ -7,3 +7,7 @@ interval = {{ .Config.Interval.Nanoseconds }}
 
 [forwarder]
 target = '{{- .ForwarderTarget -}}'
+
+[receiver]
+[receiver.teardown]
+duration = 10000000000

--- a/test/upgrade/continual/kafka-sink-source-config.toml
+++ b/test/upgrade/continual/kafka-sink-source-config.toml
@@ -7,3 +7,7 @@ interval = {{ .Config.Interval.Nanoseconds }}
 
 [forwarder]
 target = '{{- .ForwarderTarget -}}'
+
+[receiver]
+[receiver.teardown]
+duration = 10000000000


### PR DESCRIPTION
It's the time between receiving "Finished" event (which holds the number of sent events) and the moment when the number of actually received events is compared with the number from Finished event. The receiver needs to wait longer to receive all the events from different Kafka partisions.

This is what we already have in [eventing-kafka-broker config](https://github.com/openshift-knative/eventing-kafka-broker/blob/release-v1.6/test/upgrade/continual/channel-config.toml#L10).

I see in downstream testing that events from the test end are often marked as not delivered but the Trace for the events is complete. This setting should fix that.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
