### PR TITLE
[release-1.27] Update previous versions to 1.6 for downgrades

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -54,7 +54,7 @@ dependencies:
   operator: 1.5.2
   # Previous versions required for downgrade testing
   previous:
-    serving: 1.5.0
-    eventing: 1.5
+    serving: 1.6.0
+    eventing: knative-v1.6
     eventing_kafka: 1.1.0
-    eventing_kafka_broker: 1.5
+    eventing_kafka_broker: knative-v1.6


### PR DESCRIPTION
The downgrade tests on the [previous PR](https://github.com/openshift-knative/serverless-operator/pull/1973) rightfully [failed](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/1973/pull-ci-openshift-knative-serverless-operator-release-1.27-4.11-upgrade-tests-aws-ocp-411/1632988845219778560).

The previous versions of Serving/Eventing must be same as current versions because we don't bump them in the patch release.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
