### PR TITLE
Check if machineconfigpool is available before scaling

### DIFF
--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -65,6 +65,9 @@ function wait_until_machineset_scales_up {
 }
 
 function cluster_scalable {
+  if ! oc get machineconfigpool &>/dev/null; then
+    return 1
+  fi
   if [[ $(oc get infrastructure cluster -ojsonpath='{.status.platform}') = VSphere ]]; then
     return 1
   fi


### PR DESCRIPTION
This is useful for some platforms such as Hypershift where machineconfigpool is not available but we still want our script to work. When the cluster is not scalable it already has to have the right size for tests to pass.

Related to testing on Hypershift: https://github.com/openshift/release/pull/39725

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
