### PR TITLE
Use 1.10 multiarch images in image mapping for e2e tests

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/ingress/1.10/kourier/1-net-kourier.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/1.10/kourier/1-net-kourier.yaml
@@ -90,11 +90,11 @@ data:
                           routes:
                             - match:
                                 safe_regex:
-                                  google_re2: {}
                                   regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
                                 headers:
                                   - name: ':method'
-                                    exact_match: GET
+                                    string_match:
+                                      exact: GET
                               route:
                                 cluster: service_stats
       clusters:

--- a/test/images-rekt.yaml
+++ b/test/images-rekt.yaml
@@ -1,2 +1,2 @@
-knative.dev/reconciler-test/cmd/eventshub: registry.ci.openshift.org/openshift/knative-eventing-test-eventshub:knative-v1.10
-knative.dev/eventing/cmd/heartbeats: registry.ci.openshift.org/openshift/knative-eventing-heartbeats:knative-v1.10
+knative.dev/reconciler-test/cmd/eventshub: quay.io/openshift-knative/eventing/eventshub:v1.10
+knative.dev/eventing/cmd/heartbeats: quay.io/openshift-knative/eventing/heartbeats:v1.10

--- a/test/images-rekt.yaml
+++ b/test/images-rekt.yaml
@@ -1,2 +1,2 @@
-knative.dev/reconciler-test/cmd/eventshub: registry.ci.openshift.org/openshift/knative-eventing-test-eventshub:knative-nightly
-knative.dev/eventing/cmd/heartbeats: registry.ci.openshift.org/openshift/knative-eventing-heartbeats:knative-nightly
+knative.dev/reconciler-test/cmd/eventshub: registry.ci.openshift.org/openshift/knative-eventing-test-eventshub:knative-v1.10
+knative.dev/eventing/cmd/heartbeats: registry.ci.openshift.org/openshift/knative-eventing-heartbeats:knative-v1.10


### PR DESCRIPTION
As per title to address issues from https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.10-e2e-aws-ocp-410-continuous/1691238498117357568