### PR TITLE
Auto update the images-rekt.yaml on `make release-files`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,14 +246,17 @@ release-files:
 		templates/build-image.Dockerfile \
 		openshift/ci-operator/build-image/Dockerfile
 	./hack/generate/dockerfile.sh \
-  	templates/index.Dockerfile \
-  	olm-catalog/serverless-operator/index/Dockerfile
+ 		templates/index.Dockerfile \
+		olm-catalog/serverless-operator/index/Dockerfile
 	./hack/generate/index.sh \
 		templates/index.yaml \
 		olm-catalog/serverless-operator/index/configs/index.yaml
 	./hack/generate/quickstart.sh \
-  	templates/serverless-application-quickstart.yaml \
-  	knative-operator/deploy/resources/quickstart/serverless-application-quickstart.yaml
+		templates/serverless-application-quickstart.yaml \
+		knative-operator/deploy/resources/quickstart/serverless-application-quickstart.yaml
+	./hack/generate/images-rekt.sh \
+		templates/images-rekt.yaml \
+		test/images-rekt.yaml
 # TODO: uncomment as soon as chart changes are merged
 #	./hack/generate/mesh-auth-policies.sh \
 #  	tenant-1,tenant-2,serving-tests,serverless-tests

--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -7,78 +7,13 @@ target="${2:?Provide a target CSV file as arg[2]}"
 
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/metadata.bash"
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/images.bash"
 
 export CURRENT_VERSION_IMAGES=${CURRENT_VERSION_IMAGES:-"nightly"}
 
-registry_host='registry.ci.openshift.org'
-registry="${registry_host}/openshift"
 client_version="$(metadata.get dependencies.cli)"
 kn_event="${registry_host}/knative/release-${client_version%.*}:client-plugin-event"
 rbac_proxy="registry.ci.openshift.org/origin/$(metadata.get 'requirements.ocpVersion.min'):kube-rbac-proxy"
