### PR TITLE
SRVKE-1494: Install KEDA for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,12 @@ install-strimzi:
 uninstall-strimzi:
 	UNINSTALL_STRIMZI="true" ./hack/strimzi.sh
 
+install-keda:
+	UNINSTALL_KEDA="false" ./hack/keda.sh
+
+uninstall-keda:
+	UNINSTALL_KEDA="true" ./hack/keda.sh
+
 install-certmanager:
 	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 

--- a/hack/keda.sh
+++ b/hack/keda.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This script can be used to install KEDA (Custom metrics autoscaler).
+#
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/lib/__sources__.bash"
+
+set -Eeuo pipefail
+
+if [[ $UNINSTALL_KEDA == "true" ]]; then
+  uninstall_keda || exit 1
+else
+  install_keda || exit 2
+fi
+
+exit 0

--- a/hack/lib/__sources__.bash
+++ b/hack/lib/__sources__.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-declare -a __sources=(metadata vars common ui scaleup namespaces catalogsource serverless tracing mesh certmanager strimzi tracing clusterlogging testselect)
+declare -a __sources=(metadata vars common ui scaleup namespaces catalogsource serverless tracing mesh certmanager strimzi keda tracing clusterlogging testselect)
 
 for source in "${__sources[@]}"; do
   # shellcheck disable=SC1091,SC1090

--- a/hack/lib/keda.bash
+++ b/hack/lib/keda.bash
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+keda_resources_dir="$(dirname "${BASH_SOURCE[0]}")/keda_resources"
+
+function install_custom_metrics_autoscaler_operator {
+  logger.info "Installing KEDA operator"
+
+  oc apply -f "${keda_resources_dir}"/subscription.yaml || return $?
+
+  logger.info "Waiting until KEDA operator is available"
+  timeout 600 "[[ \$(oc get deploy -n openshift-keda custom-metrics-autoscaler-operator --no-headers | wc -l) != 1 ]]" || return 1
+
+  # Wait for the CRD we need to actually be active
+  oc wait crd --timeout=600s kedacontrollers.keda.sh --for=condition=Established
+}
+
+function delete_custom_metrics_autoscaler_operator {
+  logger.info "Deleting KEDA operator"
+
+  oc delete -f "${keda_resources_dir}"/subscription.yaml --ignore-not-found || return $?
+
+  logger.info "Waiting until KEDA operator is deleted"
+  timeout 600 "[[ \$(oc get deploy -n openshift-keda custom-metrics-autoscaler-operator --no-headers | wc -l) != 0 ]]" || return 1
+}
+
+function install_keda_controller {
+
+  oc apply -f "${keda_resources_dir}"/kedacontroller.yaml || return $?
+
+  logger.info "Waiting until KEDA controllers are available"
+
+  timeout 600 "[[ \$(oc get deploy -n openshift-keda keda-admission --no-headers | wc -l) != 1 ]]" || return 1
+  timeout 600 "[[ \$(oc get deploy -n openshift-keda keda-metrics-apiserver --no-headers | wc -l) != 1 ]]" || return 1
+  timeout 600 "[[ \$(oc get deploy -n openshift-keda keda-operator --no-headers | wc -l) != 1 ]]" || return 1
+}
+
+function delete_keda_controller {
+
+  oc delete -f "${keda_resources_dir}"/kedacontroller.yaml --ignore-not-found  || return $?
+
+  logger.info "Waiting until KEDA controllers are deleted"
+
+  timeout 600 "[[ \$(oc get deploy -n openshift-keda keda-admission --no-headers | wc -l) != 0 ]]" || return 1
+  timeout 600 "[[ \$(oc get deploy -n openshift-keda keda-metrics-apiserver --no-headers | wc -l) != 0 ]]" || return 1
+  timeout 600 "[[ \$(oc get deploy -n openshift-keda keda-operator --no-headers | wc -l) != 0 ]]" || return 1
+}
+
+function install_keda {
+  logger.info "KEDA install"
+  install_custom_metrics_autoscaler_operator
+  install_keda_controller
+}
+
+function uninstall_keda {
+  logger.info "KEDA uninstall"
+  delete_keda_controller
+  delete_custom_metrics_autoscaler_operator
+}

