### PR TITLE
[SRVKS-1072] Enable internal-encryption for CI

### DIFF
--- a/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
+++ b/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
@@ -5,8 +5,7 @@ metadata:
 spec:
   config:
     network:
-      # TODO: Re-enable after fixing https://issues.redhat.com/browse/SRVKS-983
-      internal-encryption: "false"
+      internal-encryption: "true"
     autoscaler:
       container-concurrency-target-default: "100"
       container-concurrency-target-percentage: "1.0"


### PR DESCRIPTION
As per title, this was disabled due to the unstable CI.
The issue was fixed by https://github.com/knative-sandbox/net-kourier/pull/959 and should be able to enable the option.