### PR TITLE
Introduce redhat-knative-istio-authz-chart dependency in project.yaml

### DIFF
--- a/hack/cmd/bumpso/bumpso.go
+++ b/hack/cmd/bumpso/bumpso.go
@@ -96,6 +96,7 @@ func run() error {
 	ekb, _, _ := unstructured.NestedString(project, "dependencies", "eventing_kafka_broker")
 
 	_ = common.SetNestedField(&node, newVersion.String(), "project", "version")
+	_ = common.SetNestedField(&node, newVersion.String(), "dependencies", "redhat-knative-istio-authz-chart")
 	_ = common.SetNestedField(&node, currentVersion.String(), "olm", "replaces")
 	_ = common.SetNestedField(&node, previousVersion.String(), "olm", "previous", "replaces")
 	_ = common.SetNestedField(&node, skipRange(currentVersion, newVersion), "olm", "skipRange")

--- a/hack/generate/mesh-auth-policies.sh
+++ b/hack/generate/mesh-auth-policies.sh
@@ -30,7 +30,7 @@ if [[ "${USE_RELEASED_HELM_CHART}" == "true" ]]; then
   for tenant in ${tenants//,/ }; do
     echo "Generating AuthorizationPolicies for tenant $tenant"
     helm template openshift-helm-charts/redhat-knative-istio-authz \
-      --version "$(metadata.get project.version)" \
+      --version "$(metadata.get dependencies.redhat-knative-istio-authz-chart)" \
       --set "name=$tenant" --set "namespaces={$tenant}" > "$policies_path/$tenant.yaml"
   done
 elif [[ "${HELM_CHART_TGZ}" != "" ]]; then

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -39,6 +39,7 @@ dependencies:
     net_kourier_artifacts_branch: release-v1.10
     net_istio: knative-v1.10
     net_istio_artifacts_branch: release-v1.10
+    redhat-knative-istio-authz-chart: 1.31.0
     maistra: 2.4-latest
     eventing: knative-v1.10
     # eventing core midstream branch name


### PR DESCRIPTION
## Proposed Changes


- Add dependencies.redhat-knative-istio-authz-chart in project.yaml
- This version is the chart version of knative-istio-authz-chart to be installed in [mesh-auth-policies.sh#L33](https://github.com/openshift-knative/serverless-operator/blob/main/hack/generate/mesh-auth-policies.sh#L33)
- Also will be used to identify correct image for downstream testing in quay.io, i.e. [quay.io/openshift-knative/knative-istio-authz-onboarding:1.31.0](http://quay.io/openshift-knative/knative-istio-authz-onboarding:1.31.0)

