### PR TITLE
Pass QE robot token when checking out helm chart in bump automation

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -45,6 +45,7 @@ jobs:
         with:
           repository: 'openshift-knative/knative-istio-authz-chart'
           path: ./src/github.com/openshift-knative/knative-istio-authz-chart
+          token: ${{ secrets.SERVERLESS_QE_ROBOT }}
           fetch-depth: 0
 
       - name: Set branch
@@ -65,10 +66,6 @@ jobs:
         working-directory: ./src/github.com/openshift-knative/knative-istio-authz-chart
         run: |
           set -euo pipefail
-          
-          git config --global user.email "serverless-support@redhat.com"
-          git config --global user.name "OpenShift Serverless"
-          git config --global user.password "${{ secrets.SERVERLESS_QE_ROBOT }}"
           
           # Check if target branch exists, otherwise create it starting from main
           if git show-ref --quiet refs/heads/${RELEASE_BRANCH}; then


### PR DESCRIPTION
This should fix the failed to push with 403 https://github.com/openshift-knative/serverless-operator/actions/runs/6405462417/job/17388514221

```
    # Personal access token (PAT) used to fetch the repository. The PAT is configured
    # with the local git config, which enables your scripts to run authenticated git
    # commands. The post-job step removes the PAT.
    #
    # We recommend using a service account with the least permissions necessary. Also
    # when generating a new PAT, select the least scopes necessary.
    #
    # [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
    #
    # Default: ${{ github.token }}
    token: ''
```