### PR TITLE
Install 1.29 from redhat-operators catalog source

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -69,6 +69,6 @@ upgrade_sequence:
     - csv: serverless-operator.v1.28.0
       source: redhat-operators
     - csv: serverless-operator.v1.29.0
-      source: serverless-operator
+      source: redhat-operators
     - csv: serverless-operator.v1.30.0
       source: serverless-operator


### PR DESCRIPTION
When 1.28 is installed from redhat-operators and 1.29 is there as well then 1.29 is immediately offered from redhat-operators and the variant from serverless-operator catalog source won't appear there even if the operator is also in serverless-operator cs.

This should fix the [latest failures](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.10-upgrade-kitchensink-ocp-410-continuous/1665841183085039616) in kitchensink upgrade tests: 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
