### PR TITLE
Apply Admin Acks before cluster upgrade

### DIFF
--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -113,6 +113,9 @@ func TestClusterUpgrade(t *testing.T) {
 		Installations: pkgupgrade.Installations{
 			UpgradeWith: []pkgupgrade.Operation{
 				pkgupgrade.NewOperation("OpenShift Upgrade", func(c pkgupgrade.Context) {
+					if err := installation.ApplyAdminAcks(ctx); err != nil {
+						c.T.Error("Applying admin acks failed:", err)
+					}
 					upgradeFunc := installation.UpgradeOpenShift
 					eus, err := installation.IsChannelEUS(ctx)
 					if err != nil {


### PR DESCRIPTION
For some cluster upgrades, the admin has to acknowledge it. This PR adds automatic admin acks for testing purposes.
This is required to EUS-to-EUS OCP upgrades.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
