### PR TITLE
Use multiarch eventshub image for REKT tests

### DIFF
--- a/test/images-rekt.yaml
+++ b/test/images-rekt.yaml
@@ -1,1 +1,1 @@
-knative.dev/reconciler-test/cmd/eventshub: registry.ci.openshift.org/openshift/knative-eventing-test-eventshub:knative-nightly
+knative.dev/reconciler-test/cmd/eventshub: quay.io/openshift-knative/eventing/eventshub:v1.10


### PR DESCRIPTION
Version 1.10 has the right backports from reconciler-test as opposed to 1.9.

Slack Discussion: [link](https://redhat-internal.slack.com/archives/C02S22DK4GP/p1691725963283329)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
