### PR TITLE
Prometheus to have permissions for endpoinds in user namespace

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/broker/eventing-kafka-broker-extra.yaml
+++ b/knative-operator/deploy/resources/knativekafka/broker/eventing-kafka-broker-extra.yaml
@@ -22,6 +22,7 @@ rules:
       - "rbac.authorization.k8s.io"
     resources:
       - clusterrolebindings
+      - rolebindings
     verbs:
       - get
       - list
@@ -38,6 +39,14 @@ rules:
       - list
       - watch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
 
 ---
 
@@ -53,3 +62,23 @@ subjects:
   - kind: ServiceAccount
     name: kafka-controller
     namespace: knative-eventing
+
+---
+# ClusterRole that will be bound to service account `openshift-monitoring/prometheus-k8s` for user namespace.
+# With that, Prometheus will be able to scrape metrics from the Kafka broker pods in user namespace.
+# ClusterRole is created when KnativeKafka is installed; RoleBinding will be created per-namespace on the fly.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eventing-kafka-knative-prometheus-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/knative-operator/deploy/resources/knativekafka_extra/broker/eventing-kafka-broker-extra.yaml
+++ b/knative-operator/deploy/resources/knativekafka_extra/broker/eventing-kafka-broker-extra.yaml
@@ -22,6 +22,7 @@ rules:
       - "rbac.authorization.k8s.io"
     resources:
       - clusterrolebindings
+      - rolebindings
     verbs:
       - get
       - list
@@ -38,6 +39,14 @@ rules:
       - list
       - watch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
 
 ---
 
@@ -53,3 +62,23 @@ subjects:
   - kind: ServiceAccount
     name: kafka-controller
     namespace: knative-eventing
+
+---
+# ClusterRole that will be bound to service account `openshift-monitoring/prometheus-k8s` for user namespace.
+# With that, Prometheus will be able to scrape metrics from the Kafka broker pods in user namespace.
+# ClusterRole is created when KnativeKafka is installed; RoleBinding will be created per-namespace on the fly.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eventing-kafka-knative-prometheus-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/knative-operator/pkg/monitoring/monitoring_kafka_test.go
+++ b/knative-operator/pkg/monitoring/monitoring_kafka_test.go
@@ -115,6 +115,20 @@ func ExampleAdditionalResourcesForNamespacedBroker() {
 	//   - kind: ServiceAccount
 	//     name: knative-kafka-broker-data-plane
 	//     namespace: '{{.Namespace}}'
+	// - apiVersion: rbac.authorization.k8s.io/v1
+	//   kind: RoleBinding
+	//   metadata:
+	//     creationTimestamp: null
+	//     name: eventing-kafka-knative-prometheus-k8s
+	//     namespace: '{{.Namespace}}'
+	//   roleRef:
+	//     apiGroup: rbac.authorization.k8s.io
+	//     kind: ClusterRole
+	//     name: eventing-kafka-knative-prometheus-k8s
+	//   subjects:
+	//   - kind: ServiceAccount
+	//     name: prometheus-k8s
+	//     namespace: openshift-monitoring
 	// - apiVersion: v1
 	//   kind: Namespace
 	//   metadata:

--- a/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
+++ b/test/extensione2e/kafka/source_native_kafka_broker_ksvc_test.go
@@ -42,7 +42,6 @@ func TestSourceToNativeKafkaBrokerToKnativeService(t *testing.T) {
 func TestSourceToNamespacedKafkaBrokerToKnativeService(t *testing.T) {
 	eventinge2e.KnativeSourceBrokerTriggerKnativeService(t, createBrokerFunc(t, kafka.NamespacedBrokerClass), func(ctx *test.Context) {
 		t.Run("verify namespaced Kafka Broker data plane metrics work correctly", func(t *testing.T) {
-			t.Skip("SRVKE-1408")
 			if err := monitoringe2e.VerifyMetrics(ctx, monitoringe2e.NamespacedKafkaBrokerDataPlaneQueries(test.Namespace)); err != nil {
 				t.Fatal("Failed to verify that namespaced Kafka Broker data plane metrics work correctly", err)
 			}


### PR DESCRIPTION
Fixes JIRA https://issues.redhat.com/browse/SRVKE-1408

- Works with https://github.com/knative-sandbox/eventing-kafka-broker/pull/2979

Basically:
- We create a new ClusterRole that gives `get`, `list` and `watch` permissions on some resources that Prometheus needs
- We create a new RoleBinding to that ClusterRole for the user namespace but for the `prometheus-k8s` SA in `openshift-monitoring` namespace
- The ClusterRole is created when KnativeKafka is installed. It is in the manifest.
- The RoleBinding is created using the "additional resources" mechanism in EKB namespaced broker.

These are all according to the fix described in JIRA. However, instead of a Role, I use a ClusterRole for reuse purposes. Then we create RoleBinding in the user namespace for that ClusterRole.

There's one caveat...
In EKB controller, we use Manifestival to create resources that are in "additional resources". When we have the RoleBinding like this in the Manifest:

```
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: knative-prometheus-k8s
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: knative-prometheus-k8s
subjects:
- kind: ServiceAccount
  name: prometheus-k8s
  namespace: openshift-monitoring           # --> changed
```

will become:

```
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: knative-prometheus-k8s
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: knative-prometheus-k8s
subjects:
- kind: ServiceAccount
  name: prometheus-k8s
  namespace: <user-namespace>        # --> changed
```

This is done here https://github.com/manifestival/manifestival/blob/82196bd303e23c641fda3d002c0663b892092e9c/transform.go#L66-L73 

So, that's why we need https://github.com/knative-sandbox/eventing-kafka-broker/pull/2979