### PR TITLE
Do not set DomainMapping CRD to v1alpha1 during downgrade

### DIFF
--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -134,22 +134,6 @@ func DowngradeServerless(ctx *test.Context) error {
 		}
 	}
 
-	dcrd := "domainmappings.serving.knative.dev"
-
-	if err := moveCRDsToAlpha(ctx, dcrd); err != nil {
-		return err
-	}
-
-	// We might have to do an empty patch as in the example bellow for all existing resources
-	//if _, err :=	ctx.Clients.Serving.ServingV1alpha1().DomainMappings("...").Patch(context.Background(), "dm_name", types.MergePatchType, []byte("{}"), metav1.PatchOptions{}, ""); err != nil {
-	//	return err
-	//}
-	//
-
-	if err := setStorageToAlpha(ctx, dcrd); err != nil {
-		return err
-	}
-
 	if _, err := test.CreateNamespace(ctx, test.OperatorsNamespace); err != nil {
 		return err
 	}
@@ -216,47 +200,6 @@ func setWebookStrategyToNone(ctx *test.Context, name string) error {
 		}
 		crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.ConversionStrategyType("None")}
 		_, err = ctx.Clients.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.Background(), crd, metav1.UpdateOptions{})
-		return err
-	})
-}
-
-func moveCRDsToAlpha(ctx *test.Context, name string) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		crd, err := ctx.Clients.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		for i, v := range crd.Spec.Versions {
-			if v.Name == "v1beta1" {
-				crd.Spec.Versions[i].Served = false
-				crd.Spec.Versions[i].Storage = false
-			}
-
-			if v.Name == "v1alpha1" {
-				crd.Spec.Versions[i].Served = true
-				crd.Spec.Versions[i].Storage = true
-			}
-		}
-		_, err = ctx.Clients.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.Background(), crd, metav1.UpdateOptions{})
-		return err
-	})
-}
-
-func setStorageToAlpha(ctx *test.Context, name string) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		crd, err := ctx.Clients.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		oldStoredVersions := crd.Status.StoredVersions
-		newStoredVersions := make([]string, 0, len(oldStoredVersions))
-		for _, stored := range oldStoredVersions {
-			if stored != "v1beta1" {
-				newStoredVersions = append(newStoredVersions, stored)
-			}
-		}
-		crd.Status.StoredVersions = newStoredVersions
-		_, err = ctx.Clients.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().UpdateStatus(context.Background(), crd, metav1.UpdateOptions{})
 		return err
 	})
 }


### PR DESCRIPTION
On release-1.32, the tests currently downgrade from Knative 1.11 to 1.11. This version already stores v1beta1 so there's no point to set v1alpha1.

Fixes error such as:
```
=== RUN   TestServerlessUpgradePrePost/Run/Steps/PostDowngradeTests/CRDStoredVersionPostUpgradeTest
    postupgrade.go:206: "domainmappings.serving.knative.dev" does not have a single stored version
```
When this error happens the CRD has:
```
storedVersions:
  - v1alpha1
  - v1beta1
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
