### PR TITLE
Start kitchensink upgrade tests from 1.26

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -62,10 +62,6 @@ dependencies:
     eventing_kafka: 1.1.0
     eventing_kafka_broker: 1.7
 upgrade_sequence:
-  - csv: serverless-operator.v1.25.0
-    source: redhat-operators
-    serving_cr: test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
-    eventing_cr: test/v1beta1/resources/operator.knative.dev_v1beta1_knativeeventing_cr.yaml
   - csv: serverless-operator.v1.26.0
     source: redhat-operators
   - csv: serverless-operator.v1.27.0


### PR DESCRIPTION
The v1alpha1 test files were removed and 1.25 requires them. We can test upgrades from just 3 versions back.

Fixes nightly job failures like [this one](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.10-upgrade-kitchensink-ocp-410-continuous/1640473967632322560)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
