### PR TITLE
Provide spec.registry like other operator CRs

### DIFF
--- a/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
+++ b/knative-operator/pkg/apis/operator/v1alpha1/knativekafka_types.go
@@ -38,6 +38,11 @@ type KnativeKafkaSpec struct {
 	// +optional
 	Logging *Logging `json:"logging,omitempty"`
 
+	// A means to override the corresponding deployment images in the upstream.
+	// If no registry is provided, the knative release images will be used.
+	// +optional
+	Registry base.Registry `json:"registry,omitempty"`
+
 	// Workloads overrides workloads configurations such as resources and replicas.
 	// +optional
 	Workloads []base.WorkloadOverride `json:"workloads,omitempty"`

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -356,6 +356,7 @@ func (r *ReconcileKnativeKafka) transform(manifest *mf.Manifest, instance *serve
 		operatorcommon.ConfigMapTransform(instance.Spec.Config, logging.FromContext(context.TODO())),
 		configureEventingKafka(instance.Spec),
 		ImageTransform(common.BuildImageOverrideMapFromEnviron(os.Environ(), "KAFKA_IMAGE_")),
+		operatorcommon.ImageTransform(&instance.Spec.Registry, logging.FromContext(context.TODO())),
 		socommon.VersionedJobNameTransform(),
 		socommon.InjectCommonEnvironment(),
 		socommon.ApplyCABundlesTransform(),

--- a/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
+++ b/olm-catalog/serverless-operator/manifests/operator_v1alpha1_knativekafka_crd.yaml
@@ -42,6 +42,33 @@ spec:
                 description: A means to override the corresponding entries in the
                   upstream configmaps
                 type: object
+              registry:
+                description: A means to override the corresponding deployment images
+                  in the upstream. This affects both apps/v1.Deployment.
+                properties:
+                  default:
+                    description: The default image reference template to use for all
+                      knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                    type: string
+                  imagePullSecrets:
+                    description: A list of secrets to be used when pulling the knative
+                      images. The secret must be created in the same namespace as
+                      the knative-eventing deployments, and not the namespace of this
+                      resource.
+                    items:
+                      properties:
+                        name:
+                          description: The name of the secret.
+                          type: string
+                      type: object
+                    type: array
+                  override:
+                    additionalProperties:
+                      type: string
+                    description: A map of a container name or image name to the full
+                      image location of the individual knative image.
+                    type: object
+                type: object
               channel:
                 description: Allows configuration for KafkaChannel installation
                 properties:


### PR DESCRIPTION
## Proposed Changes

- Like upstream adding `registry` field from its `base` for providing image overrides
