### PR TITLE
[release-1.32] Update contract downgrade script to be standalone

### DIFF
--- a/test/upgrade/installation/downgrade.sh
+++ b/test/upgrade/installation/downgrade.sh
@@ -21,7 +21,7 @@ done
 for cm_name in "${contract_configmaps[@]}"; do
   cmdata=$(kubectl get cm "$cm_name" -n "$target_namespace" -ojson || true)
   if [ -n "$cmdata" ]; then
-    new_data=$(echo "$cmdata" | jq -r .binaryData.data | base64 --decode | jq 'del(.trustBundles)' -c | base64 -w 0)
+    new_data=$(echo "$cmdata" | jq -r .binaryData.data | base64 --decode | jq 'del(.trustBundles)' | jq 'del(.resources[].ingress.enableAutoCreateEventTypes)' -c | base64 -w 0)
     echo "$cmdata" | jq --arg new_data "$new_data" '.binaryData.data = $new_data' | kubectl apply -f -
   fi
 done

--- a/test/upgrade/installation/downgrade.sh
+++ b/test/upgrade/installation/downgrade.sh
@@ -19,7 +19,7 @@ for additional_cm in "${@:2}"; do
 done
 
 for cm_name in "${contract_configmaps[@]}"; do
-  cmdata=$(kubectl get cm "$cm_name" -n "$target_namespace" -ojson 2>/dev/null || true)
+  cmdata=$(kubectl get cm "$cm_name" -n "$target_namespace" -ojson || true)
   if [ -n "$cmdata" ]; then
     new_data=$(echo "$cmdata" | jq -r .binaryData.data | base64 --decode | jq 'del(.trustBundles)' -c | base64 -w 0)
     echo "$cmdata" | jq --arg new_data "$new_data" '.binaryData.data = $new_data' | kubectl apply -f -

--- a/test/upgrade/installation/downgrade.sh
+++ b/test/upgrade/installation/downgrade.sh
@@ -25,3 +25,9 @@ for cm_name in "${contract_configmaps[@]}"; do
     echo "$cmdata" | jq --arg new_data "$new_data" '.binaryData.data = $new_data' | kubectl apply -f -
   fi
 done
+
+# Trigger a reconcile of the related pods (see https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically)
+declare -a pods_app_labels=("kafka-broker-dispatcher" "kafka-broker-receiver" "kafka-channel-dispatcher" "kafka-channel-receiver" "kafka-source-dispatcher" "kafka-source-receiver")
+for app_label in "${pods_app_labels[@]}"; do
+  kubectl -n "$target_namespace" annotate pod -l=app="$app_label" why="to trigger a reconcile" --overwrite || true
+done

--- a/test/upgrade/installation/downgrade.sh
+++ b/test/upgrade/installation/downgrade.sh
@@ -1,7 +1,25 @@
 #!/usr/bin/env bash
 
-for cm_name in "$@"; do
-  cmdata=$(kubectl get cm "$cm_name" -n knative-eventing -ojson)
+# Removes the `trustBundles` key from contract configmaps.
+#
+# Usage
+# downgrade.sh <namespace> <additional-configmaps>
+#   Example:
+#   downgrade.sh knative-eventing kafka-source-dispatcher-0 kafka-source-dispatcher-1
+#
+# namespace: Optional - The namespace in which to update the configmaps. Defaults to "knative-eventing"
+# additional-configmaps: Optional - List of additional contract configmaps to patch
+#   (in addition to kafka-broker-brokers-triggers, kafka-channel-channels-subscriptions and kafka-sink-sinks)
+
+target_namespace="${1:-"knative-eventing"}"
+declare -a contract_configmaps=("kafka-broker-brokers-triggers" "kafka-channel-channels-subscriptions" "kafka-sink-sinks")
+
+for additional_cm in "${@:2}"; do
+  contract_configmaps+=("$additional_cm")
+done
+
+for cm_name in "${contract_configmaps[@]}"; do
+  cmdata=$(kubectl get cm "$cm_name" -n "$target_namespace" -ojson 2>/dev/null || true)
   if [ -n "$cmdata" ]; then
     new_data=$(echo "$cmdata" | jq -r .binaryData.data | base64 --decode | jq 'del(.trustBundles)' -c | base64 -w 0)
     echo "$cmdata" | jq --arg new_data "$new_data" '.binaryData.data = $new_data' | kubectl apply -f -

--- a/test/upgrade/installation/downgrade.sh
+++ b/test/upgrade/installation/downgrade.sh
@@ -21,7 +21,7 @@ done
 for cm_name in "${contract_configmaps[@]}"; do
   cmdata=$(kubectl get cm "$cm_name" -n "$target_namespace" -ojson || true)
   if [ -n "$cmdata" ]; then
-    new_data=$(echo "$cmdata" | jq -r .binaryData.data | base64 --decode | jq 'del(.trustBundles)' | jq 'del(.resources[].ingress.enableAutoCreateEventTypes)' -c | base64 -w 0)
+    new_data=$(echo "$cmdata" | jq -r .binaryData.data | base64 --decode | jq 'del(.trustBundles, .resources[].ingress.enableAutoCreateEventTypes)' -c | base64 -w 0)
     echo "$cmdata" | jq --arg new_data "$new_data" '.binaryData.data = $new_data' | kubectl apply -f -
   fi
 done

--- a/test/upgrade/installation/downgrade.sh
+++ b/test/upgrade/installation/downgrade.sh
@@ -27,7 +27,7 @@ for cm_name in "${contract_configmaps[@]}"; do
 done
 
 # Trigger a reconcile of the related pods (see https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically)
-declare -a pods_app_labels=("kafka-broker-dispatcher" "kafka-broker-receiver" "kafka-channel-dispatcher" "kafka-channel-receiver" "kafka-source-dispatcher" "kafka-source-receiver")
+declare -a pods_app_labels=("kafka-broker-dispatcher" "kafka-broker-receiver" "kafka-channel-dispatcher" "kafka-channel-receiver" "kafka-source-dispatcher" "kafka-sink-receiver")
 for app_label in "${pods_app_labels[@]}"; do
   kubectl -n "$target_namespace" annotate pod -l=app="$app_label" why="to trigger a reconcile" --overwrite || true
 done

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -262,7 +262,7 @@ func setStorageToAlpha(ctx *test.Context, name string) error {
 }
 
 func downgradeKafkaContractsWithScript() error {
-	c := exec.Command("bash", "-s", "-", "kafka-broker-brokers-triggers", "kafka-channel-channels-subscriptions", "kafka-sink-sinks", "kafka-source-dispatcher-0", "kafka-source-dispatcher-1")
+	c := exec.Command("bash", "-s", "-", test.EventingNamespace, "kafka-source-dispatcher-0", "kafka-source-dispatcher-1")
 
 	c.Stdin = strings.NewReader(downgradeContractScript)
 


### PR DESCRIPTION
Update the contract downgrade script to:
* include the main contract names already (so this can be run without parameters later from support without knowing the configmap names)
* allow to set the namespace name (so this can be run on namespaced-broker configs too)