### PR TITLE
Introduce bump SO automation

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -39,9 +39,9 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           path: ./src/github.com/${{ github.repository }}
-          branch: auto/bump-so-version-${{ env.SO_VERSION }}
-          title: "[${{ github.ref_name }}] Bump SO version to version ${{ env.SO_VERSION }}"
-          commit-message: "Bump SO version to version ${{ env.SO_VERSION }}"
+          branch: auto/bump-so-version-${{ github.ref_name }}
+          title: "[${{ github.ref_name }}] Bump Serverless Operator version"
+          commit-message: "Bump SO version"
           delete-branch: true
           body: |
             Bump SO version + run `make generated-files`

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,0 +1,47 @@
+---
+name: Bump
+
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch: # Manual workflow trigger
+
+jobs:
+  bump-so-version:
+    name:
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+    steps:
+      - name: Setup Golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.20.x
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # Always checkout main, we don't support bumping for patch releases (for now)
+          ref: main
+          path: ./src/github.com/${{ github.repository }}
+          fetch-depth: 0
+
+      - name: Bump SO
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: go run hack/cmd/bumpso/bumpso.go
+
+      - name: Regenerate all generated files
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: make generated-files
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          path: ./src/github.com/${{ github.repository }}
+          branch: auto/bump-so-version-${{ env.SO_VERSION }}
+          title: "[${{ github.ref_name }}] Bump SO version to version ${{ env.SO_VERSION }}"
+          commit-message: "Bump SO version to version ${{ env.SO_VERSION }}"
+          delete-branch: true
+          body: |
+            Bump SO version + run `make generated-files`

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/blang/semver/v4 v4.0.0
+	github.com/coreos/go-semver v0.3.0
 	github.com/google/go-cmp v0.5.8
 	github.com/jaegertracing/jaeger v1.33.0
 	github.com/manifestival/controller-runtime-client v0.4.0
@@ -154,7 +155,7 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	istio.io/api v0.0.0-20220420164308-b6a03a9e477e // indirect
 	istio.io/client-go v1.13.3 // indirect
 	k8s.io/apiserver v0.25.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -518,6 +518,7 @@ github.com/coreos/go-iptables v0.5.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmeka
 github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/hack/cmd/bumpso/bumpso.go
