### PR TITLE
Protect against status.conditions being null when installing operator

### DIFF
--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -187,9 +187,7 @@ function wait_for_csv_succeeded {
   restarts=0
   ln=' ' logger.debug "${*} : Waiting until non-zero (max ${timeout} sec.)"
   while (eval "[[ \$(oc get ClusterServiceVersion -n $ns $csv -o jsonpath='{.status.phase}') != Succeeded ]]" 2>/dev/null); do
-    # Make sure there are .status.conditions available before parsing via jq
-    oc wait --for=condition=CatalogSourcesUnhealthy=False subscription.operators.coreos.com "${subscription}" -n "${ns}" --timeout=120s
-    subscription_error=$(oc get subscription.operators.coreos.com "${subscription}" -n "${ns}" -ojson | jq '.status.conditions[] | select(.message != null) | select(.message|test("exists and is not referenced by a subscription"))')
+    subscription_error=$(oc get subscription.operators.coreos.com "${subscription}" -n "${ns}" -ojson | jq '.status.conditions[]? | select(.message != null) | select(.message|test("exists and is not referenced by a subscription"))')
     if [[ "${subscription_error}" != "" && $restarts -lt 3 ]]; then
       logger.warn "Restarting OLM pods to work around OCPBUGS-19046"
       oc delete pods -n openshift-operator-lifecycle-manager -l app=catalog-operator


### PR DESCRIPTION
This will protect the installation against the following error:

```
06:50:04.827 DEBUG:   opentelemetry-operator.v0.93.0-3
opentelemetry-product openshift-operators : Waiting until non-zero (max
600 sec.)
subscription.operators.coreos.com/opentelemetry-product condition met
jq: error (at <stdin>:47): Cannot iterate over null (null)
06:50:33.495 ERROR:   🚨 Error (code: 5) occurred at
./hack/lib/tracing.bash:192, with command: subscription_error=$(oc get
subscription.operators.coreos.com "${subscription}" -n "${ns}" -ojson |
jq '.status.conditions[] | select(.message != null) |
select(.message|test("exists and is not referenced by a
subscription"))')
```

Fixes https://issues.redhat.com/browse/LPINTEROP-4185

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Adds a question mark after `jq '.status.conditions[]` to protect against unexpected values.

