### PR TITLE
Avoid running channel test in parallel for InMemory and Kafka

### DIFF
--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -256,13 +256,15 @@ func InMemoryChannelPostDowngradeTest() pkgupgrade.Operation {
 }
 
 func inMemoryChannelTest(t *testing.T) {
-	t.Parallel()
-
+	// Avoid using t.Parallel() to prevent race conditions on channel_impl.EnvCfg.ChannelGK.
 	ctx, env := defaultEnvironment(t)
 
 	if ic := environment.GetIstioConfig(ctx); ic.Enabled {
 		t.Skip("Enable when testing upgrades from 1.30 to 1.31")
 	}
+
+	channel_impl.EnvCfg.ChannelGK = "InMemoryChannel.messaging.knative.dev"
+	channel_impl.EnvCfg.ChannelV = "v1"
 
 	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
 		return subscription.WithSubscriber(ref, uri)


### PR DESCRIPTION
Fixes https://github.com/openshift-knative/serverless-operator/issues/2315

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Run test for InMemoryChannel first (non-parallel) and for KafkaChannel later in-parallel with other tests
- Make sure GVK is properly set for InMemoryChannel test even if KafkaChannel test runs first, to be on the safe side
