### PR TITLE
Use the operator-registry image more consistently

### DIFF
--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -17,7 +17,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM quay.io/openshift/origin-operator-registry:4.15
+FROM registry.ci.openshift.org/origin/4.15:operator-registry
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -17,7 +17,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM quay.io/openshift/origin-operator-registry:__OCP_MAX_VERSION__
+FROM registry.ci.openshift.org/origin/__OCP_MAX_VERSION__:operator-registry
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs


### PR DESCRIPTION
Changing the template to use the same base image on L1 and L20 consistently. 

Wrt/ https://github.com/openshift-knative/serverless-operator/pull/2495#issuecomment-1956319585

On a related subject PTAL on my comment in Jira, it seems to me that RHEL as a builder is unnecessary. But I might be missing some context. 
https://issues.redhat.com/browse/SRVCOM-2901?focusedId=24205814&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24205814


/cc @mgencur @pierDipi 