+++ b/hack/cmd/bumpso/bumpso.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/coreos/go-semver/semver"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	project := make(map[string]interface{}, 8)
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	projectPath := filepath.Join(wd, "olm-catalog/serverless-operator/project.yaml")
+
+	flag.StringVar(&projectPath, "project-path", projectPath, "")
+	flag.Parse()
+
+	var node yaml.Node
+
+	file, err := os.ReadFile(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", projectPath, err)
+	}
+
+	if err := yaml.NewDecoder(bytes.NewBuffer(file)).Decode(&project); err != nil {
+		return fmt.Errorf("failed to decode file into map: %w", err)
+	}
+	if err := yaml.NewDecoder(bytes.NewBuffer(file)).Decode(&node); err != nil {
+		return fmt.Errorf("failed to decode file into node: %w", err)
+	}
+
+	previousVersion, err := previousVersion(project)
+	if err != nil {
+		return err
+	}
+
+	currentVersion, err := currentVersion(project)
+	if err != nil {
+		return err
+	}
+	// We don't care about path versions (patch versions are potentially skipped, etc)
+	currentVersion.Patch = 0
+
+	newVersion := &semver.Version{
+		Major:      currentVersion.Major,
+		Minor:      currentVersion.Minor,
+		Patch:      currentVersion.Patch,
+		PreRelease: currentVersion.PreRelease,
+		Metadata:   currentVersion.Metadata,
+	}
+	newVersion.BumpMinor()
+
+	upgradeSequence, _, err := unstructured.NestedSlice(project, "upgrade_sequence")
+	if err != nil {
+		return err
+	}
+	channelsList, _, err := unstructured.NestedSlice(project, "olm", "channels", "list")
+	if err != nil {
+		return err
+	}
+
+	upgradeSequence = append(upgradeSequence, map[string]interface{}{
+		"csv":    fmt.Sprintf("serverless-operator.v%s", newVersion),
+		"source": "serverless-operator",
+	})
+	channelsList = append(channelsList, fmt.Sprintf("stable-%d.%d", newVersion.Major, newVersion.Minor))
+
+	serving, _, _ := unstructured.NestedString(project, "dependencies", "serving")
+	eventing, _, _ := unstructured.NestedString(project, "dependencies", "eventing")
+	ekb, _, _ := unstructured.NestedString(project, "dependencies", "eventing_kafka_broker")
+
+	_ = setNestedField(&node, newVersion.String(), "project", "version")
+	_ = setNestedField(&node, currentVersion.String(), "olm", "replaces")
+	_ = setNestedField(&node, previousVersion.String(), "olm", "previous", "replaces")
+	_ = setNestedField(&node, skipRange(currentVersion, newVersion), "olm", "skipRange")
+	_ = setNestedField(&node, skipRange(previousVersion, currentVersion), "olm", "previous", "skipRange")
+	_ = setNestedField(&node, upgradeSequence, "upgrade_sequence")
+	_ = setNestedField(&node, channelsList, "olm", "channels", "list")
+
+	_ = setNestedField(&node, serving, "dependencies", "previous", "serving")
+	_ = setNestedField(&node, eventing, "dependencies", "previous", "eventing")
+	_ = setNestedField(&node, ekb, "dependencies", "previous", "eventing_kafka_broker")
+
+	buf := bytes.NewBuffer(nil)
+	if err := yaml.NewEncoder(buf).Encode(&node); err != nil {
+		return fmt.Errorf("failed to encode node into buf: %w", err)
+	}
+
+	if err := os.WriteFile(projectPath, buf.Bytes(), 0600); err != nil {
+		return fmt.Errorf("failed to write updates: %w", err)
+	}
+
+	return nil
+}
+
+func currentVersion(project map[string]interface{}) (*semver.Version, error) {
+	v, _, err := unstructured.NestedString(project, "project", "version")
+	if err != nil {
+		return nil, err
+	}
+	ver := semver.New(v)
+	return ver, nil
+}
+
+func previousVersion(project map[string]interface{}) (*semver.Version, error) {
+	v, _, err := unstructured.NestedString(project, "olm", "replaces")
+	if err != nil {
+		return nil, err
+	}
+	ver := semver.New(v)
+	return ver, nil
+}
+
+func skipRange(prev, curr *semver.Version) string {
+	return fmt.Sprintf(">=%s <%s", prev.String(), curr.String())
+}
+
+func setNestedField(node *yaml.Node, value interface{}, fields ...string) error {
+
+	for i, n := range node.Content {
+
+		if i > 0 && node.Content[i-1].Value == fields[0] {
+
+			// Base case for scalar nodes
+			if len(fields) == 1 && n.Kind == yaml.ScalarNode {
+				n.SetString(fmt.Sprintf("%s", value))
+				break
+			}
+			// base case for sequence node
+			if len(fields) == 1 && n.Kind == yaml.SequenceNode {
+
+				if v, ok := value.([]interface{}); ok {
+					var s yaml.Node
+
+					b, err := yaml.Marshal(v)
+					if err != nil {
+						return err
+					}
+					if err := yaml.NewDecoder(bytes.NewBuffer(b)).Decode(&s); err != nil {
+						return err
+					}
+
+					n.Content = s.Content[0].Content
+				}
+				break
+			}
+
+			// Continue to the next level
+			return setNestedField(n, value, fields[1:]...)
+		}
+
+		if node.Kind == yaml.DocumentNode {
+			return setNestedField(n, value, fields...)
+		}
+	}
+
+	return nil
+}

--- a/hack/cmd/bumpso/bumpso.go
+++ b/hack/cmd/bumpso/bumpso.go
@@ -69,15 +69,16 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	channelsList, _, err := unstructured.NestedSlice(project, "olm", "channels", "list")
-	if err != nil {
-		return err
-	}
-
+	upgradeSequence = upgradeSequence[1:] // Remove first version
 	upgradeSequence = append(upgradeSequence, map[string]interface{}{
 		"csv":    fmt.Sprintf("serverless-operator.v%s", newVersion),
 		"source": "serverless-operator",
 	})
