### PR TITLE
Remove toggle for `podspec-volumes-emptydir`

### DIFF
--- a/test/serving.bash
+++ b/test/serving.bash
@@ -48,7 +48,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     --patch='{"spec": {"ingress": { "kourier": {"service-type": "LoadBalancer"}}}}'
 
   # Enable the required features for the respective tests.
-  enable_feature_flags kubernetes.podspec-volumes-emptydir kubernetes.podspec-init-containers kubernetes.podspec-persistent-volume-claim \
+  enable_feature_flags kubernetes.podspec-init-containers kubernetes.podspec-persistent-volume-claim \
   kubernetes.podspec-persistent-volume-write kubernetes.podspec-securitycontext
 
   # Create a persistent volume claim for the respective tests


### PR DESCRIPTION
## Proposed Changes

:broom: Remove toggle for `podspec-volumes-emptydir`.
* Since it is enabled by default https://github.com/openshift-knative/serving/commit/6e597fa7fd731ec7c655566bfb3bae9caa1fc0d4 it should be dropped.

midstream is also changing https://github.com/openshift-knative/serving/pull/354
