### PR TITLE
[RELEASE-1.28] [SRVKS-1044] Revert "[SRVKS-985] Enable pod security defaults (#1981)"

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -128,11 +128,6 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 	// Apply Kourier gateway service type.
 	defaultKourierServiceType(ks)
 
-	// Enable by default the required Pod Security Standards settings for OCP 4.11+
-	if err := common.CheckMinimumKubeVersion(e.kubeclient.Discovery(), common.MinimumK8sAPIDeprecationVersion); err == nil {
-		common.ConfigureIfUnset(&ks.Spec.CommonSpec, "features", "secure-pod-defaults", "enabled")
-	}
-
 	// Override the default domainTemplate to use $name-$ns rather than $name.$ns.
 	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "domainTemplate", defaultDomainTemplate)
 

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -161,6 +161,11 @@ function upstream_knative_serving_e2e_and_conformance_tests {
 
   # Feature is tested on 4.11+ as this is the version we start enabling it by default.
   if versions.ge "$(versions.major_minor "$ocp_version")" "4.11"; then
+      # Enable secure pod defaults for the following tests.
+      oc -n "${SERVING_NAMESPACE}" patch knativeserving/knative-serving \
+        --type=merge \
+        --patch='{"spec": {"config": { "features": {"secure-pod-defaults": "enabled"}}}}'
+
     # Verify that the right sc is set by default at the revision side.
     go_test_e2e -timeout=10m -tags=e2e ./test/e2e/securedefaults -run "^(TestSecureDefaults)$" \
       ${OPENSHIFT_TEST_OPTIONS} \


### PR DESCRIPTION
- This reverts commit f72a7147410c99ef1299f97538cba5945f56d5dd.
- Keeps related tests and enables the sec pod defaults flag only for those tests. 
- At the midstream we test with the flag on for all tests so we are on the safe side if users enables it.
- We should cherry-pick on main too.

For more on this [check discussion](https://redhat-internal.slack.com/archives/CD87JDUB0/p1679313888733569?thread_ts=1679309831.691089&cid=CD87JDUB0).
