### PR TITLE
Increase parallel to 16 and run autoscale tests separately

### DIFF
--- a/test/serving.bash
+++ b/test/serving.bash
@@ -96,7 +96,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     parallel=2
   fi
 
-  mv ./e2e/autoscale_test.go ./e2e/autoscale_test.backup
+  mv ./test/e2e/autoscale_test.go ./test/e2e/autoscale_test.backup
 
   SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e" -timeout=30m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
@@ -106,7 +106,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     ${OPENSHIFT_TEST_OPTIONS} \
     --imagetemplate "$image_template"
 
-  mv ./e2e/autoscale_test.backup ./e2e/autoscale_test.go
+  mv ./test/e2e/autoscale_test.backup ./test/e2e/autoscale_test.go
   # Run autoscale tests separately as they require more CPU resources
   SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e" -timeout=10m -parallel=1 \
     ./test/e2e \

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -88,7 +88,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     sed -ie '47,51d' ./test/conformance/runtime/protocol_test.go
   fi
 
-  local parallel=3
+  local parallel=16
 
   if [[ $(oc get infrastructure cluster -ojsonpath='{.status.platform}') = VSphere ]]; then
     # Since we don't have LoadBalancers working, gRPC tests will always fail.
@@ -96,11 +96,21 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     parallel=2
   fi
 
+  mv ./e2e/autoscale_test.go ./e2e/autoscale_test.backup
+
   SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e" -timeout=30m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     ./test/e2e/domainmapping \
     ./test/e2e/initcontainers \
     ./test/e2e/pvc \
+    ${OPENSHIFT_TEST_OPTIONS} \
+    --imagetemplate "$image_template"
+
+  mv ./e2e/autoscale_test.backup ./e2e/autoscale_test.go
+  # Run autoscale tests separately as they require more CPU resources
+  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e" -timeout=10m -parallel=1 \
+    ./test/e2e \
+    -run "TestAutoscale|TestRPSBased|TestTargetBurstCapacity|TestFastScaleToZero" \
     ${OPENSHIFT_TEST_OPTIONS} \
     --imagetemplate "$image_template"
 

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -108,7 +108,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
 
   mv ./test/e2e/autoscale_test.backup ./test/e2e/autoscale_test.go
   # Run autoscale tests separately as they require more CPU resources
-  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e" -timeout=10m -parallel=1 \
+  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags="e2e" -timeout=20m -parallel=3 \
     ./test/e2e \
     -run "TestAutoscale|TestRPSBased|TestTargetBurstCapacity|TestFastScaleToZero" \
     ${OPENSHIFT_TEST_OPTIONS} \


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/SRVKS-1021

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Increase parallel settings for E2E tests to 16
- Run autoscale tests separately with parallel==3

The autoscale test is affected by CPU resources of the client node. Increasing `parallel` to a high value might affect the test (cos other parallel tests utilize the client CPU as well) and it won't be able to generate enough load. Thus we run it separately with lower parallelism.
