### PR TITLE
fix pingsource metrics test

### DIFF
--- a/test/eventinge2erekt/pingsource_ksvc_test.go
+++ b/test/eventinge2erekt/pingsource_ksvc_test.go
@@ -1,6 +1,9 @@
 package eventinge2erekt
 
 import (
+	"context"
+	"github.com/openshift-knative/serverless-operator/test/monitoringe2e"
+	"knative.dev/reconciler-test/pkg/feature"
 	"testing"
 	"time"
 
@@ -18,8 +21,22 @@ func TestPingSourceToKsvc(t *testing.T) {
 	since := time.Now()
 
 	env.Test(ctx, t, pingsource.SendsEventsWithSinkRef())
+	env.Test(ctx, t, VerifyPingSourceMetrics())
 
 	if ic := environment.GetIstioConfig(ctx); ic.Enabled {
 		env.Test(ctx, t, features.VerifyEncryptedTrafficToActivatorToApp(since))
 	}
+}
+
+func VerifyPingSourceMetrics() *feature.Feature {
+	f := feature.NewFeature()
+
+	f.Stable("pingsource").
+		Must("has metrics", func(ctx context.Context, t feature.T) {
+			if err := monitoringe2e.VerifyMetrics(ctx, monitoringe2e.EventingPingSourceMetricQueries); err != nil {
+				t.Fatal("Failed to verify that PingSource data plane metrics work correctly", err)
+			}
+		})
+
+	return f
 }

--- a/test/eventinge2erekt/pingsource_ksvc_test.go
+++ b/test/eventinge2erekt/pingsource_ksvc_test.go
@@ -2,10 +2,11 @@ package eventinge2erekt
 
 import (
 	"context"
-	"github.com/openshift-knative/serverless-operator/test/monitoringe2e"
-	"knative.dev/reconciler-test/pkg/feature"
 	"testing"
 	"time"
+
+	"github.com/openshift-knative/serverless-operator/test/monitoringe2e"
+	"knative.dev/reconciler-test/pkg/feature"
 
 	"github.com/openshift-knative/serverless-operator/test/eventinge2erekt/features"
 	"knative.dev/eventing/test/rekt/features/pingsource"

--- a/test/monitoringe2e/helpers.go
+++ b/test/monitoringe2e/helpers.go
@@ -34,6 +34,9 @@ var (
 		"mt_broker_controller_go_mallocs",
 		"mt_broker_filter_go_mallocs",
 		"mt_broker_ingress_go_mallocs",
+	}
+
+	EventingPingSourceMetricQueries = []string{
 		"pingsource_event_count",
 	}
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

attempt to fix pingsource metrics test, e.g. failing in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/2368/pull-ci-openshift-knative-serverless-operator-main-4.13-operator-e2e-aws-ocp-413/1720329077899923456 

It seems to be failing because the metric is gone if pingsources are gone, so we move the metric test to the TestPingSourceToKsvc  (in the same way as we have moved namespaced broker metrics test to  TestSourceNamespacedKafkaBrokerKsvc )

## Proposed Changes
- :broom: Move pingsource metrics test to a test that has PingSource deployed