### PR TITLE
Run testselect only if CLONEREFS_OPTIONS exist

### DIFF
--- a/hack/lib/testselect.bash
+++ b/hack/lib/testselect.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function run_testselect {
-  if [[ -n "${ARTIFACT_DIR:-}" ]]; then
+  if [[ -n "${ARTIFACT_DIR:-}" && -n "${CLONEREFS_OPTIONS:-}" ]]; then
     GO111MODULE=off go get github.com/openshift-knative/hack/cmd/testselect
 
     local clonedir rootdir


### PR DESCRIPTION
It might be handy to run the s-o scripts downstream where ARTIFACT_DIR is set but not CLONEREFS_OPTIONS. And CLONEREFS_OPTIONS is necessary for correct function.

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
