### PR TITLE
Install cert-manager when installing Kafka with KEDA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ install-kafka-with-mesh:
 
 install-kafka-with-keda:
 	UNINSTALL_KEDA="false" ./hack/keda.sh
+	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 	INSTALL_SERVING="false" INSTALL_KAFKA="true" ENABLE_KEDA="true" ./hack/install.sh
 
 install-strimzi:


### PR DESCRIPTION
cert-manager is now required for E2E testing Knative Kafka