### PR TITLE
Use a specific golang version in dependabot action

### DIFF
--- a/.github/workflows/dependabot-deps.yaml
+++ b/.github/workflows/dependabot-deps.yaml
@@ -19,6 +19,11 @@ jobs:
           path: ./src/github.com/${{ github.repository }}
           fetch-depth: 0
 
+      - name: Setup Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
+
       - name: Install prerequisites
         env:
           YQ_VERSION: 3.4.0


### PR DESCRIPTION
- Use a specific golang version in dependabot action to avoid https://github.com/openshift-knative/serverless-operator/actions/runs/7622114788/job/20759605946?pr=2457

/assign @matzew 