### PR TITLE
Handle non-existent tests.txt for selecting test suites

### DIFF
--- a/hack/lib/common.bash
+++ b/hack/lib/common.bash
@@ -84,6 +84,7 @@ function should_run {
   ts=${1:?Specify test to check}
 
   if [ -n "$OPENSHIFT_CI" ]; then
+    [ -f "${ARTIFACT_DIR}/tests.txt" ] || return 0
     grep -q -e "All" -e "$ts" "${ARTIFACT_DIR}/tests.txt" || return 1
   else
     return 0

--- a/test/kitchensink-e2e-tests.sh
+++ b/test/kitchensink-e2e-tests.sh
@@ -14,6 +14,8 @@ dump_state.setup # test
 
 logger.success '🚀 Cluster prepared for testing.'
 
+run_testselect
+
 # Run serverless-operator kitchensink tests.
 downstream_kitchensink_e2e_tests
 


### PR DESCRIPTION
Fixes failing periodic job for kitchensink: https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.10-e2e-kitchensink-ocp-410-continuous

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
