### PR TITLE
Add `KUBERNETES_MIN_VERSION` to metadata-webhook

### DIFF
--- a/serving/metadata-webhook/config/webhook.yaml
+++ b/serving/metadata-webhook/config/webhook.yaml
@@ -45,6 +45,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_MIN_VERSION
+          value: v1.0.0
         - name: CONFIG_LOGGING_NAME
           value: config-logging
         - name: METRICS_DOMAIN


### PR DESCRIPTION
As per title, https://github.com/openshift-knative/serverless-operator/pull/1816 sets all components but metadata-webhook is not controlled by operator because it is only for e2e testing.

Hence it is not working on recent 4.10 cluster -
[log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.10-e2e-mesh-ocp-410-continuous/1663576158735699968/artifacts/e2e-mesh-ocp-410-continuous/gather-extra/artifacts/pods/serving-tests_webhook-8676b4699f-xcsz9_webhook.log)

This patch adds `KUBERNETES_MIN_VERSION` to avoid the issue.