### PR TITLE
Do not add `CURRENT_VERSION_IMAGES` on dependabot's push

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Set CURRENT_VERSION_IMAGES on push
         working-directory: ./src/github.com/${{ github.repository }}
-        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name != 'main'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name != 'main' && !contains(github.ref_name, 'dependabot/')
         run: |
           branch="$(yq read olm-catalog/serverless-operator/project.yaml project.version)" # example output: "1.26.0"
           # Add "v", so that the final variable is like "v1.27.0"


### PR DESCRIPTION
This patch follows up https://github.com/openshift-knative/serverless-operator/pull/2164
The action still fails due to adding `CURRENT_VERSION_IMAGES` in `push` action because dependabot does not push `main` branch as https://github.com/openshift-knative/serverless-operator/pull/2155.

Hence this patch excludes the `CURRENT_VERSION_IMAGES` for the branch name with `dependabot/`.

Verified https://github.com/nak3/serverless-operator/actions/runs/5554853451/jobs/10145200827
