### PR TITLE
Set webhook strategy to none on OCP 4.10 too

### DIFF
--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -100,7 +100,7 @@ func DowngradeServerless(ctx *test.Context) error {
 	// If we are on OCP 4.8 we need to apply the workaround in https://access.redhat.com/solutions/6992396.
 	// Currently, we only test in 4.8 (1.21) and 4.11+ (1.24+). Latest versions (eg. 4.11+) have a fix for this so no need to patch the crds,
 	// but we do it anyway for supported versions up to 4.10.
-	if err := common.CheckMinimumKubeVersion(ctx.Clients.Kube.Discovery(), "1.23.0"); err != nil {
+	if err := common.CheckMinimumKubeVersion(ctx.Clients.Kube.Discovery(), "1.24.0"); err != nil {
 		for _, name := range crds {
 			if err := setWebookStrategyToNone(ctx, name); err != nil {
 				return err


### PR DESCRIPTION
Similar to https://github.com/openshift-knative/serverless-operator/commit/c338734f5632d043a4d3b2b91150e4c978a8e90b

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
