### PR TITLE
Sort find results to ensure consistent order

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -76,7 +76,7 @@ function serverless_operator_e2e_tests {
   kubeconfigs+=("${KUBECONFIG}")
   while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0 | sort -z)
 
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
@@ -102,7 +102,7 @@ function serverless_operator_kafka_e2e_tests {
   kubeconfigs+=("${KUBECONFIG}")
   while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0 | sort -z)
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
   RUN_FLAGS=(-failfast -timeout=30m -parallel=1)
@@ -127,7 +127,7 @@ function downstream_serving_e2e_tests {
   kubeconfigs+=("${KUBECONFIG}")
   while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0 | sort -z)
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
   RUN_FLAGS=(-failfast -timeout=60m -parallel=1)
@@ -162,7 +162,7 @@ function downstream_eventing_e2e_tests {
   kubeconfigs+=("${KUBECONFIG}")
   while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0 | sort -z)
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
   # Used by eventing/test/lib
@@ -233,7 +233,7 @@ function downstream_knative_kafka_e2e_tests {
   kubeconfigs+=("${KUBECONFIG}")
   while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0 | sort -z)
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
   # Used by eventing/test/lib
@@ -308,7 +308,7 @@ function downstream_monitoring_e2e_tests {
   kubeconfigs+=("${KUBECONFIG}")
   while IFS= read -r -d '' cfg; do
     kubeconfigs+=("${cfg}")
-  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0)
+  done < <(find "$(pwd -P)" -name 'user*.kubeconfig' -print0 | sort -z)
   kubeconfigs_str="$(array.join , "${kubeconfigs[@]}")"
 
   RUN_FLAGS=(-failfast -timeout=30m -parallel=1)


### PR DESCRIPTION
## Proposed Changes
- Sort find results to ensure consistent order

As the order of the kubeconfigs is important as read, write users are determined by the order, we need to make sure that the find returns the files always in order.

/assign @nak3 , @mgencur 