### PR TITLE
Replace registry.ci.openshift.org/ocp/4.14:base with ubi-minimal

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -103,34 +103,18 @@ EOF
   logger.success "CatalogSource installed successfully"
 }
 
-# Dockerfiles might include references to images that do not exist but CI operator
-# will automatically replace them with proper images during CI builds (as long as
-# the string starts with registry.ci.openshift.org). For non-CI builds,
-# some images need to be replaced with upstream variants manually.
-function replace_images() {
-  local dockerfile_path tmp_dockerfile
-  dockerfile_path=${1:?Pass dockerfile path}
-  tmp_dockerfile=$(mktemp /tmp/Dockerfile.XXXXXX)
-  cp "${dockerfile_path}" "$tmp_dockerfile"
-  if [ -z "$OPENSHIFT_CI" ]; then
-    sed -e "s|registry.ci.openshift.org/ocp/\(.*\):base|quay.io/openshift/origin-base:\1|" -i "$tmp_dockerfile"
-  fi
-  echo "$tmp_dockerfile"
-}
-
 function build_image() {
-  local name from_dir dockerfile_path tmp_dockerfile
+  local name from_dir dockerfile_path
   name=${1:?Pass a name of image to be built as arg[1]}
   from_dir=${2:?Pass context dir}
   dockerfile_path=${3:?Pass dockerfile path}
-  tmp_dockerfile=$(replace_images "${from_dir}/${dockerfile_path}")
 
-  logger.info "Using ${tmp_dockerfile} as Dockerfile"
+  logger.info "Using ${from_dir}/${dockerfile_path} as Dockerfile"
 
   if ! oc get buildconfigs "$name" -n "$OLM_NAMESPACE" >/dev/null 2>&1; then
     logger.info "Create an image build for ${name}"
     oc -n "${OLM_NAMESPACE}" new-build \
-      --strategy=docker --name "$name" --dockerfile "$(cat "${tmp_dockerfile}")"
+      --strategy=docker --name "$name" --dockerfile "$(cat "${from_dir}/${dockerfile_path}")"
   else
     logger.info "${name} image build is already created"
   fi

--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/knative-operator/cmd/manager
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/openshift-knative-operator/cmd/operator
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/serving/ingress/cmd/controller
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/serving/metadata-webhook/Dockerfile
+++ b/serving/metadata-webhook/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/metadata-webhook ${BASE}/serving/metadata-webhook/cmd/webhook
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /tmp/metadata-webhook /ko-app/metadata-webhook

--- a/templates/knative-operator.Dockerfile
+++ b/templates/knative-operator.Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/knative-operator/cmd/manager
 
-FROM registry.ci.openshift.org/ocp/__OCP_MAX_VERSION__:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/templates/openshift-knative-operator.Dockerfile
+++ b/templates/openshift-knative-operator.Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/openshift-knative-operator/cmd/operator
 
-FROM registry.ci.openshift.org/ocp/__OCP_MAX_VERSION__:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/templates/serving-ingress.Dockerfile
+++ b/templates/serving-ingress.Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/serving/ingress/cmd/controller
 
-FROM registry.ci.openshift.org/ocp/__OCP_MAX_VERSION__:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/templates/serving-metadata-webhook.Dockerfile
+++ b/templates/serving-metadata-webhook.Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/metadata-webhook ${BASE}/serving/metadata-webhook/cmd/webhook
 
-FROM registry.ci.openshift.org/ocp/__OCP_MAX_VERSION__:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /tmp/metadata-webhook /ko-app/metadata-webhook


### PR DESCRIPTION
ubi-minimal is much smaller in size, it's multiarch, and it's used by product images anyway. CI can use the same.

Related to https://issues.redhat.com/browse/SRVCOM-2294 and https://issues.redhat.com/browse/SRVCOM-2901

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
