### PR TITLE
Add `clusterissuers` permissions for Eventing TLS

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -475,6 +475,7 @@ spec:
               resources:
                 - certificates
                 - issuers
+                - clusterissuers
               verbs:
                 - create
                 - delete
@@ -737,6 +738,7 @@ spec:
               resources:
                 - certificates
                 - issuers
+                - clusterissuers
               verbs:
                 - create
                 - delete

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -478,6 +478,7 @@ spec:
               resources:
                 - certificates
                 - issuers
+                - clusterissuers
               verbs:
                 - create
                 - delete
@@ -743,6 +744,7 @@ spec:
               resources:
                 - certificates
                 - issuers
+                - clusterissuers
               verbs:
                 - create
                 - delete


### PR DESCRIPTION
This will solve the error in https://github.com/openshift-knative/eventing/pull/490.

```
failed to delete TLS resources: clusterissuers.cert-manager.io
"knative-eventing-selfsigned-issuer" is forbidden: User
"system:serviceaccount:openshift-serverless:knative-operator" cannot
get resource "clusterissuers" in API group "cert-manager.io" at the cluster
scope
```