### PR TITLE
Simplify mesh test configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ install-serving:
 	INSTALL_EVENTING="false" ./hack/install.sh
 
 install-serving-with-mesh:
-	FULL_MESH="true" UNINSTALL_MESH="false" ./hack/mesh.sh
-	FULL_MESH=true SCALE_UP=4 INSTALL_SERVING=true INSTALL_EVENTING="false" ./hack/install.sh
+	MESH=true UNINSTALL_MESH="false" ./hack/mesh.sh
+	MESH=true SCALE_UP=4 INSTALL_SERVING=true INSTALL_EVENTING="false" ./hack/install.sh
 
 install-eventing:
 	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
@@ -41,11 +41,11 @@ install-kafka:
 	SCALE_UP=4 INSTALL_SERVING="false" INSTALL_KAFKA="true" ./hack/install.sh
 
 install-kafka-with-mesh:
-	FULL_MESH="true" UNINSTALL_MESH="false" ./hack/mesh.sh
+	UNINSTALL_MESH="false" ./hack/mesh.sh
 	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 	TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ./hack/tracing.sh
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
-	FULL_MESH=true SCALE_UP=5 INSTALL_SERVING=false INSTALL_EVENTING=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ENABLE_TRACING=true ./hack/install.sh
+	MESH=true SCALE_UP=5 INSTALL_SERVING=false INSTALL_EVENTING=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ENABLE_TRACING=true ./hack/install.sh
 
 install-kafka-with-keda:
 	UNINSTALL_KEDA="false" ./hack/keda.sh
@@ -82,14 +82,11 @@ install-mesh:
 uninstall-mesh:
 	UNINSTALL_MESH="true" ./hack/mesh.sh
 
-install-full-mesh:
-	FULL_MESH="true" UNINSTALL_MESH="false" ./hack/mesh.sh
+install-mesh:
+	UNINSTALL_MESH="false" ./hack/mesh.sh
 
-uninstall-full-mesh:
-	FULL_MESH="true" UNINSTALL_MESH="true" ./hack/mesh.sh
-
-install-with-mesh-enabled:
-	FULL_MESH=true ./hack/install.sh
+uninstall-mesh:
+	UNINSTALL_MESH="true" ./hack/mesh.sh
 
 install-tracing-zipkin:
 	TRACING_BACKEND=zipkin ./hack/tracing.sh
@@ -141,14 +138,14 @@ test-e2e-with-kafka: operator-e2e
 
 # Run E2E tests from the current repo for serving+eventing+mesh
 test-e2e-with-mesh-testonly:
-	FULL_MESH=true ./test/e2e-tests.sh
+	MESH=true ./test/e2e-tests.sh
 
 test-e2e-with-mesh:
-	FULL_MESH="true" UNINSTALL_MESH="false" ./hack/mesh.sh
+	UNINSTALL_MESH="false" ./hack/mesh.sh
 	./hack/tracing.sh
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
-	FULL_MESH=true SCALE_UP=4 INSTALL_KAFKA="true" ENABLE_TRACING=true ./hack/install.sh
-	FULL_MESH=true TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
+	MESH=true SCALE_UP=4 INSTALL_KAFKA="true" ENABLE_TRACING=true ./hack/install.sh
+	MESH=true TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
 
 # Run both unit and E2E tests from the current repo.
 test-operator: test-unit test-e2e
@@ -156,26 +153,24 @@ test-operator: test-unit test-e2e
 # Run upstream E2E tests with net-istio and sidecar.
 # TODO: Enable upgrade tests once upstream fixed the issue https://github.com/knative/serving/issues/11535.
 test-upstream-e2e-mesh-testonly:
-	FULL_MESH=true TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
-	FULL_MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	MESH=true TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
+	MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
-install-for-mesh-e2e:
+mesh-e2e:
 	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh # This avoids early failures for the skipped Eventing TLS tests
