### PR TITLE
don't attempt to scale ROSA clusters

### DIFF
--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -76,4 +76,7 @@ function cluster_scalable {
   if [[ $(oc get infrastructure cluster -ojsonpath='{.status.platform}') = VSphere ]]; then
     return 1
   fi
+  if [[ $(oc get infrastructure cluster -ojsonpath='{.status.platformStatus.aws.resourceTags[?(@.key=="red-hat-clustertype")].value}') = rosa ]]; then
+    return 1
+  fi
 }


### PR DESCRIPTION
- :broom: don't attempt to scale ROSA clusters

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/46889/rehearse-46889-periodic-ci-openshift-knative-serverless-operator-main-ocp4.14-lp-rosa-classic-operator-e2e-rosa-aws/1737057443378106368

apparently it's not allowed anymore

```
 Error from server (Prevented from accessing Red Hat managed resources. This is in an effort to prevent harmful actions that may cause unintended consequences or affect the stability of the cluster. If you have any questions about this, please reach out to Red Hat support at https://access.redhat.com/support): admission webhook "regular-user-validation.managed.openshift.io" denied the request: Prevented from accessing Red Hat managed resources. This is in an effort to prevent harmful actions that may cause unintended consequences or affect the stability of the cluster. If you have any questions about this, please reach out to Red Hat support at https://access.redhat.com/support
11:44:34.023 ERROR:   🚨 Error (code: 1) occurred at ./hack/lib/scaleup.bash:42, with command: oc scale "${mset}" -n openshift-machine-api --replicas="${replicas}" 
```