### PR TITLE
TestServiceToServiceCalls creates new context for subtests

### DIFF
--- a/test/servinge2e/kourier/service_to_service_test.go
+++ b/test/servinge2e/kourier/service_to_service_test.go
@@ -18,10 +18,6 @@ import (
 // services from within the cluster.
 func TestServiceToServiceCalls(t *testing.T) {
 
-	caCtx := test.SetupClusterAdmin(t)
-	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
-	defer test.CleanupAll(t, caCtx)
-
 	tests := []testCase{{
 		// Requests go via gateway -> activator -> pod.
 		name: "service-call-via-activator",
@@ -58,7 +54,11 @@ func TestServiceToServiceCalls(t *testing.T) {
 	for _, scenario := range tests {
 		scenario := scenario
 		t.Run(scenario.name, func(t *testing.T) {
-			testServiceToService(t, caCtx, test.Namespace, scenario)
+			// Create a new context to prevent calling ctx.T.Fatal on parent T.
+			ctx := test.SetupClusterAdmin(t)
+			test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, ctx) })
+			defer test.CleanupAll(t, ctx)
+			testServiceToService(t, ctx, test.Namespace, scenario)
 		})
 	}
 }


### PR DESCRIPTION
This is to prevent errors like:
```
testing.go:1343: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
