### PR TITLE
[WIP] Make sure InstallPlan is removed when downgrading

### DIFF
--- a/test/installplan.go
+++ b/test/installplan.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -52,6 +53,19 @@ func ApproveInstallPlan(ctx *Context, name string) error {
 	patch := []byte(`{"spec":{"approved":true}}`)
 	_, err := ctx.Clients.OLM.OperatorsV1alpha1().InstallPlans(OperatorsNamespace).
 		Patch(context.Background(), name, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func DeleteInstallPlan(ctx *Context, namespace string, csvName, olmSource string) error {
+	installPlan, err := WaitForInstallPlan(ctx, namespace, csvName, olmSource, time.Millisecond)
+	// Ignore the error when the InstallPlan is already removed.
+	if err != nil && !errors.Is(err, wait.ErrWaitTimeout) {
+		return err
+	}
+	err = ctx.Clients.OLM.OperatorsV1alpha1().InstallPlans(namespace).Delete(context.Background(), installPlan.Name, metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/installplan.go
+++ b/test/installplan.go
@@ -62,9 +62,13 @@ func ApproveInstallPlan(ctx *Context, name string) error {
 func DeleteInstallPlan(ctx *Context, namespace string, csvName, olmSource string) error {
 	installPlan, err := WaitForInstallPlan(ctx, namespace, csvName, olmSource, time.Millisecond)
 	// Ignore the error when the InstallPlan is already removed.
-	if err != nil && !errors.Is(err, wait.ErrWaitTimeout) {
+	if err != nil {
+		if errors.Is(err, wait.ErrWaitTimeout) {
+			return nil
+		}
 		return err
 	}
+
 	err = ctx.Clients.OLM.OperatorsV1alpha1().InstallPlans(namespace).Delete(context.Background(), installPlan.Name, metav1.DeleteOptions{})
 	if err != nil {
 		return err

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -105,6 +105,10 @@ func DowngradeServerless(ctx *test.Context) error {
 		return err
 	}
 
+	if err := test.DeleteInstallPlan(ctx, test.OperatorsNamespace, test.Flags.CSV, test.Flags.CatalogSource); err != nil {
+		return err
+	}
+
 	if err := test.DeleteClusterServiceVersion(ctx, test.Flags.CSV, test.OperatorsNamespace); err != nil {
 		return err
 	}


### PR DESCRIPTION
This is an attempt for fix the following error when the CSV was removed in the openshift-serverless namespace but still exists in openshift-marketplace namespace before doing another round of upgrades.

- message: 'constraints not satisfiable: @existing/openshift-serverless//serverless-operator.v1.31.0 and
serverless-operator/openshift-marketplace/stable/serverless-operator.v1.31.0 originate from package serverless-operator, subscription serverless-operator
requires
serverless-operator/openshift-marketplace/stable/serverless-operator.v1.31.0, subscription serverless-operator exists, clusterserviceversion serverless-operator.v1.31.0
      exists and is not referenced by a subscription'

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
