### PR TITLE
Bump operator yaml version to 1.13

### DIFF
--- a/olm-catalog/serverless-operator/manifests/operator_v1beta1_knativeserving_crd.yaml
+++ b/olm-catalog/serverless-operator/manifests/operator_v1beta1_knativeserving_crd.yaml
@@ -2258,8 +2258,14 @@ spec:
                         type: boolean
                       service-type:
                         type: string
+                      service-load-balancer-ip:
+                        type: string
                       bootstrap-configmap:
                         type: string
+                      http-port:
+                        type: integer
+                      https-port:
+                        type: integer
                     type: object
                 type: object
               security:

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -61,7 +61,7 @@ dependencies:
         openjdk_17: registry.access.redhat.com/ubi8/openjdk-17@sha256:b00f687d913b8d1e027f7eabd6765de6c8d469629bef9550f10dbf207af24fe5
         openjdk_21: registry.access.redhat.com/ubi8/openjdk-21@sha256:4f35566977c35306a8f2102841ceb7fa10a6d9ac47c079131caed5655140f9b2
         python-39: registry.access.redhat.com/ubi8/python-39@sha256:cf0af1732c483d4e6ba708f9f4d5541cb43c98c3c67c604c23b0e55897eebe41
-    operator: 1.11.0
+    operator: 1.13.3
     # Previous versions required for downgrade testing
     previous:
         serving: knative-v1.11


### PR DESCRIPTION
# Changes
- Bump operator yaml to version 1.13
- We use 1.13 for operator and code to make sure it is the same as in the dependants with 1.12 (which is actually 1.13 code)

/assign @skonto 
/assign @creydr 
