### PR TITLE
Use Golang builder registry.ci.openshift.org/openshift/release:rhel-8…

### DIFF
--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,5 @@
 # Dockerfile to bootstrap build and test in openshift-ci
-
-FROM registry.ci.openshift.org/openshift/release:golang-1.21
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/serving/metadata-webhook/Dockerfile
+++ b/serving/metadata-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -1,6 +1,5 @@
 # Dockerfile to bootstrap build and test in openshift-ci
-
-FROM registry.ci.openshift.org/openshift/release:golang-__GOLANG_VERSION__
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.16
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/

--- a/templates/knative-operator.Dockerfile
+++ b/templates/knative-operator.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-__GOLANG_VERSION__ AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.16 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/templates/openshift-knative-operator.Dockerfile
+++ b/templates/openshift-knative-operator.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-__GOLANG_VERSION__ AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.16 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/templates/serving-ingress.Dockerfile
+++ b/templates/serving-ingress.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-__GOLANG_VERSION__ AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.16 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/templates/serving-metadata-webhook.Dockerfile
+++ b/templates/serving-metadata-webhook.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-__GOLANG_VERSION__ AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.16 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}


### PR DESCRIPTION
…-release-<GO_VERSION>-openshift-4.16

This image is based on ubi8-minimal, same as final product builder, and includes up-to-date versions of tooling such as GIT.

A similar Builder is used in other repositories now:
* Eventing: https://github.com/openshift-knative/eventing/commit/e8eb1843a421996968e3062760f7e700baddd9c9

See related discussion on [slack](https://redhat-internal.slack.com/archives/CD87JDUB0/p1706022237180709)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