-	FULL_MESH="true" UNINSTALL_MESH="false" ./hack/mesh.sh
+	UNINSTALL_MESH="false" ./hack/mesh.sh
 	TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ./hack/tracing.sh
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
-	FULL_MESH=true SCALE_UP=6 INSTALL_SERVING=true INSTALL_EVENTING=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ENABLE_TRACING=true ./hack/install.sh
-
-mesh-e2e: install-for-mesh-e2e
-	FULL_MESH=true TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
-	FULL_MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	MESH=true SCALE_UP=6 INSTALL_SERVING=true INSTALL_EVENTING=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ENABLE_TRACING=true ./hack/install.sh
+	MESH=true TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
+	MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
 test-upstream-e2e-mesh: mesh-e2e
 
 # Run upstream E2E tests without upgrades.
 test-upstream-e2e-no-upgrade-testonly:
-	FULL_MESH=true ./test/e2e-tests.sh
-	FULL_MESH=true TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
+	MESH=true ./test/e2e-tests.sh
+	MESH=true TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
 test-upstream-e2e-kafka-no-upgrade-testonly:
 	TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
@@ -207,11 +202,11 @@ test-upgrade:
 	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
 mesh-upgrade:
-	FULL_MESH=true UNINSTALL_MESH=false ./hack/mesh.sh
+	UNINSTALL_MESH=false ./hack/mesh.sh
 	TRACING_BACKEND=zipkin ./hack/tracing.sh
 	UNINSTALL_STRIMZI=false ./hack/strimzi.sh
-	FULL_MESH=true INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=5 ./hack/install.sh
-	FULL_MESH=true TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
+	MESH=true INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=5 ./hack/install.sh
+	MESH=true TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
 test-upgrade-with-mesh: mesh-upgrade
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install-serving:
 	INSTALL_EVENTING="false" ./hack/install.sh
 
 install-serving-with-mesh:
-	MESH=true UNINSTALL_MESH="false" ./hack/mesh.sh
+	UNINSTALL_MESH="false" ./hack/mesh.sh
 	MESH=true SCALE_UP=4 INSTALL_SERVING=true INSTALL_EVENTING="false" ./hack/install.sh
 
 install-eventing:
@@ -156,12 +156,14 @@ test-upstream-e2e-mesh-testonly:
 	MESH=true TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
 	MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
-mesh-e2e:
+install-for-mesh-e2e:
 	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh # This avoids early failures for the skipped Eventing TLS tests
 	UNINSTALL_MESH="false" ./hack/mesh.sh
 	TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ./hack/tracing.sh
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	MESH=true SCALE_UP=6 INSTALL_SERVING=true INSTALL_EVENTING=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ENABLE_TRACING=true ./hack/install.sh
+
+mesh-e2e: install-for-mesh-e2e
 	MESH=true TEST_KNATIVE_KAFKA=true ./test/e2e-tests.sh
 	MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,8 @@ in `knative-eventing` namespace by default. Requires to install a Strimzi cluste
   version.
 - `make install-strimzi`: Install the latest Strimzi operator and a kafka cluster instance in `kafka` namespace by default.
 - `make unistall-strimzi`: Uninstall the Strimzi operator and any existing kafka cluster instance. 
-- `make install-mesh`: Install service mesh operator.
-- `make uninstall-mesh `: Uninstall service mesh operator.
-- `make install-full-mesh`: Install service mesh operator, Istio Gateway and PeerAuthentication to use Knative Serving for secure traffic.
-- `make uninstall-full-mesh `: Uninstall service mesh operator, Istio Gateway and PeerAuthentication.
+- `make install-mesh`: Install service mesh operator, Istio Gateway and PeerAuthentication to use Knative Serving + Eventing for secure traffic.
+- `make uninstall-mesh `: Uninstall service mesh operator, Istio Gateway and PeerAuthentication.
 
 **Note:** Don't forget you can chain `make` targets. `make images dev` is handy
 for example.

