### PR TITLE
Add links for arm64 artifacts to consoleclidownload.go

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -187,7 +187,7 @@ func populateKnConsoleCLIDownload(baseURL string, instance *operatorv1beta1.Knat
 				Href: baseURL + "/kn-macos-amd64.tar.gz",
 			}, {
 				Text: "Download kn for macOS for ARM 64",
-				Href: baseURL + "/kn-darwin-arm64.tar.gz",
+				Href: baseURL + "/kn-macos-arm64.tar.gz",
 			}, {
 				Text: "Download kn for Windows",
 				Href: baseURL + "/kn-windows-amd64.zip",

--- a/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleclidownload/consoleclidownload.go
@@ -174,14 +174,20 @@ func populateKnConsoleCLIDownload(baseURL string, instance *operatorv1beta1.Knat
 				Text: "Download kn for Linux for x86_64",
 				Href: baseURL + "/kn-linux-amd64.tar.gz",
 			}, {
+				Text: "Download kn for Linux for ARM 64",
+				Href: baseURL + "/kn-linux-arm64.tar.gz",
+			}, {
 				Text: "Download kn for Linux for IBM Power little endian",
 				Href: baseURL + "/kn-linux-ppc64le.tar.gz",
 			}, {
 				Text: "Download kn for Linux for IBM Z",
 				Href: baseURL + "/kn-linux-s390x.tar.gz",
 			}, {
-				Text: "Download kn for macOS",
+				Text: "Download kn for macOS for x86_64",
 				Href: baseURL + "/kn-macos-amd64.tar.gz",
+			}, {
+				Text: "Download kn for macOS for ARM 64",
+				Href: baseURL + "/kn-darwin-arm64.tar.gz",
 			}, {
 				Text: "Download kn for Windows",
 				Href: baseURL + "/kn-windows-amd64.zip",

--- a/test/servinge2e/verify_deploy_resources_test.go
+++ b/test/servinge2e/verify_deploy_resources_test.go
@@ -23,8 +23,8 @@ func TestKnConsoleCLIDownload(t *testing.T) {
 		t.Fatalf("Failed to GET kn ConsoleCLIDownload: %v", err)
 	}
 	// Verify the links in kn CCD CO
-	if len(ccd.Spec.Links) != 5 {
-		t.Fatalf("expecting 5 links for artifacts for kn ConsoleCLIDownload, found %d", len(ccd.Spec.Links))
+	if len(ccd.Spec.Links) != 7 {
+		t.Fatalf("expecting 7 links for artifacts for kn ConsoleCLIDownload, found %d", len(ccd.Spec.Links))
 	}
 	// Verify if individual link starts with correct route
 	for _, link := range ccd.Spec.Links {


### PR DESCRIPTION
Fixes JIRA [SRVCOM-3099](https://issues.redhat.com/browse/SRVCOM-3099)

## Proposed Changes

:bug: fix - add missing links for arm64 kn to OCP Command Line Tools page

