### PR TITLE
[SRVKS-1098] Define complete net-kourier address via operator

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/ingress/1.10/kourier/1-net-kourier.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/1.10/kourier/1-net-kourier.yaml
@@ -128,7 +128,7 @@ data:
                 endpoint:
                   address:
                     socket_address:
-                      address: "net-kourier-controller.knative-serving-ingress"
+                      address: "net-kourier-controller.knative-serving"
                       port_value: 18000
           type: STRICT_DNS
     admin:

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -69,7 +69,7 @@ func (e *extension) Transformers(ks base.KComponent) []mf.Transformer {
 			corev1.EnvVar{Name: "NO_PROXY", Value: os.Getenv("NO_PROXY")},
 		),
 		overrideKourierNamespace(ks),
-		overrideKourierBootstrap(),
+		overrideKourierBootstrap(ks),
 		addKourierEnvValues(ks),
 		addKourierAppProtocol(ks),
 		common.VersionedJobNameTransform(),

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -69,6 +69,7 @@ func (e *extension) Transformers(ks base.KComponent) []mf.Transformer {
 			corev1.EnvVar{Name: "NO_PROXY", Value: os.Getenv("NO_PROXY")},
 		),
 		overrideKourierNamespace(ks),
+		overrideKourierBootstrap(),
 		addKourierEnvValues(ks),
 		addKourierAppProtocol(ks),
 		common.VersionedJobNameTransform(),

--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/operator/pkg/apis/operator/base"
+	"knative.dev/pkg/network"
 )
 
 const (
@@ -31,6 +32,30 @@ const (
 	// ingressDefaultCertificateName is the name of the default ingress certificate.
 	ingressDefaultCertificateName = "router-certs-default"
 )
+
+// overrideKourierNamespace overrides the namespace of all Kourier related resources to
+// the -ingress suffix to be backwards compatible.
+func overrideKourierBootstrap() mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "ConfigMap" || u.GetName() != "kourier-bootstrap" {
+			return nil
+		}
+
+		clusterLocalDomain := network.GetClusterDomainName()
+
+		cm := &corev1.ConfigMap{}
+		if err := scheme.Scheme.Convert(u, cm, nil); err != nil {
+			return err
+		}
+
+		controllerAddress := "net-kourier-controller.knative-serving-ingress.svc." + clusterLocalDomain + "."
+
+		data := cm.Data["envoy-bootstrap.yaml"]
+		cm.Data["envoy-bootstrap.yaml"] = strings.Replace(data, "net-kourier-controller.knative-serving", controllerAddress, 1)
+
+		return scheme.Scheme.Convert(cm, u, nil)
+	}
+}
 
 // overrideKourierNamespace overrides the namespace of all Kourier related resources to
 // the -ingress suffix to be backwards compatible.

--- a/openshift-knative-operator/pkg/serving/kourier_test.go
+++ b/openshift-knative-operator/pkg/serving/kourier_test.go
@@ -105,6 +105,13 @@ func TestKourierServiceAppProtocol(t *testing.T) {
 }
 
 func TestKourierBootstrap(t *testing.T) {
+	ks := &operatorv1beta1.KnativeServing{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "knative-serving",
+			Name:      "test",
+		},
+	}
+
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "kourier-bootstrap",
@@ -126,7 +133,7 @@ func TestKourierBootstrap(t *testing.T) {
 		t.Fatal("Failed to convert configmap to unstructured", err)
 	}
 