--- a/docs/full-mesh.md
+++ b/docs/full-mesh.md
@@ -1,9 +1,9 @@
 # Test serverless-operator with secure traffic
 
-To test service mesh operator and setup secure traffic, run `make install-full-mesh`
+To test service mesh operator and setup secure traffic, run `make install-mesh`
 
 ```
-make install-full-mesh
+make install-mesh
 ```
 
 This command deploys resources in [mesh_resources directory](../hack/lib/mesh_resources/).
@@ -87,7 +87,7 @@ spec:
 EOF
 ```
 
-Then, create KnativeuService with `sidecar.istio.io/inject: "true"`, `sidecar.istio.io/rewriteAppHTTPProbers: "true"` and `serving.knative.openshift.io/enablePassthrough: "true"` annotations in your namespace,
+Then, create KnativeService with `sidecar.istio.io/inject: "true"`, `sidecar.istio.io/rewriteAppHTTPProbers: "true"` and `serving.knative.openshift.io/enablePassthrough: "true"` annotations in your namespace,
 which is one of the namespaces in the `ServiceMeshMemberRoll`.
 
 ```sh
@@ -123,5 +123,5 @@ Hello World!
 To uninstall service mesh operator, run `make uninstall-mesh`.
 
 ```
-make uninstall-full-mesh
+make uninstall-mesh
 ```

