### PR TITLE
Add default QPS and Burst value for kourier controller

### DIFF
--- a/openshift-knative-operator/pkg/common/env.go
+++ b/openshift-knative-operator/pkg/common/env.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	mf "github.com/manifestival/manifestival"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/operator/pkg/apis/operator/base"
+)
+
+// ConfigureEnvValueIfUnset sets env values via arguments if users haven't set in the CR.
+func ConfigureEnvValueIfUnset(s *base.CommonSpec, deployment, container, key, value string) mf.Transformer {
+	for _, o := range s.GetWorkloadOverrides() {
+		if o.Name == deployment {
+			for _, env := range o.Env {
+				if env.Container == container {
+					for _, envVar := range env.EnvVars {
+						if envVar.Name == key {
+							// Already set, nothing to do here.
+							return nil
+						}
+					}
+				}
+			}
+		}
+	}
+	return InjectEnvironmentIntoDeployment(deployment, container, corev1.EnvVar{Name: key, Value: value})
+}

--- a/openshift-knative-operator/pkg/common/env_test.go
+++ b/openshift-knative-operator/pkg/common/env_test.go
@@ -1,0 +1,123 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"knative.dev/operator/pkg/apis/operator/base"
+)
+
+func TestConfigureEnvValueIfUnset(t *testing.T) {
+	spec := func(containers ...corev1.Container) appsv1.DeploymentSpec {
+		return appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: containers,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		in         *appsv1.Deployment
+		deployment string
+		container  string
+		want       *appsv1.Deployment
+	}{{
+		name:       "add",
+		deployment: "test",
+		container:  "container1",
+		in: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: spec(corev1.Container{
+				Name: "container1",
+				Env:  []corev1.EnvVar{envVar("1", "1")},
+			}, corev1.Container{
+				Name: "container2",
+				Env:  []corev1.EnvVar{envVar("2", "2")},
+			}),
+		},
+		want: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: spec(corev1.Container{
+				Name: "container1",
+				Env:  []corev1.EnvVar{envVar("1", "1"), envVar("foo", "bar")},
+			}, corev1.Container{
+				Name: "container2",
+				Env:  []corev1.EnvVar{envVar("2", "2")},
+			}),
+		},
+	}, {
+		name:       "update",
+		deployment: "test",
+		container:  "container2",
+		in: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: spec(corev1.Container{
+				Name: "container1",
+				Env:  []corev1.EnvVar{envVar("1", "1")},
+			}, corev1.Container{
+				Name: "container2",
+				Env:  []corev1.EnvVar{envVar("2", "2"), envVar("foo", "to_be_updated")},
+			}),
+		},
+		want: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: spec(corev1.Container{
+				Name: "container1",
+				Env:  []corev1.EnvVar{envVar("1", "1")},
+			}, corev1.Container{
+				Name: "container2",
+				Env:  []corev1.EnvVar{envVar("2", "2"), envVar("foo", "bar")},
+			}),
+		},
+	}}
+
+	s := &base.CommonSpec{Workloads: []base.WorkloadOverride{{
+		Name: "net-kourier-controller",
+		Env: []base.EnvRequirementsOverride{{
+			Container: "controller",
+			EnvVars: []corev1.EnvVar{{
+				Name:  "KUBE_API_BURST",
+				Value: "100",
+			}},
+		}},
+	}}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			u := &unstructured.Unstructured{}
+			if err := scheme.Scheme.Convert(test.in, u, nil); err != nil {
+				t.Fatal("Failed to convert deployment to unstructured", err)
+			}
+
+			if err := ConfigureEnvValueIfUnset(s, test.deployment, test.container, "foo", "bar")(u); err != nil {
+				t.Fatal("Unexpected error from transformer", err)
+			}
+
+			got := &appsv1.Deployment{}
+			if err := scheme.Scheme.Convert(u, got, nil); err != nil {
+				t.Fatal("Failed to convert unstructured to deployment", err)
+			}
+
+			if !cmp.Equal(got, test.want) {
+				t.Errorf("Got = %v, want: %v, diff:\n%s", got, test.want, cmp.Diff(got, test.want))
+			}
+		})
+	}
+}

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -69,11 +69,11 @@ func (e *extension) Transformers(ks base.KComponent) []mf.Transformer {
 			corev1.EnvVar{Name: "NO_PROXY", Value: os.Getenv("NO_PROXY")},
 		),
 		overrideKourierNamespace(ks),
-		addKourierEnvValues(ks),
 		addKourierAppProtocol(ks),
 		common.VersionedJobNameTransform(),
 		common.InjectCommonEnvironment(),
 	}
+	tf = append(tf, addKourierEnvValues(ks)...)
 	tf = append(tf, enableSecretInformerFilteringTransformers(ks)...)
 	tf = append(tf, monitoring.GetServingTransformers(ks)...)
 	return append(tf, common.DeprecatedAPIsTranformers(e.kubeclient.Discovery())...)


### PR DESCRIPTION
This patch adds default QPS and Burst value for kourier controller.

When users specified the values, the specified values are used.
When users didn't specif the values, `200` is the default for both QPS and Burst.