### PR TITLE
Move installation of metadata-webhook back to serverless.bash

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -177,6 +177,11 @@ function deploy_knativeserving_cr {
   fi
 
   oc apply -n "${SERVING_NAMESPACE}" -f "$serving_cr"
+
+  if [[ $FULL_MESH == "true" ]]; then
+    # metadata-webhook adds istio annotations for e2e test by webhook.
+    oc apply -f "${rootdir}/serving/metadata-webhook/config"
+  fi
 }
 
 # If ServiceMesh is enabled:

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -18,9 +18,6 @@ create_namespaces "${TEST_NAMESPACES[@]}"
 # Install ServiceMesh and enable mTLS.
 if [[ $FULL_MESH != true ]]; then
   trust_router_ca
-else
-   # metadata-webhook adds istio annotations for e2e test by webhook.
-   oc apply -f "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/serving/metadata-webhook/config"
 fi
 
 run_testselect


### PR DESCRIPTION
The webhook is used in serverless-e2e as well.

Should fix CI failures such as https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.12-e2e-mesh-ocp-412-continuous/1677165690433310720

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
