### PR TITLE
fix(subscription): Fix ambiguous shortName

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.10/1-eventing-crds.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.10/1-eventing-crds.yaml
@@ -2279,7 +2279,7 @@ spec:
     - knative
     - messaging
     shortNames:
-    - sub
+    - ksub
   scope: Namespaced
 ---
 # Copyright 2020 The Knative Authors

--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.10/2-eventing-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.10/2-eventing-core.yaml
@@ -3502,7 +3502,7 @@ spec:
     - knative
     - messaging
     shortNames:
-    - sub
+    - ksub
   scope: Namespaced
 ---
 # Copyright 2020 The Knative Authors


### PR DESCRIPTION
`subscriptions.operators.coreos.com` and `subscriptions.messaging.knative.dev` both have shortName `sub` that is causing confusion for the client (`oc`). While using FQNs should be the best approach, there are documentations like this https://docs.openshift.com/container-platform/4.13/support/troubleshooting/troubleshooting-operator-issues.html#olm-status-viewing-cli_troubleshooting-operator-issues across openshift and there's a chance there may be scripts relying on `sub`. This is not a new issue and there's an outstanding debate as to whether this is a bug and how the client should handle such ambiguity, nothing is looking like a quick solution (see https://github.com/kubernetes/kubernetes/issues/108573#issuecomment-1084482540).

However, this is causing immediate problems when knative and coreos are being installed/used in a cluster. Further, due to the way how the version priority works wrt clients (Refer https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority), with the versions being the same, there's no guarantee which sub is returned when commands like `oc get sub` is called.

Since I'm not sure of the level of impact this has to the documentation across openshift, this PR may be a quick fix. I've opened a ticket for fixing the documentation (https://issues.redhat.com/browse/OCPBUGS-22092) but I'll let your team to decide taking this PR or close in favor of doc change or remove shortName altogether!

## Proposed Changes

:broom: Change shortName `sub` to `ksub`

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

