### PR TITLE
Bump ocpVersion.max to 4.14

### DIFF
--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/knative-operator/cmd/manager
 
-FROM registry.ci.openshift.org/ocp/4.13:base
+FROM registry.ci.openshift.org/ocp/4.14:base
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/knative-operator/deploy/resources/quickstart/serverless-application-quickstart.yaml
+++ b/knative-operator/deploy/resources/quickstart/serverless-application-quickstart.yaml
@@ -46,7 +46,7 @@ spec:
       review:
         failedTaskHelp: >-
           This task isn’t verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.13/applications/odc-viewing-application-composition-using-topology-view.html)
+          more](https://docs.openshift.com/container-platform/4.14/applications/odc-viewing-application-composition-using-topology-view.html)
           about this topic.
         instructions: >-
           #### To verify the application was successfully created:
@@ -83,7 +83,7 @@ spec:
       review:
         failedTaskHelp: >-
           This task isn’t verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.13/applications/odc-viewing-application-composition-using-topology-view.html#odc-scaling-application-pods-and-checking-builds-and-routes_viewing-application-composition-using-topology-view)
+          more](https://docs.openshift.com/container-platform/4.14/applications/odc-viewing-application-composition-using-topology-view.html#odc-scaling-application-pods-and-checking-builds-and-routes_viewing-application-composition-using-topology-view)
           about this topic.
         instructions: >-
           #### To verify the application scaled down:
@@ -124,7 +124,7 @@ spec:
       review:
         failedTaskHelp: >-
           This task isn’t verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.13/serverless/eventing/event-sources/serverless-pingsource.html#serverless-pingsource-odc_serverless-pingsource)
+          more](https://docs.openshift.com/container-platform/4.14/serverless/eventing/event-sources/serverless-pingsource.html#serverless-pingsource-odc_serverless-pingsource)
           about this topic.
         instructions: >-
           #### To verify that the event connected to your Knative service:
@@ -176,7 +176,7 @@ spec:
       review:
         failedTaskHelp: >-
           This task isn’t verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.13/serverless/knative-serving/traffic-splitting/traffic-splitting-revisions.html#odc-splitting-traffic-between-revisions-using-developer-perspective_traffic-splitting-revisions)
+          more](https://docs.openshift.com/container-platform/4.14/serverless/knative-serving/traffic-splitting/traffic-splitting-revisions.html#odc-splitting-traffic-between-revisions-using-developer-perspective_traffic-splitting-revisions)
           about this topic.
         instructions: >-
           #### To verify that you forced a new revision and set traffic
@@ -204,7 +204,7 @@ spec:
       review:
         failedTaskHelp: >-
           This task is not verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.13/applications/odc-deleting-applications.html)
