### PR TITLE
Disable tracing test if no Jaeger present

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -139,6 +139,11 @@ function downstream_serving_e2e_tests {
       mv ./test/servinge2e/user_permissions_test.go ./test/servinge2e/user_permissions_notest.go || true
   fi
 
+  # Tracing tests require Jaeger to be installed.
+  if [[ $(oc get pods -l app=jaeger --no-headers -n "$TRACING_NAMESPACE" | wc -l) -eq 0 ]]; then
+    mv ./test/servinge2e/tracing_test.go ./test/servinge2e/tracing_notest.go || true
+  fi
+
   if [[ $FULL_MESH == "true" ]]; then
     go_test_e2e "${RUN_FLAGS[@]}" ./test/servinge2e/ ./test/servinge2e/servicemesh/ \
       --kubeconfigs "${kubeconfigs_str}" \

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -139,11 +139,6 @@ function downstream_serving_e2e_tests {
       mv ./test/servinge2e/user_permissions_test.go ./test/servinge2e/user_permissions_notest.go || true
   fi
 
-  # Tracing tests require Jaeger to be installed.
-  if [[ $(oc get pods -l app=jaeger --no-headers -n "$TRACING_NAMESPACE" | wc -l) -eq 0 ]]; then
-    mv ./test/servinge2e/tracing_test.go ./test/servinge2e/tracing_notest.go || true
-  fi
-
   if [[ $FULL_MESH == "true" ]]; then
     go_test_e2e "${RUN_FLAGS[@]}" ./test/servinge2e/ ./test/servinge2e/servicemesh/ \
       --kubeconfigs "${kubeconfigs_str}" \


### PR DESCRIPTION
Some scenarios use Zipkin and the tracing is only compatible with Jaeger.

The tracing test then fails with:
```
 tracing_test.go:74: Error verifying traces: timed out waiting for the condition: expecting exactly 1 jaeger pod, got 0
```

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
