### PR TITLE
Increase scale for EKB tests to 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ test-upstream-e2e-no-upgrade:
 test-upstream-e2e-kafka-no-upgrade:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	TRACING_BACKEND=zipkin ./hack/tracing.sh
-	SCALE_UP=4 INSTALL_KAFKA="true" TRACING_BACKEND=zipkin ENABLE_TRACING=true ./hack/install.sh
+	SCALE_UP=5 INSTALL_KAFKA="true" TRACING_BACKEND=zipkin ENABLE_TRACING=true ./hack/install.sh
 	TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
 # Run only upstream upgrade tests.


### PR DESCRIPTION
This should make them more stable.

Some failures can be seen in [job history](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.12-upstream-e2e-kafka-aws-ocp-412-continuous)
They're failing even more often when testing interop with OCP 4.13: [job history](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-ocp4.13-lp-interop-operator-e2e-interop-aws-ocp413)

We run tests from openshift-knative/eventing-kafka-broker. We could also decrease the parallelism (or increase timeouts there) but the tests would just run longer so we'd not save much resources anyway. I think increasing scale to 5 is reasonable.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
