### PR TITLE
Generate Index yaml entries for older channels correctly

### DIFF
--- a/hack/generate/index.sh
+++ b/hack/generate/index.sh
@@ -18,6 +18,9 @@ values[LATEST_VERSIONED_CHANNEL]="$(metadata.get 'olm.channels.list[*]' | head -
 values[PREVIOUS_CHANNEL]="$(metadata.get 'olm.channels.list[*]' | head -n 3 | tail -n 1)"
 values[PREVIOUS_REPLACES_CHANNEL]="$(metadata.get 'olm.channels.list[*]' | head -n 4 | tail -n 1)"
 
+values[PREVIOUS_CHANNEL_HEAD]="${values[PREVIOUS_CHANNEL]#stable-}.0"
+values[PREVIOUS_REPLACES_CHANNEL_HEAD]="${values[PREVIOUS_REPLACES_CHANNEL]#stable-}.0"
+
 # Start fresh
 cp "$template" "$target"
 

--- a/templates/index.yaml
+++ b/templates/index.yaml
@@ -27,13 +27,13 @@ schema: olm.channel
 name: __PREVIOUS_CHANNEL__
 package: serverless-operator
 entries:
-  - name: "serverless-operator.v__PREVIOUS_REPLACES__"
-  - name: "serverless-operator.v__PREVIOUS_VERSION__"
-    replaces: "serverless-operator.v__PREVIOUS_REPLACES__"
-    skipRange: ">=__PREVIOUS_REPLACES__ <__PREVIOUS_VERSION__"
+  - name: "serverless-operator.v__PREVIOUS_REPLACES_CHANNEL_HEAD__"
+  - name: "serverless-operator.v__PREVIOUS_CHANNEL_HEAD__"
+    replaces: "serverless-operator.v__PREVIOUS_REPLACES_CHANNEL_HEAD__"
+    skipRange: ">=__PREVIOUS_REPLACES_CHANNEL_HEAD__ <__PREVIOUS_CHANNEL_HEAD__"
 ---
 schema: olm.channel
 name: __PREVIOUS_REPLACES_CHANNEL__
 package: serverless-operator
 entries:
-  - name: "serverless-operator.v__PREVIOUS_REPLACES__"
+  - name: "serverless-operator.v__PREVIOUS_REPLACES_CHANNEL_HEAD__"


### PR DESCRIPTION
For older channels, we ignore micro-releases and only use the initial version from those streams because we don't know how many micro release will be in that stream in advance.

Related to https://github.com/openshift-knative/serverless-operator/pull/2575/files#r1537601825

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
