### PR TITLE
[WIP][TEST_ONLY] Define knative-serving-ingress for Kourier Gateway xdp client

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/ingress/1.9/1-net-kourier.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/1.9/1-net-kourier.yaml
@@ -128,7 +128,7 @@ data:
                 endpoint:
                   address:
                     socket_address:
-                      address: "net-kourier-controller"
+                      address: "net-kourier-controller.knative-serving-ingress"
                       port_value: 18000
           type: STRICT_DNS
     admin:


### PR DESCRIPTION
As per title, this patch defines `"net-kourier-controller.knative-serving-ingress"` instead of `"net-kourier-controller"`.

Using `net-kourier-controller` causes a lot of NXDOMAIN query in DNS side so we should use `"net-kourier-controller.knative-serving-ingress"`.