### PR TITLE
Add dependabot and its update deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "knative.dev/*"

--- a/.github/workflows/dependabot-deps.yaml
+++ b/.github/workflows/dependabot-deps.yaml
@@ -19,6 +19,14 @@ jobs:
           path: ./src/github.com/${{ github.repository }}
           fetch-depth: 0
 
+      - name: Install prerequisites
+        env:
+          YQ_VERSION: 3.4.0
+        run: |
+          sudo wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
+          sudo mv /usr/bin/yq /usr/local/bin/yq
+
       - name: Run ./hack/update-deps.sh
         working-directory: ./src/github.com/${{ github.repository }}
         run: ./hack/update-deps.sh

--- a/.github/workflows/dependabot-deps.yaml
+++ b/.github/workflows/dependabot-deps.yaml
@@ -1,0 +1,36 @@
+name: depndabot - update-deps.sh
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  generate_some_code:
+    name: Generate some code!
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          path: ./src/github.com/${{ github.repository }}
+          fetch-depth: 0
+
+      - name: Run ./hack/update-deps.sh
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: ./hack/update-deps.sh
+
+      - name: git push
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: |
+          if ! git diff --exit-code --quiet
+          then
+            git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+            git add .
+            git commit -m "Run ./hack/update-deps.sh"
+            git push
+          fi


### PR DESCRIPTION
This patch adds dependabot and its update deps.

Currently dependabot bumps lib only when it has a security issue like https://github.com/openshift-knative/serverless-operator/pull/2150.
Also, it does not run update-deps.sh.

`.github/dependabot.yml` adds the dependabot and `.github/workflows/dependabot-deps.yaml` runs `update-deps.sh` when it was triggered.

Note, k8s.io and knative.dev libs need to be consistent with serving/eventing so they are excluded.