### PR TITLE
Pass --config param to prowcopy command in github action

### DIFF
--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -60,12 +60,12 @@ jobs:
       - name: Generate CI (on workflow dispatch)
         if: github.event_name == 'workflow_dispatch'
         working-directory: ./src/github.com/openshift-knative/hack
-        run: go run ./cmd/prowcopy --branch ${{ inputs.branch }} --tag ${{ inputs.branch }}
+        run: go run ./cmd/prowcopy --branch ${{ inputs.branch }} --tag ${{ inputs.branch }} --config config/serverless-operator.yaml
 
       - name: Generate CI (on branch created)
         if: github.event.created
         working-directory: ./src/github.com/openshift-knative/hack
-        run: go run ./cmd/prowcopy --branch ${{ github.ref_name }} --tag ${{ github.ref_name }}
+        run: go run ./cmd/prowcopy --branch ${{ github.ref_name }} --tag ${{ github.ref_name }} --config config/serverless-operator.yaml
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
This is for proper generation of CI jobs. The command needs to have access to the config so that it can see which tests are on-demand.

Follow-up to https://github.com/openshift-knative/hack/pull/124

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
