### PR TITLE
Upgrade tests with lots of resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,15 @@ test-kitchensink-upgrade:
 test-kitchensink-upgrade-testonly:
 	./test/kitchensink-upgrade-tests.sh
 
+test-kitchensink-upgrade-stress:
+	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
+	./hack/dev.sh
+	INSTALL_OLDEST_COMPATIBLE="true" INSTALL_KAFKA="true" ./hack/install.sh
+	./test/kitchensink-upgrade-stress-tests.sh
+
+test-kitchensink-upgrade-stress-testonly:
+	./test/kitchensink-upgrade-stress-tests.sh
+
 # Run Console UI e2e tests.
 test-ui-e2e-testonly:
 	./test/ui-e2e-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,9 @@ test-kitchensink-upgrade-testonly:
 	./test/kitchensink-upgrade-tests.sh
 
 test-kitchensink-upgrade-stress:
-	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
+	UNINSTALL_STRIMZI=false ./hack/strimzi.sh
 	./hack/dev.sh
-	INSTALL_OLDEST_COMPATIBLE="true" INSTALL_KAFKA="true" ./hack/install.sh
+	INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true ./hack/install.sh
 	./test/kitchensink-upgrade-stress-tests.sh
 
 test-kitchensink-upgrade: test-kitchensink-upgrade-stress

--- a/Makefile
+++ b/Makefile
@@ -188,11 +188,11 @@ test-upgrade-with-mesh:
 	FULL_MESH=true INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=5 ./hack/install.sh
 	FULL_MESH=true TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
-#test-kitchensink-upgrade:
-#	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
-#	./hack/dev.sh
-#	INSTALL_OLDEST_COMPATIBLE="true" INSTALL_KAFKA="true" ./hack/install.sh
-#	./test/kitchensink-upgrade-tests.sh
+test-kitchensink-upgrade:
+	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
+	./hack/dev.sh
+	INSTALL_OLDEST_COMPATIBLE="true" INSTALL_KAFKA="true" ./hack/install.sh
+	./test/kitchensink-upgrade-tests.sh
 
 test-kitchensink-upgrade-testonly:
 	./test/kitchensink-upgrade-tests.sh
@@ -201,8 +201,6 @@ test-kitchensink-upgrade-stress:
 	UNINSTALL_STRIMZI=false ./hack/strimzi.sh
 	INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true SCALE_UP=5 ./hack/install.sh
 	./test/kitchensink-upgrade-stress-tests.sh
-
-test-kitchensink-upgrade: test-kitchensink-upgrade-stress
 
 test-kitchensink-upgrade-stress-testonly:
 	./test/kitchensink-upgrade-stress-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -199,8 +199,7 @@ test-kitchensink-upgrade-testonly:
 
 test-kitchensink-upgrade-stress:
 	UNINSTALL_STRIMZI=false ./hack/strimzi.sh
-	./hack/dev.sh
-	INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true ./hack/install.sh
+	INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true SCALE_UP=5 ./hack/install.sh
 	./test/kitchensink-upgrade-stress-tests.sh
 
 test-kitchensink-upgrade: test-kitchensink-upgrade-stress

--- a/Makefile
+++ b/Makefile
@@ -188,11 +188,11 @@ test-upgrade-with-mesh:
 	FULL_MESH=true INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=5 ./hack/install.sh
 	FULL_MESH=true TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
-test-kitchensink-upgrade:
-	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
-	./hack/dev.sh
-	INSTALL_OLDEST_COMPATIBLE="true" INSTALL_KAFKA="true" ./hack/install.sh
-	./test/kitchensink-upgrade-tests.sh
+#test-kitchensink-upgrade:
+#	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
+#	./hack/dev.sh
+#	INSTALL_OLDEST_COMPATIBLE="true" INSTALL_KAFKA="true" ./hack/install.sh
+#	./test/kitchensink-upgrade-tests.sh
 
 test-kitchensink-upgrade-testonly:
 	./test/kitchensink-upgrade-tests.sh
@@ -202,6 +202,8 @@ test-kitchensink-upgrade-stress:
 	./hack/dev.sh
 	INSTALL_OLDEST_COMPATIBLE="true" INSTALL_KAFKA="true" ./hack/install.sh
 	./test/kitchensink-upgrade-stress-tests.sh
+
+test-kitchensink-upgrade: test-kitchensink-upgrade-stress
 
 test-kitchensink-upgrade-stress-testonly:
 	./test/kitchensink-upgrade-stress-tests.sh

--- a/test/clients.go
+++ b/test/clients.go
@@ -35,7 +35,11 @@ import (
 	kafkaversioned "knative.dev/eventing-kafka-broker/control-plane/pkg/client/clientset/versioned"
 )
 
