### PR TITLE
Check existence of skipRange and replaces in CSV

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -107,6 +107,16 @@ jobs:
             exit 33
           fi
 
+      - name: Check existence of skipRange and replaces in ClusterServiceVersion
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: |
+          csv="olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml"
+          if [[ "$(yq read "$csv" spec.replaces)" == "" || \
+                "$(yq read "$csv" 'metadata.annotations."olm.skipRange"')" == "" ]]; then
+            echo '::error:: Missing spec.replaces or metadata.annotations."olm.skipRange" in CSV.'
+            exit 34
+          fi
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
Both `skipRange` and `replaces` directives are important to have in CSV otherwise the product might fail during upgrades. We have been using both but this is just a double-check that both are defined. This will be even more important when we introduce multiple channels for Serverless.

Some experiments that I did:
1) olm.skipRange: '>1.28.0 <1.29.0' and no "replaces:" leads to this error in operator pod in openshift-marketplace NS when trying to install 1.28.0 through subscription:
```
	invalid package \"serverless-operator\":\n └── invalid channel \"stable-my\":\n └── multiple channel heads found in graph: serverless-operator.v1.28.0, serverless-operator.v1.29.0"	
```

2) olm.skipRange: '>1.28.0 <1.29.0' and "replaces: serverless-operator.v1.28.0"
	
    I can install 1.28.0 directly and then upgrade to 1.29 without issues

3) olm.skipRange: '>=1.28.0 <1.29.0' and "replaces: serverless-operator.v1.28.0"

    Same as before: success

It doesn't matter if the skip range starts with `>` or `>=` as long as replaces is there.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
