### PR TITLE
Return error when InstallPlan not available in time during upgrades

### DIFF
--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -39,9 +39,9 @@ func UpgradeServerlessTo(ctx *test.Context, csv, source string, timeout time.Dur
 			}
 			installPlan, err = test.WaitForInstallPlan(ctx,
 				test.OperatorsNamespace, csv, test.ServerlessOperatorPackage, timeout)
-			if err != nil {
-				return err
-			}
+		}
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Fix "invalid address error" when installplan not available in time (see below). The code might check two different catalogsources - "redhat-operators" and "serverless-operator". However, when the desired catalog source is "serverless-operator" and the code doesn't check any other catalog sources it should throw an error when the installplan is not available in time.

```
{Failed  === RUN   TestServerlessUpgradeContinual/Run/Steps/UpgradeWith/UpgradeServerless
                --- FAIL: TestServerlessUpgradeContinual/Run/Steps/UpgradeWith/UpgradeServerless (900.14s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2aed7b8]

goroutine 1900 [running]:
testing.tRunner.func1.2({0x3287760, 0x51c43c0})
	/usr/local/go/src/testing/testing.go:1396 +0x372
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1399 +0x5f0
panic({0x3287760, 0x51c43c0})
	/usr/local/go/src/runtime/panic.go:890 +0x262
github.com/openshift-knative/serverless-operator/test/upgrade/installation.UpgradeServerlessTo(0x24?, {0x7fff701e7cc0, 0x1b}, {0x7fff701e7c7d, 0x13}, 0x5c7aab?)
	/go/src/github.com/openshift-knative/serverless-operator/test/upgrade/installation/serverless.go:48 +0x2f8
github.com/openshift-knative/serverless-operator/test/upgrade/installation.UpgradeServerless(...)
	/go/src/github.com/openshift-knative/serverless-operator/test/upgrade/installation/serverless.go:97
github.com/openshift-knative/serverless-operator/test/upgrade.ServerlessUpgradeOperations.func1({0xc00afc9520?, 0xc008e7c068?})
	/go/src/github.com/openshift-knative/serverless-operator/test/upgrade/upgrade.go:12 +0xdf
knative.dev/pkg/test/upgrade.(*suiteExecution).processOperationGroup.func1.1(0x0?)
	/go/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/pkg/test/upgrade/suite_execution.go:36 +0x49
testing.tRunner(0xc00afc9520, 0xc008618648)
	/usr/local/go/src/testing/testing.go:1446 +0x217
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1493 +0x75e
}
```


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

