### PR TITLE
Append kubeconfigs only if they exist

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -74,9 +74,10 @@ function serverless_operator_e2e_tests {
 
   logger.info "Running operator e2e tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+  while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
+
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
   RUN_FLAGS=(-failfast -timeout=30m -parallel=1)
@@ -99,9 +100,9 @@ function serverless_operator_kafka_e2e_tests {
 
   logger.info "Running Kafka tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+  while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
   RUN_FLAGS=(-failfast -timeout=30m -parallel=1)
@@ -124,9 +125,9 @@ function downstream_serving_e2e_tests {
 
   logger.info "Running Serving tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+  while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
   RUN_FLAGS=(-failfast -timeout=60m -parallel=1)
@@ -160,9 +161,9 @@ function downstream_eventing_e2e_tests {
 
   logger.info "Running Eventing downstream tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+  while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
   # Used by eventing/test/lib
@@ -231,9 +232,9 @@ function downstream_knative_kafka_e2e_tests {
 
   logger.info "Running Knative Kafka tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+  while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
   # Used by eventing/test/lib
@@ -263,9 +264,9 @@ function downstream_monitoring_e2e_tests {
 
   logger.info "Running Knative monitoring tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+  while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
   RUN_FLAGS=(-failfast -timeout=30m -parallel=1)

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -74,8 +74,8 @@ function serverless_operator_e2e_tests {
 
   logger.info "Running operator e2e tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in user*.kubeconfig; do
-    kubeconfigs+=("$(pwd)/${cfg}")
+  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+    kubeconfigs+=("${cfg}")
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
@@ -99,8 +99,8 @@ function serverless_operator_kafka_e2e_tests {
 
   logger.info "Running Kafka tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in user*.kubeconfig; do
-    kubeconfigs+=("$(pwd)/${cfg}")
+  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+    kubeconfigs+=("${cfg}")
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
@@ -124,8 +124,8 @@ function downstream_serving_e2e_tests {
 
   logger.info "Running Serving tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in user*.kubeconfig; do
-    kubeconfigs+=("$(pwd)/${cfg}")
+  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+    kubeconfigs+=("${cfg}")
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
@@ -160,8 +160,8 @@ function downstream_eventing_e2e_tests {
 
   logger.info "Running Eventing downstream tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in user*.kubeconfig; do
-    kubeconfigs+=("$(pwd)/${cfg}")
+  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+    kubeconfigs+=("${cfg}")
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
@@ -231,8 +231,8 @@ function downstream_knative_kafka_e2e_tests {
 
   logger.info "Running Knative Kafka tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in user*.kubeconfig; do
-    kubeconfigs+=("$(pwd)/${cfg}")
+  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+    kubeconfigs+=("${cfg}")
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
@@ -263,8 +263,8 @@ function downstream_monitoring_e2e_tests {
 
   logger.info "Running Knative monitoring tests"
   kubeconfigs+=("${KUBECONFIG}")
-  for cfg in user*.kubeconfig; do
-    kubeconfigs+=("$(pwd)/${cfg}")
+  for cfg in $(find "$(pwd -P)" -name "user*.kubeconfig"); do
+    kubeconfigs+=("${cfg}")
   done
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 


### PR DESCRIPTION
Otherwise the script passes it like this which fails. --kubeconfigs
/tmp/kubeconfig-3494827175,/go/src/github.com/openshift-knative/serverless-operator/user*.kubeconfig

The error is following:
clients.go:80: Couldn't initialize clients for config /go/src/github.com/openshift-knative/serverless-operator/user*.kubeconfig

This is a follow-up to https://github.com/openshift-knative/serverless-operator/commit/66f9f1b1ddcd716eede604a5c2726b802fb5832b


Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
