### PR TITLE
Drop `x509ignoreCN=0`

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -140,7 +140,6 @@ function downstream_serving_e2e_tests {
   fi
 
   if [[ $FULL_MESH == "true" ]]; then
-    export GODEBUG="x509ignoreCN=0"
     go_test_e2e "${RUN_FLAGS[@]}" ./test/servinge2e/ \
       --kubeconfigs "${kubeconfigs_str}" \
       --imagetemplate "${IMAGE_TEMPLATE}" \


### PR DESCRIPTION
As per title, this patch drops unnecessary `GODEBUG="x509ignoreCN=0"`.
It was dropped in https://github.com/openshift-knative/serverless-operator/pull/1246 but it seems that the PR missed this one.