### PR TITLE
SRVKE-1510: Support collecting PingSource metrics in mesh mode

### DIFF
--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -9,6 +9,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"k8s.io/client-go/rest"
+
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller"
@@ -17,12 +22,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativeeventing"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativekafka"
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/webhook/knativeserving"
-	"github.com/spf13/pflag"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"k8s.io/client-go/rest"
 
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleutil"
 	configv1 "github.com/openshift/api/config/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/controller/knativeserving/consoleutil"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -166,6 +168,11 @@ func setupServerlessOperatorMonitoring(cfg *rest.Config) error {
 	// If we upgrade from an old version we need to remove the old Service Monitor
 	// that is not managed by OLM. See SRVCOM-1237 for more.
 	if err = monitoring.RemoveOldServiceMonitorResourcesIfExist(namespace, cl); err != nil {
+		return err
+	}
+	// If we upgrade from an old version we need to remove the old Service Monitor
+	// that is not managed by OLM. It can be removed after SRVKE-1510 is out.
+	if err = monitoring.RemoveOldPingSourceServiceMonitorResourcesIfExist(cl); err != nil {
 		return err
 	}
 

--- a/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
+++ b/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
@@ -206,5 +206,5 @@ func (s skipNonSystemNamespaceSources) Update(e event.UpdateEvent) bool {
 }
 
 func (s skipNonSystemNamespaceSources) Create(e event.CreateEvent) bool {
-	return s.Generic(event.GenericEvent{Object: e.Object})
+	return s.Generic(event.GenericEvent(e))
 }

--- a/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
+++ b/knative-operator/pkg/monitoring/sources/source_deployment_discovery_controller.go
@@ -5,9 +5,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
-	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring"
-	okomon "github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -21,6 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/common"
+	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/monitoring"
+	okomon "github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/monitoring"
 )
 
 var (
@@ -64,7 +65,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		}
 		return nil
 	})
-	return c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, handler.EnqueueRequestsFromMapFunc(enqueueRequests), skipDeletePredicate{}, skipUpdatePredicate{})
+	return c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, handler.EnqueueRequestsFromMapFunc(enqueueRequests), skipDeletePredicate{}, skipNonSystemNamespaceSources{})
 }
 
 // blank assignment to verify that ReconcileSourceDeployment implements reconcile.Reconciler
@@ -184,13 +185,26 @@ func (skipDeletePredicate) Delete(_ event.DeleteEvent) bool {
 	return false
 }
 
-type skipUpdatePredicate struct {
-	predicate.Funcs
+var _ predicate.Predicate = skipNonSystemNamespaceSources{}
+
+type skipNonSystemNamespaceSources struct {
 }
 
-func (skipUpdatePredicate) Update(e event.UpdateEvent) bool {
+func (s skipNonSystemNamespaceSources) Delete(event.DeleteEvent) bool {
+	return false
+}
+
+func (s skipNonSystemNamespaceSources) Generic(e event.GenericEvent) bool {
 	// This controller does not handle source monitoring setup in knative-eventing ns when monitoring is set to off
 	// So it is safe to avoid pingsource-mt deployment updates, for example due to HPA
 	// Note that if users scale sources up and down in a user ns this will trigger source reconciliation
-	return e.ObjectOld.GetNamespace() != "knative-eventing"
+	return e.Object.GetNamespace() != "knative-eventing"
+}
+
+func (s skipNonSystemNamespaceSources) Update(e event.UpdateEvent) bool {
+	return s.Generic(event.GenericEvent{Object: e.ObjectNew})
+}
+
+func (s skipNonSystemNamespaceSources) Create(e event.CreateEvent) bool {
+	return s.Generic(event.GenericEvent{Object: e.Object})
 }

--- a/openshift-knative-operator/pkg/monitoring/helpers.go
+++ b/openshift-knative-operator/pkg/monitoring/helpers.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	mf "github.com/manifestival/manifestival"
-	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -19,6 +18,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/operator/pkg/apis/operator/base"
 	"knative.dev/pkg/logging"
+
+	"github.com/openshift-knative/serverless-operator/openshift-knative-operator/pkg/common"
 )
 
 const (
@@ -255,6 +256,8 @@ func getSelectorLabels(component string) map[string]string {
 		labels["eventing.knative.dev/brokerRole"] = "ingress"
 	case "kafka-controller-manager":
 		labels["control-plane"] = "kafka-controller-manager"
+	case "pingsource-mt-adapter":
+		labels["app.kubernetes.io/component"] = component
 	default:
 		labels["app"] = component
 	}

--- a/openshift-knative-operator/pkg/monitoring/monitoring_eventing.go
+++ b/openshift-knative-operator/pkg/monitoring/monitoring_eventing.go
@@ -11,7 +11,17 @@ import (
 )
 
 var (
-	eventingDeployments = sets.NewString("eventing-controller", "eventing-istio-controller", "eventing-webhook", "imc-controller", "imc-dispatcher", "mt-broker-controller", "mt-broker-filter", "mt-broker-ingress")
+	eventingDeployments = sets.NewString(
+		"eventing-controller",
+		"eventing-istio-controller",
+		"eventing-webhook",
+		"imc-controller",
+		"imc-dispatcher",
+		"mt-broker-controller",
+		"mt-broker-filter",
+		"mt-broker-ingress",
+		"pingsource-mt-adapter",
+	)
 )
 
 func ReconcileMonitoringForEventing(ctx context.Context, api kubernetes.Interface, ke *operatorv1beta1.KnativeEventing) error {


### PR DESCRIPTION
PingSource monitoring is now part of the system components monitoring as opposed to previously that was considered part of the Source monitoring without any rbac-proxy sidecar.

![image](https://github.com/openshift-knative/serverless-operator/assets/33736985/0a5f9945-5417-417d-bef4-62a48b2a49ac)

Full mesh with 3 containers (pingsource adapter, rbac-proxy, and istio proxy)
```
pierdipi@pierdipi serverless-operator (main) $ k get pods -n knative-eventing 
NAME                                                  READY   STATUS      RESTARTS      AGE
pingsource-mt-adapter-c96d84ff9-4pmfc                 3/3     Running     0             16m
```

Thanks for the help @skonto @maschmid 