### PR TITLE
Trying to fix the bump automation for istio authz chart bump

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -58,8 +58,8 @@ jobs:
           echo "RELEASE_BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Bump chart version
-        working-directory: ./src/github.com/openshift-knative/knative-istio-authz-chart
-        run: go run hack/cmd/bumpistiochart/bumpistiochart.go --branch "${RELEASE_BRANCH}"
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: go run hack/cmd/bumpistiochart/bumpistiochart.go --branch "${RELEASE_BRANCH}" --chart-metadata-path "${{ github.workspace }}/src/github.com/openshift-knative/knative-istio-authz-chart/Chart.yaml"
 
       - name: Create branch
         working-directory: ./src/github.com/openshift-knative/knative-istio-authz-chart


### PR DESCRIPTION
- set the chart absolute path into env variable
- go to SO path, run the tool with `go run ...` and point the tool to the chart absolute path, using the flag https://github.com/openshift-knative/serverless-operator/blob/2cc5e46b1cdfad082a67a59d4d618b171233747f/hack/cmd/bumpistiochart/bumpistiochart.go#L34


maybe fix https://github.com/openshift-knative/serverless-operator/actions/runs/6403506901/job/17382146920