### PR TITLE
[main] adding a little note for CURRENT_VERSION_IMAGES overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,7 @@ release-files:
 
 # Generates all files that can be generated, includes release files, code generation
 # and updates vendoring.
+# Use CURRENT_VERSION_IMAGES="<branch>" if you need to override the defaulting to main
 generated-files: release-files
 	./hack/update-deps.sh
 	./hack/update-codegen.sh


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: adding a little note, when wondering about the `generated-files` target going nuts 