### PR TITLE
Split broker-related kitchensink tests

### DIFF
--- a/test/kitchensinke2e/broker_test.go
+++ b/test/kitchensinke2e/broker_test.go
@@ -4,16 +4,28 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test/kitchensinke2e/features"
-	"knative.dev/reconciler-test/pkg/feature"
 )
 
-func TestBrokerReadiness(t *testing.T) {
-	featureSets := []feature.FeatureSet{
-		features.BrokerFeatureSetWithBrokerDLS(false),
-		features.BrokerFeatureSetWithTriggerDLS(false),
+func TestBrokerReadinessBrokerDLS(t *testing.T) {
+	featureSet := features.BrokerFeatureSetWithBrokerDLS(false)
+	for _, f := range featureSet.Features {
+		f := f
+		t.Run(featureSet.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx, env := defaultEnvironment(t)
+			env.Test(ctx, t, f)
+		})
 	}
-	for _, fs := range featureSets {
-		ctx, env := defaultEnvironment(t)
-		env.ParallelTestSet(ctx, t, &fs)
+}
+
+func TestBrokerReadinessTriggerDLS(t *testing.T) {
+	featureSet := features.BrokerFeatureSetWithTriggerDLS(false)
+	for _, f := range featureSet.Features {
+		f := f
+		t.Run(featureSet.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx, env := defaultEnvironment(t)
+			env.Test(ctx, t, f)
+		})
 	}
 }

--- a/test/kitchensinke2e/broker_test.go
+++ b/test/kitchensinke2e/broker_test.go
@@ -13,13 +13,7 @@ func TestBrokerReadiness(t *testing.T) {
 		features.BrokerFeatureSetWithTriggerDLS(false),
 	}
 	for _, fs := range featureSets {
-		for _, f := range fs.Features {
-			f := f
-			t.Run(fs.Name, func(t *testing.T) {
-				t.Parallel()
-				ctx, env := defaultContext(t)
-				env.Test(ctx, t, f)
-			})
-		}
+		ctx, env := defaultEnvironment(t)
+		env.ParallelTestSet(ctx, t, &fs)
 	}
 }

--- a/test/kitchensinke2e/channel_test.go
+++ b/test/kitchensinke2e/channel_test.go
@@ -8,12 +8,6 @@ import (
 
 func TestChannelReadiness(t *testing.T) {
 	featureSet := features.ChannelFeatureSet(false)
-	for _, f := range featureSet.Features {
-		f := f
-		t.Run(featureSet.Name, func(t *testing.T) {
-			t.Parallel()
-			ctx, env := defaultContext(t)
-			env.Test(ctx, t, f)
-		})
-	}
+	ctx, env := defaultEnvironment(t)
+	env.ParallelTestSet(ctx, t, &featureSet)
 }

--- a/test/kitchensinke2e/channel_test.go
+++ b/test/kitchensinke2e/channel_test.go
@@ -8,6 +8,12 @@ import (
 
 func TestChannelReadiness(t *testing.T) {
 	featureSet := features.ChannelFeatureSet(false)
-	ctx, env := defaultEnvironment(t)
-	env.ParallelTestSet(ctx, t, &featureSet)
+	for _, f := range featureSet.Features {
+		f := f
+		t.Run(featureSet.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx, env := defaultEnvironment(t)
+			env.Test(ctx, t, f)
+		})
+	}
 }

--- a/test/kitchensinke2e/flow_test.go
+++ b/test/kitchensinke2e/flow_test.go
@@ -15,7 +15,13 @@ func TestFlowReadiness(t *testing.T) {
 		features.ParallelGlobalReplyFeatureSet(false),
 	}
 	for _, fs := range featureSets {
-		ctx, env := defaultEnvironment(t)
-		env.ParallelTestSet(ctx, t, &fs)
+		for _, f := range fs.Features {
+			f := f
+			t.Run(fs.Name, func(t *testing.T) {
+				t.Parallel()
+				ctx, env := defaultEnvironment(t)
+				env.Test(ctx, t, f)
+			})
+		}
 	}
 }

