### PR TITLE
Increase Receiver timeout in upgrade tests to 20s

### DIFF
--- a/test/upgrade/continual/channel-config.toml
+++ b/test/upgrade/continual/channel-config.toml
@@ -10,4 +10,4 @@ target = '{{- .ForwarderTarget -}}'
 
 [receiver]
 [receiver.teardown]
-duration = 10000000000
+duration = 20000000000

--- a/test/upgrade/continual/kafka-broker-config.toml
+++ b/test/upgrade/continual/kafka-broker-config.toml
@@ -10,4 +10,4 @@ target = '{{- .ForwarderTarget -}}'
 
 [receiver]
 [receiver.teardown]
-duration = 10000000000
+duration = 20000000000

--- a/test/upgrade/continual/kafka-sink-source-config.toml
+++ b/test/upgrade/continual/kafka-sink-source-config.toml
@@ -10,4 +10,4 @@ target = '{{- .ForwarderTarget -}}'
 
 [receiver]
 [receiver.teardown]
-duration = 10000000000
+duration = 20000000000


### PR DESCRIPTION
Sometimes it happens that upgrade tests compare received and sent events before the receiver gets all events.

The error is following:
```
prober.go:78: There were 12375 events propagated, but 10 errors occurred. Listing them below.
    prober.go:106: event #12317 should be received once, but was received 0 times
    prober.go:106: event #12321 should be received once, but was received 0 times
    prober.go:106: event #12329 should be received once, but was received 0 times
    prober.go:106: event #12336 should be received once, but was received 0 times
    prober.go:106: event #12342 should be received once, but was received 0 times
    prober.go:106: event #12356 should be received once, but was received 0 times
    prober.go:106: event #12358 should be received once, but was received 0 times
    prober.go:106: event #12361 should be received once, but was received 0 times
    prober.go:106: event #12367 should be received once, but was received 0 times
    prober.go:106: expecting to have 12375 unique events received, but received 12366 unique events
```

But looking at event traces, all the traces have a full path from sender to receiver. This means that the receiver needs to wait longer before comparing the number of events. 

Increasing from 10s to 20s improves the situation. We can always increase it again if the failure happens again.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
