### PR TITLE
Move creating namespaces after generating cert

### DIFF
--- a/hack/lib/mesh.bash
+++ b/hack/lib/mesh.bash
@@ -79,8 +79,6 @@ function undeploy_servicemeshcontrolplane {
 }
 
 function deploy_gateways {
-  oc apply -f "${resources_dir}"/smmr.yaml || return $?
-
   # Generate wildcard certs with cluster's subdomain.
 
   local out_dir
@@ -117,6 +115,7 @@ function deploy_gateways {
       --cert="${out_dir}"/wildcard.crt --dry-run=client -o yaml | oc apply -f -
 
   oc apply -f "${resources_dir}"/namespace.yaml || return $?
+  oc apply -f "${resources_dir}"/smmr.yaml || return $?
   oc apply -f "${resources_dir}"/gateway.yaml || return $?
   oc apply -f "${resources_dir}"/peerauthentication.yaml || return $?
 


### PR DESCRIPTION
Attempt to fix failures in the nightly job: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.12-e2e-mesh-ocp-412-continuous/1676078635846471680

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
