### PR TITLE
Upgrade sequence includes 1.32.1

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -76,5 +76,6 @@ dependencies:
 upgrade_sequence:
     - csv: serverless-operator.v1.31.0
     - csv: serverless-operator.v1.32.0
+    - csv: serverless-operator.v1.32.1
     - csv: serverless-operator.v1.33.0
       source: serverless-operator


### PR DESCRIPTION
Fixes the kitchensink periodic job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-412-kitchensink-upgrade-aws-412-c/1777150263048540160

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
