### PR TITLE
Include 1.31.1 in upgrade sequence for kitchensink tests

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -72,4 +72,5 @@ dependencies:
 upgrade_sequence:
     - csv: serverless-operator.v1.30.0
     - csv: serverless-operator.v1.31.0
+    - csv: serverless-operator.v1.31.1
     - csv: serverless-operator.v1.32.0


### PR DESCRIPTION
The version must be included because after 1.31.0, OLM offers 1.31.1 and not 1.32.0

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
