### PR TITLE
Fix cert-manager deployment availability check

### DIFF
--- a/hack/lib/certmanager.bash
+++ b/hack/lib/certmanager.bash
@@ -35,8 +35,8 @@ function deploy_certmanager_operator {
 
   timeout 600 "[[ \$(oc get deploy -n ${deployment_namespace} cert-manager --no-headers | wc -l) != 1 ]]" || return 1
   timeout 600 "[[ \$(oc get deploy -n ${deployment_namespace} cert-manager-webhook --no-headers | wc -l) != 1 ]]" || return 1
-  oc wait deployments -n ${deployment_namespace} cert-manager-webhook --for condition=ready --timeout=600s
-  oc wait deployments -n ${deployment_namespace} cert-manager --for condition=ready --timeout=600s
+  oc wait deployments -n ${deployment_namespace} cert-manager-webhook --for condition=available --timeout=600s
+  oc wait deployments -n ${deployment_namespace} cert-manager --for condition=available --timeout=600s
 
   oc apply -f "${certmanager_resources_dir}"/selfsigned-issuer.yaml || return $?
   oc apply -f "${certmanager_resources_dir}"/eventing-ca-issuer.yaml || return $?


### PR DESCRIPTION
Currently we wait for the deployment `ready` condition of the cert-manager deployments. This fails, was deployments use the `available` condition (instead of `ready` - see [deployment conditions](https://github.com/kubernetes/kubernetes/blob/f07b47c3d1e596f53640285afb0d53a81fe6f259/pkg/apis/apps/types.go#L547-L560)):

```
error: timed out waiting for the condition on deployments/cert-manager-webhook
error: timed out waiting for the condition on deployments/cert-manager
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing-kafka-broker/967/pull-ci-openshift-knative-eventing-kafka-broker-release-next-411-test-reconciler-aws-411/1755029368633036800

This PR addresses it and uses `--for condition=available` to check for availability of the deployment.