### PR TITLE
Use GOPATH for running testselect

### DIFF
--- a/hack/lib/testselect.bash
+++ b/hack/lib/testselect.bash
@@ -10,7 +10,7 @@ if [[ -n "${ARTIFACT_DIR:-}" ]]; then
 
   rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
 
-  testselect --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
+  "${GOPATH}/bin/testselect" --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
 
   logger.info 'Tests to be run:'
   cat "${ARTIFACT_DIR}/tests.txt"


### PR DESCRIPTION
Do not rely on PATH having the binary because other repositories might set GOPATH to a different directory and then "go get" will install it t here. The directory might not be on path.

Fixes the problem from https://github.com/openshift-knative/serverless-operator/pull/1985/files#r1137359087

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
