### PR TITLE
SRVCOM-2371 TestKsvcWithServiceMeshSidecar fails with subtest may hav…

### DIFF
--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -163,6 +163,10 @@ func TestKsvcWithServiceMeshSidecar(t *testing.T) {
 		for _, scenario := range tests {
 			scenario := scenario
 			t.Run(scenario.name, func(t *testing.T) {
+				// Create a new context to prevent calling ctx.T.Fatal on parent T.
+				ctx := test.SetupClusterAdmin(t)
+				test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, ctx) })
+				defer test.CleanupAll(t, ctx)
 				testServiceToService(t, ctx, test.Namespace, scenario)
 			})
 		}


### PR DESCRIPTION
…e called FailNow on a parent test

Fixes https://issues.redhat.com/browse/SRVCOM-2371

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
