### PR TITLE
Partially revert dce94da

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -21,7 +21,7 @@ requirements:
     # is ignored as it is overridden by fake version via KUBERNETES_MIN_VERSION.
     # This value is used for CSV's min version validation.
     minVersion: 1.21.0
-  golang: '1.19'
+  golang: '1.18'
   nodejs: 16.x
   ocpVersion:
     min: '4.8'

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/


### PR DESCRIPTION
We still have CI [issues](https://redhat-internal.slack.com/archives/CLUCMK7R6/p1680515798868279?thread_ts=1680505313.286459&cid=CLUCMK7R6) so let's check if reverting the build go image helps.
