### PR TITLE
Define USER_MANAGEMENT_ALLOWED flag

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -98,3 +98,6 @@ EOF
 )
 export IMAGE_TEMPLATE="${IMAGE_TEMPLATE:-"$DEFAULT_IMAGE_TEMPLATE"}"
 export INDEX_IMAGE="${INDEX_IMAGE:-}"
+# Might be used to disable tests which need additional users.
+# Managed environments such as Hypershift might now allow creating new users.
+export USER_MANAGEMENT_ALLOWED="${USER_MANAGEMENT_ALLOWED:-true}"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -24,7 +24,9 @@ logger.success '🚀 Cluster prepared for testing.'
 # Run serverless-operator specific tests.
 create_namespaces "${TEST_NAMESPACES[@]}"
 link_global_pullsecret_to_namespaces "${TEST_NAMESPACES[@]}"
-create_htpasswd_users && add_roles
+if [[ "$USER_MANAGEMENT_ALLOWED" == "true" ]]; then
+  create_htpasswd_users && add_roles
+fi
 
 run_testselect
 

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -134,6 +134,10 @@ function downstream_serving_e2e_tests {
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi
 
+  if [[ "$USER_MANAGEMENT_ALLOWED" == "false" ]]; then
+      mv ./test/servinge2e/user_permissions_test.go ./test/servinge2e/user_permissions_notest.go
+  fi
+
   if [[ $FULL_MESH == "true" ]]; then
     export GODEBUG="x509ignoreCN=0"
     go_test_e2e "${RUN_FLAGS[@]}" ./test/servinge2e/ \
@@ -168,6 +172,10 @@ function downstream_eventing_e2e_tests {
   RUN_FLAGS=(-failfast -timeout=30m -parallel=1)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
+  fi
+
+  if [[ "$USER_MANAGEMENT_ALLOWED" == "false" ]]; then
+      mv ./test/eventinge2e/user_permissions_test.go ./test/eventinge2e/user_permissions_notest.go
   fi
 
   go_test_e2e "${RUN_FLAGS[@]}" ./test/eventinge2e \
@@ -235,6 +243,10 @@ function downstream_knative_kafka_e2e_tests {
   RUN_FLAGS=(-failfast -timeout=30m -parallel=1)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
+  fi
+
+  if [[ "$USER_MANAGEMENT_ALLOWED" == "false" ]]; then
+      mv ./test/extensione2e/kafka/user_permissions_test.go ./test/extensione2e/kafka/user_permissions_notest.go
   fi
 
   go_test_e2e "${RUN_FLAGS[@]}" ./test/extensione2e/kafka \

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -135,7 +135,7 @@ function downstream_serving_e2e_tests {
   fi
 
   if [[ "$USER_MANAGEMENT_ALLOWED" == "false" ]]; then
-      mv ./test/servinge2e/user_permissions_test.go ./test/servinge2e/user_permissions_notest.go
+      mv ./test/servinge2e/user_permissions_test.go ./test/servinge2e/user_permissions_notest.go || true
   fi
 
   if [[ $FULL_MESH == "true" ]]; then
@@ -175,7 +175,7 @@ function downstream_eventing_e2e_tests {
   fi
 
   if [[ "$USER_MANAGEMENT_ALLOWED" == "false" ]]; then
-      mv ./test/eventinge2e/user_permissions_test.go ./test/eventinge2e/user_permissions_notest.go
+      mv ./test/eventinge2e/user_permissions_test.go ./test/eventinge2e/user_permissions_notest.go || true
   fi
 
   go_test_e2e "${RUN_FLAGS[@]}" ./test/eventinge2e \
@@ -246,7 +246,7 @@ function downstream_knative_kafka_e2e_tests {
   fi
 
   if [[ "$USER_MANAGEMENT_ALLOWED" == "false" ]]; then
-      mv ./test/extensione2e/kafka/user_permissions_test.go ./test/extensione2e/kafka/user_permissions_notest.go
+      mv ./test/extensione2e/kafka/user_permissions_test.go ./test/extensione2e/kafka/user_permissions_notest.go || true
   fi
 
   go_test_e2e "${RUN_FLAGS[@]}" ./test/extensione2e/kafka \


### PR DESCRIPTION
This will be used to disable tests for additional users on environments such as Hypershift.

Part of https://issues.redhat.com/browse/SRVCOM-2475

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
