### PR TITLE
Fix wrong filtering for Kourier Service

### DIFF
--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -96,7 +96,7 @@ func addKourierAppProtocol(ks base.KComponent) mf.Transformer {
 		return nil
 	}
 	return func(u *unstructured.Unstructured) error {
-		if u.GetKind() != "Service" && u.GetName() != "kourier" {
+		if u.GetKind() != "Service" || u.GetName() != "kourier" {
 			return nil
 		}
 


### PR DESCRIPTION
This patch fixes wrong filtering for Kourier Service.

We want to skip changing neither Service nor name `kourier`, so the logic operation should be `||`.