### PR TITLE
Align go version in GH actions

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -22,7 +22,7 @@ jobs:
       GOPATH: ${{ github.workspace }}
     steps:
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
 
@@ -123,10 +123,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-      - name: Set up Go 1.18.x
-        uses: actions/setup-go@v2
+      - name: Setup Golang
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -178,8 +178,8 @@ jobs:
       - name: Go Lint - knative-operator
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
-          args: --timeout=10m0s --verbose
+          version: v1.51.2
+          args: --timeout=10m0s --verbose 
           working-directory: ./src/github.com/${{ github.repository }}
 
       # This is mostly copied from https://github.com/get-woke/woke-action-reviewdog/blob/main/entrypoint.sh


### PR DESCRIPTION
As a follow-up to #2078 and partially to verify CI is green. I'd look into a bit more to have a reusable step with one place to set it ideally.

/cc @pierDipi 