### PR TITLE
Fix typo in metadata-webhook

### DIFF
--- a/serving/metadata-webhook/cmd/webhook/main.go
+++ b/serving/metadata-webhook/cmd/webhook/main.go
@@ -18,10 +18,10 @@ import (
 )
 
 var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
-	servingv1.SchemeGroupVersion.WithKind("Service"):           &defaults.TargetKService{},
-	servingv1.SchemeGroupVersion.WithKind("Route"):             &defaults.TargetRoute{},
-	servingv1.SchemeGroupVersion.WithKind("Configurtion"):      &defaults.TargetConfiguration{},
-	servingv1beta1.SchemeGroupVersion.WithKind("DomainMappig"): &defaults.TargetDomainMapping{},
+	servingv1.SchemeGroupVersion.WithKind("Service"):            &defaults.TargetKService{},
+	servingv1.SchemeGroupVersion.WithKind("Route"):              &defaults.TargetRoute{},
+	servingv1.SchemeGroupVersion.WithKind("Configuration"):      &defaults.TargetConfiguration{},
+	servingv1beta1.SchemeGroupVersion.WithKind("DomainMapping"): &defaults.TargetDomainMapping{},
 }
 
 func NewDefaultingAdmissionController(ctx context.Context, _ configmap.Watcher) *controller.Impl {

--- a/serving/metadata-webhook/config/webhook.yaml
+++ b/serving/metadata-webhook/config/webhook.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: controller
       containers:
       - name: webhook
-        image: registry.ci.openshift.org/knative/openshift-serverless-nightly:metadata-webhook
+        image: gcr.io/gcp-compute-engine-223401/webhook-b7df1373529077cf183b940dd39dc62a@sha256:943e35a04d09f6fab499e6eb05acb24ec859fedc1025c8671ee4006b7af1cc94
         resources:
           requests:
             cpu: 20m

--- a/serving/metadata-webhook/config/webhook.yaml
+++ b/serving/metadata-webhook/config/webhook.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: controller
       containers:
       - name: webhook
-        image: gcr.io/gcp-compute-engine-223401/webhook-b7df1373529077cf183b940dd39dc62a@sha256:943e35a04d09f6fab499e6eb05acb24ec859fedc1025c8671ee4006b7af1cc94
+        image: registry.ci.openshift.org/knative/openshift-serverless-nightly:metadata-webhook
         resources:
           requests:
             cpu: 20m


### PR DESCRIPTION
This patch fixes a typo included in https://github.com/openshift-knative/serverless-operator/commit/f73342fba4866f09cad95da6389ea04d1a9f7087