-const operatorNamesapce = "openshift-serverless"
+const (
+	ServingNamespace  = "knative-serving"
+	EventingNamespace = "knative-eventing"
+	IngressNamespace  = "knative-serving-ingress"
+)
 
 // Context holds objects related to test execution
 type Context struct {
@@ -194,14 +198,14 @@ func (c *Context) AddToCleanup(f CleanupFunc) {
 func (c *Context) DeleteOperatorPods(ctx context.Context) error {
 	pods, err := c.Clients.Kube.
 		CoreV1().
-		Pods(operatorNamesapce).
+		Pods(OperatorsNamespace).
 		List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to list pods in %s", operatorNamesapce)
+		return fmt.Errorf("failed to list pods in %s", OperatorsNamespace)
 	}
 
 	for _, p := range pods.Items {
-		if err := c.Clients.Kube.CoreV1().Pods(operatorNamesapce).Delete(ctx, p.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		if err := c.Clients.Kube.CoreV1().Pods(OperatorsNamespace).Delete(ctx, p.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -213,10 +217,10 @@ func (c *Context) WaitForOperatorPodsReady(ctx context.Context) error {
 	return wait.PollImmediate(Interval, Timeout, func() (done bool, err error) {
 		pods, err := c.Clients.Kube.
 			CoreV1().
-			Pods(operatorNamesapce).
+			Pods(OperatorsNamespace).
 			List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to list pods in %s", operatorNamesapce)
+			return false, fmt.Errorf("failed to list pods in %s", OperatorsNamespace)
 		}
 
 		// Verify pod readiness

--- a/test/e2e/knative_eventing_test.go
+++ b/test/e2e/knative_eventing_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	eventingNamespace  = "knative-eventing"
+	eventingNamespace  = test.EventingNamespace
 	eventingHaReplicas = 2
 )
 

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	servingNamespace = "knative-serving"
+	servingNamespace = test.ServingNamespace
 	haReplicas       = 2
 )
 

--- a/test/e2ekafka/knative_kafka_test.go
+++ b/test/e2ekafka/knative_kafka_test.go
@@ -23,8 +23,8 @@ import (
 
 const (
 	eventingName          = "knative-eventing"
-	eventingNamespace     = "knative-eventing"
-	knativeKafkaNamespace = "knative-eventing"
+	eventingNamespace     = test.EventingNamespace
+	knativeKafkaNamespace = test.EventingNamespace
 	defaultNamespace      = "default"
 )
 

--- a/test/eventinge2erekt/features/encryption.go
+++ b/test/eventinge2erekt/features/encryption.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift-knative/serverless-operator/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -53,7 +54,7 @@ func VerifyEncryptedTrafficToActivator(refs []corev1.ObjectReference, since time
 		// When running within Mesh a mesh-specific VirtualService is used which
 		// gets istio-ingressgateway out of the path.
 		logFilter := LogFilter{
-			PodNamespace:  "knative-serving",
+			PodNamespace:  test.ServingNamespace,
 			PodSelector:   metav1.ListOptions{LabelSelector: "app=activator"},
 			PodLogOptions: &corev1.PodLogOptions{Container: "istio-proxy", SinceTime: &metav1.Time{Time: since}},
 			JSONLogFilter: func(m map[string]interface{}) bool {

--- a/test/eventinge2erekt/main_test.go
+++ b/test/eventinge2erekt/main_test.go
@@ -2,12 +2,14 @@ package eventinge2erekt
 
 import (
 	"context"
+	"log"
 	"os"
 	"testing"
 	"time"
 
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/pkg/system"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/k8s"
@@ -20,7 +22,17 @@ var global environment.GlobalEnvironment
 func TestMain(m *testing.M) {
 	broker.EnvCfg.BrokerClass = "MTChannelBasedBroker"
 
-	global = environment.NewStandardGlobalEnvironment()
+	restConfig, err := pkgTest.Flags.ClientConfig.GetRESTConfig()
+	if err != nil {
+		log.Fatal("Error building client config: ", err)
+	}
+
+	// Getting the rest config explicitly and passing it further will prevent re-initializing the flagset
+	// in NewStandardGlobalEnvironment().
+	global = environment.NewStandardGlobalEnvironment(func(cfg environment.Configuration) environment.Configuration {
+		cfg.Config = restConfig
+		return cfg
+	})
 
 	// Run the tests.
 	os.Exit(m.Run())

--- a/test/extensione2erekt/features/encryption.go
+++ b/test/extensione2erekt/features/encryption.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift-knative/serverless-operator/test"
 	eventingfeatures "github.com/openshift-knative/serverless-operator/test/eventinge2erekt/features"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,7 @@ func verifyEncryptedTrafficToKafkaSink(sinkName string, since time.Time) feature
 		// source -> kafka-sink-receiver
 		sinkPath := fmt.Sprintf("/%s/%s", environment.FromContext(ctx).Namespace(), sinkName)
 		logFilter := eventingfeatures.LogFilter{
-			PodNamespace:  "knative-eventing",
+			PodNamespace:  test.EventingNamespace,
 			PodSelector:   metav1.ListOptions{LabelSelector: "app=kafka-sink-receiver"},
 			PodLogOptions: &corev1.PodLogOptions{Container: "istio-proxy", SinceTime: &metav1.Time{Time: since}},
 			JSONLogFilter: func(m map[string]interface{}) bool {
@@ -75,7 +76,7 @@ func verifyEncryptedTrafficToKafkaBroker(refs []corev1.ObjectReference, namespac
 		}
 		// source -> kafka-broker-receiver
 		brokerPath := fmt.Sprintf("/%s/%s", environment.FromContext(ctx).Namespace(), brokerName)
-		brokerReceiverNamespace := "knative-eventing"
+		brokerReceiverNamespace := test.EventingNamespace
 		if namespacedBroker {
 			brokerReceiverNamespace = environment.FromContext(ctx).Namespace()
 		}
@@ -119,7 +120,7 @@ func verifyEncryptedTrafficToChannelBasedKafkaBroker(refs []corev1.ObjectReferen
 			environment.FromContext(ctx).Namespace())
 
 		logFilter := eventingfeatures.LogFilter{
-			PodNamespace:  "knative-eventing",
+			PodNamespace:  test.EventingNamespace,
 			PodSelector:   metav1.ListOptions{LabelSelector: "app=kafka-channel-receiver"},
 			PodLogOptions: &corev1.PodLogOptions{Container: "istio-proxy", SinceTime: &metav1.Time{Time: since}},
 			JSONLogFilter: func(m map[string]interface{}) bool {
@@ -156,7 +157,7 @@ func verifyEncryptedTrafficToKafkaChannel(refs []corev1.ObjectReference, since t
 			environment.FromContext(ctx).Namespace())
 
 		logFilter := eventingfeatures.LogFilter{
-			PodNamespace:  "knative-eventing",
+			PodNamespace:  test.EventingNamespace,
 			PodSelector:   metav1.ListOptions{LabelSelector: "app=kafka-channel-receiver"},
 			PodLogOptions: &corev1.PodLogOptions{Container: "istio-proxy", SinceTime: &metav1.Time{Time: since}},
 			JSONLogFilter: func(m map[string]interface{}) bool {

--- a/test/extensione2erekt/main_test.go
+++ b/test/extensione2erekt/main_test.go
@@ -2,12 +2,14 @@ package extensione2erekt
 
 import (
 	"context"
+	"log"
 	"os"
 	"testing"
 	"time"
 
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/pkg/system"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/k8s"
@@ -21,7 +23,17 @@ func TestMain(m *testing.M) {
 	channel_impl.EnvCfg.ChannelGK = "KafkaChannel.messaging.knative.dev"
 	channel_impl.EnvCfg.ChannelV = "v1beta1"
 
-	global = environment.NewStandardGlobalEnvironment()
+	restConfig, err := pkgTest.Flags.ClientConfig.GetRESTConfig()
+	if err != nil {
+		log.Fatal("Error building client config: ", err)
+	}
+
+	// Getting the rest config explicitly and passing it further will prevent re-initializing the flagset
+	// in NewStandardGlobalEnvironment().
+	global = environment.NewStandardGlobalEnvironment(func(cfg environment.Configuration) environment.Configuration {
+		cfg.Config = restConfig
+		return cfg
+	})
 
 	// Run the tests.
 	os.Exit(m.Run())

--- a/test/kitchensink-upgrade-stress-tests.sh
+++ b/test/kitchensink-upgrade-stress-tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/lib.bash"
+
+set -Eeuo pipefail
+
+# Enable extra verbosity if running in CI.
+if [ -n "$OPENSHIFT_CI" ]; then
+  env
+fi
+debugging.setup # both install and test
+dump_state.setup # test
+
+logger.success '🚀 Cluster prepared for testing.'
+
+kitchensink_upgrade_stress_tests
+
+success

--- a/test/kitchensinke2e/broker_test.go
+++ b/test/kitchensinke2e/broker_test.go
@@ -11,11 +11,11 @@ import (
 const groupSize = 8
 
 func TestBrokerReadinessBrokerDLS(t *testing.T) {
-	testFeatureSet(t, features.BrokerFeatureSetWithBrokerDLS(false))
+	testFeatureSet(t, features.BrokerFeatureSetWithBrokerDLS())
 }
 
 func TestBrokerReadinessTriggerDLS(t *testing.T) {
-	testFeatureSet(t, features.BrokerFeatureSetWithTriggerDLS(false))
+	testFeatureSet(t, features.BrokerFeatureSetWithTriggerDLS())
 }
 
 func split(featureSet feature.FeatureSet, groupSize int) []feature.FeatureSet {

--- a/test/kitchensinke2e/channel_test.go
+++ b/test/kitchensinke2e/channel_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestChannelReadiness(t *testing.T) {
-	testFeatureSet(t, features.ChannelFeatureSet(false))
+	testFeatureSet(t, features.ChannelFeatureSet())
 }

--- a/test/kitchensinke2e/features/broker.go
+++ b/test/kitchensinke2e/features/broker.go
@@ -28,6 +28,12 @@ var sinksShort = []component{
 	ksvc,
 }
 
+// sinksLight is used when deploying multiple instances of the sink
+// to reduce CPU/Mem requirements.
+var sinksLight = []component{
+	inMemoryChannel,
+}
+
 var brokers = []component{
 	inMemoryChannelMtBroker,
 	kafkaChannelMtBroker,

--- a/test/kitchensinke2e/features/broker.go
+++ b/test/kitchensinke2e/features/broker.go
@@ -21,6 +21,7 @@ var sinksAll = []component{
 	inMemoryChannelParallel,
 	kafkaChannelParallel,
 	ksvc,
+	kafkaSink,
 }
 
 var sinksShort = []component{

--- a/test/kitchensinke2e/features/broker.go
+++ b/test/kitchensinke2e/features/broker.go
@@ -39,7 +39,7 @@ var (
 	triggers             = sinksAll
 )
 
-func BrokerReadiness(broker component, brokerDls component, triggers []component, triggerDls component) *feature.Feature {
+func BrokerReadiness(index int, broker component, brokerDls component, triggers []component, triggerDls component) *feature.Feature {
 	testLabel := shortLabel(broker)
 	if brokerDls != nil {
 		testLabel = testLabel + "b" + shortLabel(brokerDls)
@@ -47,6 +47,8 @@ func BrokerReadiness(broker component, brokerDls component, triggers []component
 	if triggerDls != nil {
 		testLabel = testLabel + "t" + shortLabel(triggerDls)
 	}
+
+	testLabel = fmt.Sprintf("%s-%d", testLabel, index)
 
 	brokerName := testLabel
 	dlsName := testLabel + "-bdls"
@@ -92,9 +94,21 @@ func BrokerReadiness(broker component, brokerDls component, triggers []component
 	return f
 }
 
+func BrokerFeatureSetWithBrokerDLS() feature.FeatureSet {
+	return brokerFeatureSetWithBrokerDLS(false, 1)
+}
+
+func BrokerFeatureSetWithBrokerDLSShort() feature.FeatureSet {
+	return brokerFeatureSetWithBrokerDLS(true, 1)
+}
+
+func BrokerFeatureSetWithBrokerDLSStress() feature.FeatureSet {
+	return brokerFeatureSetWithBrokerDLS(true, NumDeployments)
+}
+
 // BrokerFeatureSetWithBrokerDLS returns all combinations of Broker X DeadLetterSinks,
 // each broker with all possible Triggers with the DeadLetterSink set on the Broker.
-func BrokerFeatureSetWithBrokerDLS(short bool) feature.FeatureSet {
+func brokerFeatureSetWithBrokerDLS(short bool, times int) feature.FeatureSet {
 	dls := deadLetterSinks
 	if short {
 		dls = deadLetterSinksShort
@@ -102,7 +116,9 @@ func BrokerFeatureSetWithBrokerDLS(short bool) feature.FeatureSet {
 	features := make([]*feature.Feature, 0, len(brokers)*len(dls))
 	for _, broker := range brokers {
 		for _, deadLetterSink := range dls {
-			features = append(features, BrokerReadiness(broker, deadLetterSink, triggers, nil))
+			for i := 0; i < times; i++ {
+				features = append(features, BrokerReadiness(i, broker, deadLetterSink, triggers, nil))
+			}
 		}
 	}
 	return feature.FeatureSet{
@@ -111,9 +127,21 @@ func BrokerFeatureSetWithBrokerDLS(short bool) feature.FeatureSet {
 	}
 }
 
+func BrokerFeatureSetWithTriggerDLS() feature.FeatureSet {
+	return brokerFeatureSetWithTriggerDLS(false, 1)
+}
+
+func BrokerFeatureSetWithTriggerDLSShort() feature.FeatureSet {
+	return brokerFeatureSetWithTriggerDLS(true, 1)
+}
+
+func BrokerFeatureSetWithTriggerDLSStress() feature.FeatureSet {
+	return brokerFeatureSetWithTriggerDLS(true, NumDeployments)
+}
+
 // BrokerFeatureSetWithTriggerDLS returns all combinations of Broker X DeadLetterSinks,
 // each broker with all possible Triggers with the DeadLetterSink set on the Trigger.
-func BrokerFeatureSetWithTriggerDLS(short bool) feature.FeatureSet {
+func brokerFeatureSetWithTriggerDLS(short bool, times int) feature.FeatureSet {
 	dls := deadLetterSinks
 	if short {
 		dls = deadLetterSinksShort
@@ -121,7 +149,9 @@ func BrokerFeatureSetWithTriggerDLS(short bool) feature.FeatureSet {
 	features := make([]*feature.Feature, 0, len(brokers)*len(dls))
 	for _, broker := range brokers {
 		for _, deadLetterSink := range dls {
-			features = append(features, BrokerReadiness(broker, nil, triggers, deadLetterSink))
+			for i := 0; i < times; i++ {
+				features = append(features, BrokerReadiness(i, broker, nil, triggers, deadLetterSink))
+			}
 		}
 	}
 	return feature.FeatureSet{

--- a/test/kitchensinke2e/features/broker.go
+++ b/test/kitchensinke2e/features/broker.go
@@ -38,6 +38,7 @@ var (
 	deadLetterSinks      = sinksAll
 	deadLetterSinksShort = sinksShort
 	triggers             = sinksAll
+	triggersShort        = sinksShort
 )
 
 func BrokerReadiness(index int, broker component, brokerDls component, triggers []component, triggerDls component) *feature.Feature {
@@ -111,14 +112,16 @@ func BrokerFeatureSetWithBrokerDLSStress() feature.FeatureSet {
 // each broker with all possible Triggers with the DeadLetterSink set on the Broker.
 func brokerFeatureSetWithBrokerDLS(short bool, times int) feature.FeatureSet {
 	dls := deadLetterSinks
+	trgs := triggers
 	if short {
 		dls = deadLetterSinksShort
+		trgs = triggersShort
 	}
 	features := make([]*feature.Feature, 0, len(brokers)*len(dls))
 	for _, broker := range brokers {
 		for _, deadLetterSink := range dls {
 			for i := 0; i < times; i++ {
-				features = append(features, BrokerReadiness(i, broker, deadLetterSink, triggers, nil))
+				features = append(features, BrokerReadiness(i, broker, deadLetterSink, trgs, nil))
 			}
 		}
 	}
@@ -144,14 +147,16 @@ func BrokerFeatureSetWithTriggerDLSStress() feature.FeatureSet {
 // each broker with all possible Triggers with the DeadLetterSink set on the Trigger.
 func brokerFeatureSetWithTriggerDLS(short bool, times int) feature.FeatureSet {
 	dls := deadLetterSinks
+	trgs := triggers
 	if short {
 		dls = deadLetterSinksShort
+		trgs = triggersShort
 	}
 	features := make([]*feature.Feature, 0, len(brokers)*len(dls))
 	for _, broker := range brokers {
 		for _, deadLetterSink := range dls {
 			for i := 0; i < times; i++ {
-				features = append(features, BrokerReadiness(i, broker, nil, triggers, deadLetterSink))
+				features = append(features, BrokerReadiness(i, broker, nil, trgs, deadLetterSink))
 			}
 		}
 	}

--- a/test/kitchensinke2e/features/components.go
+++ b/test/kitchensinke2e/features/components.go
@@ -4,16 +4,18 @@ import (
 	"context"
 
 	"github.com/openshift-knative/serverless-operator/test/kitchensinke2e/brokerconfig"
-	testpkg "knative.dev/eventing-kafka-broker/test/pkg"
-	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkasink"
-	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkatopic"
-
 	"github.com/openshift-knative/serverless-operator/test/kitchensinke2e/inmemorychannel"
 	ksvcresources "github.com/openshift-knative/serverless-operator/test/kitchensinke2e/ksvc"
+	testpkg "knative.dev/eventing-kafka-broker/test/pkg"
 	kafkachannelresources "knative.dev/eventing-kafka-broker/test/rekt/resources/kafkachannel"
+	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkasink"
+	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkatopic"
+	"knative.dev/eventing/test/rekt/resources/apiserversource"
 	brokerresources "knative.dev/eventing/test/rekt/resources/broker"
 	channelresources "knative.dev/eventing/test/rekt/resources/channel"
+	"knative.dev/eventing/test/rekt/resources/containersource"
 	parallelresources "knative.dev/eventing/test/rekt/resources/parallel"
+	"knative.dev/eventing/test/rekt/resources/pingsource"
 	sequenceresources "knative.dev/eventing/test/rekt/resources/sequence"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
@@ -267,6 +269,42 @@ var kafkaSink = genericComponent{
 			kafkasink.Install(name, topic, testpkg.BootstrapServersPlaintextArr,
 				kafkasink.WithNumPartitions(10),
 				kafkasink.WithReplicationFactor(1))(ctx, t)
+		}
+	},
+}
+
+var pingSource = genericComponent{
+	shortLabel: "ps",
+	label:      "PingSource",
+	kind:       "PingSoure",
+	gvr:        pingsource.Gvr(),
+	install: func(name string, opts ...manifest.CfgFn) feature.StepFn {
+		return func(ctx context.Context, t feature.T) {
+			pingsource.Install(name, opts...)(ctx, t)
+		}
+	},
+}
+
+var containerSource = genericComponent{
+	shortLabel: "cs",
+	label:      "ContainerSource",
+	kind:       "ContainerSource",
+	gvr:        containersource.Gvr(),
+	install: func(name string, opts ...manifest.CfgFn) feature.StepFn {
+		return func(ctx context.Context, t feature.T) {
+			containersource.Install(name, opts...)(ctx, t)
+		}
+	},
+}
+
+var apiServerSource = genericComponent{
+	shortLabel: "apis",
+	label:      "ApiServerSource",
+	kind:       "ApiServerSource",
+	gvr:        apiserversource.Gvr(),
+	install: func(name string, opts ...manifest.CfgFn) feature.StepFn {
+		return func(ctx context.Context, t feature.T) {
+			//containersource.Install(name, opts...)(ctx, t)
 		}
 	},
 }

--- a/test/kitchensinke2e/features/components.go
+++ b/test/kitchensinke2e/features/components.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	NumDeployments = 10
+	NumDeployments = 3
 )
 
 /*

--- a/test/kitchensinke2e/features/components.go
+++ b/test/kitchensinke2e/features/components.go
@@ -269,7 +269,7 @@ var kafkaSink = genericComponent{
 	install: func(name string, opts ...manifest.CfgFn) feature.StepFn {
 		return func(ctx context.Context, t feature.T) {
 			topic := name + "-t"
-			kafkatopic.Install(topic)
+			kafkatopic.Install(topic)(ctx, t)
 			kafkasink.Install(name, topic, testpkg.BootstrapServersPlaintextArr,
 				kafkasink.WithNumPartitions(10),
 				kafkasink.WithReplicationFactor(1))(ctx, t)
@@ -284,7 +284,6 @@ var pingSource = genericComponent{
 	gvr:        pingsource.Gvr(),
 	install: func(name string, opts ...manifest.CfgFn) feature.StepFn {
 		return func(ctx context.Context, t feature.T) {
-			//pingsource.WithSink(service.AsKReference(sink), "")) // source.WithSink
 			pingsource.Install(name, opts...)(ctx, t)
 		}
 	},
@@ -297,7 +296,6 @@ var containerSource = genericComponent{
 	gvr:        containersource.Gvr(),
 	install: func(name string, opts ...manifest.CfgFn) feature.StepFn {
 		return func(ctx context.Context, t feature.T) {
-			//containersource.WithSink(channel_impl.AsRef(channels[0]), "")) // source.WithSink
 			containersource.Install(name, opts...)(ctx, t)
 		}
 	},
@@ -330,7 +328,6 @@ var apiServerSource = genericComponent{
 					Kind:       "Event",
 				}),
 			}
-			//apiserversource.WithSink(svc.AsKReference(sink), ""), // je tam namespace
 			apiserversource.Install(name, append(commonOpts, opts...)...)(ctx, t)
 		}
 	},
@@ -344,8 +341,7 @@ var kafkaSource = genericComponent{
 	install: func(name string, opts ...manifest.CfgFn) feature.StepFn {
 		return func(ctx context.Context, t feature.T) {
 			topic := name + "-t"
-			kafkatopic.Install(topic)
-			//kafkasource.WithSink(service.AsKReference(receiver), ""),
+			kafkatopic.Install(topic)(ctx, t)
 			commonOpts := []manifest.CfgFn{
 				kafkasource.WithTopics([]string{topic}),
 				kafkasource.WithBootstrapServers(testpkg.BootstrapServersPlaintextArr),

--- a/test/kitchensinke2e/features/components.go
+++ b/test/kitchensinke2e/features/components.go
@@ -12,7 +12,7 @@ import (
 	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkasink"
 	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkasource"
 	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkatopic"
-	v1 "knative.dev/eventing/pkg/apis/sources/v1"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/test/rekt/resources/account_role"
 	"knative.dev/eventing/test/rekt/resources/apiserversource"
 	brokerresources "knative.dev/eventing/test/rekt/resources/broker"
@@ -322,8 +322,8 @@ var apiServerSource = genericComponent{
 
 			commonOpts := []manifest.CfgFn{
 				apiserversource.WithServiceAccountName(saName),
-				apiserversource.WithEventMode(v1.ResourceMode),
-				apiserversource.WithResources(v1.APIVersionKindSelector{
+				apiserversource.WithEventMode(sourcesv1.ResourceMode),
+				apiserversource.WithResources(sourcesv1.APIVersionKindSelector{
 					APIVersion: "v1",
 					Kind:       "Event",
 				}),

--- a/test/kitchensinke2e/features/components.go
+++ b/test/kitchensinke2e/features/components.go
@@ -17,6 +17,10 @@ import (
 	svcresources "knative.dev/reconciler-test/resources/svc"
 )
 
+const (
+	NumDeployments = 10
+)
+
 /*
 Components are used as bogus sinks/filters/replies. We only test that the whole system becomes Ready,
 so we don't implement any kind of dataplane in the components.

--- a/test/kitchensinke2e/features/components.go
+++ b/test/kitchensinke2e/features/components.go
@@ -284,7 +284,7 @@ var pingSource = genericComponent{
 	gvr:        pingsource.Gvr(),
 	install: func(name string, opts ...manifest.CfgFn) feature.StepFn {
 		return func(ctx context.Context, t feature.T) {
-			// pingsource.WithSink(service.AsKReference(sink), "")) // source.WithSink
+			//pingsource.WithSink(service.AsKReference(sink), "")) // source.WithSink
 			pingsource.Install(name, opts...)(ctx, t)
 		}
 	},

--- a/test/kitchensinke2e/features/source.go
+++ b/test/kitchensinke2e/features/source.go
@@ -1,8 +1,66 @@
 package features
 
-var sourcesAll = []component{
+import (
+	"fmt"
+
+	sourceresources "knative.dev/eventing/test/rekt/resources/source"
+	"knative.dev/reconciler-test/pkg/feature"
+)
+
+var sources = []component{
 	pingSource,
 	containerSource,
 	apiServerSource,
 	kafkaSource,
+}
+
+func SourceReadiness(index int, source component, sink component) *feature.Feature {
+	testLabel := shortLabel(source) + shortLabel(sink)
+	testLabel = fmt.Sprintf("%s-%d", testLabel, index)
+
+	sourceName := testLabel
+	sinkName := testLabel + "-sink"
+
+	f := feature.NewFeatureNamed(fmt.Sprintf("%s with %s as sink", label(source), label(sink)))
+
+	f.Setup("Install Sink", sink.Install(sinkName))
+	f.Setup("Install Source", source.Install(sourceName,
+		sourceresources.WithSink(sink.KReference(sinkName), "")))
+
+	f.Assert("Sink is Ready", sink.IsReady(sinkName))
+	f.Assert("Source is Ready", source.IsReady(sourceName))
+
+	return f
+}
+
+func SourceFeatureSet() feature.FeatureSet {
+	return sourceFeatureSet(false, 1)
+}
+
+func SourceFeatureSetShort() feature.FeatureSet {
+	return sourceFeatureSet(true, 1)
+}
+
+func SourceFeatureSetStress() feature.FeatureSet {
+	return sourceFeatureSet(true, NumDeployments)
+}
+
+// sourceFeatureSet returns all combinations of Source x Sinks.
+func sourceFeatureSet(short bool, times int) feature.FeatureSet {
+	sinks := sinksAll
+	if short {
+		sinks = sinksShort
+	}
+	features := make([]*feature.Feature, 0, len(sources)*len(sinks))
+	for _, source := range sources {
+		for _, sink := range sinks {
+			for i := 0; i < times; i++ {
+				features = append(features, SourceReadiness(i, source, sink))
+			}
+		}
+	}
+	return feature.FeatureSet{
+		Name:     "Source",
+		Features: features,
+	}
 }

--- a/test/kitchensinke2e/features/source.go
+++ b/test/kitchensinke2e/features/source.go
@@ -3,12 +3,12 @@ package features
 import (
 	"fmt"
 
-	sourceresources "knative.dev/eventing/test/rekt/resources/source"
+	"knative.dev/eventing/test/rekt/resources/apiserversource"
 	"knative.dev/reconciler-test/pkg/feature"
 )
 
 var sources = []component{
-	pingSource,
+	//pingSource,
 	containerSource,
 	apiServerSource,
 	kafkaSource,
@@ -25,7 +25,10 @@ func SourceReadiness(index int, source component, sink component) *feature.Featu
 
 	f.Setup("Install Sink", sink.Install(sinkName))
 	f.Setup("Install Source", source.Install(sourceName,
-		sourceresources.WithSink(sink.KReference(sinkName), "")))
+		// Use apiserversource's WithSink because it's template requires .sink.ref.namespace to be set.
+		// This function is generic enough to work with other sources too.
+		apiserversource.WithSink(sink.KReference(sinkName), "")))
+	//sourceresources.WithSink(sink.KReference(sinkName), "")))
 
 	f.Assert("Sink is Ready", sink.IsReady(sinkName))
 	f.Assert("Source is Ready", source.IsReady(sourceName))

--- a/test/kitchensinke2e/features/source.go
+++ b/test/kitchensinke2e/features/source.go
@@ -1,0 +1,8 @@
+package features
+
+var sourcesAll = []component{
+	pingSource,
+	containerSource,
+	apiServerSource,
+	kafkaSource,
+}

--- a/test/kitchensinke2e/features/source.go
+++ b/test/kitchensinke2e/features/source.go
@@ -14,22 +14,16 @@ var sources = []component{
 	kafkaSource,
 }
 
-func SourceReadiness(index int, source component, sink component, installSink bool, sinkNameOverride string) *feature.Feature {
+func SourceReadiness(index int, source component, sink component) *feature.Feature {
 	testLabel := shortLabel(source) + shortLabel(sink)
 	testLabel = fmt.Sprintf("%s-%d", testLabel, index)
 
 	sourceName := testLabel
 	sinkName := testLabel + "-sink"
-	if sinkNameOverride != "" {
-		sinkName = sinkNameOverride
-	}
 
 	f := feature.NewFeatureNamed(fmt.Sprintf("%s with %s as sink", label(source), label(sink)))
 
-	if installSink {
-		f.Setup("Install Sink", sink.Install(sinkName))
-	}
-
+	f.Setup("Install Sink", sink.Install(sinkName))
 	f.Setup("Install Source", source.Install(sourceName,
 		// Use apiserversource's WithSink because its template requires .sink.ref.namespace to be set.
 		// This function is generic enough to work with other sources too.
@@ -59,23 +53,14 @@ func sourceFeatureSet(short bool, times int) feature.FeatureSet {
 	if short {
 		sinks = sinksShort
 	}
+	if times > 1 {
+		sinks = sinksLight
+	}
 	features := make([]*feature.Feature, 0, len(sources)*len(sinks))
 	for _, source := range sources {
-		if times > 1 {
-			// When deploying multiple instances of the same Source, make them share one sink
-			// to prevent running out of CPU/MEM.
-			sink := sinks[0]
+		for _, sink := range sinks {
 			for i := 0; i < times; i++ {
-				sinkNameOverride := shortLabel(sink) + "-sink"
-				if i == 0 {
-					features = append(features, SourceReadiness(i, source, sink, true /*installSink*/, sinkNameOverride))
-				} else {
-					features = append(features, SourceReadiness(i, source, sink, false, sinkNameOverride))
-				}
-			}
-		} else {
-			for _, sink := range sinks {
-				features = append(features, SourceReadiness(0, source, sink, true, ""))
+				features = append(features, SourceReadiness(i, source, sink))
 			}
 		}
 	}

--- a/test/kitchensinke2e/features/source.go
+++ b/test/kitchensinke2e/features/source.go
@@ -8,7 +8,7 @@ import (
 )
 
 var sources = []component{
-	//pingSource,
+	pingSource,
 	containerSource,
 	apiServerSource,
 	kafkaSource,
@@ -25,10 +25,9 @@ func SourceReadiness(index int, source component, sink component) *feature.Featu
 
 	f.Setup("Install Sink", sink.Install(sinkName))
 	f.Setup("Install Source", source.Install(sourceName,
-		// Use apiserversource's WithSink because it's template requires .sink.ref.namespace to be set.
+		// Use apiserversource's WithSink because its template requires .sink.ref.namespace to be set.
 		// This function is generic enough to work with other sources too.
 		apiserversource.WithSink(sink.KReference(sinkName), "")))
-	//sourceresources.WithSink(sink.KReference(sinkName), "")))
 
 	f.Assert("Sink is Ready", sink.IsReady(sinkName))
 	f.Assert("Source is Ready", source.IsReady(sourceName))

--- a/test/kitchensinke2e/flow_test.go
+++ b/test/kitchensinke2e/flow_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestFlowReadiness(t *testing.T) {
 	featureSets := []feature.FeatureSet{
-		features.SequenceNoReplyFeatureSet(false),
-		features.ParallelNoReplyFeatureSet(false),
-		features.SequenceGlobalReplyFeatureSet(false),
-		features.ParallelGlobalReplyFeatureSet(false),
+		features.SequenceNoReplyFeatureSet(),
+		features.ParallelNoReplyFeatureSet(),
+		features.SequenceGlobalReplyFeatureSet(),
+		features.ParallelGlobalReplyFeatureSet(),
 	}
 
 	for _, fs := range featureSets {

--- a/test/kitchensinke2e/source_test.go
+++ b/test/kitchensinke2e/source_test.go
@@ -1,0 +1,11 @@
+package kitchensinke2e
+
+import (
+	"testing"
+
+	"github.com/openshift-knative/serverless-operator/test/kitchensinke2e/features"
+)
+
+func TestSourceReadiness(t *testing.T) {
+	testFeatureSet(t, features.SourceFeatureSet())
+}

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -346,8 +346,8 @@ function downstream_kitchensink_e2e_tests {
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi
-
-  go_test_e2e "${RUN_FLAGS[@]}" ./test/kitchensinke2e -run=TestSourceReadiness \
+#  export GO_TEST_VERBOSITY=standard-verbose
+  go_test_e2e "${RUN_FLAGS[@]}" ./test/kitchensinke2e \
   --images.producer.file="${images_file}" \
   --imagetemplate "${IMAGE_TEMPLATE}" \
   "$@"

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -477,6 +477,21 @@ function kitchensink_upgrade_tests {
   logger.success 'Kitchensink upgrade tests passed'
 }
 
+function kitchensink_upgrade_stress_tests {
+  logger.info "Running upgrade tests - stress control plane"
+
+  export SYSTEM_NAMESPACE="$SERVING_NAMESPACE"
+
+  go_test_e2e -run=TestUpgradeStress -timeout=90m -parallel=20 ./test/upgrade/kitchensink -tags=upgrade \
+     --kubeconfigs="${KUBECONFIG}" \
+     --imagetemplate="${IMAGE_TEMPLATE}" \
+     --catalogsource="${OLM_SOURCE}" \
+     --upgradechannel="${OLM_UPGRADE_CHANNEL}" \
+     --csv="${CURRENT_CSV}"
+
+  logger.success 'Upgrade tests - stress control plane - passed'
+}
+
 function teardown {
   if [ -n "$OPENSHIFT_CI" ]; then
     logger.warn 'Skipping teardown as we are running on Openshift CI'

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -487,7 +487,10 @@ function kitchensink_upgrade_stress_tests {
      --imagetemplate="${IMAGE_TEMPLATE}" \
      --catalogsource="${OLM_SOURCE}" \
      --upgradechannel="${OLM_UPGRADE_CHANNEL}" \
-     --csv="${CURRENT_CSV}"
+     --csv="${CURRENT_CSV}" \
+     --servingversion="${KNATIVE_SERVING_VERSION/knative-v/}" \
+     --eventingversion="${KNATIVE_EVENTING_VERSION/knative-v/}" \
+     --kafkaversion="${KNATIVE_EVENTING_KAFKA_BROKER_VERSION/knative-v/}"
 
   logger.success 'Upgrade tests - stress control plane - passed'
 }

--- a/test/monitoring.go
+++ b/test/monitoring.go
@@ -1,0 +1,95 @@
+package test
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	prom "github.com/prometheus/client_golang/api"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/injection/clients/dynamicclient"
+)
+
+type authRoundtripper struct {
+	authorization string
+	inner         http.RoundTripper
+}
+
+func (a *authRoundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set("Authorization", a.authorization)
+	return a.inner.RoundTrip(r)
+}
+
+func NewPrometheusClient(ctx context.Context) (promv1.API, error) {
+	host, err := getPrometheusHost(ctx)
+	if err != nil {
+		return nil, err
+	}
+	bToken, err := getBearerTokenForPrometheusAccount(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	rt := prom.DefaultRoundTripper.(*http.Transport).Clone()
+	rt.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	client, err := prom.NewClient(prom.Config{
+		Address: "https://" + host,
+		RoundTripper: &authRoundtripper{
+			authorization: fmt.Sprintf("Bearer %s", bToken),
+			inner:         rt,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return promv1.NewAPI(client), nil
+}
+
+func getPrometheusHost(ctx context.Context) (string, error) {
+	routeGVR := schema.GroupVersionResource{Group: "route.openshift.io", Version: "v1", Resource: "routes"}
+	route, err := dynamicclient.Get(ctx).Resource(routeGVR).Namespace("openshift-monitoring").
+		Get(ctx, "prometheus-k8s", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("unable to get route: %w", err)
+	}
+	host, _, _ := unstructured.NestedString(route.Object, "spec", "host")
+	return host, nil
+}
+
+func getBearerTokenForPrometheusAccount(ctx context.Context) (string, error) {
+	secrets, err := kubeclient.Get(ctx).CoreV1().Secrets("openshift-monitoring").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error listing secrets in namespace openshift-monitoring: %w", err)
+	}
+	tokenSecret := getSecretNameForToken(secrets.Items)
+	if tokenSecret == "" {
+		return "", errors.New("token name for prometheus-k8s service account not found")
+	}
+	sec, err := kubeclient.Get(ctx).CoreV1().Secrets("openshift-monitoring").Get(context.Background(), tokenSecret, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error getting secret %s: %w", tokenSecret, err)
+	}
+	tokenContents := sec.Data["token"]
+	if len(tokenContents) == 0 {
+		return "", fmt.Errorf("token data is missing for token %s", tokenSecret)
+	}
+	return string(tokenContents), nil
+}
+
+func getSecretNameForToken(secrets []corev1.Secret) string {
+	for _, sec := range secrets {
+		if strings.HasPrefix(sec.Name, "prometheus-k8s-token") {
+			return sec.Name
+		}
+	}
+	return ""
+}

--- a/test/monitoringe2e/helpers.go
+++ b/test/monitoringe2e/helpers.go
@@ -2,24 +2,13 @@ package monitoringe2e
 
 import (
 	"context"
-	"crypto/tls"
-	"errors"
 	"fmt"
-	"net/http"
-	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"github.com/openshift-knative/serverless-operator/test"
 	"k8s.io/apimachinery/pkg/util/wait"
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
 
-	prom "github.com/prometheus/client_golang/api"
-	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	prommodel "github.com/prometheus/common/model"
 )
 
@@ -84,55 +73,8 @@ var (
 	}
 )
 
-type authRoundtripper struct {
-	authorization string
-	inner         http.RoundTripper
-}
-
-func (a *authRoundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	r.Header.Set("Authorization", a.authorization)
-	return a.inner.RoundTrip(r)
-}
-
-func newPrometheusClient(ctx context.Context) (promv1.API, error) {
-	host, err := getPrometheusHost(ctx)
-	if err != nil {
-		return nil, err
-	}
-	bToken, err := getBearerTokenForPrometheusAccount(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	rt := prom.DefaultRoundTripper.(*http.Transport).Clone()
-	rt.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	client, err := prom.NewClient(prom.Config{
-		Address: "https://" + host,
-		RoundTripper: &authRoundtripper{
-			authorization: fmt.Sprintf("Bearer %s", bToken),
-			inner:         rt,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return promv1.NewAPI(client), nil
-}
-
-func getPrometheusHost(ctx context.Context) (string, error) {
-	routeGVR := schema.GroupVersionResource{Group: "route.openshift.io", Version: "v1", Resource: "routes"}
-	route, err := dynamicclient.Get(ctx).Resource(routeGVR).Namespace("openshift-monitoring").
-		Get(ctx, "prometheus-k8s", metav1.GetOptions{})
-	if err != nil {
-		return "", fmt.Errorf("unable to get route: %w", err)
-	}
-	host, _, _ := unstructured.NestedString(route.Object, "spec", "host")
-	return host, nil
-}
-
 func VerifyHealthStatusMetric(ctx context.Context, label string, expectedValue string) error {
-	pc, err := newPrometheusClient(ctx)
+	pc, err := test.NewPrometheusClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -162,7 +104,7 @@ func VerifyHealthStatusMetric(ctx context.Context, label string, expectedValue s
 }
 
 func VerifyMetrics(ctx context.Context, metricQueries []string) error {
-	pc, err := newPrometheusClient(ctx)
+	pc, err := test.NewPrometheusClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -186,33 +128,4 @@ func VerifyMetrics(ctx context.Context, metricQueries []string) error {
 		}
 	}
 	return nil
-}
-
-func getBearerTokenForPrometheusAccount(ctx context.Context) (string, error) {
-	secrets, err := kubeclient.Get(ctx).CoreV1().Secrets("openshift-monitoring").List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return "", fmt.Errorf("error listing secrets in namespace openshift-monitoring: %w", err)
-	}
-	tokenSecret := getSecretNameForToken(secrets.Items)
-	if tokenSecret == "" {
-		return "", errors.New("token name for prometheus-k8s service account not found")
-	}
-	sec, err := kubeclient.Get(ctx).CoreV1().Secrets("openshift-monitoring").Get(context.Background(), tokenSecret, metav1.GetOptions{})
-	if err != nil {
-		return "", fmt.Errorf("error getting secret %s: %w", tokenSecret, err)
-	}
-	tokenContents := sec.Data["token"]
-	if len(tokenContents) == 0 {
-		return "", fmt.Errorf("token data is missing for token %s", tokenSecret)
-	}
-	return string(tokenContents), nil
-}
-
-func getSecretNameForToken(secrets []corev1.Secret) string {
-	for _, sec := range secrets {
-		if strings.HasPrefix(sec.Name, "prometheus-k8s-token") {
-			return sec.Name
-		}
-	}
-	return ""
 }

--- a/test/servinge2e/kourier/custom_route_test.go
+++ b/test/servinge2e/kourier/custom_route_test.go
@@ -44,7 +44,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	ksvc = test.WithServiceReadyOrFail(caCtx, ksvc)
 
 	// Verify that operator did not create OpenShift route.
-	routes, err := caCtx.Clients.Route.Routes("knative-serving-ingress").List(context.Background(), metav1.ListOptions{
+	routes, err := caCtx.Clients.Route.Routes(test.IngressNamespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", resources.OpenShiftIngressLabelKey, ksvc.Name),
 	})
 	if err != nil {
@@ -58,7 +58,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myroute",
-			Namespace: "knative-serving-ingress",
+			Namespace: test.IngressNamespace,
 		},
 		Spec: routev1.RouteSpec{
 			Host: ksvc.Status.URL.Host,
@@ -75,7 +75,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 			},
 		},
 	}
-	route, err = caCtx.Clients.Route.Routes("knative-serving-ingress").Create(context.Background(), route, metav1.CreateOptions{})
+	route, err = caCtx.Clients.Route.Routes(test.IngressNamespace).Create(context.Background(), route, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating OpenShift Route: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	dm = withDomainMappingReadyOrFail(caCtx, dm)
 
 	// Verify that operator did not create OpenShift route.
-	routes, err = caCtx.Clients.Route.Routes("knative-serving-ingress").List(context.Background(), metav1.ListOptions{
+	routes, err = caCtx.Clients.Route.Routes(test.IngressNamespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", resources.OpenShiftIngressLabelKey, dm.Name),
 	})
 	if err != nil {
@@ -120,7 +120,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	route = &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myroute-for-dm",
-			Namespace: "knative-serving-ingress",
+			Namespace: test.IngressNamespace,
 		},
 		Spec: routev1.RouteSpec{
 			Host: dm.Status.URL.Host,
@@ -133,7 +133,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 			},
 		},
 	}
-	route, err = caCtx.Clients.Route.Routes("knative-serving-ingress").Create(context.Background(), route, metav1.CreateOptions{})
+	route, err = caCtx.Clients.Route.Routes(test.IngressNamespace).Create(context.Background(), route, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating OpenShift Route: %v", err)
 	}

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -14,12 +14,6 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-const (
-	ServingNamespace  = "knative-serving"
-	EventingNamespace = "knative-eventing"
-	IngressNamespace  = "knative-serving-ingress"
-)
-
 func UpgradeServerlessTo(ctx *test.Context, csv, source string) error {
 	if _, err := test.UpdateSubscriptionChannelSource(ctx, test.Flags.Subscription, test.Flags.UpgradeChannel, source); err != nil {
 		return err
@@ -41,9 +35,10 @@ func UpgradeServerlessTo(ctx *test.Context, csv, source string) error {
 	if len(test.Flags.ServingVersion) == 0 {
 		servingInStateFunc = v1beta1.IsKnativeServingReady
 	}
+	knativeServing := test.ServingNamespace
 	if _, err := v1beta1.WaitForKnativeServingState(ctx,
-		ServingNamespace,
-		ServingNamespace,
+		knativeServing,
+		knativeServing,
 		servingInStateFunc,
 	); err != nil {
 		return fmt.Errorf("serving upgrade failed: %w", err)
@@ -53,9 +48,10 @@ func UpgradeServerlessTo(ctx *test.Context, csv, source string) error {
 	if len(test.Flags.EventingVersion) == 0 {
 		eventingInStateFunc = v1beta1.IsKnativeEventingReady
 	}
+	knativeEventing := test.EventingNamespace
 	if _, err := v1beta1.WaitForKnativeEventingState(ctx,
-		EventingNamespace,
-		EventingNamespace,
+		knativeEventing,
+		knativeEventing,
 		eventingInStateFunc,
 	); err != nil {
 		return fmt.Errorf("eventing upgrade failed: %w", err)
@@ -67,7 +63,7 @@ func UpgradeServerlessTo(ctx *test.Context, csv, source string) error {
 	}
 	if _, err := v1alpha1.WaitForKnativeKafkaState(ctx,
 		"knative-kafka",
-		EventingNamespace,
+		knativeEventing,
 		kafkaInStateFunc,
 	); err != nil {
 		return fmt.Errorf("knative kafka upgrade failed: %w", err)
@@ -137,7 +133,7 @@ func DowngradeServerless(ctx *test.Context) error {
 		return err
 	}
 
-	knativeServing := "knative-serving"
+	knativeServing := test.ServingNamespace
 	if _, err := v1beta1.WaitForKnativeServingState(ctx,
 		knativeServing,
 		knativeServing,
@@ -146,7 +142,7 @@ func DowngradeServerless(ctx *test.Context) error {
 		return fmt.Errorf("serving downgrade failed: %w", err)
 	}
 
-	knativeEventing := "knative-eventing"
+	knativeEventing := test.EventingNamespace
 	if _, err := v1beta1.WaitForKnativeEventingState(ctx,
 		knativeEventing,
 		knativeEventing,

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -14,6 +14,12 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+const (
+	ServingNamespace  = "knative-serving"
+	EventingNamespace = "knative-eventing"
+	IngressNamespace  = "knative-serving-ingress"
+)
+
 func UpgradeServerlessTo(ctx *test.Context, csv, source string) error {
 	if _, err := test.UpdateSubscriptionChannelSource(ctx, test.Flags.Subscription, test.Flags.UpgradeChannel, source); err != nil {
 		return err
@@ -35,10 +41,9 @@ func UpgradeServerlessTo(ctx *test.Context, csv, source string) error {
 	if len(test.Flags.ServingVersion) == 0 {
 		servingInStateFunc = v1beta1.IsKnativeServingReady
 	}
-	knativeServing := "knative-serving"
 	if _, err := v1beta1.WaitForKnativeServingState(ctx,
-		knativeServing,
-		knativeServing,
+		ServingNamespace,
+		ServingNamespace,
 		servingInStateFunc,
 	); err != nil {
 		return fmt.Errorf("serving upgrade failed: %w", err)
@@ -48,10 +53,9 @@ func UpgradeServerlessTo(ctx *test.Context, csv, source string) error {
 	if len(test.Flags.EventingVersion) == 0 {
 		eventingInStateFunc = v1beta1.IsKnativeEventingReady
 	}
-	knativeEventing := "knative-eventing"
 	if _, err := v1beta1.WaitForKnativeEventingState(ctx,
-		knativeEventing,
-		knativeEventing,
+		EventingNamespace,
+		EventingNamespace,
 		eventingInStateFunc,
 	); err != nil {
 		return fmt.Errorf("eventing upgrade failed: %w", err)
@@ -63,7 +67,7 @@ func UpgradeServerlessTo(ctx *test.Context, csv, source string) error {
 	}
 	if _, err := v1alpha1.WaitForKnativeKafkaState(ctx,
 		"knative-kafka",
-		knativeEventing,
+		EventingNamespace,
 		kafkaInStateFunc,
 	); err != nil {
 		return fmt.Errorf("knative kafka upgrade failed: %w", err)

--- a/test/upgrade/kitchensink/kitchensink.go
+++ b/test/upgrade/kitchensink/kitchensink.go
@@ -106,6 +106,20 @@ func (fe *FeatureWithEnvironment) PostUpgrade() pkgupgrade.Operation {
 		for _, a := range asserts {
 			a.Fn(fe.Context, c.T)
 		}
+	})
+}
+
+func (fe *FeatureWithEnvironment) PostDowngrade() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation(fe.Feature.Name, func(c pkgupgrade.Context) {
+		c.T.Parallel()
+		requirements := filterStepTimings(fe.Feature.Steps, feature.Requirement)
+		for _, r := range requirements {
+			r.Fn(fe.Context, c.T)
+		}
+		asserts := filterStepTimings(fe.Feature.Steps, feature.Assert)
+		for _, a := range asserts {
+			a.Fn(fe.Context, c.T)
+		}
 		teardowns := filterStepTimings(fe.Feature.Steps, feature.Teardown)
 		for _, td := range teardowns {
 			td.Fn(fe.Context, c.T)
@@ -137,6 +151,14 @@ func (fg FeatureWithEnvironmentGroup) PostUpgradeTests() []pkgupgrade.Operation 
 	ops := make([]pkgupgrade.Operation, 0, len(fg))
 	for _, ft := range fg {
 		ops = append(ops, ft.PostUpgrade())
+	}
+	return ops
+}
+
+func (fg FeatureWithEnvironmentGroup) PostDowngradeTests() []pkgupgrade.Operation {
+	ops := make([]pkgupgrade.Operation, 0, len(fg))
+	for _, ft := range fg {
+		ops = append(ops, ft.PostDowngrade())
 	}
 	return ops
 }

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -232,7 +232,7 @@ func VerifyPodRestarts(ctx *test.Context) pkgupgrade.Operation {
 		c.T.Parallel() // Make sure the sleep in this test doesn't delay checks in other tests.
 
 		// Give some time before checking Pod restarts which might happen later after upgrade.
-		time.Sleep(5 * time.Second)
+		time.Sleep(2 * time.Minute)
 
 		var podsRestarted []string
 		namespaces := []string{installation.ServingNamespace,

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -42,11 +42,6 @@ import (
 	pkgTest "knative.dev/pkg/test"
 )
 
-const (
-	memoryWorkingSetQuery   = `sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", namespace="%s", container!="", image!=""}) by (pod)`
-	memoryIncreaseTolerance = 1.2
-)
-
 var global environment.GlobalEnvironment
 
 func TestMain(m *testing.M) {

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -49,7 +49,7 @@ import (
 )
 
 const (
-	memoryWorkingSetQuery   = "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"\", namespace=\"%s\", container!=\"\", image!=\"\"}) by (pod)"
+	memoryWorkingSetQuery   = `sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", namespace="%s", container!="", image!=""}) by (pod)`
 	memoryIncreaseTolerance = 1.2
 )
 
@@ -241,6 +241,9 @@ func VerifyPodRestarts(ctx *test.Context) pkgupgrade.Operation {
 				c.T.Fatalf("Error listing Pods in %q: %v", ns, err)
 			}
 			for _, pod := range pods.Items {
+				if strings.Contains(pod.Name, "version-migrator") {
+					continue
+				}
 				for _, status := range pod.Status.ContainerStatuses {
 					if status.RestartCount > 0 {
 						podsRestarted = append(podsRestarted, pod.Name)

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -287,6 +288,9 @@ func VerifyMemoryUsage(ctx *test.Context, systemPodsMemory map[string]float64) p
 }
 
 func recordMemoryUsage(t *testing.T, ctx *test.Context, systemPodsMemory map[string]float64) {
+	// Force garbage collection before checking memory usage.
+	runtime.GC()
+
 	prometheusCtx := context.WithValue(context.Background(), client.Key{}, ctx.Clients.Kube)
 	prometheusCtx = context.WithValue(prometheusCtx, dynamicclient.Key{}, ctx.Clients.Dynamic)
 	prometheusCtx = logging.WithLogger(prometheusCtx, logtesting.TestLogger(t))

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -93,6 +93,7 @@ func TestKitchensink(t *testing.T) {
 		features.SequenceGlobalReplyFeatureSetShort(),
 		features.ParallelNoReplyFeatureSetShort(),
 		features.ParallelGlobalReplyFeatureSetShort(),
+		features.SourceFeatureSetShort(),
 	}
 
 	var featureGroup FeatureWithEnvironmentGroup
@@ -185,6 +186,7 @@ func TestUpgradeStress(t *testing.T) {
 		features.SequenceGlobalReplyFeatureSetStress(),
 		features.ParallelNoReplyFeatureSetStress(),
 		features.ParallelGlobalReplyFeatureSetStress(),
+		features.SourceFeatureSetStress(),
 	}
 
 	var featureGroup FeatureWithEnvironmentGroup

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -25,7 +25,6 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -288,8 +287,7 @@ func VerifyMemoryUsage(ctx *test.Context, systemPodsMemory map[string]float64) p
 }
 
 func recordMemoryUsage(t *testing.T, ctx *test.Context, systemPodsMemory map[string]float64) {
-	// Force garbage collection before checking memory usage.
-	runtime.GC()
+	time.Sleep(7 * time.Minute)
 
 	prometheusCtx := context.WithValue(context.Background(), client.Key{}, ctx.Clients.Kube)
 	prometheusCtx = context.WithValue(prometheusCtx, dynamicclient.Key{}, ctx.Clients.Dynamic)
@@ -324,4 +322,6 @@ func recordMemoryUsage(t *testing.T, ctx *test.Context, systemPodsMemory map[str
 			systemPodsMemory[component] = systemPodsMemory[component] + float64(sample.Value)
 		}
 	}
+
+	ctx.T.Fatal("Induced failure")
 }

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -21,7 +21,6 @@ package kitchensink
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"math/rand"
 	"os"
@@ -33,12 +32,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test/kitchensinke2e/features"
 	"github.com/openshift-knative/serverless-operator/test/upgrade"
 	"github.com/openshift-knative/serverless-operator/test/upgrade/installation"
-	"github.com/prometheus/common/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/client/injection/kube/client"
-	"knative.dev/pkg/injection/clients/dynamicclient"
-	"knative.dev/pkg/logging"
-	logtesting "knative.dev/pkg/logging/testing"
 	_ "knative.dev/pkg/system/testing"
 	pkgupgrade "knative.dev/pkg/test/upgrade"
 	"knative.dev/reconciler-test/pkg/environment"
@@ -196,7 +190,6 @@ func TestUpgradeStress(t *testing.T) {
 		}
 	}
 
-	systemPodsMemory := make(map[string]float64)
 	suite := pkgupgrade.Suite{
 		Tests: pkgupgrade.Tests{
 			PreUpgrade: featureGroup.PreUpgradeTests(),
@@ -214,15 +207,11 @@ func TestUpgradeStress(t *testing.T) {
 			PostDowngrade: featureGroup.PostDowngradeTests(),
 		},
 		Installations: pkgupgrade.Installations{
-			UpgradeWith: append([]pkgupgrade.Operation{
-				// Ensure memory usage is recorded after PreUpgrade tests as those can use t.Parallel.
-				RecordMemoryUsage(ctx, systemPodsMemory),
-			}, upgrade.ServerlessUpgradeOperations(ctx)...),
+			UpgradeWith: upgrade.ServerlessUpgradeOperations(ctx),
 			DowngradeWith: []pkgupgrade.Operation{
 				// Skip actual downgrade but run additional checks here. They are ensured to
 				// run after PostUpgrade tests.
 				VerifyPodRestarts(ctx),
-				VerifyMemoryUsage(ctx, systemPodsMemory),
 			},
 		},
 	}
@@ -258,69 +247,4 @@ func VerifyPodRestarts(ctx *test.Context) pkgupgrade.Operation {
 			c.T.Fatalf("Container restart detected for Pods: %v", podsRestarted)
 		}
 	})
-}
-
-func RecordMemoryUsage(ctx *test.Context, systemPodsMemory map[string]float64) pkgupgrade.Operation {
-	return pkgupgrade.NewOperation("RecordMemoryUsage", func(c pkgupgrade.Context) {
-		recordMemoryUsage(c.T, ctx, systemPodsMemory)
-	})
-}
-
-func VerifyMemoryUsage(ctx *test.Context, systemPodsMemory map[string]float64) pkgupgrade.Operation {
-	return pkgupgrade.NewOperation("VerifyMemoryUsage", func(c pkgupgrade.Context) {
-
-		newSystemPodsMemory := make(map[string]float64)
-
-		recordMemoryUsage(c.T, ctx, newSystemPodsMemory)
-
-		for pod, mem := range newSystemPodsMemory {
-			origMem, ok := systemPodsMemory[pod]
-			if !ok {
-				continue
-			}
-			if mem > (origMem * memoryIncreaseTolerance) {
-				c.T.Errorf("Memory consumption for %s higher than (%.1f * original). Original: %.1f, new: %.1f ",
-					pod, memoryIncreaseTolerance, origMem, mem)
-			}
-		}
-	})
-}
-
-func recordMemoryUsage(t *testing.T, ctx *test.Context, systemPodsMemory map[string]float64) {
-	// Give time to settle.
-	time.Sleep(30 * time.Second)
-
-	prometheusCtx := context.WithValue(context.Background(), client.Key{}, ctx.Clients.Kube)
-	prometheusCtx = context.WithValue(prometheusCtx, dynamicclient.Key{}, ctx.Clients.Dynamic)
-	prometheusCtx = logging.WithLogger(prometheusCtx, logtesting.TestLogger(t))
-	prometheus, err := test.NewPrometheusClient(prometheusCtx)
-	if err != nil {
-		t.Fatalf("Unable to get Prometheus client: %v", err)
-	}
-
-	namespaces := []string{test.ServingNamespace,
-		test.EventingNamespace, test.IngressNamespace, test.OperatorsNamespace}
-
-	for _, ns := range namespaces {
-		value, warnings, err := prometheus.Query(context.Background(),
-			fmt.Sprintf(memoryWorkingSetQuery, ns),
-			time.Now())
-		if err != nil {
-			t.Fatalf("Unable to query metrics: %v", err)
-		}
-		for _, w := range warnings {
-			t.Logf("Prometheus warning: %v", w)
-		}
-
-		vector := value.(model.Vector)
-		for _, sample := range vector {
-			pod := string(sample.Metric["pod"])
-			split := strings.Split(pod, "-")
-			// Remove the last two parts split by dash, containing random chars.
-			// Example: imc-controller-644bd94dff-7nhkx -> imc-controller
-			component := ns + "/" + strings.Join(split[0:len(split)-2], "-")
-			// There might be more Pods for each component due to HA. Compute the sum of values.
-			systemPodsMemory[component] = systemPodsMemory[component] + float64(sample.Value)
-		}
-	}
 }

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -287,7 +287,8 @@ func VerifyMemoryUsage(ctx *test.Context, systemPodsMemory map[string]float64) p
 }
 
 func recordMemoryUsage(t *testing.T, ctx *test.Context, systemPodsMemory map[string]float64) {
-	time.Sleep(7 * time.Minute)
+	// Give time to settle.
+	time.Sleep(30 * time.Second)
 
 	prometheusCtx := context.WithValue(context.Background(), client.Key{}, ctx.Clients.Kube)
 	prometheusCtx = context.WithValue(prometheusCtx, dynamicclient.Key{}, ctx.Clients.Dynamic)
@@ -322,6 +323,4 @@ func recordMemoryUsage(t *testing.T, ctx *test.Context, systemPodsMemory map[str
 			systemPodsMemory[component] = systemPodsMemory[component] + float64(sample.Value)
 		}
 	}
-
-	ctx.T.Fatal("Induced failure")
 }

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -212,11 +212,10 @@ func TestUpgradeStress(t *testing.T) {
 			PostDowngrade: featureGroup.PostDowngradeTests(),
 		},
 		Installations: pkgupgrade.Installations{
-			UpgradeWith: []pkgupgrade.Operation{
+			UpgradeWith: append([]pkgupgrade.Operation{
 				// Ensure memory usage is recorded after PreUpgrade tests as those can use t.Parallel.
 				RecordMemoryUsage(ctx, systemPodsMemory),
-				upgrade.ServerlessUpgradeOperations(ctx),
-			},
+			}, upgrade.ServerlessUpgradeOperations(ctx)...),
 			DowngradeWith: []pkgupgrade.Operation{
 				// Skip actual downgrade but run additional checks here. They are ensured to
 				// run after PostUpgrade tests.

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test/upgrade"
 	"github.com/openshift-knative/serverless-operator/test/upgrade/installation"
 	"github.com/prometheus/common/model"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
@@ -238,7 +238,7 @@ func VerifyPodRestarts(ctx *test.Context) pkgupgrade.Operation {
 		namespaces := []string{test.ServingNamespace,
 			test.EventingNamespace, test.IngressNamespace, test.OperatorsNamespace}
 		for _, ns := range namespaces {
-			pods, err := ctx.Clients.Kube.CoreV1().Pods(ns).List(context.Background(), v1.ListOptions{})
+			pods, err := ctx.Clients.Kube.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
 			if err != nil {
 				c.T.Fatalf("Error listing Pods in %q: %v", ns, err)
 			}

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -315,7 +315,7 @@ func recordMemoryUsage(t *testing.T, ctx *test.Context, systemPodsMemory map[str
 			split := strings.Split(pod, "-")
 			// Remove the last two parts split by dash, containing random chars.
 			// Example: imc-controller-644bd94dff-7nhkx -> imc-controller
-			component := strings.Join(split[0:len(split)-2], "-")
+			component := ns + "/" + strings.Join(split[0:len(split)-2], "-")
 			// There might be more Pods for each component due to HA. Compute the sum of values.
 			systemPodsMemory[component] = systemPodsMemory[component] + float64(sample.Value)
 		}

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -180,8 +180,15 @@ func TestUpgradeStress(t *testing.T) {
 
 	suite := pkgupgrade.Suite{
 		Tests: pkgupgrade.Tests{
-			PreUpgrade:  featureGroup.PreUpgradeTests(),
-			PostUpgrade: featureGroup.PostUpgradeTests(),
+			PreUpgrade: featureGroup.PreUpgradeTests(),
+			PostUpgrade: append([]pkgupgrade.Operation{
+				upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
+					Namespace: "knative-serving",
+				}),
+				upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
+					Namespace: "knative-eventing",
+				}),
+			}, featureGroup.PostUpgradeTests()...),
 		},
 		Installations: pkgupgrade.Installations{
 			UpgradeWith: upgrade.ServerlessUpgradeOperations(ctx),

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -229,8 +229,6 @@ func TestUpgradeStress(t *testing.T) {
 
 func VerifyPodRestarts(ctx *test.Context) pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("VerifyPodRestarts", func(c pkgupgrade.Context) {
-		c.T.Parallel() // Make sure the sleep in this test doesn't delay checks in other tests.
-
 		// Give some time before checking Pod restarts which might happen later after upgrade.
 		time.Sleep(2 * time.Minute)
 
@@ -259,9 +257,6 @@ func VerifyPodRestarts(ctx *test.Context) pkgupgrade.Operation {
 func RecordMemoryUsage(ctx *test.Context, systemPodsMemory map[string]float64) pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("RecordMemoryUsage", func(c pkgupgrade.Context) {
 		recordMemoryUsage(c.T, ctx, systemPodsMemory)
-		for pod, mem := range systemPodsMemory {
-			c.T.Logf("Old Pod %s: %.2f", pod, mem)
-		}
 	})
 }
 
@@ -271,10 +266,6 @@ func VerifyMemoryUsage(ctx *test.Context, systemPodsMemory map[string]float64) p
 		newSystemPodsMemory := make(map[string]float64)
 
 		recordMemoryUsage(c.T, ctx, newSystemPodsMemory)
-
-		for pod, mem := range newSystemPodsMemory {
-			c.T.Logf("New Pod %s: %.2f", pod, mem)
-		}
 
 		for pod, mem := range newSystemPodsMemory {
 			origMem, ok := systemPodsMemory[pod]

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -243,7 +243,8 @@ func VerifyPodRestarts(ctx *test.Context) pkgupgrade.Operation {
 				c.T.Fatalf("Error listing Pods in %q: %v", ns, err)
 			}
 			for _, pod := range pods.Items {
-				if strings.Contains(pod.Name, "version-migrator") {
+				// Ignore storage version migration pods.
+				if strings.Contains(pod.Name, "storage-version") {
 					continue
 				}
 				for _, status := range pod.Status.ContainerStatuses {

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -124,10 +124,10 @@ func TestKitchensink(t *testing.T) {
 			// Run these tests after each upgrade.
 			post := []pkgupgrade.Operation{
 				upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
-					Namespace: "knative-serving",
+					Namespace: test.ServingNamespace,
 				}),
 				upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
-					Namespace: "knative-eventing",
+					Namespace: test.EventingNamespace,
 				}),
 			}
 			// In the last step. Run also post-upgrade tests for all features.
@@ -202,10 +202,10 @@ func TestUpgradeStress(t *testing.T) {
 				featureGroup.PostUpgradeTests(),
 				[]pkgupgrade.Operation{
 					upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
-						Namespace: "knative-serving",
+						Namespace: test.ServingNamespace,
 					}),
 					upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
-						Namespace: "knative-eventing",
+						Namespace: test.EventingNamespace,
 					}),
 				}...,
 			),
@@ -235,8 +235,8 @@ func VerifyPodRestarts(ctx *test.Context) pkgupgrade.Operation {
 		time.Sleep(2 * time.Minute)
 
 		var podsRestarted []string
-		namespaces := []string{installation.ServingNamespace,
-			installation.EventingNamespace, installation.IngressNamespace, test.OperatorsNamespace}
+		namespaces := []string{test.ServingNamespace,
+			test.EventingNamespace, test.IngressNamespace, test.OperatorsNamespace}
 		for _, ns := range namespaces {
 			pods, err := ctx.Clients.Kube.CoreV1().Pods(ns).List(context.Background(), v1.ListOptions{})
 			if err != nil {
@@ -298,8 +298,8 @@ func recordMemoryUsage(t *testing.T, ctx *test.Context, systemPodsMemory map[str
 		t.Fatalf("Unable to get Prometheus client: %v", err)
 	}
 
-	namespaces := []string{installation.ServingNamespace,
-		installation.EventingNamespace, installation.IngressNamespace, test.OperatorsNamespace}
+	namespaces := []string{test.ServingNamespace,
+		test.EventingNamespace, test.IngressNamespace, test.OperatorsNamespace}
 
 	for _, ns := range namespaces {
 		value, warnings, err := prometheus.Query(context.Background(),
@@ -317,7 +317,7 @@ func recordMemoryUsage(t *testing.T, ctx *test.Context, systemPodsMemory map[str
 			pod := string(sample.Metric["pod"])
 			split := strings.Split(pod, "-")
 			// Remove the last two parts split by dash, containing random chars.
-			// Example: converts imc-controller-644bd94dff-7nhkx to imc-controller
+			// Example: imc-controller-644bd94dff-7nhkx -> imc-controller
 			component := strings.Join(split[0:len(split)-2], "-")
 			// There might be more Pods for each component due to HA. Compute the sum of values.
 			systemPodsMemory[component] = systemPodsMemory[component] + float64(sample.Value)

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -155,11 +155,11 @@ func preUpgradeTests() []pkgupgrade.Operation {
 func postUpgradeTests(ctx *test.Context, failOnNoJobs bool) []pkgupgrade.Operation {
 	tests := []pkgupgrade.Operation{waitForServicesReady(ctx)}
 	tests = append(tests, upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
-		Namespace:    "knative-serving",
+		Namespace:    test.ServingNamespace,
 		FailOnNoJobs: failOnNoJobs,
 	}))
 	tests = append(tests, upgrade.VerifyPostInstallJobs(ctx, upgrade.VerifyPostJobsConfig{
-		Namespace:    "knative-eventing",
+		Namespace:    test.EventingNamespace,
 		FailOnNoJobs: failOnNoJobs,
 	}))
 	tests = append(tests, EventingPostUpgradeTests()...)

--- a/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
+++ b/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
@@ -57,6 +57,7 @@ spec:
         "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
       logging.enable-request-log: "true"
       logging.enable-probe-request-log: "true"
+      profiling.enable: "true"
     tracing:
       backend: "none"
       sample-rate: "0.1"

--- a/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
+++ b/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
@@ -3,6 +3,13 @@ kind: KnativeServing
 metadata:
   name: knative-serving
 spec:
+  workloads:
+    - name: controller
+      env:
+      - container: controller
+        envVars:
+        - name: GODEBUG
+          value: "gctrace=1"
   config:
     network:
       internal-encryption: "true"

--- a/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
+++ b/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
@@ -48,7 +48,6 @@ spec:
         "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
       logging.enable-request-log: "true"
       logging.enable-probe-request-log: "true"
-      profiling.enable: "true"
     tracing:
       backend: "none"
       sample-rate: "0.1"

--- a/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
+++ b/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
@@ -3,15 +3,6 @@ kind: KnativeServing
 metadata:
   name: knative-serving
 spec:
-  workloads:
-    - name: controller
-      env:
-      - container: controller
-        envVars:
-        - name: GODEBUG
-          value: "gctrace=1"
-        - name: GOGC
-          value: "20"
   config:
     network:
       internal-encryption: "true"

--- a/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
+++ b/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
@@ -10,6 +10,8 @@ spec:
         envVars:
         - name: GODEBUG
           value: "gctrace=1"
+        - name: GOGC
+          value: "20"
   config:
     network:
       internal-encryption: "true"

--- a/vendor/knative.dev/eventing/test/rekt/resources/apiserversource/apiserversource.go
+++ b/vendor/knative.dev/eventing/test/rekt/resources/apiserversource/apiserversource.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserversource
+
+import (
+	"context"
+	"embed"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	v1 "knative.dev/eventing/pkg/apis/sources/v1"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+//go:embed *.yaml
+var yaml embed.FS
+
+func Gvr() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "sources.knative.dev", Version: "v1", Resource: "apiserversources"}
+}
+
+// IsReady tests to see if an ApiServerSource becomes ready within the time given.
+func IsReady(name string, timings ...time.Duration) feature.StepFn {
+	return k8s.IsReady(Gvr(), name, timings...)
+}
+
+// Install returns a step function which creates an ApiServerSource resource, augmented with the config fn options.
+func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		if _, err := InstallLocalYaml(ctx, name, opts...); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+// InstallLocalYaml will create a ApiServerSource resource, augmented with the config fn options.
+func InstallLocalYaml(ctx context.Context, name string, opts ...manifest.CfgFn) (manifest.Manifest, error) {
+	cfg := map[string]interface{}{
+		"name": name,
+	}
+	for _, fn := range opts {
+		fn(cfg)
+	}
+	return manifest.InstallYamlFS(ctx, yaml, cfg)
+}
+
+// WithServiceAccountName sets the service account name on the ApiServerSource spec.
+func WithServiceAccountName(serviceAccountName string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["serviceAccountName"] = serviceAccountName
+	}
+}
+
+// WithEventMode sets the event mode on the ApiServerSource spec.
+func WithEventMode(eventMode string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["mode"] = eventMode
+	}
+}
+
+// WithSink adds the sink related config to a ApiServerSource spec.
+func WithSink(ref *duckv1.KReference, uri string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		if _, set := cfg["sink"]; !set {
+			cfg["sink"] = map[string]interface{}{}
+		}
+		sink := cfg["sink"].(map[string]interface{})
+
+		if uri != "" {
+			sink["uri"] = uri
+		}
+		if ref != nil {
+			if _, set := sink["ref"]; !set {
+				sink["ref"] = map[string]interface{}{}
+			}
+			sref := sink["ref"].(map[string]interface{})
+			sref["apiVersion"] = ref.APIVersion
+			sref["kind"] = ref.Kind
+			sref["namespace"] = ref.Namespace
+			sref["name"] = ref.Name
+		}
+	}
+}
+
+// WithResources adds the resources related config to a ApiServerSource spec.
+func WithResources(resources ...v1.APIVersionKindSelector) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		if _, set := cfg["resources"]; !set {
+			cfg["resources"] = []map[string]interface{}{}
+		}
+
+		for _, resource := range resources {
+			elem := map[string]interface{}{
+				"apiVersion": resource.APIVersion,
+				"kind":       resource.Kind,
+				"selector":   labelSelectorToStringMap(resource.LabelSelector),
+			}
+			cfg["resources"] = append(cfg["resources"].([]map[string]interface{}), elem)
+		}
+	}
+}
+
+// WithNamespaceSelector adds a namespace selector to an ApiServerSource spec.
+func WithNamespaceSelector(selector *metav1.LabelSelector) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["namespaceSelector"] = labelSelectorToStringMap(selector)
+	}
+}
+
+func labelSelectorToStringMap(selector *metav1.LabelSelector) map[string]interface{} {
+	if selector == nil {
+		return nil
+	}
+
+	r := map[string]interface{}{}
+
+	r["matchLabels"] = selector.MatchLabels
+
+	if selector.MatchExpressions != nil {
+		me := []map[string]interface{}{}
+		for _, ml := range selector.MatchExpressions {
+			me = append(me, map[string]interface{}{
+				"key":      ml.Key,
+				"operator": ml.Operator,
+				"values":   ml.Values,
+			})
+		}
+		r["matchExpressions"] = me
+	}
+
+	return r
+}

--- a/vendor/knative.dev/eventing/test/rekt/resources/apiserversource/apiserversource.yaml
+++ b/vendor/knative.dev/eventing/test/rekt/resources/apiserversource/apiserversource.yaml
@@ -1,0 +1,82 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: sources.knative.dev/v1
+kind: ApiServerSource
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+spec:
+  {{ if .serviceAccountName }}
+  serviceAccountName: {{ .serviceAccountName }}
+  {{ end }}
+  {{ if .mode }}
+  mode: {{ .mode }}
+  {{ end }}
+  {{ if .namespaceSelector }}
+  namespaceSelector:
+    matchLabels:
+      {{ range $key, $value := .namespaceSelector.matchLabels }}
+      {{ $key }}: {{ $value }}
+      {{ end }}
+    matchExpressions:
+      {{ range $_, $expr := .namespaceSelector.matchExpressions }}
+      - key: {{ $expr.key }}
+        operator: {{ $expr.operator }}
+        values:
+          {{ range $_, $exprValue := $expr.values }}
+          - {{ $exprValue }}
+          {{ end }}
+      {{ end }}
+  {{ end }}
+  {{ if .resources }}
+  resources:
+    {{ range $_, $resource := .resources }}
+    - apiVersion: {{ $resource.apiVersion }}
+      kind: {{ $resource.kind }}
+      {{ if $resource.selector }}
+      selector:
+        {{ if $resource.selector.matchLabels }}
+        matchLabels:
+          {{ range $key, $value := $resource.selector.matchLabels }}
+          {{ $key }}: {{ $value }}
+          {{ end }}
+        {{ end }}
+        {{ if $resource.selector.matchExpressions }}
+        matchExpressions:
+          {{ range $_, $expr := $resource.selector.matchExpressions }}
+          - key: {{ $expr.key }}
+            operator: {{ $expr.operator }}
+            values:
+              {{ range $_, $exprValue := $expr.values }}
+              - {{ $exprValue }}
+              {{ end }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+  {{if .sink }}
+  sink:
+    {{ if .sink.ref }}
+    ref:
+      kind: {{ .sink.ref.kind }}
+      namespace: {{ .sink.ref.namespace }}
+      name: {{ .sink.ref.name }}
+      apiVersion: {{ .sink.ref.apiVersion }}
+    {{ end }}
+    {{ if .sink.uri }}
+    uri: {{ .sink.uri }}
+    {{ end }}
+  {{ end }}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1426,6 +1426,7 @@ knative.dev/eventing/test/rekt/features/pingsource
 knative.dev/eventing/test/rekt/features/trigger
 knative.dev/eventing/test/rekt/resources/account_role
 knative.dev/eventing/test/rekt/resources/addressable
+knative.dev/eventing/test/rekt/resources/apiserversource
 knative.dev/eventing/test/rekt/resources/broker
 knative.dev/eventing/test/rekt/resources/channel
 knative.dev/eventing/test/rekt/resources/channel_impl


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVCOM-2138
Fixes https://issues.redhat.com/browse/SRVCOM-2377

Note: Mostly complete. I just want to see it passing in CI.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-  Add kitchensink tests for sources (PingSource, ContainerSource, KafkaSource, ApiServerSource)
- Run kitchensink tests during upgrades. Multiple copies of resources are created, this is defined via NumDeployments const that equals 3. This is the maximum that a cluster with 5 workers can accomodate without running out of mem/cpu.

With current NumDeployments==3, these resources are deployed for the upgrade stress test:
```
Resource apiserversources.sources.knative.dev: 3
Resource brokers.eventing.knative.dev: 72
Resource certificates.networking.internal.knative.dev: 0
Resource channels.messaging.knative.dev: 54
Resource clusterdomainclaims.networking.internal.knative.dev: 0
Resource configurations.serving.knative.dev: 144
Resource consumergroups.internal.kafka.eventing.knative.dev: 3
Resource consumers.internal.kafka.eventing.knative.dev: 3
Resource containersources.sources.knative.dev: 3
Resource domainmappings.serving.knative.dev: 0
Resource eventtypes.eventing.knative.dev: 0
Resource images.caching.internal.knative.dev: 145
Resource ingresses.networking.internal.knative.dev: 144
Resource inmemorychannels.messaging.knative.dev: 216
Resource kafkachannels.messaging.knative.dev: 222
Resource kafkasinks.eventing.knative.dev: 20
Resource kafkasources.sources.knative.dev: 3
Resource knativeeventings.operator.knative.dev: 1
Resource knativekafkas.operator.serverless.openshift.io: 1
Resource knativeservings.operator.knative.dev: 1
Resource metrics.autoscaling.internal.knative.dev: 144
Resource parallels.flows.knative.dev: 50
Resource pingsources.sources.knative.dev: 3
Resource podautoscalers.autoscaling.internal.knative.dev: 144
Resource revisions.serving.knative.dev: 144
Resource routes.serving.knative.dev: 144
Resource sequences.flows.knative.dev: 50
Resource serverlessservices.networking.internal.knative.dev: 144
Resource services.serving.knative.dev: 144
Resource sinkbindings.sources.knative.dev: 3
Resource subscriptions.messaging.knative.dev: 480
Resource triggers.eventing.knative.dev: 234
```