### PR TITLE
separate execution of kitchensink e2e tests so they don't timeout on 2h CI step limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ test-ui-e2e:
 test-kitchensink-e2e-testonly:
 	./test/kitchensink-e2e-tests.sh
 
+# Run only a subset of e2e tests, e.g. "make test-kitchensink-e2e-single-testonly TEST=TestBroker"
 test-kitchensink-e2e-single-testonly:
 	./test/kitchensink-e2e-tests.sh -run $(TEST)
 
@@ -230,7 +231,11 @@ test-kitchensink-e2e-setup:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	SCALE_UP=4 INSTALL_KAFKA="true" ./hack/install.sh
 
-test-kitchensink-e2e: test-kitchensink-e2e-setup test-kitchensink-e2e-testonly
+test-kitchensink-e2e:
+	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
+	SCALE_UP=4 INSTALL_KAFKA="true" ./hack/install.sh
+	./test/kitchensink-e2e-tests.sh
+
 
 # Run all E2E tests.
 test-all-e2e:

--- a/Makefile
+++ b/Makefile
@@ -223,10 +223,14 @@ test-ui-e2e:
 test-kitchensink-e2e-testonly:
 	./test/kitchensink-e2e-tests.sh
 
-test-kitchensink-e2e:
+test-kitchensink-e2e-single-testonly:
+	./test/kitchensink-e2e-tests.sh -run $(TEST)
+
+test-kitchensink-e2e-setup:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	SCALE_UP=4 INSTALL_KAFKA="true" ./hack/install.sh
-	./test/kitchensink-e2e-tests.sh
+
+test-kitchensink-e2e: test-kitchensink-e2e-setup test-kitchensink-e2e-testonly
 
 # Run all E2E tests.
 test-all-e2e:

--- a/test/kitchensink-e2e-tests.sh
+++ b/test/kitchensink-e2e-tests.sh
@@ -17,6 +17,6 @@ logger.success '🚀 Cluster prepared for testing.'
 run_testselect
 
 # Run serverless-operator kitchensink tests.
-downstream_kitchensink_e2e_tests
+downstream_kitchensink_e2e_tests "$@"
 
 success


### PR DESCRIPTION
CI runs timeout most of the time since the added source tests, https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.13-e2e-kitchensink-ocp-413-continuous

- :broom: Add test-kitchensink-e2e-single-testonly target to be able to run tests separately
