### PR TITLE
:lady_beetle: Cluster-local ksvc displays the URL in text field instead of a link

### DIFF
--- a/test/ui/cypress/e2e/serving/cluster-local.cy.js
+++ b/test/ui/cypress/e2e/serving/cluster-local.cy.js
@@ -6,7 +6,9 @@ describe('OCP UI for Serverless Serving', () => {
 
   const environment = new Environment()
   const openshiftConsole = new OpenshiftConsole()
-  const showcaseKsvc = new ShowcaseKservice()
+  const showcaseKsvc = new ShowcaseKservice({
+    clusterLocal: true,
+  })
 
   it('can deploy a cluster-local service', () => {
     const range = '>=4.8 || ~4.7.18 || ~4.6.39'
@@ -14,7 +16,7 @@ describe('OCP UI for Serverless Serving', () => {
 
     openshiftConsole.login()
     showcaseKsvc.removeApp()
-    showcaseKsvc.deployImage({clusterLocal: true})
+    showcaseKsvc.deployImage()
     showcaseKsvc.url().and('include', 'cluster.local')
   })
 })


### PR DESCRIPTION
Fixes JIRA [SRVCOM-2403](https://issues.redhat.com/browse/SRVCOM-2403)

## Proposed Changes

- :lady_beetle: Cluster-local ksvc displays the URL in text field instead of a link

/kind bug

Caused by https://github.com/openshift/console/pull/12726

