### PR TITLE
Remove invalid references to "replace_images"

### DIFF
--- a/hack/images.sh
+++ b/hack/images.sh
@@ -31,16 +31,12 @@ if [[ $on_cluster_builds = true ]]; then
   logger.info 'Images build'
 
 else
-  tmp_dockerfile=$(replace_images openshift-knative-operator/Dockerfile)
-  podman build -t "$repo/serverless-openshift-knative-operator" -f "${tmp_dockerfile}" .
+  podman build -t "$repo/serverless-openshift-knative-operator" -f openshift-knative-operator/Dockerfile .
   podman push "$repo/serverless-openshift-knative-operator"
 
-  tmp_dockerfile=$(replace_images knative-operator/Dockerfile)
-  podman build -t "$repo/serverless-knative-operator" -f "${tmp_dockerfile}" .
+  podman build -t "$repo/serverless-knative-operator" -f knative-operator/Dockerfile .
   podman push "$repo/serverless-knative-operator"
 
-  tmp_dockerfile=$(replace_images serving/ingress/Dockerfile)
-  podman build -t "$repo/serverless-ingress" -f "${tmp_dockerfile}" .
+  podman build -t "$repo/serverless-ingress" -f serving/ingress/Dockerfile .
   podman push "$repo/serverless-ingress"
-
 fi


### PR DESCRIPTION
This is a follow-up to https://github.com/openshift-knative/serverless-operator/commit/5d688143df9e207e507a89a8bd17f175b2932bdf

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
