### PR TITLE
Include 1.29.1 in upgrade sequence

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -66,9 +66,9 @@ dependencies:
         eventing: knative-v1.9
         eventing_kafka_broker: knative-v1.9
 upgrade_sequence:
-    - csv: serverless-operator.v1.28.0
-      source: redhat-operators
     - csv: serverless-operator.v1.29.0
+      source: redhat-operators
+    - csv: serverless-operator.v1.29.1
       source: redhat-operators
     - csv: serverless-operator.v1.30.0
       source: serverless-operator


### PR DESCRIPTION
* Remove 1.28.0 to make the sequence shorter.

Serverless 1.29.1 is already released and it's available on the "stable" channel. It is offered immediately after installing 1.29.0 and the upgrade sequence needs to go through it. Only then it is possible to switch to "redhat-operators" source and get the 1.30.0 offered.

Fixes failures such as https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.10-upgrade-kitchensink-ocp-410-continuous/1688671460781985792

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
