### PR TITLE
Remove version check in KnativeServing

### DIFF
--- a/hack/patches/017-knativeserving-remove-version-check.patch
+++ b/hack/patches/017-knativeserving-remove-version-check.patch
@@ -1,0 +1,15 @@
+diff --git a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
+index 08610b70d..c2f0b0aaf 100644
+--- a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
++++ b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
+@@ -106,10 +106,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServi
+ 
+ 	logger.Infow("Reconciling KnativeServing", "status", ks.Status)
+ 
+-	if err := common.IsVersionValidMigrationEligible(ks); err != nil {
+-		ks.Status.MarkVersionMigrationNotEligible(err.Error())
+-		return nil
+-	}
+ 	ks.Status.MarkVersionMigrationEligible()
+ 
+ 	if err := r.extension.Reconcile(ctx, ks); err != nil {

--- a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
@@ -106,10 +106,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServi
 
 	logger.Infow("Reconciling KnativeServing", "status", ks.Status)
 
-	if err := common.IsVersionValidMigrationEligible(ks); err != nil {
-		ks.Status.MarkVersionMigrationNotEligible(err.Error())
-		return nil
-	}
 	ks.Status.MarkVersionMigrationEligible()
 
 	if err := r.extension.Reconcile(ctx, ks); err != nil {


### PR DESCRIPTION
## Proposed Changes
- Same as https://github.com/openshift-knative/serverless-operator/pull/2529 but for Serving


/assign @skonto 

/cherry-pick release-1.32



