### PR TITLE
[release-1.31] split kitchensink e2e execution into separate go test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,10 +223,23 @@ test-ui-e2e:
 test-kitchensink-e2e-testonly:
 	./test/kitchensink-e2e-tests.sh
 
+# Run only a subset of e2e tests, e.g. "make test-kitchensink-e2e-single-testonly TEST=TestBroker"
+test-kitchensink-e2e-single-testonly:
+	./test/kitchensink-e2e-tests.sh -run $(TEST)
+
+test-kitchensink-e2e-setup:
+	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
+	SCALE_UP=4 INSTALL_KAFKA="true" ./hack/install.sh
+
+# Runs all subsets of kitchensink tests. Runs tests separately so `go test` doesn't take too much memory in CI
 test-kitchensink-e2e:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	SCALE_UP=4 INSTALL_KAFKA="true" ./hack/install.sh
-	./test/kitchensink-e2e-tests.sh
+	./test/kitchensink-e2e-tests.sh -run TestBrokerReadinessBrokerDLS
+	./test/kitchensink-e2e-tests.sh -run TestBrokerReadinessTriggerDLS
+	./test/kitchensink-e2e-tests.sh -run TestChannelReadiness
+	./test/kitchensink-e2e-tests.sh -run TestFlowReadiness
+	./test/kitchensink-e2e-tests.sh -run TestSourceReadiness
 
 # Run all E2E tests.
 test-all-e2e:

--- a/test/kitchensink-e2e-tests.sh
+++ b/test/kitchensink-e2e-tests.sh
@@ -17,6 +17,6 @@ logger.success '🚀 Cluster prepared for testing.'
 run_testselect
 
 # Run serverless-operator kitchensink tests.
-downstream_kitchensink_e2e_tests
+downstream_kitchensink_e2e_tests "$@"
 
 success

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -342,7 +342,7 @@ function downstream_kitchensink_e2e_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  RUN_FLAGS=(-failfast -timeout=120m -parallel=8)
+  RUN_FLAGS=(-failfast -timeout=240m -parallel=8)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi


### PR DESCRIPTION
Backport from main

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