--- a/hack/lib/keda_resources/kedacontroller.yaml
+++ b/hack/lib/keda_resources/kedacontroller.yaml
@@ -1,0 +1,297 @@
+apiVersion: keda.sh/v1alpha1
+kind: KedaController
+metadata:
+  name: keda
+  namespace: openshift-keda
+spec:
+  ###
+  # THERE SHOULD BE ONLY ONE INSTANCE OF THIS RESOURCE PER CLUSTER
+  # with Name set to 'keda' created in namespace 'keda'
+  ###
+
+  ## Namespace that should be watched by KEDA,
+  # omit or set empty to watch all namespaces (default setting)
+  watchNamespace: ""
+
+  ## KEDA Operator related config
+  operator:
+    ## Logging level for KEDA Operator
+    # allowed values: 'debug', 'info', 'error', or an integer value greater than 0, specified as string
+    # default value: info
+    logLevel: info
+
+    ## Logging format for KEDA Operator
+    # allowed values are json and console
+    # default value: console
+    logEncoder: console
+
+    ## Logging time encoding for KEDA Controller
+    # allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano`
+    # default value: rfc3339
+    # logTimeEncoding: rfc3339
+
+    ## Arbitrary arguments
+    # Define any argument with possibility to override already existing ones
+    # array of strings (format is either with prefix '--key=value' or just 'value')
+    # args: []
+
+    ## Annotations to be added to the KEDA Operator Deployment
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    # deploymentAnnotations:
+    #  annotationKey: annotationValue
+
+    ## Labels to be added to the KEDA Operator Deployment
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    # deploymentLabels:
+    #  labelKey: labelValue
+
+    ## Annotations to be added to the KEDA Operator Pod
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    # podAnnotations:
+    #  annotationKey: annotationValue
+
+    ## Labels to be added to the KEDA Operator Pod
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    # podLabels:
+    #  labelKey: labelValue
+
+    ## Node selector for pod scheduling for KEDA Operator
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+    # nodeSelector:
+    #  beta.kubernetes.io/os: linux
+
+    ## Tolerations for pod scheduling for KEDA Operator
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+    # tolerations:
+    # - key: "key1"
+    #   operator: "Equal"
+    #   value: "value1"
+    #   effect: "NoSchedule"
+    # - key: "key1"
+    #   operator: "Equal"
+    #   value: "value1"
+    #   effect: "NoExecute"
+
+    ## Affinity for pod scheduling for KEDA Operator
+    # https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/
+    # affinity:
+    #  podAntiAffinity:
+    #    requiredDuringSchedulingIgnoredDuringExecution:
+    #     - labelSelector:
+    #         matchExpressions:
+    #         - key: app
+    #           operator: In
+    #           values:
+    #           - keda-operator
+    #           - keda-operator-metrics-apiserver
+    #       topologyKey: "kubernetes.io/hostname"
+
+    ## Pod priority for KEDA Operator
+    # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+    # priorityClassName: high-priority
+
+    ## Manage resource requests & limits for KEDA Operator
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    # resourcesKedaOperator:
+    #   requests:
+    #     cpu: 100m
+    #     memory: 100Mi
+    #   limits:
+    #     cpu: 1000m
+    #      memory: 1000Mi
+
+  ## KEDA Metrics Server related config
+  metricsServer:
+    ## Logging level for Metrics Server
+    # allowed values: "0" for info, "4" for debug, or an integer value greater than 0, specified as string
+    # default value: "0"
+    logLevel: "0"
+
+    ## Arbitrary arguments
+    # Define any argument with possibility to override already existing ones
+    # array of strings (format is either with prefix '--key=value' or just 'value')
+    # args: []
+
+    ## Audit Config
+    # https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#audit-policy
+    # Define basic arguments for auditing log files. If needed, more complex flags
+    # can be set via 'Args' field manually.
+    # Non-empty 'policy' field is mandatory to enable logging.
+    # If 'logOutputVolumeClaim' is empty the audit log is printed to stdout,
+    # otherwise it points to the user defined PersistentVolumeClaim resource name.
+    # auditConfig:
+    #   logFormat: "json"
+    #   logOutputVolumeClaim: "persistentVolumeClaimName"
+    #   policy:
+    #     rules:
+    #     - level: Metadata
+    #     omitStages: "RequestReceived"
+    #     omitManagedFields: false
+    #   lifetime:
+    #     maxAge: "2"
+    #     maxBackup: "1"
+    #     maxSize: "50"
+
+    ## Annotations to be added to the KEDA Metrics Server Deployment
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    # deploymentAnnotations:
+    #  annotationKey: annotationValue
+
+    ## Labels to be added to the KEDA Metrics Server Deployment
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    # deploymentLabels:
+    #  labelKey: labelValue
+
+    ## Annotations to be added to the KEDA Metrics Server Pod
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    # podAnnotations:
+    #  annotationKey: annotationValue
+
+    ## Labels to be added to the KEDA Metrics Server Pod
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    # podLabels:
+    #  labelKey: labelValue
+
+    ## Node selector for pod scheduling for Metrics Server
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+    # nodeSelector:
+    #  beta.kubernetes.io/os: linux
+
+    ## Tolerations for pod scheduling for KEDA Metrics Server
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+    # tolerations:
+    # - key: "key1"
+    #   operator: "Equal"
+    #   value: "value1"
+    #   effect: "NoSchedule"
+    # - key: "key1"
+    #   operator: "Equal"
+    #   value: "value1"
+    #   effect: "NoExecute"
+
+    ## Affinity for pod scheduling for KEDA Metrics Server
+    # https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/
+    # affinity:
+    #  podAntiAffinity:
+    #    requiredDuringSchedulingIgnoredDuringExecution:
+    #     - labelSelector:
+    #         matchExpressions:
+    #         - key: app
+    #           operator: In
+    #           values:
+    #           - keda-operator
+    #           - keda-operator-metrics-apiserver
+    #       topologyKey: "kubernetes.io/hostname"
+
+    ## Pod priority for KEDA Metrics Server
+    # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+    # priorityClassName: high-priority
+
+    ## Manage resource requests & limits for KEDA Metrics Server
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    # resourcesKedaOperator:
+    #   requests:
+    #     cpu: 100m
+    #     memory: 100Mi
+    #   limits:
+    #     cpu: 1000m
+    #      memory: 1000Mi
+
+  ## KEDA Admission Webhooks related config
+  admissionWebhooks:
+    ## Logging level for KEDA Admission Webhooks
+    # allowed values: 'debug', 'info', 'error', or an integer value greater than 0, specified as string
+    # default value: info
+    logLevel: info
+
+    ## Logging format for KEDA Admission Webhooks
+    # allowed values are json and console
+    # default value: console
+    logEncoder: console
+
+    ## Logging time encoding for KEDA Admission Webhooks
+    # allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano`
+    # default value: rfc3339
+    # logTimeEncoding: rfc3339
+
+    ## Arbitrary arguments
+    # Define any argument with possibility to override already existing ones.
+    # Array of strings (format is either with prefix '--key=value' or just 'value')
+    # args: []
+
+    ## Annotations to be added to the KEDA Admission Webhooks Deployment
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    # deploymentAnnotations:
+    #  annotationKey: annotationValue
+
+    ## Labels to be added to the KEDA Admission Webhooks Deployment
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    # deploymentLabels:
+    #  labelKey: labelValue
+
+    ## Annotations to be added to the KEDA Admission Webhooks Pod
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    # podAnnotations:
+    #  annotationKey: annotationValue
+
+    ## Labels to be added to the KEDA Admission Webhooks Pod
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    # podLabels:
+    #  labelKey: labelValue
+
+    ## Node selector for pod scheduling for KEDA Admission Webhooks
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+    # nodeSelector:
+    #  beta.kubernetes.io/os: linux
+
+    ## Tolerations for pod scheduling for KEDA Admission Webhooks
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+    # tolerations:
+    # - key: "key1"
+    #   operator: "Equal"
+    #   value: "value1"
+    #   effect: "NoSchedule"
+    # - key: "key1"
+    #   operator: "Equal"
+    #   value: "value1"
+    #   effect: "NoExecute"
+
+    ## Affinity for pod scheduling for KEDA Admission Webhooks
+    # https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/
+    # affinity:
+    #  podAntiAffinity:
+    #    requiredDuringSchedulingIgnoredDuringExecution:
+    #     - labelSelector:
+    #         matchExpressions:
+    #         - key: app
+    #           operator: In
+    #           values:
+    #           - keda-operator
+    #           - keda-operator-metrics-apiserver
+    #       topologyKey: "kubernetes.io/hostname"
+
+    ## Pod priority for KEDA Admission Webhooks
+    # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+    # priorityClassName: high-priority
+
+    ## Manage resource requests & limits for KEDA Admission Webhooks
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    # resourcesKedaOperator:
+    #   requests:
+    #     cpu: 100m
+    #     memory: 100Mi
+    #   limits:
+    #     cpu: 1000m
+    #      memory: 1000Mi
+
+  ## KEDA ServiceAccount related config
+  serviceAccount:
+    ## Annotations to be added to the Service Account
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    # annotations:
+    #  annotationKey: annotationValue
+
+    ## Labels to be added to the ServiceAccount
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    # labels:
+    #  labelKey: labelValue