+
+	channelsList, _, err := unstructured.NestedSlice(project, "olm", "channels", "list")
+	if err != nil {
+		return err
+	}
 	channelsList = append(channelsList, fmt.Sprintf("stable-%d.%d", newVersion.Major, newVersion.Minor))
 
 	serving, _, _ := unstructured.NestedString(project, "dependencies", "serving")

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -1,78 +1,69 @@
----
 project:
-  name: serverless-operator
-
-  # When bumping the Operator to a new version (major and minor), make sure to also update
-  # all components in `dependencies.previous` to the same versions as `dependencies` in the same PR.
-  # Otherwise, the upgrade tests will not pass, as we have a different SO version with the same bundle contents.
-  # Also make sure to update values under `olm.previous` by copying from `olm.replaces` and `olm.skipRange`.
-  version: 1.29.0
-
+    name: serverless-operator
+    # When bumping the Operator to a new version (major and minor), make sure to also update
+    # all components in `dependencies.previous` to the same versions as `dependencies` in the same PR.
+    # Otherwise, the upgrade tests will not pass, as we have a different SO version with the same bundle contents.
+    # Also make sure to update values under `olm.previous` by copying from `olm.replaces` and `olm.skipRange`.
+    version: 1.29.0
 olm:
-  replaces: 1.28.0
-  skipRange: '>=1.28.0 <1.29.0'
-  channels:
-    default: 'stable'
-    list:
-      - 'stable'
-      - 'stable-1.29'
-  previous:
-    replaces: 1.27.0
-    skipRange: '>=1.27.0 <1.28.0'
-
+    replaces: 1.28.0
+    skipRange: '>=1.28.0 <1.29.0'
+    channels:
+        default: 'stable'
+        list:
+            - 'stable'
+            - 'stable-1.29'
+    previous:
+        replaces: 1.27.0
+        skipRange: '>=1.27.0 <1.28.0'
 requirements:
-  kube:
-    # The min version validation in `vendor/knative.dev/pkg/version/version.go`
-    # is ignored as it is overridden by fake version via KUBERNETES_MIN_VERSION.
-    # This value is used for CSV's min version validation.
-    minVersion: 1.21.0
-  golang: '1.19'
-  nodejs: 16.x
-  ocpVersion:
-    min: '4.10'
-    max: '4.13'
-    label: 'v4.10'
-
+    kube:
+        # The min version validation in `vendor/knative.dev/pkg/version/version.go`
+        # is ignored as it is overridden by fake version via KUBERNETES_MIN_VERSION.
+        # This value is used for CSV's min version validation.
+        minVersion: 1.21.0
+    golang: '1.19'
+    nodejs: 16.x
+    ocpVersion:
+        min: '4.10'
+        max: '4.13'
+        label: 'v4.10'
 dependencies:
-  serving: knative-v1.8
-  # serving midstream branch name
-  serving_artifacts_branch: release-v1.8
-
-  # versions for networking components
-  kourier: 1.8.0
-  net_kourier_artifacts_branch: release-1.8
-  net_istio: 1.8.0
-  net_istio_artifacts_branch: release-1.8
-  maistra: 2.3-latest
-
-  eventing: knative-v1.8
-  # eventing core midstream branch name
-  eventing_artifacts_branch: release-v1.8
-
-  # eventing-kafka-broker promotion tag
-  eventing_kafka_broker: knative-v1.8
-  # eventing-kafka-broker midstream branch or commit
-  eventing_kafka_broker_artifacts_branch: release-v1.8
-  # eventing-istio promotion tag
-  eventing_istio: knative-v1.8
-
-  cli: 1.8.1
-  func:
-    util: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root
-    tekton_s2i: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
-    tekton_buildah: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
-  operator: 1.6.0
-  # Previous versions required for downgrade testing
-  previous:
-    serving: 1.7.0
-    eventing: 1.7
-    eventing_kafka_broker: 1.7
+    serving: knative-v1.8
+    # serving midstream branch name
+    serving_artifacts_branch: release-v1.8
+    # versions for networking components
+    kourier: 1.8.0
+    net_kourier_artifacts_branch: release-1.8
+    net_istio: 1.8.0
+    net_istio_artifacts_branch: release-1.8
+    maistra: 2.3-latest
+    eventing: knative-v1.8
+    # eventing core midstream branch name
+    eventing_artifacts_branch: release-v1.8
+    # eventing-kafka-broker promotion tag
+    eventing_kafka_broker: knative-v1.8
+    # eventing-kafka-broker midstream branch or commit
+    eventing_kafka_broker_artifacts_branch: release-v1.8
+    # eventing-istio promotion tag
+    eventing_istio: knative-v1.8
+    cli: 1.8.1
+    func:
+        util: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root
+        tekton_s2i: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+        tekton_buildah: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
+    operator: 1.6.0
+    # Previous versions required for downgrade testing
+    previous:
+        serving: 1.7.0
+        eventing: 1.7
+        eventing_kafka_broker: 1.7
 upgrade_sequence:
