### PR TITLE
Automation for knative-istio-authz-chart bump

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -6,11 +6,15 @@ on:
     branches:
       - 'release-**'
   workflow_dispatch: # Manual workflow trigger
+    inputs:
+      branch:
+        required: true
+        description: "SO release branch"
 
 jobs:
   bump-so-version:
     if: github.event.created || github.event_name == 'workflow_dispatch'
-    name:
+    name: bump operator metadata
     runs-on: ubuntu-latest
     env:
       GOPATH: ${{ github.workspace }}
@@ -20,14 +24,6 @@ jobs:
         with:
           go-version: 1.20.x
 
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          # Always checkout main, we don't support bumping for patch releases (for now)
-          ref: main
-          path: ./src/github.com/${{ github.repository }}
-          fetch-depth: 0
-
       - name: Install prerequisites
         env:
           YQ_VERSION: 3.4.0
@@ -36,9 +32,66 @@ jobs:
           sudo chmod +x /usr/bin/yq
           sudo mv /usr/bin/yq /usr/local/bin/yq
 
+      - name: Checkout openshift-knative/serverless-operator
+        uses: actions/checkout@v3
+        with:
+          # Always checkout main, we don't support bumping for patch releases (for now)
+          ref: main
+          path: ./src/github.com/${{ github.repository }}
+          fetch-depth: 0
+
+      - name: Checkout openshift-knative/knative-istio-authz-chart
+        uses: actions/checkout@v3
+        with:
+          repository: 'openshift-knative/knative-istio-authz-chart'
+          path: ./src/github.com/openshift-knative/knative-istio-authz-chart
+          fetch-depth: 0
+
+      - name: Set branch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "RELEASE_BRANCH=${{ inputs.branch }}" >> $GITHUB_ENV
+
+      - name: Set branch
+        if: github.event.created
+        run: |
+          echo "RELEASE_BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
+
+      - name: Bump chart version
+        working-directory: ./src/github.com/openshift-knative/knative-istio-authz-chart
+        run: go run hack/cmd/bumpistiochart/bumpistiochart.go --branch "${RELEASE_BRANCH}"
+
+      - name: Create branch
+        working-directory: ./src/github.com/openshift-knative/knative-istio-authz-chart
+        run: |
+          set -euo pipefail
+          
+          git config --global user.email "serverless-support@redhat.com"
+          git config --global user.name "OpenShift Serverless"
+          git config --global user.password "${{ secrets.SERVERLESS_QE_ROBOT }}"
+          
+          # Check if target branch exists, otherwise create it starting from main
+          if git show-ref --quiet refs/heads/${RELEASE_BRANCH}; then
+            echo "${RELEASE_BRANCH} branch exists"
+          else
+            git checkout -b ${RELEASE_BRANCH} main
+            git push origin ${RELEASE_BRANCH}:${RELEASE_BRANCH}
+            git checkout main
+          fi
+
+      - name: Set chart version
+        run: |
+          chart_version=${RELEASE_BRANCH/release-/} # remove `release-` prefix
+          
+          # This temporary use the current chart version because using the next version might fail
+          # since it's not published yet, see `mesh-auth-policies.sh` as part of the
+          # `make generated-files` command
+          
+          echo "ISTIO_CHART_VERSION=${chart_version}.0" >> $GITHUB_ENV
+
       - name: Bump SO
         working-directory: ./src/github.com/${{ github.repository }}
-        run: go run hack/cmd/bumpso/bumpso.go
+        run: go run hack/cmd/bumpso/bumpso.go --branch "${RELEASE_BRANCH}"
 
       - name: Regenerate all generated files
         working-directory: ./src/github.com/${{ github.repository }}

--- a/hack/cmd/bumpistiochart/bumpistiochart.go
+++ b/hack/cmd/bumpistiochart/bumpistiochart.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openshift-knative/serverless-operator/hack/cmd/common"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	chart := make(map[string]interface{}, 8)
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	chartMetadataPath := filepath.Join(wd, "Chart.yaml")
+	branch := ""
+
+	flag.StringVar(&chartMetadataPath, "chart-metadata-path", chartMetadataPath, "")
+	flag.StringVar(&branch, "branch", "", "")
+	flag.Parse()
+
+	var node yaml.Node
+
+	file, err := os.ReadFile(chartMetadataPath)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", chartMetadataPath, err)
+	}
+
+	if err := yaml.NewDecoder(bytes.NewBuffer(file)).Decode(&chart); err != nil {
+		return fmt.Errorf("failed to decode file into map: %w", err)
+	}
+	if err := yaml.NewDecoder(bytes.NewBuffer(file)).Decode(&node); err != nil {
+		return fmt.Errorf("failed to decode file into node: %w", err)
+	}
+
+	currentVersion, err := currentVersion(chart)
+	if err != nil {
+		return err
+	}
+	// We don't care about patch versions (patch versions are potentially skipped, etc)
+	currentVersion.Patch = 0
+
+	if branch != "" {
+		majorMinor := strings.Replace(branch, "release-", "", 1)
+		currentVersion = semver.New(fmt.Sprintf("%s.%d", majorMinor, 0))
+	}
+
+	newVersion := &semver.Version{
+		Major:      currentVersion.Major,
+		Minor:      currentVersion.Minor,
+		Patch:      currentVersion.Patch,
+		PreRelease: currentVersion.PreRelease,
+		Metadata:   currentVersion.Metadata,
+	}
+	newVersion.BumpMinor()
+
+	_ = common.SetNestedField(&node, newVersion.String(), "version")
+	_ = common.SetNestedField(&node, newVersion.String(), "appVersion")
+
+	buf := bytes.NewBuffer(nil)
+	if err := yaml.NewEncoder(buf).Encode(&node); err != nil {
+		return fmt.Errorf("failed to encode node into buf: %w", err)
+	}
+
+	if err := os.WriteFile(chartMetadataPath, buf.Bytes(), 0600); err != nil {
+		return fmt.Errorf("failed to write updates: %w", err)
+	}
+
+	return nil
+}
+
+func currentVersion(project map[string]interface{}) (*semver.Version, error) {
+	v, _, err := unstructured.NestedString(project, "version")
+	if err != nil {
+		return nil, err
+	}
+	ver := semver.New(v)
+	return ver, nil
+}

