### PR TITLE
[release-1.28] Do not overwrite existing imagePullSecret in SA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -174,7 +174,7 @@ require (
 
 replace (
 	// Knative forks.
-	knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20221223194634-91b1cee5fce4
+	knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20230303112302-e5e444f985e0
 	knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc
 	knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd
 	knative.dev/serving => github.com/openshift-knative/serving v0.10.1-0.20221227111603-f612214ac3df

--- a/go.sum
+++ b/go.sum
@@ -1449,8 +1449,8 @@ github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqi
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/openshift-knative/eventing v0.99.1-0.20221223194634-91b1cee5fce4 h1:0zkWCCrvHGmH4PtBe5iKNUN4e5yZ7DBmX0RyKYUEiRI=
-github.com/openshift-knative/eventing v0.99.1-0.20221223194634-91b1cee5fce4/go.mod h1:6UnNnPrEUNAM9PfCpf7L8N7G/1vq+HQlpOjzndY6ryw=
+github.com/openshift-knative/eventing v0.99.1-0.20230303112302-e5e444f985e0 h1:zy7q0ZRTsjW5xS7mOAyGBDO/Hkp6lvJHrclHX4QROok=
+github.com/openshift-knative/eventing v0.99.1-0.20230303112302-e5e444f985e0/go.mod h1:6UnNnPrEUNAM9PfCpf7L8N7G/1vq+HQlpOjzndY6ryw=
 github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc h1:avIbZM/BPZV7PYTgwkxZj9bauRehrSFRPcANeAtRxSE=
 github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc/go.mod h1:RZ/b/xO0sEPL0it4Xm0kSbrhATdsND1WVQq5AcHi7ro=
 github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd h1:HR6u4bFngzrZt6dTHqVo5gelfI+oCJTG7Tv/pKQPJPg=

--- a/vendor/knative.dev/eventing/pkg/reconciler/testing/deployment.go
+++ b/vendor/knative.dev/eventing/pkg/reconciler/testing/deployment.go
@@ -96,3 +96,12 @@ func WithDeploymentAvailable() DeploymentOption {
 		}
 	}
 }
+
+func WithContainerEnv(name, value string) DeploymentOption {
+	return func(deployment *appsv1.Deployment) {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1282,7 +1282,7 @@ k8s.io/utils/trace
 ## explicit; go 1.18
 knative.dev/caching/pkg/apis/caching
 knative.dev/caching/pkg/apis/caching/v1alpha1
-# knative.dev/eventing v0.35.2 => github.com/openshift-knative/eventing v0.99.1-0.20221223194634-91b1cee5fce4
+# knative.dev/eventing v0.35.2 => github.com/openshift-knative/eventing v0.99.1-0.20230303112302-e5e444f985e0
 ## explicit; go 1.18
 knative.dev/eventing/pkg/apis/config
 knative.dev/eventing/pkg/apis/duck
@@ -1676,7 +1676,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20221223194634-91b1cee5fce4
+# knative.dev/eventing => github.com/openshift-knative/eventing v0.99.1-0.20230303112302-e5e444f985e0
 # knative.dev/eventing-kafka => github.com/openshift-knative/eventing-kafka v0.19.1-0.20221226103243-fa44547a3ccc
 # knative.dev/eventing-kafka-broker => github.com/openshift-knative/eventing-kafka-broker v0.25.1-0.20230107084457-319b600560cd
 # knative.dev/serving => github.com/openshift-knative/serving v0.10.1-0.20221227111603-f612214ac3df


### PR DESCRIPTION
Produced by running
```
go mod edit -replace knative.dev/eventing=github.com/openshift-knative/eventing@release-v1.7
./hack/update-deps.sh
```

This is same as https://github.com/openshift-knative/serverless-operator/pull/1951, just for release-1.28 branch.
The "main" branch already has those updates so we're fine there.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
