### PR TITLE
Fix local build for Index image

### DIFF
--- a/hack/images.sh
+++ b/hack/images.sh
@@ -20,44 +20,13 @@ repo=$1
 on_cluster_builds=${ON_CLUSTER_BUILDS:-false}
 echo "On cluster builds: ${on_cluster_builds}"
 
-# Dockerfiles might include references to images that do not exit but CI operator
-# will automatically replace them with proper images during CI builds (as long as
-# the string starts with registry.ci.openshift.org). For non-CI builds,
-# some images need to be replaced with upstream variants manually.
-function replace_images() {
-  dockerfile_path=${1:?Pass dockerfile path}
-  tmp_dockerfile=$(mktemp /tmp/Dockerfile.XXXXXX)
-  sed -e "s|registry.ci.openshift.org/ocp/\(.*\):base|quay.io/openshift/origin-base:\1|" \
-    "${dockerfile_path}" > "$tmp_dockerfile"
-  echo "$tmp_dockerfile"
-}
-
-function build_image() {
-  name=${1:?Pass a name of image to be built as arg[1]}
-  dockerfile_path=${2:?Pass dockerfile path}
-  tmp_dockerfile=$(replace_images "${dockerfile_path}")
-
-  logger.info "Using ${tmp_dockerfile} as Dockerfile"
-
-  if ! oc get buildconfigs "$name" -n "$OLM_NAMESPACE" >/dev/null 2>&1; then
-    logger.info "Create an image build for ${name}"
-    oc -n "${OLM_NAMESPACE}" new-build \
-      --strategy=docker --name "$name" --dockerfile "$(cat "${tmp_dockerfile}")"
-  else
-    logger.info "${name} image build is already created"
-  fi
-
-  logger.info 'Build the image in the cluster-internal registry.'
-  oc -n "${OLM_NAMESPACE}" start-build "${name}" --from-dir "${root_dir}" -F
-}
-
 if [[ $on_cluster_builds = true ]]; then
   #  image-registry.openshift-image-registry.svc:5000/openshift-marketplace/openshift-knative-operator:latest
-  build_image "serverless-openshift-knative-operator" "${root_dir}/openshift-knative-operator/Dockerfile" || exit 1
+  build_image "serverless-openshift-knative-operator" "${root_dir}" "openshift-knative-operator/Dockerfile" || exit 1
   #  image-registry.openshift-image-registry.svc:5000/openshift-marketplace/knative-operator:latest
-  build_image "serverless-knative-operator" "${root_dir}/knative-operator/Dockerfile" || exit 1
+  build_image "serverless-knative-operator" "${root_dir}" "knative-operator/Dockerfile" || exit 1
   #  image-registry.openshift-image-registry.svc:5000/openshift-marketplace/knative-openshift-ingress:latest
-  build_image "serverless-ingress" "${root_dir}/serving/ingress/Dockerfile" || exit 1
+  build_image "serverless-ingress" "${root_dir}" "serving/ingress/Dockerfile" || exit 1
 
   logger.info 'Images build'
 

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -103,7 +103,7 @@ EOF
   logger.success "CatalogSource installed successfully"
 }
 
-# Dockerfiles might include references to images that do not exit but CI operator
+# Dockerfiles might include references to images that do not exist but CI operator
 # will automatically replace them with proper images during CI builds (as long as
 # the string starts with registry.ci.openshift.org). For non-CI builds,
 # some images need to be replaced with upstream variants manually.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

* Unify and reuse "build_image" function in scripts
* Align this function with CI where ci-operator accepts context dir and path to Dockerfile.
* Properly replace reference to registry.ci.openshift.org/ocp/4.14:base with quay variant which is publicly accessible.
* Remove unnecessary checking whether there are any files changed in the build directory via checksums. It is only an optimization for repeated builds against the same cluster but it might sometimes skip the build unnecessarily (e.g. when no files were changed under context dir but some base images were updated).
