### PR TITLE
[WIP] [Test] Test MT with Service mesh with multi namespace tenant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ release-files:
 		templates/images-rekt.yaml \
 		test/images-rekt.yaml
 	./hack/generate/mesh-auth-policies.sh \
-  	tenant-1,tenant-2,serving-tests,serverless-tests
+  	tenant-1=tenant-1,tenant-2=tenant-2,serving-tests=serving-tests,serverless-tests=serverless-tests+serverless-tests2
 
 # Generates all files that can be generated, includes release files, code generation
 # and updates vendoring.

--- a/hack/generate/mesh-auth-policies.sh
+++ b/hack/generate/mesh-auth-policies.sh
@@ -25,7 +25,13 @@ mkdir -p "$policies_path"
 for tenant in ${tenants//,/ }; do
   echo "Generating AuthorizationPolicies for tenant $tenant"
 
-  helm template oci://quay.io/openshift-knative/knative-istio-authz-onboarding --version "$chart_version" --set "name=$tenant" --set "namespaces={$tenant}" > "$policies_path/$tenant.yaml"
+  # shellcheck disable=SC2206
+  parts=(${tenant//=/ })
+  echo "Parts --> ${parts[*]}"
+  name=${parts[0]}
+  ns=${parts[1]/+/,}
+
+  helm template oci://quay.io/openshift-knative/knative-istio-authz-onboarding --version "$chart_version" --set "name=$name" --set "namespaces={$ns}" > "$policies_path/$name.yaml"
 done
 
 echo "Istio AuthorizationPolicies successfully updated for version $chart_version"

--- a/hack/lib/mesh_resources/authorization-policies/helm/serverless-tests.yaml
+++ b/hack/lib/mesh_resources/authorization-policies/helm/serverless-tests.yaml
@@ -13,6 +13,7 @@ spec:
         - source:
             namespaces:
               - "serverless-tests"
+              - "serverless-tests2"
               - "knative-serving"
               - "istio-system"
 
@@ -24,9 +25,39 @@ spec:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
+---
+# Source: knative-istio-authz-onboarding/templates/common-allow-knative-to-ns.yaml
+---
+# Allow namespace serverless-tests2 to receive requests from Knative system components, from istio-system and from all namespaces of the tenant.
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-from-knative-and-istio
+  namespace: serverless-tests2
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            namespaces:
+              - "serverless-tests"
+              - "serverless-tests2"
+              - "knative-serving"
+              - "istio-system"
+
+    - from:
+        - source:
+            namespaces:
+              - "knative-eventing"
+      when:
+        - key: request.headers[Kn-Namespace]
+          values:
+          - "serverless-tests"
+          - "serverless-tests2"
 ---
 # Source: knative-istio-authz-onboarding/templates/common-allow-via-knative-serving.yaml
-# Allow activator to receive requests from workloads and resources in serverless-tests.
+# Allow activator to receive requests from workloads and resources in serverless-tests,serverless-tests2.
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -38,19 +69,23 @@ spec:
     matchLabels:
       app.kubernetes.io/component: "activator"
   rules:
-    # Allow to receive requests for Knative services in serverless-tests
+    # Allow to receive requests for Knative services in serverless-tests,serverless-tests2
     - from:
         - source:
             namespaces:
             - "serverless-tests"
+            - "serverless-tests2"
       to:
         - operation:
             hosts:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
 
-    # Allow to receive requests from eventing sources, subscriptions and triggers in serverless-tests.
+    # Allow to receive requests from eventing sources, subscriptions and triggers in serverless-tests,serverless-tests2.
     - from:
         - source:
             namespaces: [ "knative-eventing" ]
@@ -73,10 +108,14 @@ spec:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
 ---
 # Source: knative-istio-authz-onboarding/templates/eventing-allow-ns-to-kafka-broker-reply.yaml
 apiVersion: security.istio.io/v1beta1
@@ -100,10 +139,12 @@ spec:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
 ---
 # Source: knative-istio-authz-onboarding/templates/eventing-allow-ns-to-mt-channel-based-broker-reply.yaml
 apiVersion: security.istio.io/v1beta1
@@ -129,13 +170,15 @@ spec:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
 ---
 # Source: knative-istio-authz-onboarding/templates/eventing-allow-to-knative-eventing-receiver.yaml
-# Allow imc-dispatcher to receive requests from workloads and resources in serverless-tests.
+# Allow imc-dispatcher to receive requests from workloads and resources in serverless-tests,serverless-tests2.
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -147,20 +190,25 @@ spec:
     matchLabels:
       app.kubernetes.io/component: "imc-dispatcher"
   rules:
-    # Allow to receive requests from event sources in serverless-tests
+    # Allow to receive requests from event sources in serverless-tests,serverless-tests2
     - from:
         - source:
             namespaces:
             - "serverless-tests"
+            - "serverless-tests2"
       to:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
         - operation:
             hosts:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
     - from:
         - source:
             namespaces: [ "knative-eventing" ]
@@ -183,10 +231,14 @@ spec:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
     - from:
         - source:
             namespaces: [ "knative-eventing" ]
@@ -207,14 +259,16 @@ spec:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
 ---
 # Source: knative-istio-authz-onboarding/templates/eventing-allow-to-knative-eventing-receiver.yaml
 ---
-# Allow kafka-broker-receiver to receive requests from workloads and resources in serverless-tests.
+# Allow kafka-broker-receiver to receive requests from workloads and resources in serverless-tests,serverless-tests2.
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -226,20 +280,25 @@ spec:
     matchLabels:
       app.kubernetes.io/component: "kafka-broker-receiver"
   rules:
-    # Allow to receive requests from event sources in serverless-tests
+    # Allow to receive requests from event sources in serverless-tests,serverless-tests2
     - from:
         - source:
             namespaces:
             - "serverless-tests"
+            - "serverless-tests2"
       to:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
         - operation:
             hosts:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
     - from:
         - source:
             namespaces: [ "knative-eventing" ]
@@ -262,10 +321,14 @@ spec:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
     - from:
         - source:
             namespaces: [ "knative-eventing" ]
@@ -286,14 +349,16 @@ spec:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
 ---
 # Source: knative-istio-authz-onboarding/templates/eventing-allow-to-knative-eventing-receiver.yaml
 ---
-# Allow kafka-channel-receiver to receive requests from workloads and resources in serverless-tests.
+# Allow kafka-channel-receiver to receive requests from workloads and resources in serverless-tests,serverless-tests2.
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -305,20 +370,25 @@ spec:
     matchLabels:
       app.kubernetes.io/component: "kafka-channel-receiver"
   rules:
-    # Allow to receive requests from event sources in serverless-tests
+    # Allow to receive requests from event sources in serverless-tests,serverless-tests2
     - from:
         - source:
             namespaces:
             - "serverless-tests"
+            - "serverless-tests2"
       to:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
         - operation:
             hosts:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
     - from:
         - source:
             namespaces: [ "knative-eventing" ]
@@ -341,10 +411,14 @@ spec:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
     - from:
         - source:
             namespaces: [ "knative-eventing" ]
@@ -365,14 +439,16 @@ spec:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
 ---
 # Source: knative-istio-authz-onboarding/templates/eventing-allow-to-knative-eventing-receiver.yaml
 ---
-# Allow kafka-sink-receiver to receive requests from workloads and resources in serverless-tests.
+# Allow kafka-sink-receiver to receive requests from workloads and resources in serverless-tests,serverless-tests2.
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -384,20 +460,25 @@ spec:
     matchLabels:
       app.kubernetes.io/component: "kafka-sink-receiver"
   rules:
-    # Allow to receive requests from event sources in serverless-tests
+    # Allow to receive requests from event sources in serverless-tests,serverless-tests2
     - from:
         - source:
             namespaces:
             - "serverless-tests"
+            - "serverless-tests2"
       to:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
         - operation:
             hosts:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
     - from:
         - source:
             namespaces: [ "knative-eventing" ]
@@ -420,10 +501,14 @@ spec:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
     - from:
         - source:
             namespaces: [ "knative-eventing" ]
@@ -444,14 +529,16 @@ spec:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
 ---
 # Source: knative-istio-authz-onboarding/templates/eventing-allow-to-knative-eventing-receiver.yaml
 ---
-# Allow broker-ingress to receive requests from workloads and resources in serverless-tests.
+# Allow broker-ingress to receive requests from workloads and resources in serverless-tests,serverless-tests2.
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -463,20 +550,25 @@ spec:
     matchLabels:
       app.kubernetes.io/component: "broker-ingress"
   rules:
-    # Allow to receive requests from event sources in serverless-tests
+    # Allow to receive requests from event sources in serverless-tests,serverless-tests2
     - from:
         - source:
             namespaces:
             - "serverless-tests"
+            - "serverless-tests2"
       to:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
         - operation:
             hosts:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
     - from:
         - source:
             namespaces: [ "knative-eventing" ]
@@ -499,10 +591,14 @@ spec:
             - "*.serverless-tests"
             - "*.serverless-tests.svc"
             - "*.serverless-tests.svc.cluster.local"
+            - "*.serverless-tests2"
+            - "*.serverless-tests2.svc"
+            - "*.serverless-tests2.svc.cluster.local"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
     - from:
         - source:
             namespaces: [ "knative-eventing" ]
@@ -523,10 +619,12 @@ spec:
         - operation:
             paths:
             - "/serverless-tests/*"
+            - "/serverless-tests2/*"
       when:
         - key: request.headers[Kn-Namespace]
           values:
           - "serverless-tests"
+          - "serverless-tests2"
 ---
 # Source: knative-istio-authz-onboarding/templates/serving-allow-wait-for-drain.yaml
 # Allow kubernetes to call the PreStopHook to wait for draining on port 8022 in serverless-tests
@@ -535,6 +633,22 @@ kind: AuthorizationPolicy
 metadata:
   name: "allow-wait-for-drain"
   namespace: "serverless-tests"
+spec:
+  action: ALLOW
+  rules:
+    - to:
+        - operation:
+            ports:
+              - "8022"
+---
+# Source: knative-istio-authz-onboarding/templates/serving-allow-wait-for-drain.yaml
+---
+# Allow kubernetes to call the PreStopHook to wait for draining on port 8022 in serverless-tests2
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: "allow-wait-for-drain"
+  namespace: "serverless-tests2"
 spec:
   action: ALLOW
   rules:

--- a/hack/lib/mesh_resources/namespace.yaml
+++ b/hack/lib/mesh_resources/namespace.yaml
@@ -29,6 +29,13 @@ metadata:
   labels:
     maistra.io/member-of: istio-system # Workaround for OSSM-1397
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: serverless-tests2
+  labels:
+    maistra.io/member-of: istio-system # Workaround for OSSM-1397
+---
 # Additional namespaces for upgrade tests
 apiVersion: v1
 kind: Namespace

--- a/hack/lib/mesh_resources/smmr.yaml
+++ b/hack/lib/mesh_resources/smmr.yaml
@@ -10,6 +10,7 @@ spec:
   - serving-tests
   - serving-tests-alt
   - serverless-tests
+  - serverless-tests2
   - eventing-e2e0
   - eventing-e2e1
   - eventing-e2e2


### PR DESCRIPTION
Fixes JIRA #

I wanted to validate that
```
      when:
        - key: request.headers[Kn-Namespace]
          values:
          - "serverless-tests"
          - "serverless-tests2"
```

works when "at least one value matches" or we need separate "rules"

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
