### PR TITLE
Create update generated files PR on push that are not for dependabot

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -82,7 +82,7 @@ jobs:
       #
       #   when it's manually triggered or a scheduled run.
       - name: Create Pull Request
-        if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || ( github.event_name == 'push' && !contains(github.ref_name, 'dependabot/') )
         uses: peter-evans/create-pull-request@v5
         with:
           path: ./src/github.com/${{ github.repository }}


### PR DESCRIPTION
This is an alternative to [1], we need the PR to be created on push events for release branches for the release automation but without touching dependabot PRs.

[1] https://github.com/openshift-knative/serverless-operator/commit/2575eb70145059b53c3276aaffba0aaf6c220cec