### PR TITLE
split kitchensink e2e execution into separate go test runs for CI stability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,11 +231,15 @@ test-kitchensink-e2e-setup:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	SCALE_UP=4 INSTALL_KAFKA="true" ./hack/install.sh
 
+# Runs all subsets of kitchensink tests. Runs tests separately so `go test` doesn't take too much memory in CI
 test-kitchensink-e2e:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	SCALE_UP=4 INSTALL_KAFKA="true" ./hack/install.sh
-	./test/kitchensink-e2e-tests.sh
-
+	./test/kitchensink-e2e-tests.sh -run TestBrokerReadinessBrokerDLS
+	./test/kitchensink-e2e-tests.sh -run TestBrokerReadinessTriggerDLS
+	./test/kitchensink-e2e-tests.sh -run TestChannelReadiness
+	./test/kitchensink-e2e-tests.sh -run TestFlowReadiness
+	./test/kitchensink-e2e-tests.sh -run TestSourceReadiness
 
 # Run all E2E tests.
 test-all-e2e:

--- a/test/kitchensinke2e/broker_test.go
+++ b/test/kitchensinke2e/broker_test.go
@@ -8,7 +8,7 @@ import (
 	"knative.dev/reconciler-test/pkg/feature"
 )
 
-const groupSize = 4
+const groupSize = 8
 
 func TestBrokerReadinessBrokerDLS(t *testing.T) {
 	testFeatureSet(t, features.BrokerFeatureSetWithBrokerDLS())

--- a/test/kitchensinke2e/broker_test.go
+++ b/test/kitchensinke2e/broker_test.go
@@ -8,7 +8,7 @@ import (
 	"knative.dev/reconciler-test/pkg/feature"
 )
 
-const groupSize = 8
+const groupSize = 4
 
 func TestBrokerReadinessBrokerDLS(t *testing.T) {
 	testFeatureSet(t, features.BrokerFeatureSetWithBrokerDLS())

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -342,7 +342,7 @@ function downstream_kitchensink_e2e_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  RUN_FLAGS=(-failfast -timeout=120m -parallel=8)
+  RUN_FLAGS=(-failfast -timeout=240m -parallel=8)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi


### PR DESCRIPTION
SRVKE-1540 , attempt to reduce flakiness by reducing `groupSize`, thus having less scenarios deployed in parallel