### PR TITLE
Updates to latest Strimzi release, no kafka bump

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -11,7 +11,7 @@ fi
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/../../vendor/knative.dev/hack/e2e-tests.sh"
 
-export STRIMZI_VERSION=0.33.2
+export STRIMZI_VERSION=0.34.0
 
 # Adjust these when upgrading the knative versions.
 export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v$(metadata.get dependencies.serving)}"


### PR DESCRIPTION
## Proposed Changes

- Just bump latest version of Strimzi upstream version
