### PR TITLE
fix kitchensink feature iterations in parallel tests

### DIFF
--- a/test/kitchensinke2e/broker_test.go
+++ b/test/kitchensinke2e/broker_test.go
@@ -14,6 +14,7 @@ func TestBrokerReadiness(t *testing.T) {
 	}
 	for _, fs := range featureSets {
 		for _, f := range fs.Features {
+			f := f
 			t.Run(fs.Name, func(t *testing.T) {
 				t.Parallel()
 				ctx, env := defaultContext(t)

--- a/test/kitchensinke2e/channel_test.go
+++ b/test/kitchensinke2e/channel_test.go
@@ -9,6 +9,7 @@ import (
 func TestChannelReadiness(t *testing.T) {
 	featureSet := features.ChannelFeatureSet(false)
 	for _, f := range featureSet.Features {
+		f := f
 		t.Run(featureSet.Name, func(t *testing.T) {
 			t.Parallel()
 			ctx, env := defaultContext(t)

--- a/test/kitchensinke2e/flow_test.go
+++ b/test/kitchensinke2e/flow_test.go
@@ -16,6 +16,7 @@ func TestFlowReadiness(t *testing.T) {
 	}
 	for _, fs := range featureSets {
 		for _, f := range fs.Features {
+			f := f
 			t.Run(fs.Name, func(t *testing.T) {
 				t.Parallel()
 				ctx, env := defaultContext(t)


### PR DESCRIPTION
- :broom: Fix feature iteration in kitchensink e2e parallel tets