### PR TITLE
Change the source for serverless 1.28 in kitchensink upgrade tests

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -73,6 +73,6 @@ upgrade_sequence:
   - csv: serverless-operator.v1.27.1
     source: redhat-operators
   - csv: serverless-operator.v1.28.0
-    source: serverless-operator
+    source: redhat-operators
   - csv: serverless-operator.v1.29.0
     source: serverless-operator


### PR DESCRIPTION
Fixes failures such as [this one](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.10-upgrade-kitchensink-ocp-410-continuous/1645547351344943104)
Serverless 1.28 was released last week. The InstallPlan for 1.28 will be offered from "redhat-operators" catalog source during upgrades.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
