### PR TITLE
[SRVCOM-2947] Annotate serverless Operator for simpler must-gather UX

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -117,6 +117,7 @@ declare -A yaml_keys
 yaml_keys[spec.version]="$(metadata.get project.version)"
 yaml_keys[metadata.name]="$(metadata.get project.name).v$(metadata.get project.version)"
 yaml_keys['metadata.annotations[olm.skipRange]']="$(metadata.get olm.skipRange)"
+yaml_keys['metadata.annotations[operators.openshift.io/must-gather-image]']="$(metadata.get dependencies.mustgather.image)"
 yaml_keys[spec.minKubeVersion]="$(metadata.get requirements.kube.minVersion)"
 yaml_keys[spec.replaces]="$(metadata.get project.name).v$(metadata.get olm.replaces)"
 

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -62,6 +62,7 @@ metadata:
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
     olm.skipRange: '>=1.31.0 <1.32.0'
+    operators.openshift.io/must-gather-image: quay.io/openshift-knative/must-gather
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -66,6 +66,9 @@ dependencies:
         serving: knative-v1.10
         eventing: knative-v1.10
         eventing_kafka_broker: knative-v1.10
+
+    mustgather:
+      image: quay.io/openshift-knative/must-gather
 upgrade_sequence:
     - csv: serverless-operator.v1.30.0
     - csv: serverless-operator.v1.31.0


### PR DESCRIPTION
Currently, `oc adm must-gather --image <image-1> --image <image-2>` helps
collect must-gather using the plugin images passed as CLI arguments. 
`oc` added the `--all-images` flag to this
command that checks the OCP cluster for Operators annotated with
`operators.openshift.io/must-gather-image`

When Operators are annotated this way, using `oc adm must-gather --all-images`
will collect a must-gather for all plugin images using their default command.
Benefits of using this command:

1. Single flag instead of multiple flags.
2. If more Operators deployed on OCP use this annotation, it could help reduce
back and forth between the technical support & customers.
3. It could help in scenario where customers can't collect multiple
must-gathers, e.g., disconnected/remote OCP clusters.

/hold as we need to make sure that in p12n we replace this image with the productized one