### PR TITLE
Use SMCP v2.4 in Service Mesh related tests

### DIFF
--- a/test/servicemesh.go
+++ b/test/servicemesh.go
@@ -20,7 +20,7 @@ func ServiceMeshControlPlaneV2(name, namespace string) *unstructured.Unstructure
 				"namespace": namespace,
 			},
 			"spec": map[string]interface{}{
-				"version": "v2.1",
+				"version": "v2.4",
 			},
 		},
 	}


### PR DESCRIPTION
Fixes failures in weekly jobs such as https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.12-gcp-e2e-gcp-ocp-412-continuous/1670220088277471232

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
