### PR TITLE
Disable internal-encryption in upgrade tests due to SRVKS-1107

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -162,9 +162,8 @@ function deploy_knativeserving_cr {
     cp "${rootdir}/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml" "$serving_cr"
   fi
 
-  # When upgrading from 1.29 or older, disable internal TLS.
-  if versions.le "$(versions.major_minor "$serverless_version")" "1.29"; then
-    logger.warn "Disabling internal encryption. Unsupported version."
+  if [[ "$serverless_version" != "${CURRENT_CSV#serverless-operator.v}" ]]; then
+    logger.warn "Disabling internal encryption in upgrade tests due to SRVKS-1107."
     yq delete --inplace "$serving_cr" spec.config.network.internal-encryption
   fi
 


### PR DESCRIPTION
Related slack discussion: https://redhat-internal.slack.com/archives/CD87JDUB0/p1690124372516329

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
