### PR TITLE
Disable TestKsvcWithServiceMeshJWTDefaultPolicy with SM and internal encryption

### DIFF
--- a/test/helpers.go
+++ b/test/helpers.go
@@ -31,6 +31,18 @@ func IsServiceMeshInstalled(ctx *Context) bool {
 	return false
 }
 
+func IsInternalEncryption(ctx *Context) bool {
+	knativeServing := "knative-serving"
+	serving, err := ctx.Clients.Operator.KnativeServings(knativeServing).Get(context.Background(), knativeServing, metav1.GetOptions{})
+	if err != nil {
+		ctx.T.Fatalf("Error getting KnativeServing: %v", err)
+	}
+
+	networkConfig, ok := serving.Spec.Config["network"]
+
+	return ok && networkConfig["internal-encryption"] == "true"
+}
+
 func LinkGlobalPullSecretToNamespace(ctx *Context, ns string) error {
 	// Wait for the default ServiceAccount to exist.
 	if err := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -277,6 +277,11 @@ func jwtHTTPGetRequestBytes(ctx *test.Context, url *url.URL, token *string) (*sp
 // via istio authentication Policy to allow valid JWT only.
 // Skipped unless ServiceMesh has been installed via "make install-mesh"
 func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
+	ctx := test.SetupClusterAdmin(t)
+	if test.IsServiceMeshInstalled(ctx) && test.IsInternalEncryption(ctx) {
+		t.Skip("JWT integration not working with internal encryption, see SRVCOM-2648")
+	}
+
 	runTestForAllServiceMeshVersions(t, func(ctx *test.Context) {
 		t := ctx.T
 		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)


### PR DESCRIPTION
Workaround for https://issues.redhat.com/browse/SRVCOM-2648
This is to make the weekly jobs in CI passing until we fix it or decide that it is unsupported.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
