### PR TITLE
Change upgrade.sequence to uprade_sequence

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -16,8 +16,8 @@ function ensure_serverless_installed {
 
   local csv
   if [[ "${INSTALL_OLDEST_COMPATIBLE}" == "true" ]]; then
-    csv="$(metadata.get "upgrades.sequence[0].csv")"
-    OLM_SOURCE="$(metadata.get "upgrades.sequence[0].source")"
+    csv="$(metadata.get "upgrade_sequence[0].csv")"
+    OLM_SOURCE="$(metadata.get "upgrade_sequence[0].source")"
   elif [[ "${INSTALL_PREVIOUS_VERSION}" == "true" ]]; then
     csv="$PREVIOUS_CSV"
   else
@@ -151,7 +151,7 @@ function deploy_knativeserving_cr {
   rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
   serving_cr="$(mktemp -t serving-XXXXX.yaml)"
   if [[ "${INSTALL_OLDEST_COMPATIBLE}" == "true" ]]; then
-    cp "${rootdir}/$(metadata.get "upgrades.sequence[0].serving_cr")" "$serving_cr"
+    cp "${rootdir}/$(metadata.get "upgrade_sequence[0].serving_cr")" "$serving_cr"
   else
     cp "${rootdir}/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml" "$serving_cr"
   fi
@@ -223,7 +223,7 @@ function deploy_knativeeventing_cr {
   rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
   eventing_cr="$(mktemp -t eventing-XXXXX.yaml)"
   if [[ "${INSTALL_OLDEST_COMPATIBLE}" == "true" ]]; then
-    cp "${rootdir}/$(metadata.get "upgrades.sequence[0].eventing_cr")" "$eventing_cr"
+    cp "${rootdir}/$(metadata.get "upgrade_sequence[0].eventing_cr")" "$eventing_cr"
   else
     cp "${rootdir}/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeeventing_cr.yaml" "$eventing_cr"
   fi

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -54,15 +54,14 @@ dependencies:
     eventing: 1.6
     eventing_kafka: 1.1.0
     eventing_kafka_broker: 1.6
-upgrades:
-  sequence:
-    - csv: serverless-operator.v1.25.0
-      source: redhat-operators
-      serving_cr: test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
-      eventing_cr: test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeeventing_cr.yaml
-    - csv: serverless-operator.v1.26.0
-      source: redhat-operators
-    - csv: serverless-operator.v1.27.0
-      source: redhat-operators
-    - csv: serverless-operator.v1.28.0
-      source: serverless-operator
+upgrade_sequence:
+  - csv: serverless-operator.v1.25.0
+    source: redhat-operators
+    serving_cr: test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeserving_cr.yaml
+    eventing_cr: test/v1alpha1/resources/operator.knative.dev_v1alpha1_knativeeventing_cr.yaml
+  - csv: serverless-operator.v1.26.0
+    source: redhat-operators
+  - csv: serverless-operator.v1.27.0
+    source: redhat-operators
+  - csv: serverless-operator.v1.28.0
+    source: serverless-operator

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -312,8 +312,8 @@ function kitchensink_upgrade_tests {
   go_test_e2e -run=TestKitchensink -timeout=90m -parallel=20 ./test/upgrade/kitchensink -tags=upgrade \
      --kubeconfigs="${KUBECONFIG}" \
      --imagetemplate="${IMAGE_TEMPLATE}" \
-     --catalogsource="$(metadata.get "upgrades.sequence[*].source" | tail -n +2 | tr '\n' ',')" \
-     --csv="$(metadata.get "upgrades.sequence[*].csv" | tail -n +2 | tr '\n' ',')" \
+     --catalogsource="$(metadata.get "upgrade_sequence[*].source" | tail -n +2 | tr '\n' ',')" \
+     --csv="$(metadata.get "upgrade_sequence[*].csv" | tail -n +2 | tr '\n' ',')" \
      --upgradechannel="${OLM_UPGRADE_CHANNEL}"
 
   logger.success 'Kitchensink upgrade tests passed'


### PR DESCRIPTION
This is to prevent errors when merging with downstream metadata. The name "upgrades" is already used and has the type "map".

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
