### PR TITLE
Use v1beta1 DomainMapping CRD

### DIFF
--- a/serving/metadata-webhook/cmd/webhook/main.go
+++ b/serving/metadata-webhook/cmd/webhook/main.go
@@ -14,14 +14,14 @@ import (
 	"knative.dev/pkg/webhook/resourcesemantics"
 	"knative.dev/pkg/webhook/resourcesemantics/defaulting"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
-	servingv1.SchemeGroupVersion.WithKind("Service"):             &defaults.TargetKService{},
-	servingv1.SchemeGroupVersion.WithKind("Route"):               &defaults.TargetRoute{},
-	servingv1.SchemeGroupVersion.WithKind("Configuration"):       &defaults.TargetConfiguration{},
-	servingv1alpha1.SchemeGroupVersion.WithKind("DomainMapping"): &defaults.TargetDomainMapping{},
+	servingv1.SchemeGroupVersion.WithKind("Service"):           &defaults.TargetKService{},
+	servingv1.SchemeGroupVersion.WithKind("Route"):             &defaults.TargetRoute{},
+	servingv1.SchemeGroupVersion.WithKind("Configurtion"):      &defaults.TargetConfiguration{},
+	servingv1beta1.SchemeGroupVersion.WithKind("DomainMappig"): &defaults.TargetDomainMapping{},
 }
 
 func NewDefaultingAdmissionController(ctx context.Context, _ configmap.Watcher) *controller.Impl {

--- a/serving/metadata-webhook/pkg/defaults/domainmapping_defaults.go
+++ b/serving/metadata-webhook/pkg/defaults/domainmapping_defaults.go
@@ -4,14 +4,14 @@ import (
 	"context"
 
 	"knative.dev/pkg/apis"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // TargetDomainMapping is a wrapper around Configuration.
 type TargetDomainMapping struct {
-	servingv1alpha1.DomainMapping `json:",inline"`
+	servingv1beta1.DomainMapping `json:",inline"`
 }
 
 // Verify that Deployment adheres to the appropriate interfaces.

--- a/serving/metadata-webhook/pkg/defaults/domainmapping_defaults_test.go
+++ b/serving/metadata-webhook/pkg/defaults/domainmapping_defaults_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -19,7 +19,7 @@ func TestTargetDomainMappingDefaulting(t *testing.T) {
 		name: "empty",
 		in:   &TargetDomainMapping{},
 		want: &TargetDomainMapping{
-			servingv1alpha1.DomainMapping{
+			servingv1beta1.DomainMapping{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						openshiftPassthrough: "true",
@@ -30,7 +30,7 @@ func TestTargetDomainMappingDefaulting(t *testing.T) {
 	}, {
 		name: "override",
 		in: &TargetDomainMapping{
-			servingv1alpha1.DomainMapping{
+			servingv1beta1.DomainMapping{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						openshiftPassthrough: "false",
@@ -39,7 +39,7 @@ func TestTargetDomainMappingDefaulting(t *testing.T) {
 			},
 		},
 		want: &TargetDomainMapping{
-			servingv1alpha1.DomainMapping{
+			servingv1beta1.DomainMapping{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						openshiftPassthrough: "true",
@@ -77,7 +77,7 @@ func TestDeepCopyObjectDomainMapping(t *testing.T) {
 	}{{
 		name: "with name",
 		in: &TargetDomainMapping{
-			servingv1alpha1.DomainMapping{
+			servingv1beta1.DomainMapping{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo-deployment",
 				},

--- a/test/service.go
+++ b/test/service.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 type ServiceCfgFunc func(*servingv1.Service)
@@ -140,13 +140,13 @@ func WaitForReadyServices(ctx *Context, namespace string) error {
 	return nil
 }
 
-func WaitForDomainMappingState(ctx *Context, name, namespace string, inState func(dm *servingv1alpha1.DomainMapping, err error) (bool, error)) (*servingv1alpha1.DomainMapping, error) {
+func WaitForDomainMappingState(ctx *Context, name, namespace string, inState func(dm *servingv1beta1.DomainMapping, err error) (bool, error)) (*servingv1beta1.DomainMapping, error) {
 	var (
-		lastState *servingv1alpha1.DomainMapping
+		lastState *servingv1beta1.DomainMapping
 		err       error
 	)
 	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
-		lastState, err = ctx.Clients.Serving.ServingV1alpha1().DomainMappings(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		lastState, err = ctx.Clients.Serving.ServingV1beta1().DomainMappings(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		return inState(lastState, err)
 	})
 
@@ -160,7 +160,7 @@ func IsServiceReady(s *servingv1.Service, err error) (bool, error) {
 	return s.IsReady() && s.Status.URL != nil && s.Status.URL.Host != "", err
 }
 
-func IsDomainMappingReady(dm *servingv1alpha1.DomainMapping, err error) (bool, error) {
+func IsDomainMappingReady(dm *servingv1beta1.DomainMapping, err error) (bool, error) {
 	return dm.IsReady() && dm.Status.URL != nil && dm.Status.URL.Host != "", err
 }
 

--- a/test/servinge2e/kourier/custom_route_test.go
+++ b/test/servinge2e/kourier/custom_route_test.go
@@ -16,7 +16,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 const (
@@ -88,13 +88,13 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 	servinge2e.WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
 
 	// Create DomainMapping with disable Annotation.
-	dm := &servingv1alpha1.DomainMapping{
+	dm := &servingv1beta1.DomainMapping{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        domainMappingName,
 			Namespace:   test.Namespace,
 			Annotations: map[string]string{resources.DisableRouteAnnotation: "true"},
 		},
-		Spec: servingv1alpha1.DomainMappingSpec{
+		Spec: servingv1beta1.DomainMappingSpec{
 			Ref: duckv1.KReference{
 				Kind:       "Service",
 				Name:       serviceName,

--- a/test/servinge2e/kourier/helpers.go
+++ b/test/servinge2e/kourier/helpers.go
@@ -5,15 +5,15 @@ import (
 
 	"github.com/openshift-knative/serverless-operator/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 const (
 	helloworldText = "Hello World!"
 )
 
-func withDomainMappingReadyOrFail(ctx *test.Context, dm *servingv1alpha1.DomainMapping) *servingv1alpha1.DomainMapping {
-	dm, err := ctx.Clients.Serving.ServingV1alpha1().DomainMappings(dm.Namespace).Create(context.Background(), dm, metav1.CreateOptions{})
+func withDomainMappingReadyOrFail(ctx *test.Context, dm *servingv1beta1.DomainMapping) *servingv1beta1.DomainMapping {
+	dm, err := ctx.Clients.Serving.ServingV1beta1().DomainMappings(dm.Namespace).Create(context.Background(), dm, metav1.CreateOptions{})
 	if err != nil {
 		ctx.T.Fatalf("Error creating ksvc: %v", err)
 	}
@@ -21,7 +21,7 @@ func withDomainMappingReadyOrFail(ctx *test.Context, dm *servingv1alpha1.DomainM
 	// Let the ksvc be deleted after test
 	ctx.AddToCleanup(func() error {
 		ctx.T.Logf("Cleaning up Knative Service '%s/%s'", dm.Namespace, dm.Name)
-		return ctx.Clients.Serving.ServingV1alpha1().DomainMappings(dm.Namespace).Delete(context.Background(), dm.Name, metav1.DeleteOptions{})
+		return ctx.Clients.Serving.ServingV1beta1().DomainMappings(dm.Namespace).Delete(context.Background(), dm.Name, metav1.DeleteOptions{})
 	})
 
 	dm, err = test.WaitForDomainMappingState(ctx, dm.Name, dm.Namespace, test.IsDomainMappingReady)


### PR DESCRIPTION
As per title, this patch changes to use v1beta1 DomainMapping CRD.
The change is only for some test codes and metadata-webhook which is also used only by test.