### PR TITLE
[SRVKS-1154] Do not configure default domain if anything is set

### DIFF
--- a/openshift-knative-operator/pkg/common/config.go
+++ b/openshift-knative-operator/pkg/common/config.go
@@ -35,9 +35,9 @@ func ConfigureIfUnset(s *base.CommonSpec, cm, key, value string) {
 	s.Config[cm][key] = value
 }
 
-// ConfigureIfUnsetAny sets a value in the config-domain if any configuration is not already set.
+// ConfigureIfConfigmapUnset sets a value in the given ConifgMap if any configuration is not already set.
 // For example, the config-domain can take an arbitrary domain as a key, so it should be used here.
-func ConfigureIfUnsetAny(s *base.CommonSpec, cm, key, value string) {
+func ConfigureIfConfigmapUnset(s *base.CommonSpec, cm, key, value string) {
 	if s.Config == nil {
 		s.Config = make(map[string]map[string]string, 1)
 	}

--- a/openshift-knative-operator/pkg/common/config.go
+++ b/openshift-knative-operator/pkg/common/config.go
@@ -35,9 +35,10 @@ func ConfigureIfUnset(s *base.CommonSpec, cm, key, value string) {
 	s.Config[cm][key] = value
 }
 
-// ConfigureIfUnsetDefaultDomain sets a value in the given ConfigMap under the given key if it is neither
-// already set the key nor another key becomes the default domain.
-func ConfigureIfUnsetDefaultDomain(s *base.CommonSpec, cm, key, value string) {
+// ConfigureIfUnsetDomain sets a value in the config-domain if it's not already set.
+// config-domain can take a domain as a key so it is different from ConfigureIfUnset.
+func ConfigureIfUnsetDefaultDomain(s *base.CommonSpec, key, value string) {
+	const cm = "domain"
 	if s.Config == nil {
 		s.Config = make(map[string]map[string]string, 1)
 	}

--- a/openshift-knative-operator/pkg/common/config.go
+++ b/openshift-knative-operator/pkg/common/config.go
@@ -34,3 +34,28 @@ func ConfigureIfUnset(s *base.CommonSpec, cm, key, value string) {
 	}
 	s.Config[cm][key] = value
 }
+
+// ConfigureIfUnsetDefaultDomain sets a value in the given ConfigMap under the given key if it is neither
+// already set the key nor another key becomes the default domain.
+func ConfigureIfUnsetDefaultDomain(s *base.CommonSpec, cm, key, value string) {
+	if s.Config == nil {
+		s.Config = make(map[string]map[string]string, 1)
+	}
+
+	if s.Config[cm] == nil {
+		s.Config[cm] = make(map[string]string, 1)
+	}
+
+	if _, ok := s.Config[cm][key]; ok {
+		// Already set, nothing to do here.
+		return
+	}
+
+	for _, v := range s.Config[cm] {
+		// Already set default domain (empty value), nothing to do here.
+		if v == "" {
+			return
+		}
+	}
+	s.Config[cm][key] = value
+}

--- a/openshift-knative-operator/pkg/common/config.go
+++ b/openshift-knative-operator/pkg/common/config.go
@@ -35,10 +35,9 @@ func ConfigureIfUnset(s *base.CommonSpec, cm, key, value string) {
 	s.Config[cm][key] = value
 }
 
-// ConfigureIfUnsetDomain sets a value in the config-domain if it's not already set.
-// config-domain can take a domain as a key so it is different from ConfigureIfUnset.
-func ConfigureIfUnsetDefaultDomain(s *base.CommonSpec, key, value string) {
-	const cm = "domain"
+// ConfigureIfUnsetAny sets a value in the config-domain if any configuration is not already set.
+// For example, the config-domain can take an arbitrary domain as a key, so it should be used here.
+func ConfigureIfUnsetAny(s *base.CommonSpec, cm, key, value string) {
 	if s.Config == nil {
 		s.Config = make(map[string]map[string]string, 1)
 	}

--- a/openshift-knative-operator/pkg/common/config.go
+++ b/openshift-knative-operator/pkg/common/config.go
@@ -46,16 +46,10 @@ func ConfigureIfUnsetDefaultDomain(s *base.CommonSpec, cm, key, value string) {
 		s.Config[cm] = make(map[string]string, 1)
 	}
 
-	if _, ok := s.Config[cm][key]; ok {
+	if len(s.Config[cm]) != 0 {
 		// Already set, nothing to do here.
 		return
 	}
 
-	for _, v := range s.Config[cm] {
-		// Already set default domain (empty value), nothing to do here.
-		if v == "" {
-			return
-		}
-	}
 	s.Config[cm][key] = value
 }

--- a/openshift-knative-operator/pkg/common/config_test.go
+++ b/openshift-knative-operator/pkg/common/config_test.go
@@ -110,6 +110,20 @@ func TestConfigureIfUnsetAny(t *testing.T) {
 			},
 		},
 	}, {
+		name: "override multiple entries",
+		in: base.ConfigMapData{
+			"foo": map[string]string{
+				"bar": "nope",
+				"qux": "baz",
+			},
+		},
+		expected: base.ConfigMapData{
+			"foo": map[string]string{
+				"bar": "nope",
+				"qux": "baz",
+			},
+		},
+	}, {
 		name: "unrelated values",
 		in: base.ConfigMapData{
 			"foo": map[string]string{

--- a/openshift-knative-operator/pkg/common/config_test.go
+++ b/openshift-knative-operator/pkg/common/config_test.go
@@ -75,7 +75,7 @@ func TestConfigure(t *testing.T) {
 	}
 }
 
-func TestConfigureIfUnsetAny(t *testing.T) {
+func TestConfigureIfConfigmapUnset(t *testing.T) {
 	cases := []struct {
 		name     string
 		in       base.ConfigMapData
@@ -146,7 +146,7 @@ func TestConfigureIfUnsetAny(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			s := &base.CommonSpec{Config: c.in}
-			ConfigureIfUnsetAny(s, "foo", "bar", "baz")
+			ConfigureIfConfigmapUnset(s, "foo", "bar", "baz")
 
 			if !cmp.Equal(s.Config, c.expected) {
 				t.Errorf("Got = %v, want: %v, diff:\n%s", s.Config, c.expected, cmp.Diff(s.Config, c.expected))

--- a/openshift-knative-operator/pkg/common/config_test.go
+++ b/openshift-knative-operator/pkg/common/config_test.go
@@ -74,3 +74,69 @@ func TestConfigure(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigureIfUnsetAny(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       base.ConfigMapData
+		expected base.ConfigMapData
+	}{{
+		name: "all nil",
+		expected: base.ConfigMapData{
+			"foo": map[string]string{
+				"bar": "baz",
+			},
+		},
+	}, {
+		name: "first level already set but empty configuration",
+		in: base.ConfigMapData{
+			"foo": map[string]string{},
+		},
+		expected: base.ConfigMapData{
+			"foo": map[string]string{
+				"bar": "baz",
+			},
+		},
+	}, {
+		name: "override",
+		in: base.ConfigMapData{
+			"foo": map[string]string{
+				"bar": "nope",
+			},
+		},
+		expected: base.ConfigMapData{
+			"foo": map[string]string{
+				"bar": "nope",
+			},
+		},
+	}, {
+		name: "unrelated values",
+		in: base.ConfigMapData{
+			"foo": map[string]string{
+				"bar2": "baz2",
+			},
+			"foo2": map[string]string{
+				"bar": "baz",
+			},
+		},
+		expected: base.ConfigMapData{
+			"foo": map[string]string{
+				"bar2": "baz2",
+			},
+			"foo2": map[string]string{
+				"bar": "baz",
+			},
+		},
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := &base.CommonSpec{Config: c.in}
+			ConfigureIfUnsetAny(s, "foo", "bar", "baz")
+
+			if !cmp.Equal(s.Config, c.expected) {
+				t.Errorf("Got = %v, want: %v, diff:\n%s", s.Config, c.expected, cmp.Diff(s.Config, c.expected))
+			}
+		})
+	}
+}

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -99,7 +99,7 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 	if domain, err := e.fetchClusterHost(ctx); err != nil {
 		return fmt.Errorf("failed to fetch cluster host: %w", err)
 	} else if domain != "" {
-		common.ConfigureIfUnsetDefaultDomain(&ks.Spec.CommonSpec, domain, "")
+		common.ConfigureIfUnsetAny(&ks.Spec.CommonSpec, "domain", domain, "")
 	}
 
 	// Attempt to locate kibana route which is available if openshift-logging has been configured

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -99,7 +99,7 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 	if domain, err := e.fetchClusterHost(ctx); err != nil {
 		return fmt.Errorf("failed to fetch cluster host: %w", err)
 	} else if domain != "" {
-		common.Configure(&ks.Spec.CommonSpec, "domain", domain, "")
+		common.ConfigureIfUnset(&ks.Spec.CommonSpec, "domain", domain, "")
 	}
 
 	// Attempt to locate kibana route which is available if openshift-logging has been configured

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -99,7 +99,7 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 	if domain, err := e.fetchClusterHost(ctx); err != nil {
 		return fmt.Errorf("failed to fetch cluster host: %w", err)
 	} else if domain != "" {
-		common.ConfigureIfUnset(&ks.Spec.CommonSpec, "domain", domain, "")
+		common.ConfigureIfUnsetDefaultDomain(&ks.Spec.CommonSpec, "domain", domain, "")
 	}
 
 	// Attempt to locate kibana route which is available if openshift-logging has been configured

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -99,7 +99,7 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 	if domain, err := e.fetchClusterHost(ctx); err != nil {
 		return fmt.Errorf("failed to fetch cluster host: %w", err)
 	} else if domain != "" {
-		common.ConfigureIfUnsetDefaultDomain(&ks.Spec.CommonSpec, "domain", domain, "")
+		common.ConfigureIfUnsetDefaultDomain(&ks.Spec.CommonSpec, domain, "")
 	}
 
 	// Attempt to locate kibana route which is available if openshift-logging has been configured

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -99,7 +99,7 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 	if domain, err := e.fetchClusterHost(ctx); err != nil {
 		return fmt.Errorf("failed to fetch cluster host: %w", err)
 	} else if domain != "" {
-		common.ConfigureIfUnsetAny(&ks.Spec.CommonSpec, "domain", domain, "")
+		common.ConfigureIfConfigmapUnset(&ks.Spec.CommonSpec, "domain", domain, "")
 	}
 
 	// Attempt to locate kibana route which is available if openshift-logging has been configured


### PR DESCRIPTION
Fixes JIRA [SRVKS-1154](https://issues.redhat.com/browse/SRVKS-1154)

## Proposed Changes

Currently default domain is always inserted into `config-domain`. It does not allow users to set the domain like `svc.cluster.local` by default.

Hence, this patch changes to use `ConfigureIfUnsetAny` for `config-domain`. User will be able to change the default domain to `svc.cluster.local`.