### PR TITLE
Scale cluster to 4 when running install-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install-operator:
 install-all:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	./hack/tracing.sh
-	INSTALL_KAFKA="true" ENABLE_TRACING=true ./hack/install.sh
+	SCALE_UP=4 INSTALL_KAFKA="true" ENABLE_TRACING=true ./hack/install.sh
 
 install-tracing:
 	./hack/tracing.sh


### PR DESCRIPTION
This is the same change as was done for the target test-e2e-with-kafka. It should be possible to run "make install-all" followed by "make test-e2e-with-kafka-testonly" to separate installation and testing. These could be run as separate Prow checks.

This change will be used in INTEROP testing which is being implemented in https://github.com/openshift/release/pull/36697

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
