### PR TITLE
[release-1.32] Include 1.31.1 in upgrade sequence for kitchensink tests

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -73,4 +73,5 @@ dependencies:
 upgrade_sequence:
     - csv: serverless-operator.v1.30.0
     - csv: serverless-operator.v1.31.0
+    - csv: serverless-operator.v1.31.1
     - csv: serverless-operator.v1.32.0


### PR DESCRIPTION
The version must be included because after 1.31.0, OLM offers 1.31.1 and not 1.32.0