### PR TITLE
[release-1.31] Ignore no match errors on deleting obsolete resources

### DIFF
--- a/hack/patches/cert_manager_no_match_error_warning.patch
+++ b/hack/patches/cert_manager_no_match_error_warning.patch
@@ -1,0 +1,35 @@
+diff --git a/vendor/knative.dev/operator/pkg/reconciler/common/stages.go b/vendor/knative.dev/operator/pkg/reconciler/common/stages.go
+index ce299592a..d6bf5d5b1 100644
+--- a/vendor/knative.dev/operator/pkg/reconciler/common/stages.go
++++ b/vendor/knative.dev/operator/pkg/reconciler/common/stages.go
+@@ -18,11 +18,15 @@ package common
+ 
+ import (
+ 	"context"
++	"fmt"
+ 	"strings"
+ 
+ 	mf "github.com/manifestival/manifestival"
+-	"knative.dev/operator/pkg/apis/operator/base"
++	"k8s.io/apimachinery/pkg/api/meta"
++	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+ 	"knative.dev/pkg/logging"
++
++	"knative.dev/operator/pkg/apis/operator/base"
+ )
+ 
+ // Stage represents a step in the reconcile process
+@@ -113,6 +117,12 @@ func DeleteObsoleteResources(ctx context.Context, instance base.KComponent, fetc
+ 		return NoOp
+ 	}
+ 	return func(_ context.Context, manifest *mf.Manifest, _ base.KComponent) error {
+-		return installed.Filter(mf.NoCRDs, mf.Not(mf.In(*manifest))).Delete()
++		for _, r := range installed.Filter(mf.NoCRDs, mf.Not(mf.In(*manifest))).Resources() {
++			m, _ := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{r}), mf.UseClient(manifest.Client))
++			if err := m.Delete(); err != nil && !meta.IsNoMatchError(err) {
++				return fmt.Errorf("failed to delete obsolete resources: %w", err)
++			}
++		}
++		return nil
+ 	}
+ }

--- a/vendor/knative.dev/operator/pkg/reconciler/common/stages.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/common/stages.go
@@ -18,11 +18,15 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	mf "github.com/manifestival/manifestival"
-	"knative.dev/operator/pkg/apis/operator/base"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"knative.dev/pkg/logging"
+
+	"knative.dev/operator/pkg/apis/operator/base"
 )
 
 // Stage represents a step in the reconcile process
@@ -113,6 +117,12 @@ func DeleteObsoleteResources(ctx context.Context, instance base.KComponent, fetc
 		return NoOp
 	}
 	return func(_ context.Context, manifest *mf.Manifest, _ base.KComponent) error {
-		return installed.Filter(mf.NoCRDs, mf.Not(mf.In(*manifest))).Delete()
+		for _, r := range installed.Filter(mf.NoCRDs, mf.Not(mf.In(*manifest))).Resources() {
+			m, _ := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{r}), mf.UseClient(manifest.Client))
+			if err := m.Delete(); err != nil && !meta.IsNoMatchError(err) {
+				return fmt.Errorf("failed to delete obsolete resources: %w", err)
+			}
+		}
+		return nil
 	}
 }


### PR DESCRIPTION
Patch related https://github.com/knative/operator/pull/1749/files

This issue is not affecting functionality, it's a warning, so we can include it in a future 1.31.x release