### PR TITLE
Provide Kafka image through template

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -94,7 +94,7 @@ DEFAULT_IMAGE_TEMPLATE=$(
 {{- else if eq . "recordevents" }}${QUAY_REGISTRY}/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
 {{- else if eq . "wathola-forwarder" }}${QUAY_REGISTRY}/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
 {{- else if eq . "kafka" }}strimzi/kafka:0.16.2-kafka-2.4.0
-{{- else }}{{.}}:multiarch{{end -}}
+{{- else }}${QUAY_REGISTRY}/{{.}}:multiarch{{end -}}
 {{end -}}
 EOF
 )

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -86,12 +86,14 @@ export ENABLE_TRACING="${ENABLE_TRACING:-false}"
 # Define sample-rate for tracing.
 export SAMPLE_RATE="${SAMPLE_RATE:-"1.0"}"
 export ZIPKIN_DEDICATED_NODE="${ZIPKIN_DEDICATED_NODE:-false}"
+export QUAY_REGISTRY=quay.io/openshift-knative
 DEFAULT_IMAGE_TEMPLATE=$(
   cat <<-EOF
-quay.io/openshift-knative/{{- with .Name }}
-{{- if eq . "httpproxy" }}serving/{{.}}:v$(echo "${KNATIVE_SERVING_VERSION#v}" | awk -F \. '{printf "%d.%d", $1, $2}')
-{{- else if eq . "recordevents" }}eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
-{{- else if eq . "wathola-forwarder" }}eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
+{{- with .Name }}
+{{- if eq . "httpproxy" }}${QUAY_REGISTRY}/serving/{{.}}:v$(echo "${KNATIVE_SERVING_VERSION#v}" | awk -F \. '{printf "%d.%d", $1, $2}')
+{{- else if eq . "recordevents" }}${QUAY_REGISTRY}/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
+{{- else if eq . "wathola-forwarder" }}${QUAY_REGISTRY}/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
+{{- else if eq . "kafka" }}strimzi/kafka:0.16.2-kafka-2.4.0
 {{- else }}{{.}}:multiarch{{end -}}
 {{end -}}
 EOF

--- a/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
+++ b/test/extensione2e/kafka/kafka_source_to_ksvc_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/openshift-knative/serverless-operator/test/eventinge2e"
+	pkgTest "knative.dev/pkg/test"
 
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -65,7 +66,7 @@ func createCronJobObjV1Beta1(name, topic, server string) *batchv1beta1.CronJob {
 							Containers: []corev1.Container{
 								{
 									Name:    "kafka-message-test",
-									Image:   "strimzi/kafka:0.16.2-kafka-2.4.0",
+									Image:   pkgTest.ImagePath(test.KafkaImg),
 									Command: []string{"sh", "-c", fmt.Sprintf(`echo '%s' | bin/kafka-console-producer.sh --broker-list %s --topic %s`, eventinge2e.PingSourceData, server, topic)},
 								},
 							},
@@ -93,7 +94,7 @@ func createCronJobObjV1(name, topic, server string) *batchv1.CronJob {
 							Containers: []corev1.Container{
 								{
 									Name:    "kafka-message-test",
-									Image:   "strimzi/kafka:0.16.2-kafka-2.4.0",
+									Image:   pkgTest.ImagePath(test.KafkaImg),
 									Command: []string{"sh", "-c", fmt.Sprintf(`echo '%s' | bin/kafka-console-producer.sh --broker-list %s --topic %s`, eventinge2e.PingSourceData, server, topic)},
 								},
 							},

--- a/test/images.go
+++ b/test/images.go
@@ -7,4 +7,5 @@ const (
 	HTTPProxyImg        = "httpproxy"
 	RecordEventsImg     = "recordevents"
 	WatholaForwarderImg = "wathola-forwarder"
+	KafkaImg            = "kafka"
 )


### PR DESCRIPTION
This is to enable testing disconnected environments where different template will be provided, pointing to images mirrored into a specific image registry.

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
