### PR TITLE
SRVCOM-2356: Use specific labels for Knative gateways to omit conflict

### DIFF
--- a/hack/lib/mesh_resources/gateway.yaml
+++ b/hack/lib/mesh_resources/gateway.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: knative-serving
 spec:
   selector:
-    istio: ingressgateway
+    knative: ingressgateway
   servers:
     - port:
         number: 443
@@ -24,12 +24,14 @@ metadata:
   namespace: knative-serving
 spec:
   selector:
-    istio: ingressgateway
+    knative: ingressgateway
   servers:
     - port:
         number: 8081
-        name: http
-        protocol: HTTP
+        name: https
+        protocol: HTTPS
+      tls:
+        mode: ISTIO_MUTUAL
       hosts:
         - "*"
 ---

--- a/hack/lib/mesh_resources/smcp.yaml
+++ b/hack/lib/mesh_resources/smcp.yaml
@@ -6,6 +6,16 @@ metadata:
 spec:
   profiles:
   - default
+  techPreview:
+    meshConfig:
+      defaultConfig:
+        terminationDrainDuration: 35s
+  gateways:
+    ingress:
+      service:
+        metadata:
+          labels:
+            knative: ingressgateway
   proxy:
     networking:
       trafficControl:


### PR DESCRIPTION
This is extracting independent changes from https://github.com/openshift-knative/serverless-operator/pull/2183 to help debugging

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Use specific labels for Knative gateways to omit conflict
