### PR TITLE
Workaround for OCPBUGS-19046 when installing operators

### DIFF
--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -190,7 +190,7 @@ function wait_for_csv_succeeded {
     # Make sure there are .status.conditions available before parsing via jq
     timeout 120 "[[ \$(oc get subscription.operators.coreos.com ${subscription} -n ${ns} -ojson | jq '.status.conditions | length') == 0 ]]"
     subscription_error=$(oc get subscription.operators.coreos.com "${subscription}" -n "${ns}" -ojson | jq '.status.conditions[] | select(.message|test("exists and is not referenced by a subscription"))')
-    if [[ "${subscription_error}" != "" && restarts == 0 ]]; then
+    if [[ "${subscription_error}" != "" && $restarts -eq 0 ]]; then
       logger.warn "Restarting OLM pods to work around OCPBUGS-19046"
       oc delete pods -n openshift-operator-lifecycle-manager -l app=catalog-operator
       oc delete pods -n openshift-operator-lifecycle-manager -l app=olm-operator

--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -187,6 +187,8 @@ function wait_for_csv_succeeded {
   restarts=0
   ln=' ' logger.debug "${*} : Waiting until non-zero (max ${timeout} sec.)"
   while (eval "[[ \$(oc get ClusterServiceVersion -n $ns $csv -o jsonpath='{.status.phase}') != Succeeded ]]" 2>/dev/null); do
+    # Make sure there are .status.conditions available before parsing via jq
+    oc wait --for=condition=CatalogSourcesUnhealthy=False subscription.operators.coreos.com "${subscription}" -n "${ns}" --timeout=120s
     subscription_error=$(oc get subscription.operators.coreos.com "${subscription}" -n "${ns}" -ojson | jq '.status.conditions[] | select(.message != null) | select(.message|test("exists and is not referenced by a subscription"))')
     if [[ "${subscription_error}" != "" && $restarts -lt 3 ]]; then
       logger.warn "Restarting OLM pods to work around OCPBUGS-19046"


### PR DESCRIPTION
Workaround for https://issues.redhat.com/browse/OCPBUGS-19046 which hits us in interop testing on OCP 4.15 quite often.

The script restarts OLM pods when the Subscription reports the known issue in its status, and keeps waiting for the CSV to succeed. 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
