### PR TITLE
Prevent scaling cluster for single-node openshift

### DIFF
--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -68,6 +68,11 @@ function cluster_scalable {
   if ! oc get machineconfigpool &>/dev/null; then
     return 1
   fi
+  # Prevent scaling for single-node OpenShift.
+  if [[ $(oc get machineconfigpool master -ojsonpath='{.status.machineCount}') == 1 && \
+        $(oc get machineconfigpool worker -ojsonpath='{.status.machineCount}') == 0 ]]; then
+    return 1
+  fi
   if [[ $(oc get infrastructure cluster -ojsonpath='{.status.platform}') = VSphere ]]; then
     return 1
   fi


### PR DESCRIPTION
The machineconfigpool is available there but we don't want to scale it up. We want to use the exact cluster that was provided in CI.

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
