### PR TITLE
Fix skipping test run when testselect chooses no tests

### DIFF
--- a/test/eventing-kafka.bash
+++ b/test/eventing-kafka.bash
@@ -4,7 +4,7 @@
 set -e
 
 function upstream_knative_eventing_kafka_e2e {
-  should_run "${FUNCNAME[0]}" || return
+  should_run "${FUNCNAME[0]}" || return 0
 
   logger.info 'Running eventing-kafka tests'
 
@@ -33,7 +33,7 @@ function upstream_knative_eventing_kafka_e2e {
 }
 
 function upstream_knative_eventing_kafka_broker_e2e {
-  should_run "${FUNCNAME[0]}" || return
+  should_run "${FUNCNAME[0]}" || return 0
 
   if [[ $FULL_MESH = true ]]; then
     upstream_knative_eventing_kafka_broker_e2e_mesh

--- a/test/eventing.bash
+++ b/test/eventing.bash
@@ -4,7 +4,7 @@
 set -e
 
 function upstream_knative_eventing_e2e {
-  should_run "${FUNCNAME[0]}" || return
+  should_run "${FUNCNAME[0]}" || return 0
 
   logger.info 'Running eventing tests'
 

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -67,7 +67,7 @@ function print_test_result {
 }
 
 function serverless_operator_e2e_tests {
-  should_run "${FUNCNAME[0]}" || return
+  should_run "${FUNCNAME[0]}" || return 0
 
   declare -a kubeconfigs
   local kubeconfigs_str
@@ -92,7 +92,7 @@ function serverless_operator_e2e_tests {
 }
 
 function serverless_operator_kafka_e2e_tests {
-  should_run "${FUNCNAME[0]}" || return
+  should_run "${FUNCNAME[0]}" || return 0
 
   declare -a kubeconfigs
   local kubeconfigs_str
@@ -117,7 +117,7 @@ function serverless_operator_kafka_e2e_tests {
 }
 
 function downstream_serving_e2e_tests {
-  should_run "${FUNCNAME[0]}" || return
+  should_run "${FUNCNAME[0]}" || return 0
 
   declare -a kubeconfigs
   local kubeconfigs_str
@@ -149,7 +149,7 @@ function downstream_serving_e2e_tests {
 }
 
 function downstream_eventing_e2e_tests {
-  should_run "${FUNCNAME[0]}" || return
+  should_run "${FUNCNAME[0]}" || return 0
 
   declare -a kubeconfigs
   local kubeconfigs_str
@@ -177,7 +177,7 @@ function downstream_eventing_e2e_tests {
 }
 
 function downstream_knative_kafka_e2e_tests {
-  should_run "${FUNCNAME[0]}" || return
+  should_run "${FUNCNAME[0]}" || return 0
 
   declare -a kubeconfigs
   local kubeconfigs_str
@@ -205,7 +205,7 @@ function downstream_knative_kafka_e2e_tests {
 }
 
 function downstream_monitoring_e2e_tests {
-  should_run "${FUNCNAME[0]}" || return
+  should_run "${FUNCNAME[0]}" || return 0
 
   declare -a kubeconfigs
   local kubeconfigs_str
@@ -229,7 +229,7 @@ function downstream_monitoring_e2e_tests {
 }
 
 function downstream_kitchensink_e2e_tests {
-  should_run "${FUNCNAME[0]}" || return
+  should_run "${FUNCNAME[0]}" || return 0
 
   logger.info "Running Knative kitchensink tests"
 
@@ -257,6 +257,8 @@ function downstream_kitchensink_e2e_tests {
 # == Upgrade testing
 
 function run_rolling_upgrade_tests {
+  should_run "${FUNCNAME[0]}" || return 0
+
   logger.info "Running rolling upgrade tests"
 
   local base serving_image_version eventing_image_version eventing_kafka_image_version eventing_kafka_broker_image_version image_template channels common_opts

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -33,7 +33,7 @@ function prepare_knative_serving_tests {
 }
 
 function upstream_knative_serving_e2e_and_conformance_tests {
-  should_run "${FUNCNAME[0]}" || return
+  should_run "${FUNCNAME[0]}" || return 0
 
   logger.info "Running Serving E2E and conformance tests"
 

--- a/test/testsuites.yaml
+++ b/test/testsuites.yaml
@@ -24,6 +24,7 @@ testsuites:
       - ^serving/ingress/
     tests:
       - serverless_operator_e2e_tests
+      - run_rolling_upgrade_tests
   - name: "Eventing Kafka"
     run_if_changed:
       - "^knative-operator/pkg/controller/knativekafka/"
@@ -33,6 +34,7 @@ testsuites:
       - downstream_knative_kafka_e2e_tests
       - upstream_knative_eventing_kafka_e2e # TODO: Run this at all? Should this test suite be removed completely?
       - upstream_knative_eventing_kafka_broker_e2e
+      - run_rolling_upgrade_tests
   - name: "Eventing"
     run_if_changed:
       - "^knative-operator/pkg/controller/knativeeventing/"


### PR DESCRIPTION
* return 0 instead of calling just "return" which then returns the retcode of the previous commmand, i.e. non-zero
* make it possible to skip upgrade tests as well when no tests should be run

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
