### PR TITLE
Add install cert-manager operator scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ install-operator:
 
 install-all:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
+	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 	./hack/tracing.sh
 	SCALE_UP=4 INSTALL_KAFKA="true" ENABLE_TRACING=true ./hack/install.sh
 
@@ -27,9 +28,11 @@ install-serving-with-mesh:
 	FULL_MESH=true SCALE_UP=4 INSTALL_SERVING=true INSTALL_EVENTING="false" ./hack/install.sh
 
 install-eventing:
+	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 	INSTALL_SERVING="false" ./hack/install.sh
 
 install-kafka:
+	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 	INSTALL_SERVING="false" INSTALL_KAFKA="true" ./hack/install.sh
 
 install-kafka-with-mesh:
@@ -43,6 +46,12 @@ install-strimzi:
 
 uninstall-strimzi:
 	UNINSTALL_STRIMZI="true" ./hack/strimzi.sh
+
+install-certmanager:
+	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
+
+uninstall-certmanager:
+	UNINSTALL_CERTMANAGER="true" ./hack/certmanager.sh
 
 install-previous:
 	INSTALL_PREVIOUS_VERSION="true" ./hack/install.sh

--- a/hack/certmanager.sh
+++ b/hack/certmanager.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This script can be used to install cert-manager operator.
+#
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/lib/__sources__.bash"
+
+set -Eeuo pipefail
+
+if [[ $UNINSTALL_CERTMANAGER == "true" ]]; then
+  uninstall_certmanager || exit 1
+else
+  install_certmanager || exit 2
+fi
+
+exit 0

--- a/hack/lib/__sources__.bash
+++ b/hack/lib/__sources__.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-declare -a __sources=(metadata vars common ui scaleup namespaces catalogsource serverless tracing mesh strimzi tracing clusterlogging testselect)
+declare -a __sources=(metadata vars common ui scaleup namespaces catalogsource serverless tracing mesh certmanager strimzi tracing clusterlogging testselect)
 
 for source in "${__sources[@]}"; do
   # shellcheck disable=SC1091,SC1090

--- a/hack/lib/certmanager.bash
+++ b/hack/lib/certmanager.bash
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+certmanager_resources_dir="$(dirname "${BASH_SOURCE[0]}")/certmanager_resources"
+  
+function install_certmanager {
+  deploy_certmanager_operator
+}
+
+function uninstall_certmanager {
+  undeploy_certmanager_operator
+}
+
+function deploy_certmanager_operator {
+  logger.info "Installing cert manager operator in namespace openshift-operators"
+  oc apply -f "${certmanager_resources_dir}"/subscription.yaml || return $?
+
+  logger.info "Waiting until cert manager operator is available"
+  oc wait --for=condition=Available deployment cert-manager --timeout=300s -n cert-manager || return $?
+  oc wait --for=condition=Available deployment cert-manager-webhook --timeout=300s -n cert-manager || return $?
+}
+
+function undeploy_certmanager_operator {
+  logger.info "Deleting cert manager subscriptions"
+  oc delete -f "${certmanager_resources_dir}"/subscription.yaml || return $?
+
+  logger.info 'Ensure no CRDs left'
+  if [[ ! $(oc get crd -oname | grep -c 'maistra.io') -eq 0 ]]; then
+    oc get crd -oname | grep 'cert-manager.io' | xargs oc delete --timeout=60s
+  fi
+  logger.success "cert manager has been uninstalled"
+}

--- a/hack/lib/certmanager.bash
+++ b/hack/lib/certmanager.bash
@@ -11,12 +11,12 @@ function uninstall_certmanager {
 }
 
 function deploy_certmanager_operator {
-  logger.info "Installing cert manager operator in namespace openshift-operators"
+  logger.info "Installing cert manager operator"
   oc apply -f "${certmanager_resources_dir}"/subscription.yaml || return $?
 
   logger.info "Waiting until cert manager operator is available"
-  oc wait --for=condition=Available deployment cert-manager --timeout=300s -n cert-manager || return $?
-  oc wait --for=condition=Available deployment cert-manager-webhook --timeout=300s -n cert-manager || return $?
+
+  timeout 600 "[[ \$(oc get deploy -n cert-manager cert-manager --no-headers | wc -l) != 1 ]]" || return 1
 }
 
 function undeploy_certmanager_operator {

--- a/hack/lib/certmanager_resources/subscription.yaml
+++ b/hack/lib/certmanager_resources/subscription.yaml
@@ -1,0 +1,24 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: openshift-operators
+spec:
+  targetNamespaces:
+    - openshift-operators
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/openshift-cert-manager-operator.cert-manager-operator: ""
+  name: openshift-cert-manager-operator
+  namespace: openshift-operators
+spec:
+  channel: stable-v1
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: cert-manager-operator.v1.10.2

--- a/hack/lib/certmanager_resources/subscription.yaml
+++ b/hack/lib/certmanager_resources/subscription.yaml
@@ -1,11 +1,20 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: Red Hat Certificate Manager Operator
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: cert-manager-operator
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: cert-manager-operator
-  namespace: openshift-operators
+  namespace: cert-manager-operator
 spec:
   targetNamespaces:
-    - openshift-operators
+    - cert-manager-operator
   upgradeStrategy: Default
 ---
 apiVersion: operators.coreos.com/v1alpha1
@@ -14,7 +23,7 @@ metadata:
   labels:
     operators.coreos.com/openshift-cert-manager-operator.cert-manager-operator: ""
   name: openshift-cert-manager-operator
-  namespace: openshift-operators
+  namespace: cert-manager-operator
 spec:
   channel: stable-v1
   installPlanApproval: Automatic


### PR DESCRIPTION
Eventing needs cert-manager for testing TLS.

Tested with:

```bash
$ make install-certmanager
UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
INFO    12:50:35.446 Installing cert manager operator in namespace cert-manager-operator
operatorgroup.operators.coreos.com/cert-manager-operator created
subscription.operators.coreos.com/openshift-cert-manager-operator created

$ k create ns knative-eventing
namespace/knative-eventing created

$ kubectl apply -f https://raw.githubusercontent.com/knative/eventing/main/config/tls/issuers/selfsigned-ca-issuer.yaml
$ kubectl apply -f https://raw.githubusercontent.com/knative/eventing/main/config/tls/issuers/selfsigned-issuer.yaml

$ kubectl get certificates,issuers -n knative-eventing

NAME                                        READY   SECRET        AGE
certificate.cert-manager.io/selfsigned-ca   True    eventing-ca   2m10s

NAME                                          READY   AGE
issuer.cert-manager.io/selfsigned-ca-issuer   True    2m10s
issuer.cert-manager.io/selfsigned-issuer      True    2m10s

$ make uninstall-certmanager
UNINSTALL_CERTMANAGER="true" ./hack/certmanager.sh
INFO    12:56:16.684 Deleting cert manager subscriptions
operatorgroup.operators.coreos.com "cert-manager-operator" deleted
subscription.operators.coreos.com "openshift-cert-manager-operator" deleted
INFO    12:56:17.521 Ensure no CRDs left
SUCCESS 12:56:19.175 cert manager has been uninstalled
```