-  - csv: serverless-operator.v1.26.0
-    source: redhat-operators
-  - csv: serverless-operator.v1.27.1
-    source: redhat-operators
-  - csv: serverless-operator.v1.28.0
-    source: redhat-operators
-  - csv: serverless-operator.v1.29.0
-    source: serverless-operator
+    - csv: serverless-operator.v1.26.0
+      source: redhat-operators
+    - csv: serverless-operator.v1.27.1
+      source: redhat-operators
+    - csv: serverless-operator.v1.28.0
+      source: redhat-operators
+    - csv: serverless-operator.v1.29.0
+      source: serverless-operator

--- a/vendor/github.com/coreos/go-semver/LICENSE
+++ b/vendor/github.com/coreos/go-semver/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/coreos/go-semver/NOTICE
+++ b/vendor/github.com/coreos/go-semver/NOTICE
@@ -1,0 +1,5 @@
+CoreOS Project
+Copyright 2018 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).

--- a/vendor/github.com/coreos/go-semver/semver/semver.go
+++ b/vendor/github.com/coreos/go-semver/semver/semver.go
@@ -1,0 +1,296 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Semantic Versions http://semver.org
+package semver
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Major      int64
+	Minor      int64
+	Patch      int64
+	PreRelease PreRelease
+	Metadata   string
+}
+
+type PreRelease string
+
+func splitOff(input *string, delim string) (val string) {
+	parts := strings.SplitN(*input, delim, 2)
+
+	if len(parts) == 2 {
+		*input = parts[0]
+		val = parts[1]
+	}
+
+	return val
+}
+
+func New(version string) *Version {
+	return Must(NewVersion(version))
+}
+
+func NewVersion(version string) (*Version, error) {
+	v := Version{}
+
+	if err := v.Set(version); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Must is a helper for wrapping NewVersion and will panic if err is not nil.
+func Must(v *Version, err error) *Version {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// Set parses and updates v from the given version string. Implements flag.Value
+func (v *Version) Set(version string) error {
+	metadata := splitOff(&version, "+")
+	preRelease := PreRelease(splitOff(&version, "-"))
+	dotParts := strings.SplitN(version, ".", 3)
+
+	if len(dotParts) != 3 {
+		return fmt.Errorf("%s is not in dotted-tri format", version)
+	}
+
+	if err := validateIdentifier(string(preRelease)); err != nil {
+		return fmt.Errorf("failed to validate pre-release: %v", err)
+	}
+
+	if err := validateIdentifier(metadata); err != nil {
+		return fmt.Errorf("failed to validate metadata: %v", err)
+	}
+
+	parsed := make([]int64, 3, 3)
+
+	for i, v := range dotParts[:3] {
+		val, err := strconv.ParseInt(v, 10, 64)
+		parsed[i] = val
+		if err != nil {
+			return err
+		}
+	}
+
+	v.Metadata = metadata
+	v.PreRelease = preRelease
+	v.Major = parsed[0]
+	v.Minor = parsed[1]
+	v.Patch = parsed[2]
+	return nil
+}
+
+func (v Version) String() string {
+	var buffer bytes.Buffer
+
+	fmt.Fprintf(&buffer, "%d.%d.%d", v.Major, v.Minor, v.Patch)
+
+	if v.PreRelease != "" {
+		fmt.Fprintf(&buffer, "-%s", v.PreRelease)
+	}
+
+	if v.Metadata != "" {
+		fmt.Fprintf(&buffer, "+%s", v.Metadata)
+	}
+
+	return buffer.String()
+}
+
+func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var data string
+	if err := unmarshal(&data); err != nil {
+		return err
+	}
+	return v.Set(data)
+}
+
+func (v Version) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + v.String() + `"`), nil
+}
+
+func (v *Version) UnmarshalJSON(data []byte) error {
+	l := len(data)
+	if l == 0 || string(data) == `""` {
+		return nil
+	}
+	if l < 2 || data[0] != '"' || data[l-1] != '"' {
+		return errors.New("invalid semver string")
+	}
+	return v.Set(string(data[1 : l-1]))
+}
+
+// Compare tests if v is less than, equal to, or greater than versionB,
+// returning -1, 0, or +1 respectively.
+func (v Version) Compare(versionB Version) int {
+	if cmp := recursiveCompare(v.Slice(), versionB.Slice()); cmp != 0 {
+		return cmp
+	}
+	return preReleaseCompare(v, versionB)
+}
+
+// Equal tests if v is equal to versionB.
+func (v Version) Equal(versionB Version) bool {
+	return v.Compare(versionB) == 0
+}
+
+// LessThan tests if v is less than versionB.
+func (v Version) LessThan(versionB Version) bool {
+	return v.Compare(versionB) < 0
+}
+
+// Slice converts the comparable parts of the semver into a slice of integers.
+func (v Version) Slice() []int64 {
+	return []int64{v.Major, v.Minor, v.Patch}
+}
+
+func (p PreRelease) Slice() []string {
+	preRelease := string(p)
+	return strings.Split(preRelease, ".")
+}
+
+func preReleaseCompare(versionA Version, versionB Version) int {
+	a := versionA.PreRelease
+	b := versionB.PreRelease
+
+	/* Handle the case where if two versions are otherwise equal it is the
+	 * one without a PreRelease that is greater */
+	if len(a) == 0 && (len(b) > 0) {
+		return 1
+	} else if len(b) == 0 && (len(a) > 0) {
+		return -1
+	}
+
+	// If there is a prerelease, check and compare each part.
+	return recursivePreReleaseCompare(a.Slice(), b.Slice())
+}
+
+func recursiveCompare(versionA []int64, versionB []int64) int {
+	if len(versionA) == 0 {
+		return 0
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursiveCompare(versionA[1:], versionB[1:])
+}
+
+func recursivePreReleaseCompare(versionA []string, versionB []string) int {
+	// A larger set of pre-release fields has a higher precedence than a smaller set,
+	// if all of the preceding identifiers are equal.
+	if len(versionA) == 0 {
+		if len(versionB) > 0 {
+			return -1
+		}
+		return 0
+	} else if len(versionB) == 0 {
+		// We're longer than versionB so return 1.
+		return 1
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	aInt := false
+	bInt := false
+
+	aI, err := strconv.Atoi(versionA[0])
+	if err == nil {
+		aInt = true
+	}
+
+	bI, err := strconv.Atoi(versionB[0])
+	if err == nil {
+		bInt = true
+	}
+
+	// Numeric identifiers always have lower precedence than non-numeric identifiers.
+	if aInt && !bInt {
+		return -1
+	} else if !aInt && bInt {
+		return 1
+	}
+
+	// Handle Integer Comparison
+	if aInt && bInt {
+		if aI > bI {
+			return 1
+		} else if aI < bI {
+			return -1
+		}
+	}
+
+	// Handle String Comparison
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursivePreReleaseCompare(versionA[1:], versionB[1:])
+}
+
+// BumpMajor increments the Major field by 1 and resets all other fields to their default values
+func (v *Version) BumpMajor() {
+	v.Major += 1
+	v.Minor = 0
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpMinor increments the Minor field by 1 and resets all other fields to their default values
+func (v *Version) BumpMinor() {
+	v.Minor += 1
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpPatch increments the Patch field by 1 and resets all other fields to their default values
+func (v *Version) BumpPatch() {
+	v.Patch += 1
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// validateIdentifier makes sure the provided identifier satisfies semver spec
+func validateIdentifier(id string) error {
+	if id != "" && !reIdentifier.MatchString(id) {
+		return fmt.Errorf("%s is not a valid semver identifier", id)
+	}
+	return nil
+}
+
+// reIdentifier is a regular expression used to check that pre-release and metadata
+// identifiers satisfy the spec requirements
+var reIdentifier = regexp.MustCompile(`^[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*$`)

--- a/vendor/github.com/coreos/go-semver/semver/sort.go
+++ b/vendor/github.com/coreos/go-semver/semver/sort.go
@@ -1,0 +1,38 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"sort"
+)
+
+type Versions []*Version
+
+func (s Versions) Len() int {
+	return len(s)
+}
+
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s Versions) Less(i, j int) bool {
+	return s[i].LessThan(*s[j])
+}
+
+// Sort sorts the given slice of Version
+func Sort(versions []*Version) {
+	sort.Sort(Versions(versions))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -93,6 +93,9 @@ github.com/cloudevents/sdk-go/v2/protocol
 github.com/cloudevents/sdk-go/v2/protocol/http
 github.com/cloudevents/sdk-go/v2/test
 github.com/cloudevents/sdk-go/v2/types
+# github.com/coreos/go-semver v0.3.0
+## explicit
+github.com/coreos/go-semver/semver
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew


### PR DESCRIPTION
Fixes #2074

This PR is introducing an automation that allows
bumping SO automatically. 

Such bump is often error prone and time consuming,
in addition to being something to learn as more people
join us in the release coordination.

The automation is automatically triggered when a new
branch is created (similar to https://github.com/openshift-knative/serverless-operator/pull/2061) with an option of 
manually triggering the workflow in case we ever need to
re-trigger it for  whatever reason.

This is the diff I'm getting by running this tool on top of the
current PR:

```diff
diff --git a/olm-catalog/serverless-operator/project.yaml b/olm-catalog/serverless-operator/project.yaml
index dd67fddcc..4ce5427d1 100644
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -4,18 +4,19 @@ project:
     # all components in `dependencies.previous` to the same versions as `dependencies` in the same PR.
     # Otherwise, the upgrade tests will not pass, as we have a different SO version with the same bundle contents.
     # Also make sure to update values under `olm.previous` by copying from `olm.replaces` and `olm.skipRange`.
-    version: 1.29.0
+    version: 1.30.0
 olm:
-    replaces: 1.28.0
-    skipRange: '>=1.28.0 <1.29.0'
+    replaces: 1.29.0
+    skipRange: '>=1.29.0 <1.30.0'
     channels:
         default: 'stable'
         list:
-            - 'stable'
-            - 'stable-1.29'
+            - stable
+            - stable-1.29
+            - stable-1.30
     previous:
-        replaces: 1.27.0
-        skipRange: '>=1.27.0 <1.28.0'
+        replaces: 1.28.0
+        skipRange: '>=1.28.0 <1.29.0'
 requirements:
     kube:
         # The min version validation in `vendor/knative.dev/pkg/version/version.go`
@@ -55,9 +56,9 @@ dependencies:
     operator: 1.6.0
     # Previous versions required for downgrade testing
     previous:
-        serving: 1.7.0
-        eventing: 1.7
-        eventing_kafka_broker: 1.7
+        serving: knative-v1.8
+        eventing: knative-v1.8
+        eventing_kafka_broker: knative-v1.8
 upgrade_sequence:
     - csv: serverless-operator.v1.26.0
       source: redhat-operators
@@ -67,3 +68,5 @@ upgrade_sequence:
       source: redhat-operators
     - csv: serverless-operator.v1.29.0
       source: serverless-operator
+    - csv: serverless-operator.v1.30.0
+      source: serverless-operator
```

Which is similar to: https://github.com/openshift-knative/serverless-operator/pull/2073