### PR TITLE
Create a writable temp directory for the go_run() function

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -7,6 +7,10 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
 RUN yum install -y kubectl httpd-tools
 
+# Create a temp directory for the go_run() function that is writable by runtime users
+ENV GORUN_PATH=/tmp/gorun
+RUN mkdir /tmp/gorun && chmod g+rw /tmp/gorun
+
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
 

--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -7,6 +7,10 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
 RUN yum install -y kubectl httpd-tools
 
+# Create a temp directory for the go_run() function that is writable by runtime users
+ENV GORUN_PATH=/tmp/gorun
+RUN mkdir /tmp/gorun && chmod g+rw /tmp/gorun
+
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
 


### PR DESCRIPTION
Fixes CI issues like [in](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-ocp4.13-lp-interop-operator-e2e-interop-aws-ocp413/1642769139414077440).

Full context see: https://redhat-internal.slack.com/archives/CLUCMK7R6/p1680505313286459

/cc @mgencur 