### PR TITLE
Drop nak3 from OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,7 +7,6 @@ aliases:
   - lberk
   - matzew
   - mgencur
-  - nak3
   - openshift-cherrypick-robot
   - pierDipi
   - ReToCode
@@ -21,7 +20,6 @@ aliases:
   - lberk
   - matzew
   - mgencur
-  - nak3
   - pierDipi
   - ReToCode
   - rhuss


### PR DESCRIPTION
As per title, this patch drops nak3 from OWNERS file.