### PR TITLE
project.yaml start upgrade sequence with 1.30.2

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -67,6 +67,6 @@ dependencies:
         eventing: knative-v1.10
         eventing_kafka_broker: knative-v1.10
 upgrade_sequence:
-    - csv: serverless-operator.v1.30.1
+    - csv: serverless-operator.v1.30.2
     - csv: serverless-operator.v1.31.0
     - csv: serverless-operator.v1.32.0


### PR DESCRIPTION
- :broom: start upgrade sequence with 1.30.2, as that is the current released 1.30.x

trying to fix https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.11-upgrade-kitchensink-ocp-411-continuous/1721829936035008512 