### PR TITLE
Rename channel name as per recommendation

### DIFF
--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -8,7 +8,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=serverless-operator
 LABEL operators.operatorframework.io.bundle.channel.default.v1="stable"
-LABEL operators.operatorframework.io.bundle.channels.v1="stable,serverless-1.29"
+LABEL operators.operatorframework.io.bundle.channels.v1="stable,stable-1.29"
 
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \

--- a/olm-catalog/serverless-operator/index/configs/index.yaml
+++ b/olm-catalog/serverless-operator/index/configs/index.yaml
@@ -12,7 +12,7 @@ entries:
     skipRange: ">=1.28.0 <1.29.0"
 ---
 schema: olm.channel
-name: serverless-1.29
+name: stable-1.29
 package: serverless-operator
 entries:
   - name: "serverless-operator.v1.27.0"

--- a/olm-catalog/serverless-operator/metadata/annotations.yaml
+++ b/olm-catalog/serverless-operator/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable,serverless-1.29
+  operators.operatorframework.io.bundle.channels.v1: stable,stable-1.29
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -15,7 +15,7 @@ olm:
     default: 'stable'
     list:
       - 'stable'
-      - 'serverless-1.29'
+      - 'stable-1.29'
   previous:
     replaces: 1.27.0
     skipRange: '>=1.27.0 <1.28.0'


### PR DESCRIPTION
As per the Slack discussion, we agree to use Channel naming as stable, stable-1.29