-
-function default_knative_serving_images() {
-  local serving
-  serving="${registry}/knative-serving"
-  local tag
-  tag=$(metadata.get dependencies.serving)
-  export KNATIVE_SERVING_QUEUE=${KNATIVE_SERVING_QUEUE:-"${serving}-queue:${tag}"}
-  export KNATIVE_SERVING_ACTIVATOR=${KNATIVE_SERVING_ACTIVATOR:-"${serving}-activator:${tag}"}
-  export KNATIVE_SERVING_AUTOSCALER=${KNATIVE_SERVING_AUTOSCALER:-"${serving}-autoscaler:${tag}"}
-  export KNATIVE_SERVING_AUTOSCALER_HPA=${KNATIVE_SERVING_AUTOSCALER_HPA:-"${serving}-autoscaler-hpa:${tag}"}
-  export KNATIVE_SERVING_CONTROLLER=${KNATIVE_SERVING_CONTROLLER:-"${serving}-controller:${tag}"}
-  export KNATIVE_SERVING_WEBHOOK=${KNATIVE_SERVING_WEBHOOK:-"${serving}-webhook:${tag}"}
-  export KNATIVE_SERVING_DOMAIN_MAPPING=${KNATIVE_SERVING_DOMAIN_MAPPING:-"${serving}-domain-mapping:${tag}"}
-  export KNATIVE_SERVING_DOMAIN_MAPPING_WEBHOOK=${KNATIVE_SERVING_DOMAIN_MAPPING_WEBHOOK:-"${serving}-domain-mapping-webhook:${tag}"}
-  export KNATIVE_SERVING_STORAGE_VERSION_MIGRATION=${KNATIVE_SERVING_STORAGE_VERSION_MIGRATION:-"${serving}-storage-version-migration:${tag}"}
-}
-
-function default_knative_eventing_images() {
-  local eventing
-  eventing="${registry}/knative-eventing"
-  local tag
-  tag=$(metadata.get dependencies.eventing)
-  export KNATIVE_EVENTING_CONTROLLER=${KNATIVE_EVENTING_CONTROLLER:-"${eventing}-controller:${tag}"}
-  export KNATIVE_EVENTING_WEBHOOK=${KNATIVE_EVENTING_WEBHOOK:-"${eventing}-webhook:${tag}"}
-  export KNATIVE_EVENTING_STORAGE_VERSION_MIGRATION=${KNATIVE_EVENTING_STORAGE_VERSION_MIGRATION:-"${eventing}-migrate:${tag}"}
-  export KNATIVE_EVENTING_MTBROKER_INGRESS=${KNATIVE_EVENTING_MTBROKER_INGRESS:-"${eventing}-mtbroker-ingress:${tag}"}
-  export KNATIVE_EVENTING_MTBROKER_FILTER=${KNATIVE_EVENTING_MTBROKER_FILTER:-"${eventing}-mtbroker-filter:${tag}"}
-  export KNATIVE_EVENTING_MTCHANNEL_BROKER=${KNATIVE_EVENTING_MTCHANNEL_BROKER:-"${eventing}-mtchannel-broker:${tag}"}
-  export KNATIVE_EVENTING_MTPING=${KNATIVE_EVENTING_MTPING:-"${eventing}-mtping:${tag}"}
-  export KNATIVE_EVENTING_CHANNEL_CONTROLLER=${KNATIVE_EVENTING_CHANNEL_CONTROLLER:-"${eventing}-channel-controller:${tag}"}
-  export KNATIVE_EVENTING_CHANNEL_DISPATCHER=${KNATIVE_EVENTING_CHANNEL_DISPATCHER:-"${eventing}-channel-dispatcher:${tag}"}
-  export KNATIVE_EVENTING_APISERVER_RECEIVE_ADAPTER=${KNATIVE_EVENTING_APISERVER_RECEIVE_ADAPTER:-"${eventing}-apiserver-receive-adapter:${tag}"}
-}
-
-function default_knative_eventing_istio_images() {
-  local eventing_istio
-  eventing_istio="${registry}/knative-eventing-istio"
-  local tag
-  tag=$(metadata.get dependencies.eventing_istio)
-  export KNATIVE_EVENTING_ISTIO_CONTROLLER=${KNATIVE_EVENTING_ISTIO_CONTROLLER:-"${eventing_istio}-controller:${tag}"}
-}
-
-function default_knative_eventing_kafka_broker_images() {
-  local eventing_kafka_broker
-  local tag
-  tag=$(metadata.get dependencies.eventing_kafka_broker)
-  eventing_kafka_broker="${registry}/knative-eventing-kafka-broker"
-  export KNATIVE_EVENTING_KAFKA_BROKER_DISPATCHER=${KNATIVE_EVENTING_KAFKA_BROKER_DISPATCHER:-"${eventing_kafka_broker}-dispatcher:${tag}"}
-  export KNATIVE_EVENTING_KAFKA_BROKER_RECEIVER=${KNATIVE_EVENTING_KAFKA_BROKER_RECEIVER:-"${eventing_kafka_broker}-receiver:${tag}"}
-  export KNATIVE_EVENTING_KAFKA_BROKER_KAFKA_CONTROLLER=${KNATIVE_EVENTING_KAFKA_BROKER_KAFKA_CONTROLLER:-"${eventing_kafka_broker}-kafka-controller:${tag}"}
-  export KNATIVE_EVENTING_KAFKA_BROKER_WEBHOOK_KAFKA=${KNATIVE_EVENTING_KAFKA_BROKER_WEBHOOK_KAFKA:-"${eventing_kafka_broker}-webhook-kafka":${tag}}
-  export KNATIVE_EVENTING_KAFKA_BROKER_POST_INSTALL=${KNATIVE_EVENTING_KAFKA_BROKER_POST_INSTALL:-"${eventing_kafka_broker}-post-install:${tag}"}
-}
-
-function default_knative_ingress_images() {
-  local knative_kourier knative_istio
-  knative_kourier="$(metadata.get dependencies.kourier)"
-  export KNATIVE_KOURIER_CONTROL=${KNATIVE_KOURIER_CONTROL:-"${registry}/net-kourier-kourier:${knative_kourier}"}
-  export KNATIVE_KOURIER_GATEWAY=${KNATIVE_KOURIER_GATEWAY:-"quay.io/maistra-dev/proxyv2-ubi8:$(metadata.get dependencies.maistra)"}
-
-  knative_istio="$(metadata.get dependencies.net_istio)"
-  export KNATIVE_ISTIO_CONTROLLER=${KNATIVE_ISTIO_CONTROLLER:-"${registry}/net-istio-controller:${knative_istio}"}
-  export KNATIVE_ISTIO_WEBHOOK=${KNATIVE_ISTIO_WEBHOOK:-"${registry}/net-istio-webhook:${knative_istio}"}
-}
 
 default_knative_eventing_images
 default_knative_eventing_istio_images