--- a/hack/lib/keda_resources/subscription.yaml
+++ b/hack/lib/keda_resources/subscription.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-keda
+  labels:
+    openshift.io/cluster-monitoring: "true"
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-keda
+  namespace: openshift-keda
+spec:
+  targetNamespaces:
+    - openshift-keda
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/openshift-custom-metrics-autoscaler-operator.openshift-keda: ""
+  name: openshift-custom-metrics-autoscaler-operator
+  namespace: openshift-keda
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: openshift-custom-metrics-autoscaler-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Install CMA (KEDA) for testing KEDA integration in OpenShift

Part of SRVKE-1494

Tested locally on 4.12

```shell
pierdipi@pierdipi serverless-operator (install-keda) $ make install-keda
UNINSTALL_KEDA="false" ./hack/keda.sh
INFO    18:04:06.390 KEDA install
INFO    18:04:06.391 Installing KEDA operator
namespace/openshift-keda created
operatorgroup.operators.coreos.com/openshift-keda created
subscription.operators.coreos.com/openshift-custom-metrics-autoscaler-operator created
INFO    18:04:11.283 Waiting until KEDA operator is available
DEBUG   18:04:11.287 [[ $(oc get deploy -n openshift-keda custom-metrics-autoscaler-operator --no-headers | wc -l) != 1 ]] : Waiting until non-zero (max 600 sec.) ... done
customresourcedefinition.apiextensions.k8s.io/kedacontrollers.keda.sh condition met
kedacontroller.keda.sh/keda created
INFO    18:04:24.576 Waiting until KEDA controllers are available
DEBUG   18:04:24.577 [[ $(oc get deploy -n openshift-keda keda-admission --no-headers | wc -l) != 1 ]] : Waiting until non-zero (max 600 sec.) done
DEBUG   18:04:25.276 [[ $(oc get deploy -n openshift-keda keda-metrics-apiserver --no-headers | wc -l) != 1 ]] : Waiting until non-zero (max 600 sec.) done
DEBUG   18:04:26.154 [[ $(oc get deploy -n openshift-keda keda-operator --no-headers | wc -l) != 1 ]] : Waiting until non-zero (max 600 sec.) done
pierdipi@pierdipi serverless-operator (install-keda) $ make uninstall-keda
UNINSTALL_KEDA="true" ./hack/keda.sh
INFO    18:04:34.947 KEDA uninstall
kedacontroller.keda.sh "keda" deleted
INFO    18:04:36.643 Waiting until KEDA controllers are deleted
DEBUG   18:04:36.647 [[ $(oc get deploy -n openshift-keda keda-admission --no-headers | wc -l) != 0 ]] : Waiting until non-zero (max 600 sec.) done
DEBUG   18:04:37.321 [[ $(oc get deploy -n openshift-keda keda-metrics-apiserver --no-headers | wc -l) != 0 ]] : Waiting until non-zero (max 600 sec.) done
DEBUG   18:04:38.017 [[ $(oc get deploy -n openshift-keda keda-operator --no-headers | wc -l) != 0 ]] : Waiting until non-zero (max 600 sec.) done
INFO    18:04:38.661 Deleting KEDA operator
namespace "openshift-keda" deleted
operatorgroup.operators.coreos.com "openshift-keda" deleted
subscription.operators.coreos.com "openshift-custom-metrics-autoscaler-operator" deleted
INFO    18:06:55.283 Waiting until KEDA operator is deleted
DEBUG   18:06:55.285 [[ $(oc get deploy -n openshift-keda custom-metrics-autoscaler-operator --no-headers | wc -l) != 0 ]] : Waiting until non-zero (max 600 sec.) done
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Install KEDA for testing
