### PR TITLE
Fix promotion tag name in generate CI

### DIFF
--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -60,12 +60,12 @@ jobs:
       - name: Generate CI (on workflow dispatch)
         if: github.event_name == 'workflow_dispatch'
         working-directory: ./src/github.com/openshift-knative/hack
-        run: go run ./cmd/prowcopy --branch ${{ inputs.branch }} --tag "$(yq read ../serverless-operator/olm-catalog/serverless-operator/project.yaml project.name)-v$(yq read ../serverless-operator/olm-catalog/serverless-operator/project.yaml project.version)"
+        run: go run ./cmd/prowcopy --branch ${{ inputs.branch }} --tag "openshift-serverless-v$(yq read ../serverless-operator/olm-catalog/serverless-operator/project.yaml project.version)"
 
       - name: Generate CI (on branch created)
         if: github.event.created
         working-directory: ./src/github.com/openshift-knative/hack
-        run: go run ./cmd/prowcopy --branch ${{ github.ref_name }} --tag "$(yq read ../serverless-operator/olm-catalog/serverless-operator/project.yaml project.name)-v$(yq read ../serverless-operator/olm-catalog/serverless-operator/project.yaml project.version)"
+        run: go run ./cmd/prowcopy --branch ${{ github.ref_name }} --tag "openshift-serverless-v$(yq read ../serverless-operator/olm-catalog/serverless-operator/project.yaml project.version)"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
The expected promotion name is: `openshift-serverless-v1.30.0`