### PR TITLE
Use ubi-minimal from CI registry

### DIFF
--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/knative-operator/cmd/manager
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.ci.openshift.org/ocp/ubi-minimal:8
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/openshift-knative-operator/cmd/operator
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.ci.openshift.org/ocp/ubi-minimal:8
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/serving/ingress/cmd/controller
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.ci.openshift.org/ocp/ubi-minimal:8
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/serving/metadata-webhook/Dockerfile
+++ b/serving/metadata-webhook/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/metadata-webhook ${BASE}/serving/metadata-webhook/cmd/webhook
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.ci.openshift.org/ocp/ubi-minimal:8
 USER 65532
 
 COPY --from=builder /tmp/metadata-webhook /ko-app/metadata-webhook

--- a/templates/knative-operator.Dockerfile
+++ b/templates/knative-operator.Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/knative-operator/cmd/manager
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.ci.openshift.org/ocp/ubi-minimal:8
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/templates/openshift-knative-operator.Dockerfile
+++ b/templates/openshift-knative-operator.Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/openshift-knative-operator/cmd/operator
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.ci.openshift.org/ocp/ubi-minimal:8
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/templates/serving-ingress.Dockerfile
+++ b/templates/serving-ingress.Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/operator ${BASE}/serving/ingress/cmd/controller
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.ci.openshift.org/ocp/ubi-minimal:8
 USER 65532
 
 COPY --from=builder /tmp/operator /ko-app/operator

--- a/templates/serving-metadata-webhook.Dockerfile
+++ b/templates/serving-metadata-webhook.Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN go build -o /tmp/metadata-webhook ${BASE}/serving/metadata-webhook/cmd/webhook
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.ci.openshift.org/ocp/ubi-minimal:8
 USER 65532
 
 COPY --from=builder /tmp/metadata-webhook /ko-app/metadata-webhook


### PR DESCRIPTION
There're several error in other projects that try to rebuild S-O on spot: 

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing-kafka-broker/967/pull-ci-openshift-knative-eventing-kafka-broker-release-next-414-test-e2e-aws-ocp-414/1752855085005672448#1:build-log.txt%3A1138

It seems the fails are intermittent either on ubi image pull or image stream creation. I have seen the same error on client midstream as well. Not happening on every run though. 


- Trying to verify if we can work with CI image of ubi to fix other project building from S-O base
