### PR TITLE
Bump strimzi 0.38.0 kafka 3.6.0

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -24,7 +24,7 @@ function install_strimzi_cluster {
       namespace: kafka
     spec:
       kafka:
-        version: 3.5.1
+        version: 3.6.0
         replicas: 3
         listeners:
           # PLAINTEXT
@@ -68,7 +68,7 @@ function install_strimzi_cluster {
           offsets.topic.replication.factor: 3
           transaction.state.log.replication.factor: 3
           transaction.state.log.min.isr: 2
-          inter.broker.protocol.version: "3.5"
+          inter.broker.protocol.version: "3.6"
           auto.create.topics.enable: "false"
         storage:
           type: jbod

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -11,7 +11,7 @@ fi
 # shellcheck disable=SC1091,SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/../../vendor/knative.dev/hack/e2e-tests.sh"
 
-export STRIMZI_VERSION=0.37.0
+export STRIMZI_VERSION=0.38.0
 
 # Adjust these when upgrading the knative versions.
 export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-$(metadata.get dependencies.serving)}"


### PR DESCRIPTION
## Proposed Changes

As per title. Doing bumps

- latest Strimzi upstream operator
- latest Apache Kafka version, available in the Strimzi operator
