### PR TITLE
Remove toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/openshift-knative/serverless-operator
 
 go 1.21
 
-toolchain go1.21.6
-
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/coreos/go-semver v0.3.1


### PR DESCRIPTION
Per title, ditching `toolchain` to avoid any havoc downstream. We can't guarantee `1.21.6` will be in prod env. 

/cc @ReToCode @pierDipi @skonto 
