### PR TITLE
Set min kube version to 1.23.0

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -188,7 +188,7 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  minKubeVersion: 1.21.0
+  minKubeVersion: 1.23.0
   customresourcedefinitions:
     owned:
       - description: Represents an installation of a particular version of Knative Serving

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -22,7 +22,7 @@ requirements:
         # The min version validation in `vendor/knative.dev/pkg/version/version.go`
         # is ignored as it is overridden by fake version via KUBERNETES_MIN_VERSION.
         # This value is used for CSV's min version validation.
-        minVersion: 1.21.0
+        minVersion: 1.23.0
     golang: '1.19'
     nodejs: 16.x
     ocpVersion:


### PR DESCRIPTION
* Serverless 1.28 is the last release supported on kube 1.21.0
* Serverless >=1.29 is supported on kube >=1.23 (OCP >=4.10)

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
