### PR TITLE
Image template for Serving points to multiarch images

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -88,9 +88,9 @@ export QUAY_REGISTRY=quay.io/openshift-knative
 DEFAULT_IMAGE_TEMPLATE=$(
   cat <<-EOF
 {{- with .Name }}
-{{- if eq . "httpproxy" }}${QUAY_REGISTRY}/knative-serving-test-{{.}}:${KNATIVE_SERVING_VERSION}
-{{- else if eq . "recordevents" }}${QUAY_REGISTRY}/knative-eventing-test-{{.}}:${KNATIVE_EVENTING_VERSION}
-{{- else if eq . "wathola-forwarder" }}${QUAY_REGISTRY}/knative-eventing-test-{{.}}:${KNATIVE_EVENTING_VERSION}
+{{- if eq . "httpproxy" }}${QUAY_REGISTRY}/serving/{{.}}:${KNATIVE_SERVING_VERSION#knative-}
+{{- else if eq . "recordevents" }}${QUAY_REGISTRY}/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
+{{- else if eq . "wathola-forwarder" }}${QUAY_REGISTRY}/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
 {{- else if eq . "kafka" }}strimzi/kafka:0.16.2-kafka-2.4.0
 {{- else }}${QUAY_REGISTRY}/{{.}}:multiarch{{end -}}
 {{end -}}


### PR DESCRIPTION
The path for publishing Serving images was recently changed in openshift-knative/serving repo. The template was updated to point to the new images. However, there are also Github actions in openshift-knative/serving which still build "multiarch" images and push them to quay and serverless-operator needs to use those images so as to allow testing on P/Z.

Link to an example Github action that builds the images: https://github.com/openshift-knative/serving/actions/runs/4921272450

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
