### PR TITLE
Use 1.30.0 as the first first in kitchensink upgrades

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -67,6 +67,6 @@ dependencies:
         eventing: knative-v1.10
         eventing_kafka_broker: knative-v1.10
 upgrade_sequence:
-    - csv: serverless-operator.v1.30.2
+    - csv: serverless-operator.v1.30.0
     - csv: serverless-operator.v1.31.0
     - csv: serverless-operator.v1.32.0


### PR DESCRIPTION
This version is installable as opposed to 1.30.2 because both 1.30.2 and 1.31.0 replace 1.30.0 so 1.30.2 is superceded by 1.31.0. As a result, 1.30.2 is not directly installable. Only 1.30.0, 1.31.0 and 1.32.0.

Fixes issues such as https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-411-kitchensink-upgrade-aws-ocp-411-continuous/1735540468810256384

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