--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -7,6 +7,7 @@ target="${2:?Provide a target CSV file as arg[2]}"
 
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/metadata.bash"
+# shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/images.bash"
 
 export CURRENT_VERSION_IMAGES=${CURRENT_VERSION_IMAGES:-"nightly"}

--- a/hack/generate/images-rekt.sh
+++ b/hack/generate/images-rekt.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+template="${1:?Provide template file as arg[1]}"
+target="${2:?Provide a target file as arg[2]}"
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/images.bash"
+
+default_knative_eventing_images
+default_knative_eventing_test_images
+default_knative_eventing_istio_images
+default_knative_eventing_kafka_broker_images
+default_knative_serving_images
+default_knative_ingress_images
+
+envsubst < $template > $target

--- a/hack/generate/images-rekt.sh
+++ b/hack/generate/images-rekt.sh
@@ -15,4 +15,4 @@ default_knative_eventing_kafka_broker_images
 default_knative_serving_images
 default_knative_ingress_images
 
-envsubst < $template > $target
+envsubst < "$template" > "$target"

--- a/hack/lib/images.bash
+++ b/hack/lib/images.bash
@@ -40,29 +40,32 @@ function default_knative_eventing_images() {
 
   export KNATIVE_EVENTING_APPENDER=${KNATIVE_EVENTING_APPENDER:-"${eventing}-appender:${tag}"}
   export KNATIVE_EVENTING_EVENT_DISPLAY=${KNATIVE_EVENTING_EVENT_DISPLAY:-"${eventing}-event-display:${tag}"}
-  export KNATIVE_EVENTING_HEARTBEATS=${KNATIVE_EVENTING_HEARTBEATS:-"${eventing}-heartbeats:${tag}"}
   export KNATIVE_EVENTING_HEARTBEATS_RECEIVER=${KNATIVE_EVENTING_HEARTBEATS_RECEIVER:-"${eventing}-heartbeats-receiver:${tag}"}
   export KNATIVE_EVENTING_MIGRATE=${KNATIVE_EVENTING_MIGRATE:-"${eventing}-migrate:${tag}"}
   export KNATIVE_EVENTING_PONG=${KNATIVE_EVENTING_PONG:-"${eventing}-pong:${tag}"}
   export KNATIVE_EVENTING_SCHEMA=${KNATIVE_EVENTING_SCHEMA:-"${eventing}-schema:${tag}"}
   export KNATIVE_EVENTING_WEBSOCKETSOURCE=${KNATIVE_EVENTING_WEBSOCKETSOURCE:-"${eventing}-websocketsource:${tag}"}
+  
+  # quay.io multiarch images:
+  tag="${tag/knative-/}"
+  export KNATIVE_EVENTING_HEARTBEATS=${KNATIVE_EVENTING_HEARTBEATS:-"quay.io/openshift-knative/eventing/heartbeats:${tag}"}
 }
 
 function default_knative_eventing_test_images() {
-  local eventing_test
-  eventing_test="${registry}/knative-eventing-test"
   local tag
   tag=$(metadata.get dependencies.eventing)
-  export KNATIVE_EVENTING_TEST_EVENT_SENDER=${KNATIVE_EVENTING_TEST_EVENT_SENDER:-"${eventing_test}-event-sender:${tag}"}
-  export KNATIVE_EVENTING_TEST_EVENTSHUB=${KNATIVE_EVENTING_TEST_EVENTSHUB:-"${eventing_test}-eventshub:${tag}"}
-  export KNATIVE_EVENTING_TEST_PERFORMANCE=${KNATIVE_EVENTING_TEST_PERFORMANCE:-"${eventing_test}-performance:${tag}"}
-  export KNATIVE_EVENTING_TEST_PRINT=${KNATIVE_EVENTING_TEST_PRINT:-"${eventing_test}-print:${tag}"}
-  export KNATIVE_EVENTING_TEST_RECORDEVENTS=${KNATIVE_EVENTING_TEST_RECORDEVENTS:-"${eventing_test}-recordevents:${tag}"}
-  export KNATIVE_EVENTING_TEST_REQUEST_SENDER=${KNATIVE_EVENTING_TEST_REQUEST_SENDER:-"${eventing_test}-request-sender:${tag}"}
-  export KNATIVE_EVENTING_TEST_WATHOLA_FETCHER=${KNATIVE_EVENTING_TEST_WATHOLA_FETCHER:-"${eventing_test}-wathola-fetcher:${tag}"}
-  export KNATIVE_EVENTING_TEST_WATHOLA_FORWARDER=${KNATIVE_EVENTING_TEST_WATHOLA_FORWARDER:-"${eventing_test}-wathola-forwarder:${tag}"}
-  export KNATIVE_EVENTING_TEST_WATHOLA_RECEIVER=${KNATIVE_EVENTING_TEST_WATHOLA_RECEIVER:-"${eventing_test}-wathola-receiver:${tag}"}
-  export KNATIVE_EVENTING_TEST_WATHOLA_SENDER=${KNATIVE_EVENTING_TEST_WATHOLA_SENDER:-"${eventing_test}-wathola-sender:${tag}"}
+  tag="${tag/knative-/}"
+
+  export KNATIVE_EVENTING_TEST_EVENT_SENDER=${KNATIVE_EVENTING_TEST_EVENT_SENDER:-"quay.io/openshift-knative/eventing/event-sender:${tag}"}
+  export KNATIVE_EVENTING_TEST_EVENTSHUB=${KNATIVE_EVENTING_TEST_EVENTSHUB:-"quay.io/openshift-knative/eventing/eventshub:${tag}"}
+  export KNATIVE_EVENTING_TEST_PERFORMANCE=${KNATIVE_EVENTING_TEST_PERFORMANCE:-"quay.io/openshift-knative/eventing/performance:${tag}"}
+  export KNATIVE_EVENTING_TEST_PRINT=${KNATIVE_EVENTING_TEST_PRINT:-"quay.io/openshift-knative/eventing/print:${tag}"}
+  export KNATIVE_EVENTING_TEST_RECORDEVENTS=${KNATIVE_EVENTING_TEST_RECORDEVENTS:-"quay.io/openshift-knative/eventing/recordevents:${tag}"}
+  export KNATIVE_EVENTING_TEST_REQUEST_SENDER=${KNATIVE_EVENTING_TEST_REQUEST_SENDER:-"quay.io/openshift-knative/eventing/request-sender:${tag}"}
+  export KNATIVE_EVENTING_TEST_WATHOLA_FETCHER=${KNATIVE_EVENTING_TEST_WATHOLA_FETCHER:-"quay.io/openshift-knative/eventing/wathola-fetcher:${tag}"}
+  export KNATIVE_EVENTING_TEST_WATHOLA_FORWARDER=${KNATIVE_EVENTING_TEST_WATHOLA_FORWARDER:-"quay.io/openshift-knative/eventing/wathola-forwarder:${tag}"}
+  export KNATIVE_EVENTING_TEST_WATHOLA_RECEIVER=${KNATIVE_EVENTING_TEST_WATHOLA_RECEIVER:-"quay.io/openshift-knative/eventing/wathola-receiver:${tag}"}
+  export KNATIVE_EVENTING_TEST_WATHOLA_SENDER=${KNATIVE_EVENTING_TEST_WATHOLA_SENDER:-"quay.io/openshift-knative/eventing/wathola-sender:${tag}"}
 }
 
 function default_knative_eventing_istio_images() {

--- a/hack/lib/images.bash
+++ b/hack/lib/images.bash
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/metadata.bash"
 
 registry_host='registry.ci.openshift.org'

--- a/hack/lib/images.bash
+++ b/hack/lib/images.bash
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/metadata.bash"
+
+registry_host='registry.ci.openshift.org'
+registry="${registry_host}/openshift"
+
+function default_knative_serving_images() {
+  local serving
+  serving="${registry}/knative-serving"
+  local tag
+  tag=$(metadata.get dependencies.serving)
+  export KNATIVE_SERVING_QUEUE=${KNATIVE_SERVING_QUEUE:-"${serving}-queue:${tag}"}
+  export KNATIVE_SERVING_ACTIVATOR=${KNATIVE_SERVING_ACTIVATOR:-"${serving}-activator:${tag}"}
+  export KNATIVE_SERVING_AUTOSCALER=${KNATIVE_SERVING_AUTOSCALER:-"${serving}-autoscaler:${tag}"}
+  export KNATIVE_SERVING_AUTOSCALER_HPA=${KNATIVE_SERVING_AUTOSCALER_HPA:-"${serving}-autoscaler-hpa:${tag}"}
+  export KNATIVE_SERVING_CONTROLLER=${KNATIVE_SERVING_CONTROLLER:-"${serving}-controller:${tag}"}
+  export KNATIVE_SERVING_WEBHOOK=${KNATIVE_SERVING_WEBHOOK:-"${serving}-webhook:${tag}"}
+  export KNATIVE_SERVING_DOMAIN_MAPPING=${KNATIVE_SERVING_DOMAIN_MAPPING:-"${serving}-domain-mapping:${tag}"}
+  export KNATIVE_SERVING_DOMAIN_MAPPING_WEBHOOK=${KNATIVE_SERVING_DOMAIN_MAPPING_WEBHOOK:-"${serving}-domain-mapping-webhook:${tag}"}
+  export KNATIVE_SERVING_STORAGE_VERSION_MIGRATION=${KNATIVE_SERVING_STORAGE_VERSION_MIGRATION:-"${serving}-storage-version-migration:${tag}"}
+}
+
+function default_knative_eventing_images() {
+  local eventing
+  eventing="${registry}/knative-eventing"
+  local tag
+  tag=$(metadata.get dependencies.eventing)
+  export KNATIVE_EVENTING_CONTROLLER=${KNATIVE_EVENTING_CONTROLLER:-"${eventing}-controller:${tag}"}
+  export KNATIVE_EVENTING_WEBHOOK=${KNATIVE_EVENTING_WEBHOOK:-"${eventing}-webhook:${tag}"}
+  export KNATIVE_EVENTING_STORAGE_VERSION_MIGRATION=${KNATIVE_EVENTING_STORAGE_VERSION_MIGRATION:-"${eventing}-migrate:${tag}"}
+  export KNATIVE_EVENTING_MTBROKER_INGRESS=${KNATIVE_EVENTING_MTBROKER_INGRESS:-"${eventing}-mtbroker-ingress:${tag}"}
+  export KNATIVE_EVENTING_MTBROKER_FILTER=${KNATIVE_EVENTING_MTBROKER_FILTER:-"${eventing}-mtbroker-filter:${tag}"}
+  export KNATIVE_EVENTING_MTCHANNEL_BROKER=${KNATIVE_EVENTING_MTCHANNEL_BROKER:-"${eventing}-mtchannel-broker:${tag}"}
+  export KNATIVE_EVENTING_MTPING=${KNATIVE_EVENTING_MTPING:-"${eventing}-mtping:${tag}"}
+  export KNATIVE_EVENTING_CHANNEL_CONTROLLER=${KNATIVE_EVENTING_CHANNEL_CONTROLLER:-"${eventing}-channel-controller:${tag}"}
+  export KNATIVE_EVENTING_CHANNEL_DISPATCHER=${KNATIVE_EVENTING_CHANNEL_DISPATCHER:-"${eventing}-channel-dispatcher:${tag}"}
+  export KNATIVE_EVENTING_APISERVER_RECEIVE_ADAPTER=${KNATIVE_EVENTING_APISERVER_RECEIVE_ADAPTER:-"${eventing}-apiserver-receive-adapter:${tag}"}
+
+  export KNATIVE_EVENTING_APPENDER=${KNATIVE_EVENTING_APPENDER:-"${eventing}-appender:${tag}"}
+  export KNATIVE_EVENTING_EVENT_DISPLAY=${KNATIVE_EVENTING_EVENT_DISPLAY:-"${eventing}-event-display:${tag}"}
+  export KNATIVE_EVENTING_HEARTBEATS=${KNATIVE_EVENTING_HEARTBEATS:-"${eventing}-heartbeats:${tag}"}
+  export KNATIVE_EVENTING_HEARTBEATS_RECEIVER=${KNATIVE_EVENTING_HEARTBEATS_RECEIVER:-"${eventing}-heartbeats-receiver:${tag}"}
+  export KNATIVE_EVENTING_MIGRATE=${KNATIVE_EVENTING_MIGRATE:-"${eventing}-migrate:${tag}"}
+  export KNATIVE_EVENTING_PONG=${KNATIVE_EVENTING_PONG:-"${eventing}-pong:${tag}"}
+  export KNATIVE_EVENTING_SCHEMA=${KNATIVE_EVENTING_SCHEMA:-"${eventing}-schema:${tag}"}
+  export KNATIVE_EVENTING_WEBSOCKETSOURCE=${KNATIVE_EVENTING_WEBSOCKETSOURCE:-"${eventing}-websocketsource:${tag}"}
+}
+
+function default_knative_eventing_test_images() {
+  local eventing_test
+  eventing_test="${registry}/knative-eventing-test"
+  local tag
+  tag=$(metadata.get dependencies.eventing)
+  export KNATIVE_EVENTING_TEST_EVENT_SENDER=${KNATIVE_EVENTING_TEST_EVENT_SENDER:-"${eventing_test}-event-sender:${tag}"}
+  export KNATIVE_EVENTING_TEST_EVENTSHUB=${KNATIVE_EVENTING_TEST_EVENTSHUB:-"${eventing_test}-eventshub:${tag}"}
+  export KNATIVE_EVENTING_TEST_PERFORMANCE=${KNATIVE_EVENTING_TEST_PERFORMANCE:-"${eventing_test}-performance:${tag}"}
+  export KNATIVE_EVENTING_TEST_PRINT=${KNATIVE_EVENTING_TEST_PRINT:-"${eventing_test}-print:${tag}"}
+  export KNATIVE_EVENTING_TEST_RECORDEVENTS=${KNATIVE_EVENTING_TEST_RECORDEVENTS:-"${eventing_test}-recordevents:${tag}"}
+  export KNATIVE_EVENTING_TEST_REQUEST_SENDER=${KNATIVE_EVENTING_TEST_REQUEST_SENDER:-"${eventing_test}-request-sender:${tag}"}
+  export KNATIVE_EVENTING_TEST_WATHOLA_FETCHER=${KNATIVE_EVENTING_TEST_WATHOLA_FETCHER:-"${eventing_test}-wathola-fetcher:${tag}"}
+  export KNATIVE_EVENTING_TEST_WATHOLA_FORWARDER=${KNATIVE_EVENTING_TEST_WATHOLA_FORWARDER:-"${eventing_test}-wathola-forwarder:${tag}"}
+  export KNATIVE_EVENTING_TEST_WATHOLA_RECEIVER=${KNATIVE_EVENTING_TEST_WATHOLA_RECEIVER:-"${eventing_test}-wathola-receiver:${tag}"}
+  export KNATIVE_EVENTING_TEST_WATHOLA_SENDER=${KNATIVE_EVENTING_TEST_WATHOLA_SENDER:-"${eventing_test}-wathola-sender:${tag}"}
+}
+
+function default_knative_eventing_istio_images() {
+  local eventing_istio
+  eventing_istio="${registry}/knative-eventing-istio"
+  local tag
+  tag=$(metadata.get dependencies.eventing_istio)
+  export KNATIVE_EVENTING_ISTIO_CONTROLLER=${KNATIVE_EVENTING_ISTIO_CONTROLLER:-"${eventing_istio}-controller:${tag}"}
+}
+
+function default_knative_eventing_kafka_broker_images() {
+  local eventing_kafka_broker
+  local tag
+  tag=$(metadata.get dependencies.eventing_kafka_broker)
+  eventing_kafka_broker="${registry}/knative-eventing-kafka-broker"
+  export KNATIVE_EVENTING_KAFKA_BROKER_DISPATCHER=${KNATIVE_EVENTING_KAFKA_BROKER_DISPATCHER:-"${eventing_kafka_broker}-dispatcher:${tag}"}
+  export KNATIVE_EVENTING_KAFKA_BROKER_RECEIVER=${KNATIVE_EVENTING_KAFKA_BROKER_RECEIVER:-"${eventing_kafka_broker}-receiver:${tag}"}
+  export KNATIVE_EVENTING_KAFKA_BROKER_KAFKA_CONTROLLER=${KNATIVE_EVENTING_KAFKA_BROKER_KAFKA_CONTROLLER:-"${eventing_kafka_broker}-kafka-controller:${tag}"}
+  export KNATIVE_EVENTING_KAFKA_BROKER_WEBHOOK_KAFKA=${KNATIVE_EVENTING_KAFKA_BROKER_WEBHOOK_KAFKA:-"${eventing_kafka_broker}-webhook-kafka":${tag}}
+  export KNATIVE_EVENTING_KAFKA_BROKER_POST_INSTALL=${KNATIVE_EVENTING_KAFKA_BROKER_POST_INSTALL:-"${eventing_kafka_broker}-post-install:${tag}"}
+}
+
+function default_knative_ingress_images() {
+  local knative_kourier knative_istio
+  knative_kourier="$(metadata.get dependencies.kourier)"
+  export KNATIVE_KOURIER_CONTROL=${KNATIVE_KOURIER_CONTROL:-"${registry}/net-kourier-kourier:${knative_kourier}"}
+  export KNATIVE_KOURIER_GATEWAY=${KNATIVE_KOURIER_GATEWAY:-"quay.io/maistra-dev/proxyv2-ubi8:$(metadata.get dependencies.maistra)"}
+
+  knative_istio="$(metadata.get dependencies.net_istio)"
+  export KNATIVE_ISTIO_CONTROLLER=${KNATIVE_ISTIO_CONTROLLER:-"${registry}/net-istio-controller:${knative_istio}"}
+  export KNATIVE_ISTIO_WEBHOOK=${KNATIVE_ISTIO_WEBHOOK:-"${registry}/net-istio-webhook:${knative_istio}"}
+}

--- a/templates/images-rekt.yaml
+++ b/templates/images-rekt.yaml
@@ -1,0 +1,2 @@
+knative.dev/reconciler-test/cmd/eventshub: ${KNATIVE_EVENTING_TEST_EVENTSHUB}
+knative.dev/eventing/cmd/heartbeats: ${KNATIVE_EVENTING_HEARTBEATS}


### PR DESCRIPTION
Follow up on #2233 to auto update the image-rekt.yaml file, when the version gets bumped and `make release-files` is run.