### PR TITLE
[SRVCOM-2370] Update build Go version to 1.19

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Install prerequisites
         env:
@@ -113,10 +113,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-      - name: Set up Go 1.18.x
+      - name: Setup Golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -22,7 +22,7 @@ jobs:
       GOPATH: ${{ github.workspace }}
     steps:
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
 
@@ -114,7 +114,7 @@ jobs:
       GOPATH: ${{ github.workspace }}
     steps:
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-knative/serverless-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -54,14 +54,14 @@ if (( GO_GET )); then
     go mod edit -replace "${dep}"
     # Let the dependency update the magic SHA otherwise the
     # following "go mod edit" will fail.
-    go mod tidy -compat=1.18
+    go mod tidy -compat=1.19
     go mod vendor
   done
   go get -d "${FLOATING_DEPS[@]}"
 fi
 
 # Prune modules.
-go mod tidy -compat=1.18
+go mod tidy -compat=1.19
 go mod vendor
 
 # Remove unnecessary files.

--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -23,14 +23,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//     import (
+//       "k8s.io/client-go/kubernetes"
+//       clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//       aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//     )
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//     kclientset, _ := kubernetes.NewForConfig(c)
+//     _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -23,14 +23,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//     import (
-//       "k8s.io/client-go/kubernetes"
-//       clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//       aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//     )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//     kclientset, _ := kubernetes.NewForConfig(c)
-//     _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -23,14 +23,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//     import (
-//       "k8s.io/client-go/kubernetes"
-//        clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//        aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//     )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	   clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	   aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//     kclientset, _ := kubernetes.NewForConfig(c)
-//     _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -23,14 +23,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//     import (
+//       "k8s.io/client-go/kubernetes"
+//        clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//        aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//     )
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//     kclientset, _ := kubernetes.NewForConfig(c)
+//     _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -25,8 +25,8 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 //
 //	import (
 //	  "k8s.io/client-go/kubernetes"
-//	   clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//	   aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
 //	)
 //
 //	kclientset, _ := kubernetes.NewForConfig(c)

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/serving/metadata-webhook/Dockerfile
+++ b/serving/metadata-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}


### PR DESCRIPTION
Per SIG release call discussion, bumping Go to 1.19.

@ReToCode @matzew @pierDipi @skonto 