### PR TITLE
Using subPath for the actual file, so we have just one folder

### DIFF
--- a/openshift-knative-operator/pkg/common/cabundle_test.go
+++ b/openshift-knative-operator/pkg/common/cabundle_test.go
@@ -45,6 +45,7 @@ func TestApplyCABundlesTransform(t *testing.T) {
 				corev1.VolumeMount{
 					Name:      TrustedCAConfigMapVolume,
 					MountPath: filepath.Join("/ocp-serverless-custom-certs", TrustedCAKey),
+					SubPath:   TrustedCAKey,
 					ReadOnly:  true,
 				}),
 		),

--- a/openshift-knative-operator/pkg/common/certificates.go
+++ b/openshift-knative-operator/pkg/common/certificates.go
@@ -114,8 +114,8 @@ func AddCABundlesToContainerVolumes(c *corev1.Container) {
 			Name: TrustedCAConfigMapVolume,
 			// We only want the first entry in SSL_CERT_DIR for the mount
 			MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], TrustedCAKey),
-			//			SubPath:   TrustedCAKey,
-			ReadOnly: true,
+			SubPath:   TrustedCAKey,
+			ReadOnly:  true,
 		},
 	)
 	c.VolumeMounts = volumeMounts

--- a/openshift-knative-operator/pkg/common/certificates_test.go
+++ b/openshift-knative-operator/pkg/common/certificates_test.go
@@ -153,6 +153,7 @@ func TestAddCABundlesToContainerVolumes(t *testing.T) {
 					{
 						Name:      TrustedCAConfigMapVolume,
 						MountPath: filepath.Join("/ocp-serverless-custom-certs", TrustedCAKey),
+						SubPath:   TrustedCAKey,
 						ReadOnly:  true,
 					},
 				},
@@ -165,6 +166,7 @@ func TestAddCABundlesToContainerVolumes(t *testing.T) {
 					{
 						Name:      TrustedCAConfigMapVolume,
 						MountPath: "bleh",
+						SubPath:   "bleh",
 						ReadOnly:  false,
 					},
 				},
@@ -180,6 +182,7 @@ func TestAddCABundlesToContainerVolumes(t *testing.T) {
 					{
 						Name:      TrustedCAConfigMapVolume,
 						MountPath: filepath.Join("/ocp-serverless-custom-certs", TrustedCAKey),
+						SubPath:   TrustedCAKey,
 						ReadOnly:  true,
 					},
 				},
@@ -192,6 +195,7 @@ func TestAddCABundlesToContainerVolumes(t *testing.T) {
 					{
 						Name:      "bleh",
 						MountPath: "bleh",
+						SubPath:   "bleh",
 						ReadOnly:  false,
 					},
 				},
@@ -207,11 +211,13 @@ func TestAddCABundlesToContainerVolumes(t *testing.T) {
 					{
 						Name:      "bleh",
 						MountPath: "bleh",
+						SubPath:   "bleh",
 						ReadOnly:  false,
 					},
 					{
 						Name:      TrustedCAConfigMapVolume,
 						MountPath: filepath.Join("/ocp-serverless-custom-certs", TrustedCAKey),
+						SubPath:   TrustedCAKey,
 						ReadOnly:  true,
 					},
 				},
@@ -238,6 +244,7 @@ func TestAddCABundlesToContainerVolumes(t *testing.T) {
 					{
 						Name:      TrustedCAConfigMapVolume,
 						MountPath: filepath.Join("/existing/ssl/cert/dir", TrustedCAKey),
+						SubPath:   TrustedCAKey,
 						ReadOnly:  true,
 					},
 				},


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Using `subPath` for the actual file, so we have just one folder (and works with `SSL_CERT_DIR`), containing the certs injected by Openshift

/hold
