### PR TITLE
[SRVKS-944] improve secret informer filtering

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -71,10 +71,10 @@ func (e *extension) Transformers(ks base.KComponent) []mf.Transformer {
 		overrideKourierNamespace(ks),
 		addKourierEnvValues(ks),
 		addKourierAppProtocol(ks),
-		enableSecretInformerFiltering(ks),
 		common.VersionedJobNameTransform(),
 		common.InjectCommonEnvironment(),
 	}
+	tf = append(tf, enableSecretInformerFilteringTransformers(ks)...)
 	tf = append(tf, monitoring.GetServingTransformers(ks)...)
 	return append(tf, common.DeprecatedAPIsTranformers(e.kubeclient.Discovery())...)
 }

--- a/openshift-knative-operator/pkg/serving/secretinformerfiltering.go
+++ b/openshift-knative-operator/pkg/serving/secretinformerfiltering.go
@@ -84,18 +84,5 @@ func configIfUnsetAndCheckIfShouldInject(comp *operatorv1beta1.KnativeServing, d
 				corev1.EnvVar{Name: EnableSecretInformerFilteringByCertUIDEnv, Value: v})
 		}
 	}
-
-	// If nothing is set enable by default via overriding the env variable for the deployment
-	comp.Spec.DeploymentOverride = append(comp.Spec.DeploymentOverride, base.WorkloadOverride{
-		Name: deployment,
-		Env: []base.EnvRequirementsOverride{
-			{
-				Container: container,
-				EnvVars: []corev1.EnvVar{{
-					Name:  EnableSecretInformerFilteringByCertUIDEnv,
-					Value: "true",
-				}},
-			}},
-	})
-	return true, nil
+	return false, nil
 }

--- a/openshift-knative-operator/pkg/serving/secretinformerfiltering.go
+++ b/openshift-knative-operator/pkg/serving/secretinformerfiltering.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	mf "github.com/manifestival/manifestival"
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"knative.dev/networking/pkg/apis/networking"
@@ -12,21 +13,28 @@ import (
 )
 
 const (
-	// TODO: remove when available in knative.dev/networking/config
+	// TODO: Remove when available in knative.dev/networking/config
 	ServingInternalCertName = "knative-serving-certs"
 	// TODO: Maybe decide to fetch from net-kourier deps instead
 	EnableSecretInformerFilteringByCertUIDEnv = "ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID"
+	// TODO: Annotation is deprecated, remove in future releases
+	secretInformerFilteringAnnotation = "serverless.openshift.io/enable-secret-informer-filtering"
 )
 
