### PR TITLE
[WIP] Label OpenShift CA trust bundle as Knative trust bundle

### DIFF
--- a/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.11/2-eventing-core.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/knative-eventing/1.11/2-eventing-core.yaml
@@ -5057,3 +5057,4 @@ metadata:
     app.kubernetes.io/version: v1.11
     app.kubernetes.io/name: knative-eventing
     config.openshift.io/inject-trusted-cabundle: "true"
+    networking.knative.dev/trust-bundle: "true"


### PR DESCRIPTION
Do not merge!

This is adding the expected `netwoking.knative.dev/trust-bundle: true` label to the OpenShift CA trust bundle ConfigMap (see https://docs.openshift.com/container-platform/4.12/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki for details)