--- a/hack/lib/mesh.bash
+++ b/hack/lib/mesh.bash
@@ -5,17 +5,13 @@ resources_dir="$(dirname "${BASH_SOURCE[0]}")/mesh_resources"
 function install_mesh {
   ensure_catalog_pods_running
   deploy_servicemesh_operators
-  if [[ ${FULL_MESH:-} == "true" ]]; then
-    deploy_servicemeshcontrolplane
-    deploy_gateways
-  fi
+  deploy_servicemeshcontrolplane
+  deploy_gateways
 }
 
 function uninstall_mesh {
-  if [[ ${FULL_MESH:-} == "true" ]]; then
-    undeploy_gateways
-    undeploy_servicemeshcontrolplane
-  fi
+  undeploy_gateways
+  undeploy_servicemeshcontrolplane
   undeploy_servicemesh_operators
 }
 

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -167,7 +167,7 @@ function deploy_knativeserving_cr {
     yq delete --inplace "$serving_cr" spec.config.network.internal-encryption
   fi
 
-  if [[ $FULL_MESH == "true" ]]; then
+  if [[ $MESH == "true" ]]; then
     enable_istio "$serving_cr"
     # Disable internal encryption.
     yq delete --inplace "$serving_cr" spec.config.network.internal-encryption
@@ -192,7 +192,7 @@ function deploy_knativeserving_cr {
 
   oc apply -n "${SERVING_NAMESPACE}" -f "$serving_cr"
 
-  if [[ $FULL_MESH == "true" ]]; then
+  if [[ $MESH == "true" ]]; then
     # metadata-webhook adds istio annotations for e2e test by webhook.
     oc apply -f "${rootdir}/serving/metadata-webhook/config"
   fi
@@ -229,7 +229,7 @@ EOF
 }
 
 # If ServiceMesh is enabled:
-# - Set ingress.istio.enbled to "true"
+# - Set ingress.istio.enabled to "true"
 # - Set inject and rewriteAppHTTPProbers annotations for activator and autoscaler
 #   as "test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml" has the value "prometheus".
 function enable_istio_eventing {
@@ -292,7 +292,7 @@ EOF
 }
 
 # If ServiceMesh is enabled:
-# - Set ingress.istio.enbled to "true"
+# - Set ingress.istio.enabled to "true"
 # - Set inject and rewriteAppHTTPProbers annotations for activator and autoscaler
 #   as "test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml" has the value "prometheus".
 function enable_istio_eventing_kafka {
@@ -363,7 +363,7 @@ function deploy_knativeeventing_cr {
   if [[ $ENABLE_TRACING == "true" ]]; then
     enable_tracing "$eventing_cr"
   fi
-  if [[ $FULL_MESH == "true" ]]; then
+  if [[ $MESH == "true" ]]; then
     enable_istio_eventing "$eventing_cr"
   fi
 
@@ -403,7 +403,7 @@ spec:
     bootstrapServers: my-cluster-kafka-bootstrap.kafka:9092
 EOF
 
-  if [[ $FULL_MESH == "true" ]]; then
+  if [[ $MESH == "true" ]]; then
     enable_istio_eventing_kafka "$knativekafka_cr"
   fi
 
@@ -579,7 +579,7 @@ function gather_knative_state {
   local gatherImageMesh="${MUST_GATHER_IMAGE_MESH:-registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7}"
   mkdir -p "$gather_dir"
   IMAGE_OPTION=("--image=${gatherImageKnative}")
-  if [[ $FULL_MESH == true ]]; then
+  if [[ $MESH == true ]]; then
     IMAGE_OPTION=("${IMAGE_OPTION[@]}" "--image=${gatherImageMesh}")
   fi
 

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -81,7 +81,7 @@ export TEST_KNATIVE_KAFKA_BROKER="${TEST_KNATIVE_KAFKA_BROKER:-false}"
 export INSTALL_SERVING="${INSTALL_SERVING:-true}"
 export INSTALL_EVENTING="${INSTALL_EVENTING:-true}"
 export INSTALL_KAFKA="${INSTALL_KAFKA:-false}"
-export FULL_MESH="${FULL_MESH:-false}"
+export MESH="${MESH:-false}"
 export ENABLE_TRACING="${ENABLE_TRACING:-false}"
 export ENABLE_KEDA="${ENABLE_KEDA:-false}"
 # Define sample-rate for tracing.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -12,7 +12,7 @@ fi
 debugging.setup # both install and test
 dump_state.setup # test
 
-if [[ $FULL_MESH == "true" ]]; then
+if [[ $MESH == "true" ]]; then
   # net-istio does not use knative-serving-ingress namespace.
   export INGRESS_NAMESPACE="knative-serving"
 else

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -66,8 +66,8 @@ func TestKnativeServing(t *testing.T) {
 		}
 		ingressNamespace := servingNamespace + "-ingress"
 
-		// If FULL_MESH is true, net-istio is used instead of net-kourier.
-		if os.Getenv("FULL_MESH") == "true" {
+		// If MESH is true, net-istio is used instead of net-kourier.
+		if os.Getenv("MESH") == "true" {
 			ingressDeployments = []test.Deployment{
 				{Name: "net-istio-controller"},
 				{Name: "net-istio-webhook"},

--- a/test/eventing-kafka.bash
+++ b/test/eventing-kafka.bash
@@ -6,7 +6,7 @@ set -e
 function upstream_knative_eventing_kafka_broker_e2e {
   should_run "${FUNCNAME[0]}" || return 0
 
-  if [[ $FULL_MESH = true ]]; then
+  if [[ $MESH == "true" ]]; then
     # upstream_knative_eventing_e2e_mesh function in eventing.bash runs:
     # - Eventing core tests
     # - EKB tests

--- a/test/eventing.bash
+++ b/test/eventing.bash
@@ -8,7 +8,7 @@ function upstream_knative_eventing_e2e {
 
   logger.info 'Running eventing tests'
 
-  if [[ $FULL_MESH = true ]]; then
+  if [[ $MESH == "true" ]]; then
     upstream_knative_eventing_e2e_mesh
     return $?
   fi

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -139,7 +139,7 @@ function downstream_serving_e2e_tests {
       mv ./test/servinge2e/user_permissions_test.go ./test/servinge2e/user_permissions_notest.go || true
   fi
 
-  if [[ $FULL_MESH == "true" ]]; then
+  if [[ $MESH == "true" ]]; then
     go_test_e2e "${RUN_FLAGS[@]}" ./test/servinge2e/ ./test/servinge2e/servicemesh/ \
       --kubeconfigs "${kubeconfigs_str}" \
       --imagetemplate "${IMAGE_TEMPLATE}" \
@@ -209,13 +209,13 @@ function downstream_eventing_e2e_rekt_tests {
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi
 
-  if [[ $FULL_MESH == "true" ]]; then
+  if [[ $MESH == "true" ]]; then
     # Need to specify a namespace that is in Mesh.
     go_test_e2e "${RUN_FLAGS[@]}" ./test/eventinge2erekt ./test/eventinge2erekt/servicemesh \
       --images.producer.file="${images_file}" \
       --poll.timeout="8m" \
       --environment.namespace=serverless-tests \
-      --istio.enabled="$FULL_MESH" \
+      --istio.enabled="$MESH" \
       "$@"
   else
     go_test_e2e "${RUN_FLAGS[@]}" ./test/eventinge2erekt \
@@ -281,13 +281,13 @@ function downstream_knative_kafka_e2e_rekt_tests {
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi
 
-  if [[ $FULL_MESH == "true" ]]; then
+  if [[ $MESH == "true" ]]; then
     # Need to specify a namespace that is in Mesh.
     go_test_e2e "${RUN_FLAGS[@]}" ./test/extensione2erekt ./test/extensione2erekt/servicemesh \
       --images.producer.file="${images_file}" \
       --environment.namespace=serverless-tests \
       --poll.timeout="8m" \
-      --istio.enabled="$FULL_MESH" \
+      --istio.enabled="$MESH" \
       "$@"
 
     # Workaround for https://github.com/knative-sandbox/eventing-kafka-broker/issues/3133
@@ -463,7 +463,7 @@ EOF
     --resolvabledomain \
     --https)
 
-  if [[ $FULL_MESH == "true" ]]; then
+  if [[ $MESH == "true" ]]; then
       common_opts+=("--environment.namespace=serverless-tests")
       common_opts+=("--istio.enabled")
       common_opts+=("--poll.timeout=8m")

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -65,15 +65,6 @@ function upstream_knative_serving_e2e_and_conformance_tests {
   subdomain=$(oc get ingresses.config.openshift.io cluster  -o jsonpath="{.spec.domain}")
   OPENSHIFT_TEST_OPTIONS="--kubeconfig $KUBECONFIG --enable-beta --enable-alpha --resolvabledomain --customdomain=$subdomain --https --skip-cleanup-on-fail"
 
-# as https://issues.redhat.com/browse/SRVKS-211 is closed, check if this works now
-#  if [[ $MESH == "true" ]]; then
-#    # TODO: SRVKS-211: Can not run grpc and http2 tests.
-#    rm ./test/e2e/grpc_test.go
-#    rm ./test/e2e/http2_test.go
-#    # Remove h2c test
-#    sed -ie '47,51d' ./test/conformance/runtime/protocol_test.go
-#  fi
-
   local parallel=16
 
   if [[ $(oc get infrastructure cluster -ojsonpath='{.status.platform}') = VSphere ]]; then

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -32,8 +32,13 @@ function prepare_knative_serving_tests {
   add_networkpolicy "serving-tests"
   add_networkpolicy "serving-tests-alt"
 
-  export GATEWAY_OVERRIDE="kourier"
-  export GATEWAY_NAMESPACE_OVERRIDE="${INGRESS_NAMESPACE}"
+  if [[ $MESH == "true" ]]; then
+    export GATEWAY_OVERRIDE="istio-ingressgateway"
+    export GATEWAY_NAMESPACE_OVERRIDE="istio-system"
+  else
+    export GATEWAY_OVERRIDE="kourier"
+    export GATEWAY_NAMESPACE_OVERRIDE="${INGRESS_NAMESPACE}"
+  fi
 }
 
 function upstream_knative_serving_e2e_and_conformance_tests {

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -22,7 +22,7 @@ function prepare_knative_serving_tests {
   # Create test resources (namespaces, configMaps, secrets)
   oc apply -f test/config/cluster-resources.yaml
   # Workaround for https://issues.redhat.com/browse/OSSM-1397
-  if [[ $FULL_MESH == "true" ]]; then
+  if [[ $MESH == "true" ]]; then
     oc label namespace serving-tests maistra.io/member-of=istio-system --overwrite
   fi
   oc apply -f test/config/test-resources.yaml
@@ -65,13 +65,14 @@ function upstream_knative_serving_e2e_and_conformance_tests {
   subdomain=$(oc get ingresses.config.openshift.io cluster  -o jsonpath="{.spec.domain}")
   OPENSHIFT_TEST_OPTIONS="--kubeconfig $KUBECONFIG --enable-beta --enable-alpha --resolvabledomain --customdomain=$subdomain --https --skip-cleanup-on-fail"
 
-  if [[ $FULL_MESH == "true" ]]; then
-    # TODO: SRVKS-211: Can not run grpc and http2 tests.
-    rm ./test/e2e/grpc_test.go
-    rm ./test/e2e/http2_test.go
-    # Remove h2c test
-    sed -ie '47,51d' ./test/conformance/runtime/protocol_test.go
-  fi
+# as https://issues.redhat.com/browse/SRVKS-211 is closed, check if this works now
+#  if [[ $MESH == "true" ]]; then
+#    # TODO: SRVKS-211: Can not run grpc and http2 tests.
+#    rm ./test/e2e/grpc_test.go
+#    rm ./test/e2e/http2_test.go
+#    # Remove h2c test
+#    sed -ie '47,51d' ./test/conformance/runtime/protocol_test.go
+#  fi
 
   local parallel=16
 
@@ -81,7 +82,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
     parallel=2
   fi
 
-  if [[ $FULL_MESH == "true" ]]; then
+  if [[ $MESH == "true" ]]; then
     # reconfiguring istio-proxies is flaky on too much parallelism,
     # random pods will fail to start with `PostStartHook failed`
     parallel=8

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -65,7 +65,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
   subdomain=$(oc get ingresses.config.openshift.io cluster  -o jsonpath="{.spec.domain}")
   OPENSHIFT_TEST_OPTIONS="--kubeconfig $KUBECONFIG --enable-beta --enable-alpha --resolvabledomain --customdomain=$subdomain --https --skip-cleanup-on-fail"
 
-  if [[ $FULL_MESH == "true" ]]; then
+  if [[ $MESH == "true" ]]; then
     # TODO: SRVKS-211: Can not run grpc and http2 tests.
     rm ./test/e2e/grpc_test.go
     rm ./test/e2e/http2_test.go

--- a/test/upstream-e2e-tests.sh
+++ b/test/upstream-e2e-tests.sh
@@ -15,8 +15,8 @@ dump_state.setup
 logger.success '🚀 Cluster prepared for testing.'
 
 create_namespaces "${TEST_NAMESPACES[@]}"
-# Install ServiceMesh and enable mTLS.
-if [[ $FULL_MESH != true ]]; then
+
+if [[ $MESH != true ]]; then
   trust_router_ca
 fi
 


### PR DESCRIPTION
Fixes JIRA SRVKS-1178

## Proposed Changes
- Simplifies the mesh configuration (FULL_MESH = false with mesh does no longer exist)
- Renamed `FULL_MESH` to `MESH` to make this fact more clear
- `hack/mesh.sh` will always install/uninstall "full mesh" now
- Dropped no longer used make targets

/assign @mgencur 
/assign @skonto 

Please let me know if you know of any other places where we tested kourier with ServiceMesh integration (as per JIRA). I did not exactly find that.