### PR TITLE
Pull Istio helm chart image only once in generator

### DIFF
--- a/hack/generate/mesh-auth-policies.sh
+++ b/hack/generate/mesh-auth-policies.sh
@@ -29,10 +29,14 @@ echo "Cleaning up old resources in $policies_path"
 rm -rf "$policies_path"
 mkdir -p "$policies_path"
 
+# Pull image template only once
+template_cache=$(mktemp -d)
+helm pull oci://quay.io/openshift-knative/knative-istio-authz-onboarding --version "$chart_version" -d "$template_cache" --untar
+
 for tenant in ${tenants//,/ }; do
   echo "Generating AuthorizationPolicies for tenant $tenant"
 
-  helm template oci://quay.io/openshift-knative/knative-istio-authz-onboarding --version "$chart_version" --set "name=$tenant" --set "namespaces={$tenant}" > "$policies_path/$tenant.yaml"
+  helm template "$template_cache/knative-istio-authz-onboarding" --version "$chart_version" --set "name=$tenant" --set "namespaces={$tenant}" > "$policies_path/$tenant.yaml"
 done
 
 echo "Istio AuthorizationPolicies successfully updated for version $chart_version"

--- a/hack/generate/mesh-auth-policies.sh
+++ b/hack/generate/mesh-auth-policies.sh
@@ -24,6 +24,8 @@ else
   chart_version="${ISTIO_CHART_VERSION}"
 fi
 
+helm version
+
 echo "Cleaning up old resources in $policies_path"
 
 rm -rf "$policies_path"


### PR DESCRIPTION
## Proposed Changes

- :broom:  Pull Istio helm chart image only once in generator

This change should address running into Quay API limits in generated files check. 

/cc @ReToCode @pierDipi 