### PR TITLE
Remove workaround for SRVKE-1506

### DIFF
--- a/test/upgrade/kitchensink/kitchensink.go
+++ b/test/upgrade/kitchensink/kitchensink.go
@@ -125,12 +125,6 @@ func (fe *FeatureWithEnvironment) PostDowngrade() pkgupgrade.Operation {
 			td.Fn(fe.Context, c.T)
 		}
 
-		// Related to https://issues.redhat.com/browse/SRVKE-1506
-		// The tests are very quick and there might be cases when the reconciler doesn't manage to
-		// update resources in time. Deleting the namespace quickly might cause the resources to
-		// be stuck in FinalizeKind.
-		time.Sleep(30 * time.Second)
-
 		if err := fe.DeleteNamespace(); err != nil {
 			c.T.Error(err)
 		}


### PR DESCRIPTION
Serverless 1.31 now includes a proper fix for SRVKE-1506

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
