### PR TITLE
Upgrade tests: export logs from Pods in knative-eventing ns

### DIFF
--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -447,6 +447,8 @@ func exportEventingLogsOnError(t *testing.T) logstream.Canceler {
 		"kafka-channel-dispatcher",
 		"kafka-sink-receiver",
 		"kafka-source-dispatcher",
+		"kafka-controller",
+		"kafka-webhook",
 		"eventing-controller",
 		"eventing-webhook",
 		"imc-controller",


### PR DESCRIPTION
Export the logs when the test fails. We don't need to do it for Serving because Serving upstream tests already stream logs into t.Logf.

In order to analyze errors from upgrade tests, logs from current version (after upgrade) and previous version (before upgrade) of pods are required. Exporting log stream will make them available.

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
