### PR TITLE
Use full path for coping to index and bundle image

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -108,8 +108,8 @@ function build_image {
 
   if ! oc get buildconfigs "$name" -n "$OLM_NAMESPACE" >/dev/null 2>&1; then
     logger.info "Create an image build for ${name}"
-    oc -n "${OLM_NAMESPACE}" new-build --binary \
-      --strategy=docker --name "$name"
+    oc -n "${OLM_NAMESPACE}" new-build \
+      --strategy=docker --name "$name" --dockerfile "$(cat "${build_dir}/Dockerfile")"
   else
     logger.info "${name} image build is already created"
   fi
@@ -124,7 +124,7 @@ function build_image {
       ! sha1sum --check --status "${rootdir}/_output/${name}.sha1sum"; then
     logger.info 'Build the image in the cluster-internal registry.'
     oc -n "${OLM_NAMESPACE}" start-build "${name}" \
-      --from-dir "${build_dir}" -F
+      --from-dir "${rootdir}" -F
     mkdir -p "${rootdir}/_output"
     find "${build_dir}" -type f -exec sha1sum {} + \
       > "${rootdir}/_output/${name}.sha1sum"

--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 
-COPY manifests /manifests
-COPY metadata/annotations.yaml /metadata/annotations.yaml
+COPY olm-catalog/serverless-operator/manifests /manifests
+COPY olm-catalog/serverless-operator/metadata/annotations.yaml /metadata/annotations.yaml
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -17,7 +17,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM opm
+FROM quay.io/openshift/origin-operator-registry:4.13
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -5,7 +5,7 @@ FROM quay.io/openshift/origin-base:4.13 as builder
 COPY --from=opm /bin/opm /bin/opm
 
 # Copy declarative config root into image at /configs
-COPY configs /configs
+COPY olm-catalog/serverless-operator/index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.30.0:serverless-bundle \

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -17,7 +17,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM opm
+FROM quay.io/openshift/origin-operator-registry:__OCP_MAX_VERSION__
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -5,7 +5,7 @@ FROM quay.io/openshift/origin-base:__OCP_MAX_VERSION__ as builder
 COPY --from=opm /bin/opm /bin/opm
 
 # Copy declarative config root into image at /configs
-COPY configs /configs
+COPY olm-catalog/serverless-operator/index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \

--- a/templates/main.Dockerfile
+++ b/templates/main.Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 
-COPY manifests /manifests
-COPY metadata/annotations.yaml /metadata/annotations.yaml
+COPY olm-catalog/serverless-operator/manifests /manifests
+COPY olm-catalog/serverless-operator/metadata/annotations.yaml /metadata/annotations.yaml
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/


### PR DESCRIPTION
Should be merged immediately after: https://github.com/openshift/release/pull/45387
The current CI config has this:
```
- context_dir: olm-catalog/serverless-operator/index
  from: opm
  to: serverless-index
```

The goal is to support the following where "context_path" is removed:
```
- dockerfile_path: olm-catalog/serverless-operator/index/Dockerfile
  from: opm
  to: serverless-index
```

This is for https://issues.redhat.com/browse/SRVCOM-2846

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
