### PR TITLE
Using 0.33 of Strimzi

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -11,7 +11,7 @@ fi
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/../../vendor/knative.dev/hack/e2e-tests.sh"
 
-export STRIMZI_VERSION=0.32.0
+export STRIMZI_VERSION=0.33.0
 
 # Adjust these when upgrading the knative versions.
 export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v$(metadata.get dependencies.serving)}"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- as per title

0.33 release notes: https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.33.0
Highlights:
* Use Java 17 as the runtime for all containers...
* Improved FIPS (Federal Information Processing Standards) support
