### PR TITLE
Upgrade sequence does not include 1.31.1

### DIFF
--- a/hack/cmd/bumpso/bumpso.go
+++ b/hack/cmd/bumpso/bumpso.go
@@ -81,8 +81,7 @@ func run() error {
 	}
 	upgradeSequence = upgradeSequence[1:] // Remove first version
 	upgradeSequence = append(upgradeSequence, map[string]interface{}{
-		"csv":    fmt.Sprintf("serverless-operator.v%s", newVersion),
-		"source": "serverless-operator",
+		"csv": fmt.Sprintf("serverless-operator.v%s", newVersion),
 	})
 
 	defaultChannel, _, _ := unstructured.NestedString(project, "olm", "channels", "default")

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -71,7 +71,6 @@ dependencies:
         image: quay.io/openshift-knative/must-gather
 upgrade_sequence:
     - csv: serverless-operator.v1.31.0
-    - csv: serverless-operator.v1.31.1
     - csv: serverless-operator.v1.32.0
     - csv: serverless-operator.v1.33.0
       source: serverless-operator


### PR DESCRIPTION
This will fix an error such as https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-415-kitchensink-upgrade-aws-415-c/1772096123641532416

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- When 1.31.0 is instsalled on 4.15, the next offered version is 1.32.0
- Do not define "source" in project.yaml, the source is picked automatically now
