### PR TITLE
Update test-source-image to use new serving tagging schema

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -33,7 +33,7 @@ requirements:
     label: 'v4.8'
 
 dependencies:
-  serving: 1.8.0
+  serving: knative-v1.8
   # serving midstream branch name
   serving_artifacts_branch: release-v1.8
 

--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -1,7 +1,7 @@
 FROM src
 
 COPY oc /usr/bin/oc
-COPY --from=registry.ci.openshift.org/openshift/knative-v1.8.0:knative-serving-src /go/src/knative.dev/serving/ /go/src/knative.dev/serving/
+COPY --from=registry.ci.openshift.org/openshift/knative-serving-src:knative-v1.8 /go/src/github.com/openshift-knative/serving/ /go/src/knative.dev/serving/
 COPY --from=registry.ci.openshift.org/openshift/knative-eventing-src:knative-v1.8 /go/src/github.com/openshift-knative/eventing/ /go/src/knative.dev/eventing/
 COPY --from=registry.ci.openshift.org/openshift/eventing-kafka-broker-src:knative-v1.8 /go/src/github.com/openshift-knative/eventing-kafka-broker/ /go/src/knative.dev/eventing-kafka-broker/
 COPY --from=registry.ci.openshift.org/openshift/eventing-istio-src:knative-v1.8 /go/src/github.com/openshift-knative/eventing-istio/ /go/src/knative.dev/eventing-istio/

--- a/templates/test-source-image.Dockerfile
+++ b/templates/test-source-image.Dockerfile
@@ -1,7 +1,7 @@
 FROM src
 
 COPY oc /usr/bin/oc
-COPY --from=registry.ci.openshift.org/openshift/knative-v__SERVING_VERSION__:knative-serving-src /go/src/knative.dev/serving/ /go/src/knative.dev/serving/
+COPY --from=registry.ci.openshift.org/openshift/knative-serving-src:__SERVING_VERSION__ /go/src/github.com/openshift-knative/serving/ /go/src/knative.dev/serving/
 COPY --from=registry.ci.openshift.org/openshift/knative-eventing-src:__EVENTING_VERSION__ /go/src/github.com/openshift-knative/eventing/ /go/src/knative.dev/eventing/
 COPY --from=registry.ci.openshift.org/openshift/eventing-kafka-broker-src:__EVENTING_KAFKA_BROKER_VERSION__ /go/src/github.com/openshift-knative/eventing-kafka-broker/ /go/src/knative.dev/eventing-kafka-broker/
 COPY --from=registry.ci.openshift.org/openshift/eventing-istio-src:__EVENTING_ISTIO_VERSION__ /go/src/github.com/openshift-knative/eventing-istio/ /go/src/knative.dev/eventing-istio/


### PR DESCRIPTION
Fixes JIRA [SRVKS-1011](https://issues.redhat.com/browse/SRVKS-1011)
Prerequisite to make https://github.com/openshift-knative/serverless-operator/pull/2046 pass.

## Proposed Changes
- Just bump the CI source image to avoid `registry-replacer` to interfere with tests in https://github.com/openshift-knative/serverless-operator/pull/2046
