### PR TITLE
Create SOP for knative_up != 1

### DIFF
--- a/docs/sops/README.md
+++ b/docs/sops/README.md
@@ -1,0 +1,3 @@
+# OpenShift Serverless SOPS
+
+This directory contains SOPS for common issues for OpenShift Serverless.

--- a/docs/sops/README.md
+++ b/docs/sops/README.md
@@ -1,3 +1,3 @@
-# OpenShift Serverless SOPS
+# OpenShift Serverless Standard Operating Procedures (SOPs)
 
-This directory contains SOPS for common issues for OpenShift Serverless.
+This directory contains Standard Operating Procedures (SOPs) for common issues for OpenShift Serverless.

--- a/docs/sops/serverless-controller-knative-up.md
+++ b/docs/sops/serverless-controller-knative-up.md
@@ -9,9 +9,9 @@ This means, any new Knative Services might not be created, and any existing Knat
 
 ## Summary
 
-OpenShift Serverless does not create any alerts out-of-the box. However, users can create alerts based on the metrics exposed.
+OpenShift Serverless does not create any alerts out-of-the box. However, users can create alerts based on the gauges and metrics exposed.
 
-The metric `knative_up{namespace="openshift-serverless", type="serving_status"}` should always have a value of `1`. 
+The gauge `knative_up{namespace="openshift-serverless", type="serving_status"}` should always have a value of `1`.  You should create an alert as described in https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0/ for using this gauge and measure it over some period of time.
 
 This failure should only occur in extremely catastrophic scenarios as all components are deployed in HA configuration.
 

--- a/docs/sops/serverless-controller-knative-up.md
+++ b/docs/sops/serverless-controller-knative-up.md
@@ -142,7 +142,7 @@ $ oc -n knative-serving-ingress rollout restart deployments -l app.kubernetes.io
 
 This should result in new pods getting deployed, attempt step (8) again and see if the pods achieve running state.
 
