### PR TITLE
Use promotion by name for operator images

### DIFF
--- a/hack/lib/__sources__.bash
+++ b/hack/lib/__sources__.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-declare -a __sources=(metadata vars common ui scaleup namespaces catalogsource serverless tracing mesh certmanager strimzi keda tracing clusterlogging testselect)
+declare -a __sources=(metadata vars images common ui scaleup namespaces catalogsource serverless tracing mesh certmanager strimzi keda tracing clusterlogging testselect)
 
 for source in "${__sources[@]}"; do
   # shellcheck disable=SC1091,SC1090

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -64,8 +64,13 @@ function install_catalogsource {
     logger.debug "Create a backup of the index Dockerfile."
     cp "${rootdir}/${index_dorkerfile_path}" "${rootdir}/_output/bkp.Dockerfile"
 
-    # Replace the nightly bundle reference with the previously built bundle
-    sed -i "s_\(.*\)\(registry.ci.openshift.org/knative/${CURRENT_VERSION_IMAGES}:serverless-bundle\)\(.*\)_\1image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle:latest\3_" "${rootdir}/${index_dorkerfile_path}"
+    # Replace bundle reference with previously built bundle
+    bundle="registry.ci.openshift.org/knative/release-${CURRENT_VERSION}:serverless-bundle"
+    if ! grep "${bundle}" "${rootdir}/${index_dorkerfile_path}"; then
+      logger.error "Bundle ${bundle} not found in Dockerfile."
+      return 1
+    fi
+    sed -i "s_\(.*\)\(${bundle}\)\(.*\)_\1image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle:latest\3_" "${rootdir}/${index_dorkerfile_path}"
 
     build_image "serverless-index" "${rootdir}" "${index_dorkerfile_path}"
 

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -65,7 +65,7 @@ function install_catalogsource {
     cp "${rootdir}/${index_dorkerfile_path}" "${rootdir}/_output/bkp.Dockerfile"
 
     # Replace the nightly bundle reference with the previously built bundle
-    sed -i "s_\(.*\)\(registry.ci.openshift.org/knative/openshift-serverless-v${CURRENT_VERSION}:serverless-bundle\)\(.*\)_\1image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle:latest\3_" "${rootdir}/${index_dorkerfile_path}"
+    sed -i "s_\(.*\)\(registry.ci.openshift.org/knative/${CURRENT_VERSION_IMAGES}:serverless-bundle\)\(.*\)_\1image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle:latest\3_" "${rootdir}/${index_dorkerfile_path}"
 
     build_image "serverless-index" "${rootdir}" "${index_dorkerfile_path}"
 

--- a/hack/lib/images.bash
+++ b/hack/lib/images.bash
@@ -11,7 +11,7 @@ function default_serverless_operator_images() {
   local serverless
   serverless="${registry_host}/knative/${CURRENT_VERSION_IMAGES}:serverless"
   export SERVERLESS_KNATIVE_OPERATOR=${SERVERLESS_KNATIVE_OPERATOR:-"${serverless}-knative-operator"}
-  export SERVERLESS_OPENSHIFT_KNATIVE_OPERATOR=${SERVERLESS_OPENSHIFT_KNATIVE_OPERATOR:-"${serverless}-knative-operator"}
+  export SERVERLESS_OPENSHIFT_KNATIVE_OPERATOR=${SERVERLESS_OPENSHIFT_KNATIVE_OPERATOR:-"${serverless}-openshift-knative-operator"}
   export SERVERLESS_INGRESS=${SERVERLESS_INGRESS:-"${serverless}-ingress"}
 }
 

--- a/hack/lib/images.bash
+++ b/hack/lib/images.bash
@@ -9,10 +9,10 @@ export CURRENT_VERSION_IMAGES=${CURRENT_VERSION_IMAGES:-"main"}
 
 function default_serverless_operator_images() {
   local serverless
-  serverless="${registry_host}/knative/serverless"
-  export SERVERLESS_KNATIVE_OPERATOR=${SERVERLESS_KNATIVE_OPERATOR:-"${serverless}-knative-operator:${CURRENT_VERSION_IMAGES}"}
-  export SERVERLESS_OPENSHIFT_KNATIVE_OPERATOR=${SERVERLESS_OPENSHIFT_KNATIVE_OPERATOR:-"${serverless}-openshift-knative-operator:${CURRENT_VERSION_IMAGES}"}
-  export SERVERLESS_INGRESS=${SERVERLESS_INGRESS:-"${serverless}-ingress:${CURRENT_VERSION_IMAGES}"}
+  serverless="${registry_host}/knative/${CURRENT_VERSION_IMAGES}:serverless"
+  export SERVERLESS_KNATIVE_OPERATOR=${SERVERLESS_KNATIVE_OPERATOR:-"${serverless}-knative-operator"}
+  export SERVERLESS_OPENSHIFT_KNATIVE_OPERATOR=${SERVERLESS_OPENSHIFT_KNATIVE_OPERATOR:-"${serverless}-knative-operator"}
+  export SERVERLESS_INGRESS=${SERVERLESS_INGRESS:-"${serverless}-ingress"}
 }
 
 function knative_serving_images_release_next() {

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -9,11 +9,11 @@ COPY olm-catalog/serverless-operator/index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.31.0:serverless-bundle \
-      registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
+      registry.ci.openshift.org/knative/release-1.32.0:serverless-bundle \
       registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle >> /configs/index.yaml || \
     /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.31.0:serverless-bundle \
-      registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
-      registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml
+      registry.ci.openshift.org/knative/release-1.32.0:serverless-bundle \
+      registry.ci.openshift.org/knative/main:serverless-bundle >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -10,7 +10,7 @@ COPY olm-catalog/serverless-operator/index/configs /configs
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.31.0:serverless-bundle \
       registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
-      registry.ci.openshift.org/knative/openshift-serverless-v1.33.0:serverless-bundle >> /configs/index.yaml || \
+      registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle >> /configs/index.yaml || \
     /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.31.0:serverless-bundle \
       registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
       registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -13,7 +13,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/
       registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle >> /configs/index.yaml || \
     /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.31.0:serverless-bundle \
       registry.ci.openshift.org/knative/release-1.32.0:serverless-bundle \
-      registry.ci.openshift.org/knative/main:serverless-bundle >> /configs/index.yaml
+      registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -820,7 +820,7 @@ spec:
                 serviceAccountName: knative-operator
                 containers:
                   - name: knative-operator
-                    image: registry.ci.openshift.org/knative/serverless-openshift-knative-operator:main
+                    image: registry.ci.openshift.org/knative/main:serverless-knative-operator
                     readinessProbe:
                       periodSeconds: 1
                       httpGet:
@@ -975,7 +975,7 @@ spec:
                           - ALL
                 containers:
                   - name: knative-openshift
-                    image: registry.ci.openshift.org/knative/serverless-knative-operator:main
+                    image: registry.ci.openshift.org/knative/main:serverless-knative-operator
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -1147,7 +1147,7 @@ spec:
                 serviceAccountName: knative-openshift-ingress
                 containers:
                   - name: knative-openshift-ingress
-                    image: registry.ci.openshift.org/knative/serverless-ingress:main
+                    image: registry.ci.openshift.org/knative/main:serverless-ingress
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -1296,11 +1296,11 @@ spec:
         - knativeeventings.operator.knative.dev
   relatedImages:
     - name: "knative-operator"
-      image: "registry.ci.openshift.org/knative/serverless-openshift-knative-operator:main"
+      image: "registry.ci.openshift.org/knative/main:serverless-knative-operator"
     - name: "knative-openshift"
-      image: "registry.ci.openshift.org/knative/serverless-knative-operator:main"
+      image: "registry.ci.openshift.org/knative/main:serverless-knative-operator"
     - name: "knative-openshift-ingress"
-      image: "registry.ci.openshift.org/knative/serverless-ingress:main"
+      image: "registry.ci.openshift.org/knative/main:serverless-ingress"
     - name: "IMAGE_queue-proxy"
       image: "registry.ci.openshift.org/openshift/knative-serving-queue:knative-v1.12"
     - name: "IMAGE_activator"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -820,7 +820,7 @@ spec:
                 serviceAccountName: knative-operator
                 containers:
                   - name: knative-operator
-                    image: registry.ci.openshift.org/knative/main:serverless-knative-operator
+                    image: registry.ci.openshift.org/knative/main:serverless-openshift-knative-operator
                     readinessProbe:
                       periodSeconds: 1
                       httpGet:
@@ -1296,7 +1296,7 @@ spec:
         - knativeeventings.operator.knative.dev
   relatedImages:
     - name: "knative-operator"
-      image: "registry.ci.openshift.org/knative/main:serverless-knative-operator"
+      image: "registry.ci.openshift.org/knative/main:serverless-openshift-knative-operator"
     - name: "knative-openshift"
       image: "registry.ci.openshift.org/knative/main:serverless-knative-operator"
     - name: "knative-openshift-ingress"

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -10,7 +10,7 @@ COPY olm-catalog/serverless-operator/index/configs /configs
 RUN /bin/opm init serverless-operator --default-channel=__DEFAULT_CHANNEL__ --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
       registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_VERSION__:serverless-bundle \
-      registry.ci.openshift.org/knative/openshift-serverless-v__VERSION__:serverless-bundle >> /configs/index.yaml || \
+      registry.ci.openshift.org/knative/release-__VERSION__:serverless-bundle >> /configs/index.yaml || \
     /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
       registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_VERSION__:serverless-bundle \
       registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -9,11 +9,11 @@ COPY olm-catalog/serverless-operator/index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=__DEFAULT_CHANNEL__ --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
-      registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_VERSION__:serverless-bundle \
+      registry.ci.openshift.org/knative/release-__PREVIOUS_VERSION__:serverless-bundle \
       registry.ci.openshift.org/knative/release-__VERSION__:serverless-bundle >> /configs/index.yaml || \
     /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
-      registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_VERSION__:serverless-bundle \
-      registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml
+      registry.ci.openshift.org/knative/release-__PREVIOUS_VERSION__:serverless-bundle \
+      registry.ci.openshift.org/knative/main:serverless-bundle >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -13,7 +13,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/
       registry.ci.openshift.org/knative/release-__VERSION__:serverless-bundle >> /configs/index.yaml || \
     /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
       registry.ci.openshift.org/knative/release-__PREVIOUS_VERSION__:serverless-bundle \
-      registry.ci.openshift.org/knative/main:serverless-bundle >> /configs/index.yaml
+      registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe


### PR DESCRIPTION
This brings some changes from the following two PRs into main:
* https://github.com/openshift-knative/serverless-operator/pull/2581
* https://github.com/openshift-knative/serverless-operator/pull/2575

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Use promotion by name where the format is `registry.ci.openshift.org/knative/main:serverless-knative-operator` instead of  `registry.ci.openshift.org/knative/serverless-openshift-knative-operator:main`. The reason is: old images that are promoted by "tag" in CI are cleaned up if no CI config uses them whereas images promoted by name remain there.
- Use the new promotion names (release-X.Y.Z instead of openshift-serverless.vX.Y.Z)
- Make sure the catalogsource script fails if the sed command is not able to replace the bundle image. Replacing the image is crucial for correct functioning.