### PR TITLE
Increase test timeout for Serving HA tests to 25mins

### DIFF
--- a/test/serving.bash
+++ b/test/serving.bash
@@ -151,7 +151,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
 
   # Run HA tests separately as they're stopping core Knative Serving pods
   # Define short -spoofinterval to ensure frequent probing while stopping pods
-  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags=e2e -timeout=15m -failfast -parallel=1 ./test/ha \
+  SYSTEM_NAMESPACE="$SERVING_NAMESPACE" go_test_e2e -tags=e2e -timeout=25m -failfast -parallel=1 ./test/ha \
     -replicas="${REPLICAS}" -buckets="${BUCKETS}" -spoofinterval="10ms" \
     ${OPENSHIFT_TEST_OPTIONS} \
     --imagetemplate "$image_template"


### PR DESCRIPTION
In OSD runs such as [this one](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47488/rehearse-47488-periodic-ci-openshift-knative-serverless-operator-main-414-osd-e2e-osd-continuous/1745510966017134592) the tests are timing out but it looks like a longer timeout would help.
The test waits for 32 consecutive requests and only 12 are reached:
```
spoof.go:210: Retrying https://controller-h-a-rywppebx-serving-tests.apps.ci-op-mjr41dhl.o9mu.s1.devshift.org/: successful requests: 12, required: 32
    stream.go:305: D 20:50:18.136 autoscaler-57fb5d4f4f-55k2x [statforwarder/processor.go:119] [serving-tests/controller-h-a-rywppebx-00001] Forward stat of bucket autoscaler-bucket-00-of-01 to the holder autoscaler-57fb5d4f4f-4rq94_10.131.2.140
    stream.go:305: D 20:50:18.136 autoscaler-57fb5d4f4f-4rq94 [statforwarder/processor.go:64] [serving-tests/controller-h-a-rywppebx-00001] Accept stat as owner of bucket autoscaler-bucket-00-of-01
panic: test timed out after 15m0s
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Increase test timeout for "ha" test suite to 25 mins.
