### PR TITLE
[RELEASE-1.28] Run pod sec default tests only for 4.11+

### DIFF
--- a/hack/lib/common.bash
+++ b/hack/lib/common.bash
@@ -44,6 +44,15 @@ function versions.le {
   [ "${v1}" = "${cmp}" ]
 }
 
+function versions.ge {
+  local v1 v2 cmp
+  v1="${1:?Pass a version to check as arg[1]}"
+  v2="${2:?Pass a version to check against as arg[2]}"
+  cmp="$(echo -e "${v1}\n${v2}" | sort -V | tail -n 1)"
+
+  [ "${v1}" = "${cmp}" ]
+}
+
 function versions.lt {
   local v1 v2
   v1="${1:?Pass a version to check as arg[1]}"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -822,7 +822,7 @@ spec:
                 containers:
                   - name: knative-operator
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/knative/openshift-serverless-nightly:openshift-knative-operator
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.28.0:openshift-knative-operator
                     readinessProbe:
                       periodSeconds: 1
                       httpGet:
@@ -974,7 +974,7 @@ spec:
                 containers:
                   - name: knative-openshift
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-operator
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.28.0:knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -1143,7 +1143,7 @@ spec:
                 containers:
                   - name: knative-openshift-ingress
                     # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-                    image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-openshift-ingress
+                    image: registry.ci.openshift.org/knative/openshift-serverless-v1.28.0:knative-openshift-ingress
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -1293,13 +1293,13 @@ spec:
   relatedImages:
     - name: knative-operator
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/knative/openshift-serverless-nightly:openshift-knative-operator
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.28.0:openshift-knative-operator
     - name: knative-openshift
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-operator
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.28.0:knative-operator
     - name: knative-openshift-ingress
       # This reference will be replaced in local builds and CI via hack/lib/catalogsource.bash.
-      image: registry.ci.openshift.org/knative/openshift-serverless-nightly:knative-openshift-ingress
+      image: registry.ci.openshift.org/knative/openshift-serverless-v1.28.0:knative-openshift-ingress
     - name: "IMAGE_queue-proxy"
       image: "registry.ci.openshift.org/openshift/knative-v1.7.0:knative-serving-queue"
     - name: "IMAGE_activator"

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -160,7 +160,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
   ocp_version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}')
 
   # Feature is tested on 4.11+ as this is the version we start enabling it by default.
-  if versions.ge "$(versions.major_minor "$ocp_version")" "1.24"; then
+  if versions.ge "$(versions.major_minor "$ocp_version")" "4.11"; then
     # Verify that the right sc is set by default at the revision side.
     go_test_e2e -timeout=10m -tags=e2e ./test/e2e/securedefaults -run "^(TestSecureDefaults)$" \
       ${OPENSHIFT_TEST_OPTIONS} \

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -157,18 +157,23 @@ function upstream_knative_serving_e2e_and_conformance_tests {
   oc -n "$SERVING_NAMESPACE" patch hpa activator --patch \
     '{"spec": {"maxReplicas": '"${max_replicas}"', "minReplicas": '"${min_replicas}"'}}'
 
-  # Verify that the right sc is set by default and seccompProfile is injected on OCP >= 4.11.
-  go_test_e2e -timeout=3m -tags=e2e ./test/e2e/securedefaults -run "^(TestSecureDefaults)$" \
-    ${OPENSHIFT_TEST_OPTIONS} \
-     --imagetemplate "$image_template"
+  ocp_version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}')
 
-  # Allow to use any seccompProfile for non default cases,
-  # for more check https://docs.openshift.com/container-platform/4.12/authentication/managing-security-context-constraints.html
-  oc adm policy add-scc-to-user privileged -z default -n serving-tests
+  # Feature is tested on 4.11+ as this is the version we start enabling it by default.
+  if versions.ge "$(versions.major_minor "$ocp_version")" "1.24"; then
+    # Verify that the right sc is set by default at the revision side.
+    go_test_e2e -timeout=10m -tags=e2e ./test/e2e/securedefaults -run "^(TestSecureDefaults)$" \
+      ${OPENSHIFT_TEST_OPTIONS} \
+      --imagetemplate "$image_template"
 
-  # Verify that non secure settings are allowed, although not-recommended.
-  # It requires scc privileged or a custom scc that allows any seccompProfile to be set.
-  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags=e2e -timeout=3m ./test/e2e/securedefaults -run "^(TestUnsafePermitted)$" \
-     ${OPENSHIFT_TEST_OPTIONS} \
-     --imagetemplate "$image_template"
+    # Allow to use any seccompProfile for non default cases,
+    # for more check https://docs.openshift.com/container-platform/4.12/authentication/managing-security-context-constraints.html
+    oc adm policy add-scc-to-user privileged -z default -n serving-tests
+
+    # Verify that non secure settings are allowed, although not-recommended.
+    # It requires scc privileged or a custom scc that allows any seccompProfile to be set.
+    SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags=e2e -timeout=10m ./test/e2e/securedefaults -run "^(TestUnsafePermitted)$" \
+      ${OPENSHIFT_TEST_OPTIONS} \
+      --imagetemplate "$image_template"
+  fi
 }


### PR DESCRIPTION
- See https://github.com/openshift/release/pull/36912#issuecomment-1462052251 for more.

