### PR TITLE
Fix upgrade sequence for kitchensink tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ test-upgrade-with-mesh:
 test-kitchensink-upgrade:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	./hack/dev.sh
-	INSTALL_OLDEST_COMPATIBLE="true" INSTALL_KAFKA="true" ./hack/install.sh
+	INSTALL_OLDEST_COMPATIBLE="true" INSTALL_KAFKA="true" SCALE_UP=4 ./hack/install.sh
 	./test/kitchensink-upgrade-tests.sh
 
 test-kitchensink-upgrade-testonly:

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -17,7 +17,7 @@ function ensure_serverless_installed {
   local csv
   if [[ "${INSTALL_OLDEST_COMPATIBLE}" == "true" ]]; then
     csv="$(metadata.get "upgrade_sequence[0].csv")"
-    OLM_SOURCE="$(metadata.get "upgrade_sequence[0].source")"
+    OLM_SOURCE=redhat-operators
   elif [[ "${INSTALL_PREVIOUS_VERSION}" == "true" ]]; then
     csv="$PREVIOUS_CSV"
   else

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -68,9 +68,7 @@ dependencies:
 upgrade_sequence:
     - csv: serverless-operator.v1.29.0
       source: redhat-operators
-    - csv: serverless-operator.v1.29.1
-      source: redhat-operators
     - csv: serverless-operator.v1.30.0
-      source: serverless-operator
+      source: redhat-operators
     - csv: serverless-operator.v1.31.0
       source: serverless-operator

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -67,8 +67,5 @@ dependencies:
         eventing_kafka_broker: knative-v1.9
 upgrade_sequence:
     - csv: serverless-operator.v1.29.0
-      source: redhat-operators
     - csv: serverless-operator.v1.30.0
-      source: redhat-operators
     - csv: serverless-operator.v1.31.0
-      source: serverless-operator

--- a/test/installplan.go
+++ b/test/installplan.go
@@ -13,9 +13,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func WaitForInstallPlan(ctx *Context, namespace string, csvName, olmSource string) (*operatorsv1alpha1.InstallPlan, error) {
+func WaitForInstallPlan(ctx *Context, namespace string, csvName, olmSource string, timeout time.Duration) (*operatorsv1alpha1.InstallPlan, error) {
 	var plan *operatorsv1alpha1.InstallPlan
-	if waitErr := wait.PollImmediate(Interval, 15*time.Minute, func() (bool, error) {
+	if waitErr := wait.PollImmediate(Interval, timeout, func() (bool, error) {
 		installPlans, err := ctx.Clients.OLM.OperatorsV1alpha1().InstallPlans(namespace).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return false, err

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -480,7 +480,6 @@ function kitchensink_upgrade_tests {
      --kubeconfigs="${KUBECONFIG}" \
      --images.producer.file="${images_file}" \
      --imagetemplate="${IMAGE_TEMPLATE}" \
-     --catalogsource="$(metadata.get "upgrade_sequence[*].source" | tail -n +2 | tr '\n' ',')" \
      --csv="$(metadata.get "upgrade_sequence[*].csv" | tail -n +2 | tr '\n' ',')" \
      --upgradechannel="${OLM_UPGRADE_CHANNEL}"
 

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -29,11 +29,17 @@ func UpgradeServerlessTo(ctx *test.Context, csv, source string, timeout time.Dur
 		if !strings.Contains(err.Error(), "not found") {
 			return err
 		}
-		// InstallPlan not found in the original catalog source, try the one that was just built.
-		installPlan, err = test.WaitForInstallPlan(ctx,
-			test.OperatorsNamespace, csv, test.ServerlessOperatorPackage, timeout)
-		if err != nil {
-			return err
+		if source != test.ServerlessOperatorPackage {
+			// InstallPlan not found in the original catalog source, try the one that was just built.
+			if _, err := test.UpdateSubscriptionChannelSource(ctx,
+				test.Flags.Subscription, test.Flags.UpgradeChannel, test.ServerlessOperatorPackage); err != nil {
+				return err
+			}
+			installPlan, err = test.WaitForInstallPlan(ctx,
+				test.OperatorsNamespace, csv, test.ServerlessOperatorPackage, timeout)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -133,7 +139,7 @@ func DowngradeServerless(ctx *test.Context) error {
 		return err
 	}
 
-	installPlan, err := test.WaitForInstallPlan(ctx, test.OperatorsNamespace, test.Flags.CSVPrevious, test.Flags.CatalogSource)
+	installPlan, err := test.WaitForInstallPlan(ctx, test.OperatorsNamespace, test.Flags.CSVPrevious, test.Flags.CatalogSource, DefaultInstallPlanTimeout)
 	if err != nil {
 		return err
 	}

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -2,6 +2,7 @@ package installation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -26,7 +28,7 @@ func UpgradeServerlessTo(ctx *test.Context, csv, source string, timeout time.Dur
 
 	installPlan, err := test.WaitForInstallPlan(ctx, test.OperatorsNamespace, csv, source, timeout)
 	if err != nil {
-		if !strings.Contains(err.Error(), "not found") {
+		if !errors.Is(err, wait.ErrWaitTimeout) {
 			return err
 		}
 		if source != test.ServerlessOperatorPackage {

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -98,11 +98,7 @@ func TestKitchensink(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(featureGroup), func(i, j int) { featureGroup[i], featureGroup[j] = featureGroup[j], featureGroup[i] })
 
-	sources := strings.Split(strings.Trim(test.Flags.CatalogSource, ","), ",")
 	csvs := strings.Split(strings.Trim(test.Flags.CSV, ","), ",")
-	if len(sources) != len(csvs) {
-		t.Fatal("The number of operator sources and CSVs for upgrades must match")
-	}
 
 	// Split features across upgrades.
 	groups := featureGroup.Split(len(csvs))
@@ -129,8 +125,6 @@ func TestKitchensink(t *testing.T) {
 				post = append(post, featureGroup.PostDowngradeTests()...)
 			}
 
-			source := sources[i]
-
 			suite := pkgupgrade.Suite{
 				Tests: pkgupgrade.Tests{
 					// Run pre-upgrade tests only for given sub-group
@@ -140,7 +134,7 @@ func TestKitchensink(t *testing.T) {
 				Installations: pkgupgrade.Installations{
 					UpgradeWith: []pkgupgrade.Operation{
 						pkgupgrade.NewOperation("UpgradeServerless", func(c pkgupgrade.Context) {
-							if err := installation.UpgradeServerlessTo(ctx, csv, source); err != nil {
+							if err := installation.UpgradeServerlessTo(ctx, csv, "redhat-operators", 3*time.Minute); err != nil {
 								c.T.Error("Serverless upgrade failed:", err)
 							}
 						}),


### PR DESCRIPTION
* 1.30.0 now replaces 1.29.0 so 1.29.1 is not offered for upgrades
* 1.30.0 was released so it's not in redhat-operators Catalog Sourec

Should fix failures like [this one](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.10-upgrade-kitchensink-ocp-410-continuous/1704801507704049664

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