+          more](https://docs.openshift.com/container-platform/4.14/applications/odc-deleting-applications.html)
           about this topic.
         instructions: |-
           #### To verify you deleted your application:          :

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -1,6 +1,6 @@
-FROM registry.ci.openshift.org/origin/4.13:operator-registry AS opm
+FROM registry.ci.openshift.org/origin/4.14:operator-registry AS opm
 
-FROM registry.ci.openshift.org/ocp/4.13:base as builder
+FROM registry.ci.openshift.org/ocp/4.14:base as builder
 
 COPY --from=opm /bin/opm /bin/opm
 
@@ -17,7 +17,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM quay.io/openshift/origin-operator-registry:4.13
+FROM quay.io/openshift/origin-operator-registry:4.14
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ spec:
 
     The components provided with the OpenShift Serverless operator require minimum cluster sizes on
     OpenShift Container Platform. For more information, see the documentation on [Getting started
-    with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless#install-serverless-operator).
+    with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/installing-serverless#install-serverless-operator).
 
     # Supported Features
     - **Easy to get started:** Provides a simplified developer experience to deploy
@@ -154,8 +154,8 @@ spec:
     # Further Information
     For documentation on OpenShift Serverless, see:
     - [Installation
-    Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless)
-    - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/serving#serverless-applications)
+    Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/installing-serverless)
+    - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/serving#serverless-applications)
   icon:
     - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij48ZGVmcz48c3R5bGU+LmF7ZmlsbDojZmZmO30uYntmaWxsOiNlMDA7fTwvc3R5bGU+PC9kZWZzPjxwYXRoIGNsYXNzPSJhIiBkPSJNMjgsMUgxMGE5LDksMCwwLDAtOSw5VjI4YTksOSwwLDAsMCw5LDlIMjhhOSw5LDAsMCwwLDktOVYxMGE5LDksMCwwLDAtOS05WiIvPjxwYXRoIGQ9Ik0yOCwyLjI1QTcuNzU4Nyw3Ljc1ODcsMCwwLDEsMzUuNzUsMTBWMjhBNy43NTg3LDcuNzU4NywwLDAsMSwyOCwzNS43NUgxMEE3Ljc1ODcsNy43NTg3LDAsMCwxLDIuMjUsMjhWMTBBNy43NTg3LDcuNzU4NywwLDAsMSwxMCwyLjI1SDI4TTI4LDFIMTBhOSw5LDAsMCwwLTksOVYyOGE5LDksMCwwLDAsOSw5SDI4YTksOSwwLDAsMCw5LTlWMTBhOSw5LDAsMCwwLTktOVoiLz48cGF0aCBjbGFzcz0iYiIgZD0iTTE0LDIzLjQ3NjZIMTBhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwxNCwyMy40NzY2Wm0tMy4zNzUtMS4yNWgyLjc1di0yLjc1aC0yLjc1WiIvPjxwYXRoIGNsYXNzPSJiIiBkPSJNMjEsMjMuNDc2NkgxN2EuNjI1My42MjUzLDAsMCwxLS42MjUtLjYyNXYtNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUtLjYyNWg0YS42MjUyLjYyNTIsMCwwLDEsLjYyNS42MjV2NEEuNjI1My42MjUzLDAsMCwxLDIxLDIzLjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0xNy41LDE2LjQ3NjZoLTRhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwxNy41LDE2LjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0yNC41LDE2LjQ3NjZoLTRhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwyNC41LDE2LjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0yOCwyMy40NzY2SDI0YS42MjUzLjYyNTMsMCwwLDEtLjYyNS0uNjI1di00YS42MjUyLjYyNTIsMCwwLDEsLjYyNS0uNjI1aDRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LjYyNXY0QS42MjUzLjYyNTMsMCwwLDEsMjgsMjMuNDc2NlptLTMuMzc1LTEuMjVoMi43NXYtMi43NWgtMi43NVoiLz48cGF0aCBkPSJNMjksMjYuNDc2Nkg5YS42MjUuNjI1LDAsMCwxLDAtMS4yNUgyOWEuNjI1LjYyNSwwLDAsMSwwLDEuMjVaIi8+PC9zdmc+
       mediatype: image/svg+xml
@@ -179,7 +179,7 @@ spec:
     - kafka
   links:
     - name: Documentation
-      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/index
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/index
     - name: Source Repository
       url: https://github.com/openshift-knative/serverless-operator
   maintainers:
@@ -904,7 +904,7 @@ spec:
                       - name: "IMAGE_DISPATCHER_IMAGE"
                         value: "registry.ci.openshift.org/openshift/knative-eventing-channel-dispatcher:knative-v1.11"
                       - name: "IMAGE_KUBE_RBAC_PROXY"
-                        value: "registry.ci.openshift.org/origin/4.13:kube-rbac-proxy"
+                        value: "registry.ci.openshift.org/origin/4.14:kube-rbac-proxy"
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
                         value: "registry.ci.openshift.org/knative/release-1.10:client-plugin-event-sender"
                       - name: "IMAGE_KN_CLIENT"
@@ -1065,7 +1065,7 @@ spec:
                       - name: "IMAGE_DISPATCHER_IMAGE"
                         value: "registry.ci.openshift.org/openshift/knative-eventing-channel-dispatcher:knative-v1.11"
                       - name: "IMAGE_KUBE_RBAC_PROXY"
-                        value: "registry.ci.openshift.org/origin/4.13:kube-rbac-proxy"
+                        value: "registry.ci.openshift.org/origin/4.14:kube-rbac-proxy"
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
                         value: "registry.ci.openshift.org/knative/release-1.10:client-plugin-event-sender"
                       - name: "IMAGE_KN_CLIENT"
@@ -1336,7 +1336,7 @@ spec:
     - name: "IMAGE_DISPATCHER_IMAGE"
       image: "registry.ci.openshift.org/openshift/knative-eventing-channel-dispatcher:knative-v1.11"
     - name: "IMAGE_KUBE_RBAC_PROXY"
-      image: "registry.ci.openshift.org/origin/4.13:kube-rbac-proxy"
+      image: "registry.ci.openshift.org/origin/4.14:kube-rbac-proxy"
     - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
       image: "registry.ci.openshift.org/knative/release-1.10:client-plugin-event-sender"
     - name: "IMAGE_KN_CLIENT"

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -29,7 +29,7 @@ requirements:
     nodejs: 16.x
     ocpVersion:
         min: '4.11'
-        max: '4.13'
+        max: '4.14'
         label: 'v4.11'
 dependencies:
     serving: knative-v1.11

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/openshift-knative-operator/cmd/operator
 
-FROM registry.ci.openshift.org/ocp/4.13:base
+FROM registry.ci.openshift.org/ocp/4.14:base
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.13:cli AS oc-image
+FROM registry.ci.openshift.org/ocp/4.14:cli AS oc-image
 
 FROM src
 

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/serving/ingress/cmd/controller
 
-FROM registry.ci.openshift.org/ocp/4.13:base
+FROM registry.ci.openshift.org/ocp/4.14:base
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/serving/metadata-webhook/Dockerfile
+++ b/serving/metadata-webhook/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/metadata-webhook ${BASE}/serving/metadata-webhook/cmd/webhook
 
-FROM registry.ci.openshift.org/ocp/4.13:base
+FROM registry.ci.openshift.org/ocp/4.14:base
 USER 65532
 
 COPY --from=builder /tmp/metadata-webhook /ko-app/metadata-webhook


### PR DESCRIPTION
The latest available OCP version is 4.14 now.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
