### PR TITLE
Specify --channel param for upgrade tests

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -416,6 +416,7 @@ EOF
     "--imagetemplate=${image_template}" \
     "--images.producer.file=${images_file}" \
     "--catalogsource=${OLM_SOURCE}" \
+    "--channel=${OLM_CHANNEL}" \
     "--upgradechannel=${OLM_UPGRADE_CHANNEL}" \
     "--csv=${CURRENT_CSV}" \
     "--csvprevious=${PREVIOUS_CSV}" \


### PR DESCRIPTION
When performing downgrade we need to use test.Flags.Channel otherwise default channel will be used for the given OCP version. And that version might be different than what we want (e.g. stable-1.29 instead of desired "stable"), resulting in InstallPlan not being found.

Should fix issue from https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.10-upgrade-tests-aws-ocp-410-continuous/1706851266522517504:
```
upgrade.go:23: Serverless downgrade failed: installplan for CSV serverless-operator.v1.30.0 and OLM source serverless-operator not found: timed out waiting for the condition
```
The Subscription reports this status:
```
- message: 'constraints not satisfiable: serverless-operator/openshift-marketplace/stable-1.29/serverless-operator.v1.30.0,
      serverless-operator/openshift-marketplace/stable/serverless-operator.v1.30.0,
      @existing/openshift-serverless//serverless-operator.v1.30.0, serverless-operator/openshift-marketplace/stable-1.31/serverless-operator.v1.30.0
      and serverless-operator/openshift-marketplace/stable-1.30/serverless-operator.v1.30.0
      provide KnativeServing (operator.knative.dev/v1beta1), clusterserviceversion
      serverless-operator.v1.30.0 exists and is not referenced by a subscription,
      subscription serverless-operator requires at least one of serverless-operator/openshift-marketplace/stable-1.31/serverless-operator.v1.30.0,
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