--- a/hack/cmd/common/common.go
+++ b/hack/cmd/common/common.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func SetNestedField(node *yaml.Node, value interface{}, fields ...string) error {
+
+	for i, n := range node.Content {
+
+		if i > 0 && node.Content[i-1].Value == fields[0] {
+
+			// Base case for scalar nodes
+			if len(fields) == 1 && n.Kind == yaml.ScalarNode {
+				n.SetString(fmt.Sprintf("%s", value))
+				break
+			}
+			// base case for sequence node
+			if len(fields) == 1 && n.Kind == yaml.SequenceNode {
+
+				if v, ok := value.([]interface{}); ok {
+					var s yaml.Node
+
+					b, err := yaml.Marshal(v)
+					if err != nil {
+						return err
+					}
+					if err := yaml.NewDecoder(bytes.NewBuffer(b)).Decode(&s); err != nil {
+						return err
+					}
+
+					n.Content = s.Content[0].Content
+				}
+				break
+			}
+
+			// Continue to the next level
+			return SetNestedField(n, value, fields[1:]...)
+		}
+
+		if node.Kind == yaml.DocumentNode {
+			return SetNestedField(n, value, fields...)
+		}
+	}
+
+	return nil
+}

--- a/hack/generate/mesh-auth-policies.sh
+++ b/hack/generate/mesh-auth-policies.sh
@@ -11,7 +11,11 @@ helm > /dev/null || exit 127
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/metadata.bash"
 
 policies_path="$(dirname "${BASH_SOURCE[0]}")/../lib/mesh_resources/authorization-policies/helm"
-chart_version="$(metadata.get project.version)"
+if [ -z "${ISTIO_CHART_VERSION:-}" ]; then
+  chart_version="$(metadata.get project.version)"
+else
+  chart_version="${ISTIO_CHART_VERSION}"
+fi
 
 echo "Cleaning up old resources in $policies_path"
 


### PR DESCRIPTION
This introduces a new automation for the bump of the
knative-istio-authz-chart helm chart metadata.

It will bump the chart metadata in `Chart.yaml` when the
same SO bump automation is triggered.

In addition, since SO bump itself depends on the chart
availability, it temporarly configures the `make generated-files`
command to use the "current SO version" as opposed to the
"bumped/next version" so that we don't need to retry until
it's available.

I've tested locally `bumpistiochart` command with:

```shell
$ go run ./hack/cmd/bumpistiochart/bumpistiochart.go --chart-metadata-path ../knative-istio-authz-chart/Chart.yaml 

$ git diff
diff --git a/Chart.yaml b/Chart.yaml
index 31f924e..12edd19 100644
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: knative-istio-authz-onboarding
 description: Helm chart to onboard a set of authorization-based isolated namespaces to Knative when using Istio.
-
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -11,14 +10,12 @@ description: Helm chart to onboard a set of authorization-based isolated namespa
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.31.0
-
+version: 1.32.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.31.0"
+appVersion: "1.32.0"


$ go run ./hack/cmd/bumpistiochart/bumpistiochart.go --chart-metadata-path ../knative-istio-authz-chart/Chart.yaml --branch release-1.31

# Validate idempotency

$ go run ./hack/cmd/bumpistiochart/bumpistiochart.go --chart-metadata-path ../knative-istio-authz-chart/Chart.yaml --branch release-1.31

$ git diff
diff --git a/Chart.yaml b/Chart.yaml
index 31f924e..12edd19 100644
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: knative-istio-authz-onboarding
 description: Helm chart to onboard a set of authorization-based isolated namespaces to Knative when using Istio.
-
 # A chart can be either an 'application' or a 'library' chart.
 #
...skipping...
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.31.0
-
+version: 1.32.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.31.0"
+appVersion: "1.32.0"
```

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>