### PR TITLE
RHEL9 base image for building Index image

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -111,8 +111,10 @@ function replace_images() {
   local dockerfile_path tmp_dockerfile
   dockerfile_path=${1:?Pass dockerfile path}
   tmp_dockerfile=$(mktemp /tmp/Dockerfile.XXXXXX)
-  sed -e "s|registry.ci.openshift.org/ocp/\(.*\):base|quay.io/openshift/origin-base:\1|" \
-    "${dockerfile_path}" > "$tmp_dockerfile"
+  cp "${dockerfile_path}" "$tmp_dockerfile"
+  if [ -z "$OPENSHIFT_CI" ]; then
+    sed -e "s|registry.ci.openshift.org/ocp/\(.*\):base|quay.io/openshift/origin-base:\1|" -i "$tmp_dockerfile"
+  fi
   echo "$tmp_dockerfile"
 }
 

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/origin/4.14:operator-registry AS opm
 
-FROM registry.ci.openshift.org/ocp/4.14:base as builder
+FROM registry.ci.openshift.org/ocp/4.14:base-rhel9 as builder
 
 COPY --from=opm /bin/opm /bin/opm
 

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/origin/4.14:operator-registry AS opm
 
-FROM registry.ci.openshift.org/ocp/4.14:base-rhel9 as builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 
 COPY --from=opm /bin/opm /bin/opm
 

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/origin/__OCP_MAX_VERSION__:operator-registry AS opm
 
-FROM registry.ci.openshift.org/ocp/__OCP_MAX_VERSION__:base-rhel9 as builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 
 COPY --from=opm /bin/opm /bin/opm
 

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/origin/__OCP_MAX_VERSION__:operator-registry AS opm
 
-FROM registry.ci.openshift.org/ocp/__OCP_MAX_VERSION__:base as builder
+FROM registry.ci.openshift.org/ocp/__OCP_MAX_VERSION__:base-rhel9 as builder
 
 COPY --from=opm /bin/opm /bin/opm
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVCOM-2901

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Use registry.access.redhat.com/ubi9/ubi-minimal for building Index in advance for 4.14. The upgrade to 4.15 should be then seamless. The ubi-minimal image is publicly available so it can be used for local builds as well, unlike registry.ci.openshift.org/ocp/4.15:base-rhel9
- Additional fix: replace base image only if outside CI. In CI it's not necessary as the image is pull-able.

