### PR TITLE
[release-1.27] Update openshift-knative/eventing dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	k8s.io/api v0.25.2
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
-	knative.dev/eventing v0.35.2
+	knative.dev/eventing v0.36.0
 	knative.dev/eventing-kafka v0.35.1
 	knative.dev/eventing-kafka-broker v0.35.5
 	knative.dev/hack v0.0.0-20221010154335-3fdc50b9c24a
@@ -171,9 +171,9 @@ require (
 
 replace (
 	// Knative forks.
-	knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20221208103831-67c3ebda00db
+	knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20230130094656-e11701ad855c
 	knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221109100552-26eea5293bca
-	knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd
+	knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230127115120-3f520bb27b43
 	knative.dev/serving => github.com/openshift-knative/serving v0.10.1-0.20221116115404-cef28ae09f49
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1442,12 +1442,12 @@ github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqi
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/openshift-knative/eventing v0.99.1-0.20221208103831-67c3ebda00db h1:uNru4e60MZPwb5rQ0jIm2lgET24uMhDpn5lJWbh3aTg=
-github.com/openshift-knative/eventing v0.99.1-0.20221208103831-67c3ebda00db/go.mod h1:rxI/ijzHbAYenRZpGapYlJHwGEfdUcWjJh4N1bP9+zQ=
+github.com/openshift-knative/eventing v0.99.1-0.20230130094656-e11701ad855c h1:kcwHj8F0GO2QZbqv9qJKRoOIO550frCVIw07tCCWgJ8=
+github.com/openshift-knative/eventing v0.99.1-0.20230130094656-e11701ad855c/go.mod h1:rxI/ijzHbAYenRZpGapYlJHwGEfdUcWjJh4N1bP9+zQ=
 github.com/openshift-knative/eventing-kafka v0.19.1-0.20221109100552-26eea5293bca h1:yXBHJxnGSpuE2EmpmEhEOwQFw5cJmgbW/o0zIfZMKb4=
 github.com/openshift-knative/eventing-kafka v0.19.1-0.20221109100552-26eea5293bca/go.mod h1:RZ/b/xO0sEPL0it4Xm0kSbrhATdsND1WVQq5AcHi7ro=
-github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd h1:HR6u4bFngzrZt6dTHqVo5gelfI+oCJTG7Tv/pKQPJPg=
-github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd/go.mod h1:Kod8wexuKfcKm6le7W7ZgSUnvL4AvQuls8c/TWksOXE=
+github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230127115120-3f520bb27b43 h1:YIcIX/lRlNn3HjjzlJ0vOrxGaorq4RJcMBq4pL/wid4=
+github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230127115120-3f520bb27b43/go.mod h1:Kod8wexuKfcKm6le7W7ZgSUnvL4AvQuls8c/TWksOXE=
 github.com/openshift-knative/serving v0.10.1-0.20221116115404-cef28ae09f49 h1:g+6FsQ/Yhvg4XL2LZzi8xQ2mHZY5E3xiCc3BP0IrxJg=
 github.com/openshift-knative/serving v0.10.1-0.20221116115404-cef28ae09f49/go.mod h1:6tBCyhVH14YTDfHQMMeF1gP0oLp3tkjHU2cBeZ6oZP4=
 github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=

--- a/vendor/knative.dev/eventing/pkg/reconciler/testing/deployment.go
+++ b/vendor/knative.dev/eventing/pkg/reconciler/testing/deployment.go
@@ -96,3 +96,12 @@ func WithDeploymentAvailable() DeploymentOption {
 		}
 	}
 }
+
+func WithContainerEnv(name, value string) DeploymentOption {
+	return func(deployment *appsv1.Deployment) {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1266,7 +1266,7 @@ k8s.io/utils/trace
 ## explicit; go 1.15
 knative.dev/caching/pkg/apis/caching
 knative.dev/caching/pkg/apis/caching/v1alpha1
-# knative.dev/eventing v0.35.2 => github.com/openshift-knative/eventing v0.99.1-0.20221208103831-67c3ebda00db
+# knative.dev/eventing v0.36.0 => github.com/openshift-knative/eventing v0.99.1-0.20230130094656-e11701ad855c
 ## explicit; go 1.17
 knative.dev/eventing/pkg/apis/config
 knative.dev/eventing/pkg/apis/duck
@@ -1401,7 +1401,7 @@ knative.dev/eventing-kafka/test/rekt/resources/kafkachannel
 knative.dev/eventing-kafka/test/upgrade
 knative.dev/eventing-kafka/test/upgrade/continual
 knative.dev/eventing-kafka/test/upgrade/installation
-# knative.dev/eventing-kafka-broker v0.35.5 => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd
+# knative.dev/eventing-kafka-broker v0.35.5 => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230127115120-3f520bb27b43
 ## explicit; go 1.18
 knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing
 knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1
@@ -1661,9 +1661,9 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20221208103831-67c3ebda00db
+# knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20230130094656-e11701ad855c
 # knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221109100552-26eea5293bca
-# knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd
+# knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230127115120-3f520bb27b43
 # knative.dev/serving => github.com/openshift-knative/serving v0.10.1-0.20221116115404-cef28ae09f49
 # github.com/antlr/antlr4/runtime/Go/antlr => github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20211221011931-643d94fcab96
 # github.com/go-logr/logr => github.com/go-logr/logr v0.4.0


### PR DESCRIPTION
The point is to pull the changes in vendor/knative.dev/eventing/pkg/utils/secret.go so that we can properly test disconnected environment. We copy a global pull secret to the service account before the test to work around [SRVKS-833 ](https://issues.redhat.com/browse/SRVKS-833 ) and we need to prevent overwriting the secret.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
