### PR TITLE
use actually nightly `main` images

### DIFF
--- a/docs/gitops/serverless/100-subscription.yaml
+++ b/docs/gitops/serverless/100-subscription.yaml
@@ -16,7 +16,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
 spec:
   displayName: Serverless Operator
-  image: registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-index
+  image: registry.ci.openshift.org/knative/serverless-index:main
   publisher: Red Hat
   sourceType: grpc
 ---

--- a/docs/install-midstream.md
+++ b/docs/install-midstream.md
@@ -63,7 +63,7 @@ metadata:
 spec:
   displayName: Serverless Operator
   # Replace the version with whatever version you want to install
-  image: registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-index
+  image: registry.ci.openshift.org/knative/serverless-index:main
   publisher: Red Hat
   sourceType: grpc
 ```

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -14,7 +14,7 @@ function install_catalogsource {
 
   local rootdir csv index_image
 
-  index_image=registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-index
+  index_image=registry.ci.openshift.org/knative/serverless-index:main
 
   # Build bundle and index images only when running in CI or when DOCKER_REPO_OVERRIDE is defined.
   # Otherwise the latest nightly build will be used for CatalogSource.

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -13,7 +13,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/
       registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle >> /configs/index.yaml || \
     /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.30.0:serverless-bundle \
       registry.ci.openshift.org/knative/openshift-serverless-v1.31.0:serverless-bundle \
-      registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
+      registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe

--- a/serving/metadata-webhook/config/webhook.yaml
+++ b/serving/metadata-webhook/config/webhook.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: controller
       containers:
       - name: webhook
-        image: registry.ci.openshift.org/knative/openshift-serverless-nightly:metadata-webhook
+        image: registry.ci.openshift.org/knative/serverless-metadata-webhook:main
         resources:
           requests:
             cpu: 20m

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -13,7 +13,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/
       registry.ci.openshift.org/knative/openshift-serverless-v__VERSION__:serverless-bundle >> /configs/index.yaml || \
     /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
       registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_VERSION__:serverless-bundle \
-      registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-bundle >> /configs/index.yaml
+      registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe


### PR DESCRIPTION
- :bug: Use proper nightly CI images for index and bundle

According to https://github.com/openshift/release/blob/master/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main__413.yaml, we now promote to 

registry.ci.openshift.org/knative/serverless-index:main

not

registry.ci.openshift.org/knative/openshift-serverless-nightly:serverless-index