-11. If Istio (or Red Hat OpenShift OpenShift Service Mesh) is used as the Knative Serving Ingress, check its status. You may find the SOPs for Istio (Red Hat OpenShift OpenShift Service Mesh) by contacting Istio (Red Hat OpenShift OpenShift Service Mesh) support. 
+11. If Istio (or Red Hat OpenShift OpenShift Service Mesh) is used as the Knative Serving Ingress, check its status. You may find the SOPs for Istio (Red Hat OpenShift OpenShift Service Mesh) by contacting Istio (Red Hat OpenShift OpenShift Service Mesh) support via their [mailing list](https://groups.google.com/a/redhat.com/g/service-mesh-sme?pli=1) and [Slack channel](https://redhat-internal.slack.com/archives/C01R9E3SFEV). 
 
 12. If the problem persists, capture the logs and escalate to OpenShift Serverless engineering team.
 

--- a/docs/sops/serverless-controller-knative-up.md
+++ b/docs/sops/serverless-controller-knative-up.md
@@ -22,6 +22,10 @@ Possible causes can be:
 
 You should check both OpenShift Serverless operator and Knative Serving control plane status.
 
+## Prerequisites
+
+1. You must have admin access to the cluster via `oc` CLI.
+
 ## Steps
 
 1. Check to see if all the pods are running in `openshift-serverless` namespace:
@@ -48,7 +52,7 @@ $ done
 $ oc -n openshift-serverless get events
 
 # Check pod status fields
-$ oc -n openshift-serverless get pods -o jsonpath="{range .items[*]}{.status}{\"\n\n\"}{end}"
+$ oc -n openshift-serverless get pods -o jsonpath="{range .items[*]}{.status}{\"\n\n\"}{end}" 
 ```
 
 3. Redeploy any failing controllers by restarting the deployments:

--- a/docs/sops/serverless-controller-knative-up.md
+++ b/docs/sops/serverless-controller-knative-up.md
@@ -92,6 +92,6 @@ $ oc -n knative-serving rollout restart deployments -l app.kubernetes.io/name=kn
 
 This should result in new pods getting deployed, attempt step (5) again and see if the pods achieve running state.
 
-8. If the problem persists, capture the logs and escalate to OpenShift Serverless engineering team.
+8. If the problem persists, capture the logs and escalate to OpenShift Serverless engineering team with a Knative ["must-gather"](https://github.com/openshift-knative/must-gather) dump.
 
 

--- a/docs/sops/serverless-controller-knative-up.md
+++ b/docs/sops/serverless-controller-knative-up.md
@@ -61,14 +61,14 @@ $ oc -n openshift-serverless get pods
 
 ```bash
 # Get Pod names as we don't have a common label
-$ SERVERLESS_OPERATOR_POD_NAMES_STR=$(oc -n openshift-serverless get pods --template '{{range .items}}{{.metadata.name}}{{" "}}{{end}}')
-$ SERVERLESS_OPERATOR_POD_NAMES=($(echo "$SERVERLESS_OPERATOR_POD_NAMES_STR" | tr ' ' '\n'))
+SERVERLESS_OPERATOR_POD_NAMES_STR=$(oc -n openshift-serverless get pods --template '{{range .items}}{{.metadata.name}}{{" "}}{{end}}')
+SERVERLESS_OPERATOR_POD_NAMES=($(echo "$SERVERLESS_OPERATOR_POD_NAMES_STR" | tr ' ' '\n'))
 
 # Check pod logs
-$ for element in "${SERVERLESS_OPERATOR_POD_NAMES[@]}"
-$ do
-$     oc -n openshift-serverless logs "$element" --prefix=true
-$ done
+for element in "${SERVERLESS_OPERATOR_POD_NAMES[@]}"
+do
+     oc -n openshift-serverless logs "$element" --prefix=true
+done
 
 
 # Check events 
@@ -81,9 +81,9 @@ $ oc -n openshift-serverless get pods -o jsonpath="{range .items[*]}{.status}{\"
 3. Redeploy any failing controllers by restarting the deployments:
 
 ```bash
-$ oc -n openshift-serverless rollout restart deployments/knative-openshift
-$ oc -n openshift-serverless rollout restart deployments/knative-openshift-ingress
-$ oc -n openshift-serverless rollout restart deployments/knative-operator-webhook
+oc -n openshift-serverless rollout restart deployments/knative-openshift
+oc -n openshift-serverless rollout restart deployments/knative-openshift-ingress
+oc -n openshift-serverless rollout restart deployments/knative-operator-webhook
 ```
 
 This should result in new pods getting deployed, attempt step (1) again and see if the pods achieve running state.

--- a/docs/sops/serverless-controller-knative-up.md
+++ b/docs/sops/serverless-controller-knative-up.md
@@ -47,7 +47,7 @@ If the output is not empty, check which Ingress is used by looking at which ingr
     enabled: false
 ```
 
-In this case, Istio is used as the Knative Serving Ingress.
+In this case, Istio (or Red Hat OpenShift OpenShift Service Mesh) is used as the Knative Serving Ingress.
 
 ## Steps
 
@@ -142,8 +142,8 @@ $ oc -n knative-serving-ingress rollout restart deployments -l app.kubernetes.io
 
 This should result in new pods getting deployed, attempt step (8) again and see if the pods achieve running state.
 
-11. If Istio is used as the Knative Serving Ingress, check Istio status. You may find the SOPs for Istio by contacting Istio support. 
+11. If Istio (or Red Hat OpenShift OpenShift Service Mesh) is used as the Knative Serving Ingress, check its status. You may find the SOPs for Istio (Red Hat OpenShift OpenShift Service Mesh) by contacting Istio (Red Hat OpenShift OpenShift Service Mesh) support. 
 
-12. If the problem persists, capture the logs and escalate to OpenShift Serverless engineering team with a Knative ["must-gather"](https://github.com/openshift-knative/must-gather) dump.
+12. If the problem persists, capture the logs and escalate to OpenShift Serverless engineering team.
 
 

--- a/docs/sops/serverless-controller-knative-up.md
+++ b/docs/sops/serverless-controller-knative-up.md
@@ -1,0 +1,93 @@
+# OpenShift Serverless Knative Serving Control Plane Readiness
+
+## Severity: Critical
+
+## Impact
+
+Any users or services using Knative Serving will be unable to get their Knative Services reconciled.
+This means, any new Knative Services might not be created, and any existing Knative Services might not be updated. Also, it might also mean that the user workload is not being served.
+
+## Summary
+
+OpenShift Serverless does not create any alerts out-of-the box. However, users can create alerts based on the metrics exposed.
+
+The metric `knative_up{namespace="openshift-serverless", type="serving_status"}` should always have a value of `1`. 
+
+This failure should only occur in extremely catastrophic scenarios as all components are deployed in HA configuration.
+
+Possible causes can be:
+- Network issues in the cluster
+- Resource starvation on the cluster
+- OpenShift Serverless upgrade issues
+
+You should check both OpenShift Serverless operator and Knative Serving control plane status.
+
+## Steps
+
+1. Check to see if all the pods are running in `openshift-serverless` namespace:
+
+```bash
+$ oc -n openshift-serverless get pods
+```
+
+2. If they are not running, look at the pod's logs/events to see what may be causing the issues. Please make sure to grab the logs/events so they can be shared with the engineering team later:
+
+```bash
+# Get Pod names as we don't have a common label
+$ SERVERLESS_OPERATOR_POD_NAMES_STR=$(oc -n openshift-serverless get pods --template '{{range .items}}{{.metadata.name}}{{" "}}{{end}}')
+$ SERVERLESS_OPERATOR_POD_NAMES=($(echo "$SERVERLESS_OPERATOR_POD_NAMES_STR" | tr ' ' '\n'))
+
+# Check pod logs
+$ for element in "${SERVERLESS_OPERATOR_POD_NAMES[@]}"
+$ do
+$     oc -n openshift-serverless logs "$element" --prefix=true
+$ done
+
+
+# Check events 
+$ oc -n openshift-serverless get events
+
+# Check pod status fields
+$ oc -n openshift-serverless get pods -o jsonpath="{range .items[*]}{.status}{\"\n\n\"}{end}"
+```
+
+3. Redeploy any failing controllers by restarting the deployments:
+
+```bash
+$ oc -n openshift-serverless rollout restart deployments/knative-openshift
+$ oc -n openshift-serverless rollout restart deployments/knative-openshift-ingress
+$ oc -n openshift-serverless rollout restart deployments/knative-operator-webhook
+```
+
+This should result in new pods getting deployed, attempt step (1) again and see if the pods achieve running state.
+
+5. Check to see if all the pods are running in `knative-serving` namespace:
+
+```bash
+$ oc -n knative-serving get pods -l app.kubernetes.io/name=knative-serving
+``` 
+
+6. If they are not running, look at the pod's logs/events to see what may be causing the issues. Please make sure to grab the logs/events so they can be shared with the engineering team later:
+
+```bash
+# Check pod logs 
+$ oc -n knative-serving logs -l app.kubernetes.io/name=knative-serving --prefix=true
+
+# Check events 
+$ oc -n knative-serving get events | grep pod
+
+# Check pod status fields
+$ oc -n knative-serving get pods -l app.kubernetes.io/name=knative-serving -o jsonpath="{range .items[*]}{.status}{\"\n\n\"}{end}"
+```
+
+7. Redeploy Knative Serving controllers by restarting the deployments:
+
+```bash
+$ oc -n knative-serving rollout restart deployments -l app.kubernetes.io/name=knative-serving
+```
+
+This should result in new pods getting deployed, attempt step (5) again and see if the pods achieve running state.
+
+8. If the problem persists, capture the logs and escalate to OpenShift Serverless engineering team.
+
+


### PR DESCRIPTION
Create a simple SOP for the case where `knative_up` metric is not `1`.

Users/services can create an alert on their own, using this metric and can use this document as a SOP for that alert.

cc @ReToCode 
cc @lberk 
cc @skonto 

@jewzaam is this a good SOP? Could please take a look?

@danielezonca is this usable for your project?



