### PR TITLE
Add missing restricted SASL user

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -233,6 +233,7 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: my-restricted-sasl-user
+  namespace: kafka
   labels:
     strimzi.io/cluster: my-cluster
 spec:

--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -227,6 +227,42 @@ spec:
         host: "*"
 EOF
 
+  logger.info "Applying Strimzi SASL Restricted User"
+  cat <<-EOF | oc apply -f -
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: my-restricted-sasl-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # Example ACL rules for Broker with names following knative default brokers.topic.template
+      - resource:
+          type: topic
+          name: knative-broker-
+          patternType: prefix
+        operations:
+          - Create
+          - Describe
+          - Read
+          - Write
+          - Delete
+        host: "*"
+      # Example ACL rules for Consumer Group ID following knative default triggers.consumergroup.template
+      - resource:
+          type: group
+          name: knative-trigger-
+          patternType: prefix
+        operations:
+          - Read
+        host: "*"
+EOF
+
   logger.info "Waiting for Strimzi admin users to become ready"
   oc wait kafkauser --all --timeout=-1s --for=condition=Ready -n kafka
 


### PR DESCRIPTION
Fixes issue like this one:
```
panic: secrets "my-restricted-sasl-user" not found [recovered]
	panic: secrets "my-restricted-sasl-user" not found
```
Seen in periodic runs, e.g. [here](https://storage.googleapis.com/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-412-upstream-e2e-kafka-aws-412-c/1774613338089590784/build-log.txt)
This should also fix the periodic run on OCP 4.16 as reported in https://issues.redhat.com/browse/SRVCOM-3024

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add the missing sasl user that was added midstream in [this commit](https://github.com/openshift-knative/eventing-kafka-broker/commit/ef01093f12e08d4c31b9996de19f4d75456b901a)
