### PR TITLE
Use status codes from http package

### DIFF
--- a/test/eventinge2erekt/pingsource_ksvc_test.go
+++ b/test/eventinge2erekt/pingsource_ksvc_test.go
@@ -20,6 +20,6 @@ func TestPingSourceToKsvc(t *testing.T) {
 	env.Test(ctx, t, pingsource.SendsEventsWithSinkRef())
 
 	if ic := environment.GetIstioConfig(ctx); ic.Enabled {
-		env.Test(ctx, t, features.VerifyEncryptedTrafficToActivatorToApp(env.References(), since))
+		env.Test(ctx, t, features.VerifyEncryptedTrafficToActivatorToApp(since))
 	}
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/openshift-knative/serverless-operator/pull/2276

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Use status codes from http package
- Remove unused parameter in VerifyEncryptedTrafficToActivatorToApp