### PR TITLE
[release-1.29] Use multiarch test images in upgrade tests

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -263,30 +263,30 @@ function run_rolling_upgrade_tests {
 
   local base serving_image_version eventing_image_version eventing_kafka_broker_image_version image_template channels common_opts
 
-  serving_image_version=$(versions.major_minor "${KNATIVE_SERVING_VERSION}")
-  eventing_image_version="${KNATIVE_EVENTING_VERSION}"
-  eventing_kafka_broker_image_version="${KNATIVE_EVENTING_KAFKA_BROKER_VERSION}"
+  serving_image_version=${KNATIVE_SERVING_VERSION#knative-}
+  eventing_image_version="${KNATIVE_EVENTING_VERSION#knative-}"
+  eventing_kafka_broker_image_version="${KNATIVE_EVENTING_KAFKA_BROKER_VERSION#knative-}"
 
   # mapping based on https://github.com/openshift/release/tree/master/core-services/image-mirroring/knative
   base="quay.io/openshift-knative/"
   image_template=$(
     cat <<-EOF
 $base{{- with .Name }}
-{{- if eq .      "kafka-consumer"      }}knative-eventing-kafka-broker-test-kafka-consumer:$eventing_kafka_broker_image_version
-{{- else if eq . "event-flaker"        }}knative-eventing-test-event-flaker:$eventing_image_version
-{{- else if eq . "event-library"       }}knative-eventing-test-event-library:$eventing_image_version
-{{- else if eq . "event-sender"        }}knative-eventing-test-event-sender:$eventing_image_version
-{{- else if eq . "eventshub"           }}knative-eventing-test-eventshub:$eventing_image_version
-{{- else if eq . "heartbeats"          }}knative-eventing-test-heartbeats:$eventing_image_version
-{{- else if eq . "performance"         }}knative-eventing-test-performance:$eventing_image_version
-{{- else if eq . "print"               }}knative-eventing-test-print:$eventing_image_version
-{{- else if eq . "recordevents"        }}knative-eventing-test-recordevents:$eventing_image_version
-{{- else if eq . "request-sender"      }}knative-eventing-test-request-sender:$eventing_image_version
-{{- else if eq . "wathola-fetcher"     }}knative-eventing-test-wathola-fetcher:$eventing_image_version
-{{- else if eq . "wathola-forwarder"   }}knative-eventing-test-wathola-forwarder:$eventing_image_version
-{{- else if eq . "wathola-receiver"    }}knative-eventing-test-wathola-receiver:$eventing_image_version
-{{- else if eq . "wathola-sender"      }}knative-eventing-test-wathola-sender:$eventing_image_version
-{{- else                               }}knative-serving-test-{{.}}:$serving_image_version{{end -}}
+{{- if eq .      "kafka-consumer"      }}eventing-kafka-broker/{{.}}:$eventing_kafka_broker_image_version
+{{- else if eq . "event-flaker"        }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "event-library"       }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "event-sender"        }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "eventshub"           }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "heartbeats"          }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "performance"         }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "print"               }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "recordevents"        }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "request-sender"      }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "wathola-fetcher"     }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "wathola-forwarder"   }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "wathola-receiver"    }}eventing/{{.}}:$eventing_image_version
+{{- else if eq . "wathola-sender"      }}eventing/{{.}}:$eventing_image_version
+{{- else                               }}serving/{{.}}:$serving_image_version{{end -}}
 {{end -}}
 EOF
 )


### PR DESCRIPTION
Same as https://github.com/openshift-knative/serverless-operator/pull/2179, only for release-1.29 branch
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
