### PR TITLE
[release-1.28] replace 1.27.1 operator

### DIFF
--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -8,9 +8,9 @@ COPY --from=opm /bin/opm /bin/opm
 COPY configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
-RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.27.0:serverless-stop-bundle \
+RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.27.1:serverless-stop-bundle \
       registry.ci.openshift.org/knative/openshift-serverless-v1.28.0:serverless-bundle >> /configs/index.yaml || \
-    /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.27.0:serverless-stop-bundle \
+    /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.27.1:serverless-stop-bundle \
       registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
 
 # The base image is expected to contain

--- a/olm-catalog/serverless-operator/index/configs/index.yaml
+++ b/olm-catalog/serverless-operator/index/configs/index.yaml
@@ -2,7 +2,7 @@ schema: olm.channel
 name: stable
 package: serverless-operator
 entries:
-  - name: "serverless-operator.v1.27.0"
+  - name: "serverless-operator.v1.27.1"
   - name: "serverless-operator.v1.28.0"
-    replaces: serverless-operator.v1.27.0
+    replaces: serverless-operator.v1.27.1
     skipRange: ">=1.27.0 <1.28.0"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -1382,5 +1382,5 @@ spec:
       image: "registry.ci.openshift.org/openshift/knative-eventing-kafka-broker-post-install:knative-v1.7"
     - name: "KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate"
       image: "registry.ci.openshift.org/openshift/knative-eventing-storage-version-migration:knative-v1.7"
-  replaces: serverless-operator.v1.27.0
+  replaces: serverless-operator.v1.27.1
   version: 1.28.0

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -5,7 +5,7 @@ project:
   version: 1.28.0
 
 olm:
-  replaces: 1.27.0
+  replaces: 1.27.1
   skipRange: '>=1.27.0 <1.28.0'
   channels:
     default: 'stable'


### PR DESCRIPTION
We found a problem, the patch releases were not installable once the next "minor" release out we replace 1.27.1 operator.
More discussion- https://redhat-internal.slack.com/archives/CLUCMK7R6/p1678870380676189?thread_ts=1678851673.095989&cid=CLUCMK7R6
cc @mgencur @maschmid 