### PR TITLE
[RELEASE-1.32] Disable http2 for operator webhook

### DIFF
--- a/hack/patches/013-http2-CVE.patch
+++ b/hack/patches/013-http2-CVE.patch
@@ -11,3 +11,48 @@ index d2338d0b7..af34768cb 100644
  		GetCertificate: certWatcher.GetCertificate,
  		MinVersion:     tlsMinVersion,
  	}
+---
+diff --git a/vendor/knative.dev/pkg/webhook/webhook.go b/vendor/knative.dev/pkg/webhook/webhook.go
+index 435dfe38a..00fcd3c4a 100644
+--- a/vendor/knative.dev/pkg/webhook/webhook.go
++++ b/vendor/knative.dev/pkg/webhook/webhook.go
+@@ -63,6 +63,17 @@ type Options struct {
+ 	// GracePeriod is how long to wait after failing readiness probes
+ 	// before shutting down.
+ 	GracePeriod time.Duration
++
++	// EnableHTTP2 enables HTTP2 for webhooks.
++	// Mitigate CVE-2023-44487 by disabling HTTP2 by default until the Go
++	// standard library and golang.org/x/net are fully fixed.
++	// Right now, it is possible for authenticated and unauthenticated users to
++	// hold open HTTP2 connections and consume huge amounts of memory.
++	// See:
++	// * https://github.com/kubernetes/kubernetes/pull/121120
++	// * https://github.com/kubernetes/kubernetes/issues/121197
++	// * https://github.com/golang/go/issues/63417#issuecomment-1758858612
++	EnableHTTP2 bool
+ }
+
+ // Operation is the verb being operated on
+@@ -208,11 +219,18 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
+ 		QuietPeriod: wh.Options.GracePeriod,
+ 	}
+
++	// If TLSNextProto is not nil, HTTP/2 support is not enabled automatically.
++	nextProto := map[string]func(*http.Server, *tls.Conn, http.Handler){}
++	if wh.Options.EnableHTTP2 {
++		nextProto = nil
++	}
++
+ 	//nolint:gosec
+ 	server := &http.Server{
+-		Handler:   drainer,
+-		Addr:      fmt.Sprint(":", wh.Options.Port),
+-		TLSConfig: wh.tlsConfig,
++		Handler:      drainer,
++		Addr:         fmt.Sprint(":", wh.Options.Port),
++		TLSConfig:    wh.tlsConfig,
++		TLSNextProto: nextProto,
+ 	}
+
+ 	eg, ctx := errgroup.WithContext(ctx)

--- a/vendor/knative.dev/pkg/webhook/webhook.go
+++ b/vendor/knative.dev/pkg/webhook/webhook.go
@@ -64,6 +64,17 @@ type Options struct {
 	// GracePeriod is how long to wait after failing readiness probes
 	// before shutting down.
 	GracePeriod time.Duration
+
+	// EnableHTTP2 enables HTTP2 for webhooks.
+	// Mitigate CVE-2023-44487 by disabling HTTP2 by default until the Go
+	// standard library and golang.org/x/net are fully fixed.
+	// Right now, it is possible for authenticated and unauthenticated users to
+	// hold open HTTP2 connections and consume huge amounts of memory.
+	// See:
+	// * https://github.com/kubernetes/kubernetes/pull/121120
+	// * https://github.com/kubernetes/kubernetes/issues/121197
+	// * https://github.com/golang/go/issues/63417#issuecomment-1758858612
+	EnableHTTP2 bool
 }
 
 // Operation is the verb being operated on
@@ -237,11 +248,18 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
 		QuietPeriod: wh.Options.GracePeriod,
 	}
 
+	// If TLSNextProto is not nil, HTTP/2 support is not enabled automatically.
+	nextProto := map[string]func(*http.Server, *tls.Conn, http.Handler){}
+	if wh.Options.EnableHTTP2 {
+		nextProto = nil
+	}
+
 	//nolint:gosec
 	server := &http.Server{
-		Handler:   drainer,
-		Addr:      fmt.Sprint(":", wh.Options.Port),
-		TLSConfig: wh.tlsConfig,
+		Handler:      drainer,
+		Addr:         fmt.Sprint(":", wh.Options.Port),
+		TLSConfig:    wh.tlsConfig,
+		TLSNextProto: nextProto,
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Adds the missed patch for 1.30.2, see https://github.com/openshift-knative/serverless-operator/pull/2349#discussion_r1370006594. Other branches do have the fix because we run: `make update-deps --upgrade`, on this branch we didnt to avoid adding too many changes and so we missed it.

