### PR TITLE
Fix OLM index image generator

### DIFF
--- a/hack/cmd/bumpso/bumpso.go
+++ b/hack/cmd/bumpso/bumpso.go
@@ -85,11 +85,14 @@ func run() error {
 		"source": "serverless-operator",
 	})
 
-	channelsList, _, err := unstructured.NestedSlice(project, "olm", "channels", "list")
-	if err != nil {
-		return err
+	defaultChannel, _, _ := unstructured.NestedString(project, "olm", "channels", "default")
+
+	channelsList := []interface{}{
+		defaultChannel,
+		fmt.Sprintf("stable-%d.%d", newVersion.Major, newVersion.Minor),
+		fmt.Sprintf("stable-%d.%d", currentVersion.Major, currentVersion.Minor),
+		fmt.Sprintf("stable-%d.%d", previousVersion.Major, previousVersion.Minor),
 	}
-	channelsList = append(channelsList, fmt.Sprintf("stable-%d.%d", newVersion.Major, newVersion.Minor))
 
 	serving, _, _ := unstructured.NestedString(project, "dependencies", "serving")
 	eventing, _, _ := unstructured.NestedString(project, "dependencies", "eventing")
@@ -102,7 +105,6 @@ func run() error {
 	_ = common.SetNestedField(&node, skipRange(previousVersion, currentVersion), "olm", "previous", "skipRange")
 	_ = common.SetNestedField(&node, upgradeSequence, "upgrade_sequence")
 	_ = common.SetNestedField(&node, channelsList, "olm", "channels", "list")
-
 	_ = common.SetNestedField(&node, serving, "dependencies", "previous", "serving")
 	_ = common.SetNestedField(&node, eventing, "dependencies", "previous", "eventing")
 	_ = common.SetNestedField(&node, ekb, "dependencies", "previous", "eventing_kafka_broker")

--- a/hack/generate/annotations.sh
+++ b/hack/generate/annotations.sh
@@ -10,7 +10,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/metadata.bash"
 
 declare -A values
 values[operators.operatorframework.io.bundle.channel.default.v1]="$(metadata.get olm.channels.default)"
-values[operators.operatorframework.io.bundle.channels.v1]="$(metadata.get 'olm.channels.list.*' | paste -sd ',' -)"
+values[operators.operatorframework.io.bundle.channels.v1]="$(metadata.get olm.channels.default),$(metadata.get 'olm.channels.list[*]' | head -n 2 | tail -n 1)"
 values[operators.operatorframework.io.bundle.package.v1]="$(metadata.get project.name)"
 
 # Start fresh

--- a/hack/generate/dockerfile.sh
+++ b/hack/generate/dockerfile.sh
@@ -10,7 +10,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/metadata.bash"
 
 declare -A values
 values[NAME]="$(metadata.get project.name)"
-values[CHANNEL_LIST]="$(metadata.get 'olm.channels.list.*' | paste -sd ',' -)"
+values[LATEST_VERSIONED_CHANNEL]="$(metadata.get 'olm.channels.list[*]' | head -n 2 | tail -n 1)"
 values[DEFAULT_CHANNEL]="$(metadata.get olm.channels.default)"
 values[VERSION]="$(metadata.get project.version)"
 values[SERVING_VERSION]="$(metadata.get dependencies.serving)"

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -62,8 +62,7 @@ export UPGRADE_OCP_IMAGE="${UPGRADE_OCP_IMAGE:-}"
 export INSTALL_PREVIOUS_VERSION="${INSTALL_PREVIOUS_VERSION:-"false"}"
 export INSTALL_OLDEST_COMPATIBLE="${INSTALL_OLDEST_COMPATIBLE:-"false"}"
 
-# Using first channel on the list, instead of default one
-OLM_CHANNEL="${OLM_CHANNEL:-$(metadata.get 'olm.channels.list[*]' | head -n 1)}"
+OLM_CHANNEL="${OLM_CHANNEL:-$(metadata.get olm.channels.default)}"
 export OLM_CHANNEL
 # Change this when upgrades need switching to a different channel
 export OLM_UPGRADE_CHANNEL="${OLM_UPGRADE_CHANNEL:-"$OLM_CHANNEL"}"

--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -8,7 +8,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=serverless-operator
 LABEL operators.operatorframework.io.bundle.channel.default.v1="stable"
-LABEL operators.operatorframework.io.bundle.channels.v1="stable,stable-1.29,stable-1.30,stable-1.31,stable-1.32"
+LABEL operators.operatorframework.io.bundle.channels.v1="stable,stable-1.32"
 
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \

--- a/olm-catalog/serverless-operator/index/configs/index.yaml
+++ b/olm-catalog/serverless-operator/index/configs/index.yaml
@@ -12,19 +12,7 @@ entries:
     skipRange: ">=1.31.0 <1.32.0"
 ---
 schema: olm.channel
-name: stable-1.29
-package: serverless-operator
-entries:
-  - name: "serverless-operator.v1.30.0"
-  - name: "serverless-operator.v1.31.0"
-    replaces: "serverless-operator.v1.30.0"
-    skipRange: ">=1.30.0 <1.31.0"
-  - name: "serverless-operator.v1.32.0"
-    replaces: "serverless-operator.v1.31.0"
-    skipRange: ">=1.31.0 <1.32.0"
----
-schema: olm.channel
-name: stable-1.30
+name: stable-1.32
 package: serverless-operator
 entries:
   - name: "serverless-operator.v1.30.0"
@@ -43,18 +31,9 @@ entries:
   - name: "serverless-operator.v1.31.0"
     replaces: "serverless-operator.v1.30.0"
     skipRange: ">=1.30.0 <1.31.0"
-  - name: "serverless-operator.v1.32.0"
-    replaces: "serverless-operator.v1.31.0"
-    skipRange: ">=1.31.0 <1.32.0"
 ---
 schema: olm.channel
-name: stable-1.32
+name: stable-1.30
 package: serverless-operator
 entries:
   - name: "serverless-operator.v1.30.0"
-  - name: "serverless-operator.v1.31.0"
-    replaces: "serverless-operator.v1.30.0"
-    skipRange: ">=1.30.0 <1.31.0"
-  - name: "serverless-operator.v1.32.0"
-    replaces: "serverless-operator.v1.31.0"
-    skipRange: ">=1.31.0 <1.32.0"

--- a/olm-catalog/serverless-operator/metadata/annotations.yaml
+++ b/olm-catalog/serverless-operator/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable,stable-1.29,stable-1.30,stable-1.31,stable-1.32
+  operators.operatorframework.io.bundle.channels.v1: stable,stable-1.32
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -9,13 +9,12 @@ olm:
     replaces: 1.31.0
     skipRange: '>=1.31.0 <1.32.0'
     channels:
-        default: 'stable'
+        default: stable
         list:
             - stable
-            - stable-1.29
-            - stable-1.30
-            - stable-1.31
             - stable-1.32
+            - stable-1.31
+            - stable-1.30
     previous:
         replaces: 1.30.0
         skipRange: '>=1.30.0 <1.31.0'

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -7,7 +7,7 @@ COPY --from=opm /bin/opm /bin/opm
 # Copy declarative config root into image at /configs
 COPY olm-catalog/serverless-operator/index/configs /configs
 
-RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
+RUN /bin/opm init serverless-operator --default-channel=__DEFAULT_CHANNEL__ --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
       registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_VERSION__:serverless-bundle \
       registry.ci.openshift.org/knative/openshift-serverless-v__VERSION__:serverless-bundle >> /configs/index.yaml || \

--- a/templates/index.yaml
+++ b/templates/index.yaml
@@ -1,4 +1,39 @@
 ---
 schema: olm.channel
-name: __CHANNEL__
+name: __DEFAULT_CHANNEL__
 package: serverless-operator
+entries:
+  - name: "serverless-operator.v__PREVIOUS_REPLACES__"
+  - name: "serverless-operator.v__PREVIOUS_VERSION__"
+    replaces: "serverless-operator.v__PREVIOUS_REPLACES__"
+    skipRange: ">=__PREVIOUS_REPLACES__ <__PREVIOUS_VERSION__"
+  - name: "serverless-operator.v__VERSION__"
+    replaces: "serverless-operator.v__PREVIOUS_VERSION__"
+    skipRange: ">=__PREVIOUS_VERSION__ <__VERSION__"
+---
+schema: olm.channel
+name: __LATEST_VERSIONED_CHANNEL__
+package: serverless-operator
+entries:
+  - name: "serverless-operator.v__PREVIOUS_REPLACES__"
+  - name: "serverless-operator.v__PREVIOUS_VERSION__"
+    replaces: "serverless-operator.v__PREVIOUS_REPLACES__"
+    skipRange: ">=__PREVIOUS_REPLACES__ <__PREVIOUS_VERSION__"
+  - name: "serverless-operator.v__VERSION__"
+    replaces: "serverless-operator.v__PREVIOUS_VERSION__"
+    skipRange: ">=__PREVIOUS_VERSION__ <__VERSION__"
+---
+schema: olm.channel
+name: __PREVIOUS_CHANNEL__
+package: serverless-operator
+entries:
+  - name: "serverless-operator.v__PREVIOUS_REPLACES__"
+  - name: "serverless-operator.v__PREVIOUS_VERSION__"
+    replaces: "serverless-operator.v__PREVIOUS_REPLACES__"
+    skipRange: ">=__PREVIOUS_REPLACES__ <__PREVIOUS_VERSION__"
+---
+schema: olm.channel
+name: __PREVIOUS_REPLACES_CHANNEL__
+package: serverless-operator
+entries:
+  - name: "serverless-operator.v__PREVIOUS_REPLACES__"

--- a/templates/main.Dockerfile
+++ b/templates/main.Dockerfile
@@ -8,7 +8,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=__NAME__
 LABEL operators.operatorframework.io.bundle.channel.default.v1="__DEFAULT_CHANNEL__"
-LABEL operators.operatorframework.io.bundle.channels.v1="__CHANNEL_LIST__"
+LABEL operators.operatorframework.io.bundle.channels.v1="__DEFAULT_CHANNEL__,__LATEST_VERSIONED_CHANNEL__"
 
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVCOM-2898

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Index image offers last three releases for installation. Align this with olm-catalog/serverless-operator/index/Dockerfile which only places CSV from last three versions in the index (through running `/bin/opm`). Any versions older than last three releases were not installable anyway.
- Annotations now properly include the default channel and latest versioned channel, not any previous versioned channels that are not supposed to include the latest release
- Same applies for the bundle Dockerfile for `operators.operatorframework.io.bundle.channels.v1`
- Project yaml includes in `olm.channels.list` only the last three releases. The list was too long and having all possible versions in it didn't make sense as they were not installable. And it was incorrectly used for annotations and dockerfiles (see previous points)
