### PR TITLE
[RELEASE-1.32] Add required label for trusted-ca ConfigMap

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -55,7 +55,7 @@ const (
 	// https://github.com/openshift/cluster-network-operator/pull/2111
 	// Otherwise, both operators will revert each other's changes.
 	trustedCAOwningAnnotationKey   = "openshift.io/owning-component"
-	trustedCAOwningAnnotationValue = "Networking / cluster-network-operator"
+	trustedCAOwningAnnotationValue = "Serverless Operator"
 
 	// certVersionKey is an annotation key used by the Serverless operator to annotate the Knative Serving
 	// controller's PodTemplate to make it redeploy on certificate changes.

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller.go
@@ -51,6 +51,12 @@ const (
 	// Docs: https://docs.openshift.com/container-platform/4.3/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki
 	trustedCAKey = "config.openshift.io/inject-trusted-cabundle"
 
+	// cluster-network-operator enforces the following annotation to be there
+	// https://github.com/openshift/cluster-network-operator/pull/2111
+	// Otherwise, both operators will revert each other's changes.
+	trustedCAOwningAnnotationKey   = "openshift.io/owning-component"
+	trustedCAOwningAnnotationValue = "Networking / cluster-network-operator"
+
 	// certVersionKey is an annotation key used by the Serverless operator to annotate the Knative Serving
 	// controller's PodTemplate to make it redeploy on certificate changes.
 	certVersionKey = socommon.ServingDownstreamDomain + "/mounted-cert-version"
@@ -271,7 +277,9 @@ func (r *ReconcileKnativeServing) ensureCustomCertsConfigMap(instance *operatorv
 	if err != nil {
 		return fmt.Errorf("error reconciling serviceCACM: %w", err)
 	}
-	trustedCACM, err := r.reconcileConfigMap(instance, certs.Name+"-trusted-ca", nil, map[string]string{trustedCAKey: "true"}, nil)
+	trustedCACM, err := r.reconcileConfigMap(instance, certs.Name+"-trusted-ca",
+		map[string]string{trustedCAOwningAnnotationKey: trustedCAOwningAnnotationValue},
+		map[string]string{trustedCAKey: "true"}, nil)
 	if err != nil {
 		return fmt.Errorf("error reconciling serviceCACM: %w", err)
 	}

--- a/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
+++ b/knative-operator/pkg/controller/knativeserving/knativeserving_controller_test.go
@@ -226,6 +226,7 @@ func TestCustomCertsConfigMap(t *testing.T) {
 
 	serviceCAAnnotations := map[string]string{serviceCAKey: "true"}
 	trustedCALabels := map[string]string{trustedCAKey: "true"}
+	trustedCAAnnotations := map[string]string{trustedCAOwningAnnotationKey: trustedCAOwningAnnotationValue}
 
 	tests := []struct {
 		name    string
@@ -237,7 +238,7 @@ func TestCustomCertsConfigMap(t *testing.T) {
 		out: []*corev1.ConfigMap{
 			cm("test-cm", nil, nil, nil, "1"),
 			cm("test-cm-service-ca", nil, serviceCAAnnotations, nil, "1"),
-			cm("test-cm-trusted-ca", trustedCALabels, nil, nil, "1"),
+			cm("test-cm-trusted-ca", trustedCALabels, trustedCAAnnotations, nil, "1"),
 		},
 	}, {
 		name: "upgrade from 1.6.0",
@@ -248,7 +249,7 @@ func TestCustomCertsConfigMap(t *testing.T) {
 		out: []*corev1.ConfigMap{
 			cm("test-cm", nil, nil, nil, "2"), // TODO: maybe we shouldn't stomp, retaining current behavior though.
 			cm("test-cm-service-ca", nil, serviceCAAnnotations, nil, "1"),
-			cm("test-cm-trusted-ca", trustedCALabels, nil, nil, "1"),
+			cm("test-cm-trusted-ca", trustedCALabels, trustedCAAnnotations, nil, "1"),
 		},
 		outCtrl: ctrl("2"),
 	}, {
@@ -257,12 +258,12 @@ func TestCustomCertsConfigMap(t *testing.T) {
 			ctrl("2"),
 			cm("test-cm", nil, serviceCAAnnotations, nil, "3"),
 			cm("test-cm-service-ca", nil, serviceCAAnnotations, nil, "1"),
-			cm("test-cm-trusted-ca", trustedCALabels, nil, map[string]string{"trustedCA": "baz"}, "1"),
+			cm("test-cm-trusted-ca", trustedCALabels, trustedCAAnnotations, map[string]string{"trustedCA": "baz"}, "1"),
 		},
 		out: []*corev1.ConfigMap{
 			cm("test-cm", nil, nil, map[string]string{"trustedCA": "baz"}, "4"),
 			cm("test-cm-service-ca", nil, serviceCAAnnotations, nil, "1"),
-			cm("test-cm-trusted-ca", trustedCALabels, nil, map[string]string{"trustedCA": "baz"}, "1"),
+			cm("test-cm-trusted-ca", trustedCALabels, trustedCAAnnotations, map[string]string{"trustedCA": "baz"}, "1"),
 		},
 		outCtrl: ctrl("4"),
 	}, {
@@ -271,12 +272,12 @@ func TestCustomCertsConfigMap(t *testing.T) {
 			ctrl("0"),
 			cm("test-cm", nil, serviceCAAnnotations, nil, "1"),
 			cm("test-cm-service-ca", nil, serviceCAAnnotations, map[string]string{"serviceCA": "bar"}, "1"),
-			cm("test-cm-trusted-ca", trustedCALabels, nil, map[string]string{"trustedCA": "baz"}, "1"),
+			cm("test-cm-trusted-ca", trustedCALabels, trustedCAAnnotations, map[string]string{"trustedCA": "baz"}, "1"),
 		},
 		out: []*corev1.ConfigMap{
 			cm("test-cm", nil, nil, map[string]string{"serviceCA": "bar", "trustedCA": "baz"}, "2"),
 			cm("test-cm-service-ca", nil, serviceCAAnnotations, map[string]string{"serviceCA": "bar"}, "1"),
-			cm("test-cm-trusted-ca", trustedCALabels, nil, map[string]string{"trustedCA": "baz"}, "1"),
+			cm("test-cm-trusted-ca", trustedCALabels, trustedCAAnnotations, map[string]string{"trustedCA": "baz"}, "1"),
 		},
 		outCtrl: ctrl("2"),
 	}, {
@@ -285,12 +286,12 @@ func TestCustomCertsConfigMap(t *testing.T) {
 			ctrl("10"),
 			cm("test-cm", nil, serviceCAAnnotations, map[string]string{"serviceCA": "bar", "trustedCA": "baz"}, "100"),
 			cm("test-cm-service-ca", nil, serviceCAAnnotations, map[string]string{"serviceCA": "bar"}, "1"),
-			cm("test-cm-trusted-ca", trustedCALabels, nil, map[string]string{"trustedCA": "baz2"}, "1"),
+			cm("test-cm-trusted-ca", trustedCALabels, trustedCAAnnotations, map[string]string{"trustedCA": "baz2"}, "1"),
 		},
 		out: []*corev1.ConfigMap{
 			cm("test-cm", nil, nil, map[string]string{"serviceCA": "bar", "trustedCA": "baz2"}, "101"),
 			cm("test-cm-service-ca", nil, serviceCAAnnotations, map[string]string{"serviceCA": "bar"}, "1"),
-			cm("test-cm-trusted-ca", trustedCALabels, nil, map[string]string{"trustedCA": "baz2"}, "1"),
+			cm("test-cm-trusted-ca", trustedCALabels, trustedCAAnnotations, map[string]string{"trustedCA": "baz2"}, "1"),
 		},
 		outCtrl: ctrl("101"),
 	}}


### PR DESCRIPTION
Fixes JIRA SRVKS-1218

## Proposed Changes
- Adds a label to our injected CA cluster bundle to avoid operator reconciliation war on OCP 4.15
- Values have to line up with `cluster-network-operator` as in https://github.com/openshift/cluster-network-operator/pull/2111

/assign @skonto 
/assign @maschmid 