--- a/test/kitchensinke2e/flow_test.go
+++ b/test/kitchensinke2e/flow_test.go
@@ -15,13 +15,7 @@ func TestFlowReadiness(t *testing.T) {
 		features.ParallelGlobalReplyFeatureSet(false),
 	}
 	for _, fs := range featureSets {
-		for _, f := range fs.Features {
-			f := f
-			t.Run(fs.Name, func(t *testing.T) {
-				t.Parallel()
-				ctx, env := defaultContext(t)
-				env.Test(ctx, t, f)
-			})
-		}
+		ctx, env := defaultEnvironment(t)
+		env.ParallelTestSet(ctx, t, &fs)
 	}
 }

--- a/test/kitchensinke2e/main_test.go
+++ b/test/kitchensinke2e/main_test.go
@@ -25,7 +25,7 @@ func defaultContext(t *testing.T) (context.Context, environment.Environment) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
-		environment.WithPollTimings(4*time.Second, 600*time.Second),
+		environment.WithPollTimings(4*time.Second, 15*time.Minute),
 		environment.Managed(t),
 	)
 }

--- a/test/kitchensinke2e/main_test.go
+++ b/test/kitchensinke2e/main_test.go
@@ -19,7 +19,7 @@ import (
 
 var global environment.GlobalEnvironment
 
-func defaultContext(t *testing.T) (context.Context, environment.Environment) {
+func defaultEnvironment(t *testing.T) (context.Context, environment.Environment) {
 	return global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,

--- a/test/kitchensinke2e/main_test.go
+++ b/test/kitchensinke2e/main_test.go
@@ -25,7 +25,7 @@ func defaultContext(t *testing.T) (context.Context, environment.Environment) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
-		environment.WithPollTimings(4*time.Second, 15*time.Minute),
+		environment.WithPollTimings(4*time.Second, 10*time.Minute),
 		environment.Managed(t),
 	)
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -334,7 +334,7 @@ function downstream_kitchensink_e2e_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  RUN_FLAGS=(-failfast -timeout=120m -parallel=4)
+  RUN_FLAGS=(-failfast -timeout=120m -parallel=8)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -334,7 +334,7 @@ function downstream_kitchensink_e2e_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  RUN_FLAGS=(-failfast -timeout=120m -parallel=8)
+  RUN_FLAGS=(-failfast -timeout=120m -parallel=20)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi
@@ -450,7 +450,7 @@ function kitchensink_upgrade_tests {
 
   export SYSTEM_NAMESPACE="$SERVING_NAMESPACE"
 
-  go_test_e2e -run=TestKitchensink -timeout=90m -parallel=10 ./test/upgrade/kitchensink -tags=upgrade \
+  go_test_e2e -run=TestKitchensink -timeout=90m -parallel=20 ./test/upgrade/kitchensink -tags=upgrade \
      --kubeconfigs="${KUBECONFIG}" \
      --imagetemplate="${IMAGE_TEMPLATE}" \
      --catalogsource="$(metadata.get "upgrade_sequence[*].source" | tail -n +2 | tr '\n' ',')" \

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -323,6 +323,10 @@ function downstream_kitchensink_e2e_tests {
 
   logger.info "Running Knative kitchensink tests"
 
+  local images_file
+
+  images_file="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/images-rekt.yaml"
+
   # Create a secret for reconciler-test. The framework will copy this secret
   # to newly created namespaces and link to default service account in the namespace.
   if ! oc -n default get secret kn-test-image-pull-secret; then
@@ -340,6 +344,7 @@ function downstream_kitchensink_e2e_tests {
   fi
 
   go_test_e2e "${RUN_FLAGS[@]}" ./test/kitchensinke2e \
+  --images.producer.file="${images_file}" \
   --imagetemplate "${IMAGE_TEMPLATE}" \
   "$@"
 }
@@ -448,10 +453,15 @@ EOF
 function kitchensink_upgrade_tests {
   logger.info "Running kitchensink upgrade tests"
 
+  local images_file
+
+  images_file="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/images-rekt.yaml"
+
   export SYSTEM_NAMESPACE="$SERVING_NAMESPACE"
 
   go_test_e2e -run=TestKitchensink -timeout=90m -parallel=20 ./test/upgrade/kitchensink -tags=upgrade \
      --kubeconfigs="${KUBECONFIG}" \
+     --images.producer.file="${images_file}" \
      --imagetemplate="${IMAGE_TEMPLATE}" \
      --catalogsource="$(metadata.get "upgrade_sequence[*].source" | tail -n +2 | tr '\n' ',')" \
      --csv="$(metadata.get "upgrade_sequence[*].csv" | tail -n +2 | tr '\n' ',')" \

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -323,10 +323,6 @@ function downstream_kitchensink_e2e_tests {
 
   logger.info "Running Knative kitchensink tests"
 
-  local images_file
-
-  images_file="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/images-rekt.yaml"
-
   # Create a secret for reconciler-test. The framework will copy this secret
   # to newly created namespaces and link to default service account in the namespace.
   if ! oc -n default get secret kn-test-image-pull-secret; then
@@ -344,7 +340,6 @@ function downstream_kitchensink_e2e_tests {
   fi
 
   go_test_e2e "${RUN_FLAGS[@]}" ./test/kitchensinke2e \
-  --images.producer.file="${images_file}" \
   --imagetemplate "${IMAGE_TEMPLATE}" \
   "$@"
 }
@@ -453,15 +448,10 @@ EOF
 function kitchensink_upgrade_tests {
   logger.info "Running kitchensink upgrade tests"
 
-  local images_file
-
-  images_file="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/images-rekt.yaml"
-
   export SYSTEM_NAMESPACE="$SERVING_NAMESPACE"
 
   go_test_e2e -run=TestKitchensink -timeout=90m -parallel=10 ./test/upgrade/kitchensink -tags=upgrade \
      --kubeconfigs="${KUBECONFIG}" \
-     --images.producer.file="${images_file}" \
      --imagetemplate="${IMAGE_TEMPLATE}" \
      --catalogsource="$(metadata.get "upgrade_sequence[*].source" | tail -n +2 | tr '\n' ',')" \
      --csv="$(metadata.get "upgrade_sequence[*].csv" | tail -n +2 | tr '\n' ',')" \

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -459,7 +459,7 @@ function kitchensink_upgrade_tests {
 
   export SYSTEM_NAMESPACE="$SERVING_NAMESPACE"
 
-  go_test_e2e -run=TestKitchensink -timeout=90m -parallel=20 ./test/upgrade/kitchensink -tags=upgrade \
+  go_test_e2e -run=TestKitchensink -timeout=90m -parallel=10 ./test/upgrade/kitchensink -tags=upgrade \
      --kubeconfigs="${KUBECONFIG}" \
      --images.producer.file="${images_file}" \
      --imagetemplate="${IMAGE_TEMPLATE}" \

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -334,7 +334,7 @@ function downstream_kitchensink_e2e_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  RUN_FLAGS=(-failfast -timeout=120m -parallel=20)
+  RUN_FLAGS=(-failfast -timeout=120m -parallel=6)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -334,7 +334,7 @@ function downstream_kitchensink_e2e_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  RUN_FLAGS=(-failfast -timeout=120m -parallel=6)
+  RUN_FLAGS=(-failfast -timeout=120m -parallel=4)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi


### PR DESCRIPTION
Fixes failing periodic kitchensink tests such as https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.12-e2e-kitchensink-ocp-412-continuous/1666173187857059840

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Split Broker related tests into two groups otherwise too many tests run in parallel and some tests time out.
- The number of tests in each group is now following:
TestFlowReadiness: 753
TestBrokerReadinessBrokerDLS: 1621
TestBrokerReadinessTriggerDLS: 1621
TestChannelReadiness: 1680
