### PR TITLE
Drop sed for queueSidecarImage

### DIFF
--- a/hack/lib/common.bash
+++ b/hack/lib/common.bash
@@ -77,8 +77,6 @@ function versions.major_minor {
 function yaml.break_image_references {
   sed -i "s,image: .*,image: TO_BE_REPLACED," "$1"
   sed -i "s,value: gcr.io/knative-releases.*,value: TO_BE_REPLACED," "$1"
-  # TODO: Replace queueSidecarImage with queue-sidecar-image when upstream v1.8 is used. See: https://github.com/knative/serving/pull/13347.
-  sed -i "s,queueSidecarImage: .*,queue-sidecar-image: TO_BE_REPLACED," "$1"
 }
 
 function should_run {


### PR DESCRIPTION
This patch drops sed for `queueSidecarImage`.

The name was replaced since upstream v1.8 as https://github.com/knative/serving/commit/79a45887a7d56b305a714f21a36e736f1b9f5ebe

Note, `queue-sidecar-image: ko://knative.dev/serving/cmd/queue` is included in this sed:

```
  sed -i "s,image: .*,image: TO_BE_REPLACED," "$1"
```

So it is NOT necessary to replace the `queue-sidecar-image: ko://knative.dev/serving/cmd/queue` though TODO commented said it.