-	overrideKourierBootstrap()(got)
+	overrideKourierBootstrap(ks)(got)
 
 	want := &unstructured.Unstructured{}
 	if err := scheme.Scheme.Convert(expected, want, nil); err != nil {

--- a/openshift-knative-operator/pkg/serving/kourier_test.go
+++ b/openshift-knative-operator/pkg/serving/kourier_test.go
@@ -1,6 +1,7 @@
 package serving
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -97,6 +98,40 @@ func TestKourierServiceAppProtocol(t *testing.T) {
 	}
 
 	addKourierAppProtocol(ks)(got)
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("Resource was not as expected:\n%s", cmp.Diff(got, want))
+	}
+}
+
+func TestKourierBootstrap(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "kourier-bootstrap",
+			Labels: map[string]string{providerLabel: "kourier"},
+		},
+		Data: map[string]string{"envoy-bootstrap.yaml": bootstrapData("net-kourier-controller.knative-serving")},
+	}
+
+	expected := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "kourier-bootstrap",
+			Labels: map[string]string{providerLabel: "kourier"},
+		},
+		Data: map[string]string{"envoy-bootstrap.yaml": bootstrapData("net-kourier-controller.knative-serving-ingress.svc.cluster.local.")},
+	}
+
+	got := &unstructured.Unstructured{}
+	if err := scheme.Scheme.Convert(cm, got, nil); err != nil {
+		t.Fatal("Failed to convert configmap to unstructured", err)
+	}
+
+	overrideKourierBootstrap()(got)
+
+	want := &unstructured.Unstructured{}
+	if err := scheme.Scheme.Convert(expected, want, nil); err != nil {
+		t.Fatal("Failed to convert configmap to unstructured", err)
+	}
 
 	if !cmp.Equal(got, want) {
 		t.Errorf("Resource was not as expected:\n%s", cmp.Diff(got, want))
@@ -280,3 +315,105 @@ func TestOverrideKourierNamespaceOther(t *testing.T) {
 		t.Errorf("Resource was not as expected:\n%s", cmp.Diff(other, want))
 	}
 }
+
+func bootstrapData(address string) string {
+	return fmt.Sprintf(testData, address)
+}
+
+const testData = `
+    dynamic_resources:
+      ads_config:
+        transport_api_version: V3
+        api_type: GRPC
+        rate_limit_settings: {}
+        grpc_services:
+        - envoy_grpc: {cluster_name: xds_cluster}
+      cds_config:
+        resource_api_version: V3
+        ads: {}
+      lds_config:
+        resource_api_version: V3
+        ads: {}
+    node:
+      cluster: kourier-knative
+      id: 3scale-kourier-gateway
+    static_resources:
+      listeners:
+        - name: stats_listener
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9000
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: stats_server
+                    http_filters:
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                    route_config:
+                      virtual_hosts:
+                        - name: admin_interface
+                          domains:
+                            - "*"
+                          routes:
+                            - match:
+                                safe_regex:
+                                  regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
+                                headers:
+                                  - name: ':method'
+                                    string_match:
+                                      exact: GET
+                              route:
+                                cluster: service_stats
+      clusters:
+        - name: service_stats
+          connect_timeout: 0.250s
+          type: static
+          load_assignment:
+            cluster_name: service_stats
+            endpoints:
+              lb_endpoints:
+                endpoint:
+                  address:
+                    pipe:
+                      path: /tmp/envoy.admin
+        - name: xds_cluster
+          # This keepalive is recommended by envoy docs.
+          # https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options:
+                  connection_keepalive:
+                    interval: 30s
+                    timeout: 5s
+          connect_timeout: 1s
+          load_assignment:
+            cluster_name: xds_cluster
+            endpoints:
+              lb_endpoints:
+                endpoint:
+                  address:
+                    socket_address:
+                      address: %q
+                      port_value: 18000
+          type: STRICT_DNS
+    admin:
+      access_log:
+      - name: envoy.access_loggers.stdout
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+      address:
+        pipe:
+          path: /tmp/envoy.admin
+    layered_runtime:
+      layers:
+        - name: static-layer
+          static_layer:
+            envoy.reloadable_features.override_request_timeout_by_gateway_timeout: false
+`


### PR DESCRIPTION
Fixes JIRA SRVKS-1098

With the address `net-kourier-controller.knative-serving`, client (envoy gateway) still sends the DNS query with  `net-kourier-controller.knative-serving.`,  `net-kourier-controller.knative-serving.svc.` etc with `NXDOMAIN`.

Hence, this patch defines the  `net-kourier-controller.knative-serving.svc.cluster.local.` (the full name & trailing dot `.`) then client stops sending the extra query. 

TODO: 
- [x] Remove https://github.com/openshift-knative/net-kourier/blob/main/openshift/patches/001-service-location.patch