### PR TITLE
Replace private images for local image builds

### DIFF
--- a/hack/images.sh
+++ b/hack/images.sh
@@ -31,12 +31,15 @@ if [[ $on_cluster_builds = true ]]; then
   logger.info 'Images build'
 
 else
-  podman build -t "$repo/serverless-openshift-knative-operator" -f openshift-knative-operator/Dockerfile .
+  tmp_dockerfile=$(replace_images openshift-knative-operator/Dockerfile)
+  podman build -t "$repo/serverless-openshift-knative-operator" -f "${tmp_dockerfile}" .
   podman push "$repo/serverless-openshift-knative-operator"
 
-  podman build -t "$repo/serverless-knative-operator" -f knative-operator/Dockerfile .
+  tmp_dockerfile=$(replace_images knative-operator/Dockerfile)
+  podman build -t "$repo/serverless-knative-operator" -f "${tmp_dockerfile}" .
   podman push "$repo/serverless-knative-operator"
 
-  podman build -t "$repo/serverless-ingress" -f serving/ingress/Dockerfile .
+  tmp_dockerfile=$(replace_images serving/ingress/Dockerfile)
+  podman build -t "$repo/serverless-ingress" -f "${tmp_dockerfile}" .
   podman push "$repo/serverless-ingress"
 fi

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -103,10 +103,8 @@ EOF
   logger.success "CatalogSource installed successfully"
 }
 
-# Dockerfiles might include references to images that do not exist but CI operator
-# will automatically replace them with proper images during CI builds (as long as
-# the string starts with registry.ci.openshift.org). For non-CI builds,
-# some images need to be replaced with public variants manually.
+# Dockerfiles might include references to private images that are only available in CI.
+# For non-CI builds, some images need to be replaced with public variants.
 function replace_images() {
   local dockerfile_path tmp_dockerfile
   dockerfile_path=${1:?Pass dockerfile path}


### PR DESCRIPTION
This is a follow-up to https://github.com/openshift-knative/serverless-operator/pull/2473
For local image builds, some images need to be replaced with public variants.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