-func enableSecretInformerFiltering(ks base.KComponent) mf.Transformer {
+func enableSecretInformerFilteringTransformers(ks base.KComponent) []mf.Transformer {
 	shouldInject := false
-	for _, dep := range []string{"net-istio-controller", "net-kourier-controller"} {
-		if configIfUnsetAndCheckIfShouldInject(ks, dep, "controller") {
-			shouldInject = true
-		}
+	var tf mf.Transformer
+	comp := ks.(*operatorv1beta1.KnativeServing)
+
+	// This works because the Knative operator runs extension reconcile before the manifest transformation
+	if comp.Spec.Ingress.Istio.Enabled {
+		shouldInject, tf = configIfUnsetAndCheckIfShouldInject(comp, "net-istio-controller", "controller")
+	}
+	if comp.Spec.Ingress.Kourier.Enabled {
+		shouldInject, _ = configIfUnsetAndCheckIfShouldInject(comp, "net-kourier-controller", "controller")
 	}
 	if shouldInject {
-		return injectLabelIntoInternalEncryptionSecret()
+		return []mf.Transformer{injectLabelIntoInternalEncryptionSecret(), tf}
 	}
 	return nil
 }
@@ -47,9 +55,8 @@ func injectLabelIntoInternalEncryptionSecret() mf.Transformer {
 }
 
 // Adds default (true) to env vars for secret informer filtering in net-* deployments and returns if we should inject
-// metadata to other resources eg. label to secrets
-func configIfUnsetAndCheckIfShouldInject(ks base.KComponent, deployment string, container string) bool {
-	comp := ks.(*operatorv1beta1.KnativeServing)
+// metadata to other resources eg. label to secrets, keeps the deprecated Istio annotation
+func configIfUnsetAndCheckIfShouldInject(comp *operatorv1beta1.KnativeServing, deployment string, container string) (bool, mf.Transformer) {
 	for _, o := range comp.Spec.GetWorkloadOverrides() {
 		if o.Name == deployment {
 			for _, env := range o.Env {
@@ -57,15 +64,28 @@ func configIfUnsetAndCheckIfShouldInject(ks base.KComponent, deployment string, 
 					for _, envVar := range env.EnvVars {
 						if envVar.Name == EnableSecretInformerFilteringByCertUIDEnv {
 							if b, err := strconv.ParseBool(envVar.Value); err == nil {
-								return b
+								return b, nil
 							}
-							return false
+							return false, nil
 						}
 					}
 				}
 			}
 		}
 	}
+
+	// The annotation is deprecated
+	// TODO: Remove this block in future releases
+	if deployment == "net-istio-controller" {
+		if v, ok := comp.GetAnnotations()[secretInformerFilteringAnnotation]; ok {
+			b, _ := strconv.ParseBool(v)
+			// Keep the same behavior as in 1.27
+			return b, common.InjectEnvironmentIntoDeployment("net-istio-controller", "controller",
+				corev1.EnvVar{Name: EnableSecretInformerFilteringByCertUIDEnv, Value: v})
+		}
+	}
+
+	// If nothing is set enable by default via overriding the env variable for the deployment
 	comp.Spec.DeploymentOverride = append(comp.Spec.DeploymentOverride, base.WorkloadOverride{
 		Name: deployment,
 		Env: []base.EnvRequirementsOverride{
@@ -77,5 +97,5 @@ func configIfUnsetAndCheckIfShouldInject(ks base.KComponent, deployment string, 
 				}},
 			}},
 	})
-	return true
+	return true, nil
 }

--- a/openshift-knative-operator/pkg/serving/secretinformerfilterting_test.go
+++ b/openshift-knative-operator/pkg/serving/secretinformerfilterting_test.go
@@ -16,7 +16,7 @@ func TestSecretInformerFitleringOverride(t *testing.T) {
 		expected               *operatorv1beta1.KnativeServing
 		shouldAddLabelToSecret bool
 	}{{
-		name: "default overrides, enabled secret filtering, with kourier enabled",
+		name: "by default no overrides, disabled secret filtering, with kourier enabled",
 		in: ks(func(ks *operatorv1beta1.KnativeServing) {
 			ks.Spec.Ingress = &operatorv1beta1.IngressConfigs{Kourier: base.KourierIngressConfiguration{
 				Enabled: true,
@@ -26,21 +26,10 @@ func TestSecretInformerFitleringOverride(t *testing.T) {
 			ks.Spec.Ingress = &operatorv1beta1.IngressConfigs{Kourier: base.KourierIngressConfiguration{
 				Enabled: true,
 			}}
-			ks.Spec.DeploymentOverride = append(ks.Spec.DeploymentOverride, base.WorkloadOverride{
-				Name: "net-kourier-controller",
-				Env: []base.EnvRequirementsOverride{
-					{
-						Container: "controller",
-						EnvVars: []corev1.EnvVar{{
-							Name:  EnableSecretInformerFilteringByCertUIDEnv,
-							Value: "true",
-						}},
-					}},
-			})
 		}),
-		shouldAddLabelToSecret: true,
+		shouldAddLabelToSecret: false,
 	}, {
-		name: "default overrides, enabled secret filtering, with istio enabled",
+		name: "by default no overrides, disabled secret filtering, with istio enabled",
 		in: ks(func(ks *operatorv1beta1.KnativeServing) {
 			ks.Spec.Ingress = &operatorv1beta1.IngressConfigs{Istio: base.IstioIngressConfiguration{
 				Enabled: true,
@@ -50,21 +39,10 @@ func TestSecretInformerFitleringOverride(t *testing.T) {
 			ks.Spec.Ingress = &operatorv1beta1.IngressConfigs{Istio: base.IstioIngressConfiguration{
 				Enabled: true,
 			}}
-			ks.Spec.DeploymentOverride = append(ks.Spec.DeploymentOverride, base.WorkloadOverride{
-				Name: "net-istio-controller",
-				Env: []base.EnvRequirementsOverride{
-					{
-						Container: "controller",
-						EnvVars: []corev1.EnvVar{{
-							Name:  EnableSecretInformerFilteringByCertUIDEnv,
-							Value: "true",
-						}},
-					}},
-			})
 		}),
-		shouldAddLabelToSecret: true,
+		shouldAddLabelToSecret: false,
 	}, {
-		name: "no default overrides, deprecated annotation set to true, enabled secret filtering, istio enabled",
+		name: "by default no overrides, deprecated annotation set to true, enabled secret filtering, istio enabled",
 		in: ks(func(ks *operatorv1beta1.KnativeServing) {
 			ks.Spec.Ingress = &operatorv1beta1.IngressConfigs{Istio: base.IstioIngressConfiguration{
 				Enabled: true,
@@ -80,34 +58,23 @@ func TestSecretInformerFitleringOverride(t *testing.T) {
 		}),
 		shouldAddLabelToSecret: true,
 	}, {
-		name: "no default overrides, istio deprecated annotation set to false but has no effect, enabled secret filtering, kourier enabled",
+		name: "by default no overrides, istio deprecated annotation set to true but has no effect, disabled secret filtering, kourier enabled",
 		in: ks(func(ks *operatorv1beta1.KnativeServing) {
 			ks.Spec.Ingress = &operatorv1beta1.IngressConfigs{Kourier: base.KourierIngressConfiguration{
 				Enabled: true,
 			}}
 			ks.Annotations = map[string]string{}
-			ks.Annotations = map[string]string{secretInformerFilteringAnnotation: "false"}
+			ks.Annotations = map[string]string{secretInformerFilteringAnnotation: "true"}
 		}),
 		expected: ks(func(ks *operatorv1beta1.KnativeServing) {
 			ks.Spec.Ingress = &operatorv1beta1.IngressConfigs{Kourier: base.KourierIngressConfiguration{
 				Enabled: true,
 			}}
-			ks.Annotations = map[string]string{secretInformerFilteringAnnotation: "false"}
-			ks.Spec.DeploymentOverride = append(ks.Spec.DeploymentOverride, base.WorkloadOverride{
-				Name: "net-kourier-controller",
-				Env: []base.EnvRequirementsOverride{
-					{
-						Container: "controller",
-						EnvVars: []corev1.EnvVar{{
-							Name:  EnableSecretInformerFilteringByCertUIDEnv,
-							Value: "true",
-						}},
-					}},
-			})
+			ks.Annotations = map[string]string{secretInformerFilteringAnnotation: "true"}
 		}),
 		shouldAddLabelToSecret: false,
 	}, {
-		name: "no default overrides, deprecated annotation set to false, disabled secret filtering, istio enabled",
+		name: "by default no overrides, istio deprecated annotation set to false, disabled secret filtering, istio enabled",
 		in: ks(func(ks *operatorv1beta1.KnativeServing) {
 			ks.Spec.Ingress = &operatorv1beta1.IngressConfigs{Istio: base.IstioIngressConfiguration{
 				Enabled: true,
@@ -122,7 +89,7 @@ func TestSecretInformerFitleringOverride(t *testing.T) {
 		}),
 		shouldAddLabelToSecret: false,
 	}, {
-		name: "no default overrides, deprecated annotation value with bad string, disabled secret filtering, istio enabled",
+		name: "by default no overrides, istio deprecated annotation value with bad string, disabled secret filtering, istio enabled",
 		in: ks(func(ks *operatorv1beta1.KnativeServing) {
 			ks.Spec.Ingress = &operatorv1beta1.IngressConfigs{Istio: base.IstioIngressConfiguration{
 				Enabled: true,


### PR DESCRIPTION
- Brings back the deprecated Istio annotation that we preserved in [1.27](https://github.com/openshift/openshift-docs/pull/54913#discussion_r1090375002). When the annotation is applied it has the same behavior as in 1.27. It will stay around for a release at least so users can be prepared.
- By default we set the filtering off. It will be enabled by default in 1.29.
- If user uses the new way of setting the env vars the annotation is ignored for Istio.
- The deprecated annotation is not introduced for Kourier since it is going to be removed.
- Added a number of test cases covering all required scenarios.
- Any configuration applied is based on the ingress enabled.