### PR TITLE
Minimal ServiceEntry for Kafka cluster

### DIFF
--- a/hack/lib/mesh_resources/kafka-service-entry.yaml
+++ b/hack/lib/mesh_resources/kafka-service-entry.yaml
@@ -5,9 +5,6 @@ metadata:
 spec:
   hosts:
     - my-cluster-kafka-bootstrap.kafka
-    - my-cluster-kafka-brokers.kafka
-    - my-cluster-kafka-bootstrap.kafka.svc.cluster.local
-    - my-cluster-kafka-brokers.kafka.svc.cluster.local
   exportTo:
     - "."
   ports:


### PR DESCRIPTION
Reduce the ServiceEntry hosts configuration to the minimum. 