### PR TITLE
Incorporate new upstream Serving encryption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ install-operator:
 
 install-all:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
-	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 	./hack/tracing.sh
 	SCALE_UP=4 INSTALL_KAFKA="true" ENABLE_TRACING=true ./hack/install.sh
 
@@ -33,23 +32,19 @@ install-serving-with-mesh:
 	MESH=true SCALE_UP=4 INSTALL_SERVING=true INSTALL_EVENTING="false" ./hack/install.sh
 
 install-eventing:
-	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 	INSTALL_SERVING="false" ./hack/install.sh
 
 install-kafka:
-	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 	SCALE_UP=4 INSTALL_SERVING="false" INSTALL_KAFKA="true" ./hack/install.sh
 
 install-kafka-with-mesh:
 	UNINSTALL_MESH="false" ./hack/mesh.sh
-	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 	TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ./hack/tracing.sh
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
 	MESH=true SCALE_UP=5 INSTALL_SERVING=false INSTALL_EVENTING=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ENABLE_TRACING=true ./hack/install.sh
 
 install-kafka-with-keda:
 	UNINSTALL_KEDA="false" ./hack/keda.sh
-	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 	SCALE_UP=4 INSTALL_SERVING="false" INSTALL_KAFKA="true" ENABLE_KEDA="true" ./hack/install.sh
 
 install-strimzi:
@@ -75,12 +70,6 @@ install-previous:
 
 install-previous-with-kafka:
 	INSTALL_PREVIOUS_VERSION="true" INSTALL_KAFKA="true" ./hack/install.sh
-
-install-mesh:
-	UNINSTALL_MESH="false" ./hack/mesh.sh
-
-uninstall-mesh:
-	UNINSTALL_MESH="true" ./hack/mesh.sh
 
 install-mesh:
 	UNINSTALL_MESH="false" ./hack/mesh.sh
@@ -157,7 +146,6 @@ test-upstream-e2e-mesh-testonly:
 	MESH=true TEST_KNATIVE_KAFKA=false TEST_KNATIVE_SERVING=true TEST_KNATIVE_EVENTING=true TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh
 
 install-for-mesh-e2e:
-	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh # This avoids early failures for the skipped Eventing TLS tests
 	UNINSTALL_MESH="false" ./hack/mesh.sh
 	TRACING_BACKEND=zipkin TRACING_NAMESPACE=knative-eventing ./hack/tracing.sh
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
@@ -186,7 +174,6 @@ test-upstream-e2e-no-upgrade: upstream-e2e
 
 upstream-e2e-kafka:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
-	UNINSTALL_CERTMANAGER="false" ./hack/certmanager.sh
 	TRACING_BACKEND=zipkin ./hack/tracing.sh
 	SCALE_UP=5 INSTALL_KAFKA="true" TRACING_BACKEND=zipkin ENABLE_TRACING=true ./hack/install.sh
 	TEST_KNATIVE_KAFKA_BROKER=true TEST_KNATIVE_E2E=true TEST_KNATIVE_UPGRADE=false ./test/upstream-e2e-tests.sh

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -19,5 +19,6 @@ dump_state.setup
 scale_up_workers
 create_namespaces "${SYSTEM_NAMESPACES[@]}"
 
+install_certmanager
 ensure_catalogsource_installed
 ensure_serverless_installed

--- a/hack/lib/certmanager.bash
+++ b/hack/lib/certmanager.bash
@@ -82,6 +82,7 @@ function sync_trust_bundle {
    for ns in "${namespaces[@]}"; do
      echo "Syncing trust-bundle for namespace: ${ns}"
      oc create namespace "${ns}" --dry-run=client -o yaml | oc apply -f -
+     oc label namespace "${ns}" knative.openshift.io/part-of="openshift-serverless" --overwrite
      oc create configmap -n "${ns}" knative-ca-bundle --from-file=tls.crt --from-file=ca.crt \
         --dry-run=client -o yaml | kubectl apply -n "${ns}" -f - || return $?
      oc label configmap -n "${ns}" knative-ca-bundle networking.knative.dev/trust-bundle=true --overwrite

--- a/hack/lib/certmanager_resources/serving-ca-certificate.yaml
+++ b/hack/lib/certmanager_resources/serving-ca-certificate.yaml
@@ -1,0 +1,15 @@
+# Aligned with upstream Serving configuration, used by --https e2e tests
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: knative-selfsigned-ca
+  namespace: cert-manager
+spec:
+  secretName: knative-selfsigned-ca # Knative Serving e2e tests will look for this secret to be used in --https e2e tests
+  commonName: knative.dev
+  usages:
+    - server auth
+  isCA: true
+  issuerRef:
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer

--- a/hack/lib/certmanager_resources/serving-ca-issuer.yaml
+++ b/hack/lib/certmanager_resources/serving-ca-issuer.yaml
@@ -1,0 +1,8 @@
+# Aligned with upstream Serving configuration, used by --https e2e tests
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: knative-selfsigned-issuer
+spec:
+  ca:
+    secretName: knative-selfsigned-ca

--- a/hack/lib/certmanager_resources/serving-selfsigned-issuer.yaml
+++ b/hack/lib/certmanager_resources/serving-selfsigned-issuer.yaml
@@ -1,0 +1,8 @@
+# Aligned with upstream Serving configuration, used by --https e2e tests
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-cluster-issuer
+spec:
+  selfSigned: {}
+

--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
+	"knative.dev/networking/pkg/config"
 	"knative.dev/operator/pkg/apis/operator/base"
 	"knative.dev/pkg/network"
 )
@@ -17,10 +18,6 @@ const (
 	providerLabel           = "networking.knative.dev/ingress-provider"
 	kourierIngressClassName = "kourier.ingress.networking.knative.dev"
 	networkCMName           = "network"
-
-	// TODO: Use "knative.dev/networking/pkg/config" once the repo pulled Knative 1.6.
-	// Backport messes up the dependencies.
-	InternalEncryptionKey = "internal-encryption"
 
 	// IngressDefaultCertificateKey is the OpenShift Ingress default certificate name.
 	// The default cert name is different when users changed the default ingress certificate name via IngressController CR (SRVKS-955).
@@ -101,7 +98,7 @@ func addKourierEnvValues(ks base.KComponent) mf.Transformer {
 	}
 
 	networkCM := ks.GetSpec().GetConfig()[networkCMName]
-	if encrypt := networkCM[InternalEncryptionKey]; strings.ToLower(encrypt) == "true" {
+	if encrypt := networkCM[config.SystemInternalTLSKey]; strings.ToLower(encrypt) == string(config.EncryptionEnabled) {
 		if certName := networkCM[IngressDefaultCertificateKey]; certName != "" {
 			envVars = append(envVars,
 				corev1.EnvVar{Name: "CERTS_SECRET_NAMESPACE", Value: ingressDefaultCertificateNameSpace},

--- a/openshift-knative-operator/pkg/serving/kourier_test.go
+++ b/openshift-knative-operator/pkg/serving/kourier_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
+	"knative.dev/networking/pkg/config"
 	"knative.dev/operator/pkg/apis/operator/base"
 	operatorv1beta1 "knative.dev/operator/pkg/apis/operator/v1beta1"
 )
@@ -155,7 +156,7 @@ func TestKourierEnvValue(t *testing.T) {
 			CommonSpec: base.CommonSpec{
 				Config: base.ConfigMapData{
 					"network": map[string]string{
-						InternalEncryptionKey: "true",
+						config.SystemInternalTLSKey: string(config.EncryptionEnabled),
 					},
 				},
 			},
@@ -229,7 +230,7 @@ func TestKourierInternalEncryptionOverrideCertName(t *testing.T) {
 			CommonSpec: base.CommonSpec{
 				Config: base.ConfigMapData{
 					"network": map[string]string{
-						InternalEncryptionKey:        "true",
+						config.SystemInternalTLSKey:  string(config.EncryptionEnabled),
 						IngressDefaultCertificateKey: "custom-cert",
 					},
 				},

--- a/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
@@ -23,9 +23,10 @@ const (
 	lbService   = "lb-service"
 	lbNamespace = "lb-namespace"
 
-	uid        = "8a7e9a9d-fbc6-11e9-a88e-0261aff8d6d8"
-	routeName0 = "route-" + uid + "-323531366235"
-	routeName1 = "route-" + uid + "-663738313063"
+	uid             = "8a7e9a9d-fbc6-11e9-a88e-0261aff8d6d8"
+	routeName0      = "route-" + uid + "-323531366235"
+	routeName1      = "route-" + uid + "-663738313063"
+	customRouteName = "route-" + uid + "-323563643265"
 )
 
 func TestMakeRoute(t *testing.T) {
@@ -258,7 +259,7 @@ func TestMakeRoute(t *testing.T) {
 			name: "valid, passthrough by BYO cert",
 			ingress: ingress(
 				withTLS(networkingv1alpha1.IngressTLS{Hosts: []string{"custom.example.com"}, SecretName: "someSecretName"}),
-				withRules(rule(withHosts([]string{localDomain, externalDomain}))),
+				withRules(rule(withHosts([]string{"custom.example.com"}))),
 			),
 			want: []*routev1.Route{{
 				ObjectMeta: metav1.ObjectMeta{
@@ -273,10 +274,10 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: DefaultTimeout,
 					},
 					Namespace: lbNamespace,
-					Name:      routeName0,
+					Name:      customRouteName,
 				},
 				Spec: routev1.RouteSpec{
-					Host: externalDomain,
+					Host: "custom.example.com",
 					To: routev1.RouteTargetReference{
 						Kind:   "Service",
 						Name:   lbService,
@@ -333,7 +334,7 @@ func TestMakeRoute(t *testing.T) {
 			}},
 		},
 		{
-			name: "internal encryption is enabled",
+			name: "system-internal-tls is enabled",
 			ingress: ingress(
 				withRules(rule(withHosts([]string{localDomain, externalDomain}), withHTTPSBackendService())),
 			),
@@ -414,6 +415,7 @@ func ingress(options ...ingressOption) *networkingv1alpha1.Ingress {
 
 func rule(options ...ruleOption) networkingv1alpha1.IngressRule {
 	rule := networkingv1alpha1.IngressRule{
+		Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
 		HTTP: &networkingv1alpha1.HTTPIngressRuleValue{
 			Paths: []networkingv1alpha1.HTTPIngressPath{{}},
 		},

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -15,11 +15,11 @@ dump_state.setup # test
 if [[ $MESH == "true" ]]; then
   # net-istio does not use knative-serving-ingress namespace.
   export INGRESS_NAMESPACE="knative-serving"
-else
-  trust_router_ca
 fi
 
 logger.success '🚀 Cluster prepared for testing.'
+
+trust_router_ca
 
 # Run serverless-operator specific tests.
 create_namespaces "${TEST_NAMESPACES[@]}"

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -150,6 +150,37 @@ function downstream_serving_e2e_tests {
       --imagetemplate "${IMAGE_TEMPLATE}" \
       "$@"
   fi
+
+  # Enable Serving encryption
+  configure_cm network system-internal-tls:enabled
+  configure_cm network cluster-local-domain-tls:enabled
+
+  logger.info "Restart controller to enable cert-manager integration"
+  oc delete pod -n "${SERVING_NAMESPACE}" -l app=controller
+  oc wait --timeout=60s --for=condition=Available deployment  -n "${SERVING_NAMESPACE}" controller
+
+  logger.info "Restart activator to mount the certificates"
+  oc delete pod -n "${SERVING_NAMESPACE}" -l app=activator
+  oc wait --timeout=60s --for=condition=Available deployment  -n "${SERVING_NAMESPACE}" activator
+  logger.info "cluster-local-domain-tls and system-internal-tls are ENABLED"
+
+  go_test_e2e "${RUN_FLAGS[@]}" ./test/servinge2e/encryption/ \
+    --kubeconfigs "${kubeconfigs_str}" \
+    --imagetemplate "${IMAGE_TEMPLATE}" \
+    "$@"
+
+  # Disable Serving encryption for following tests
+  configure_cm network system-internal-tls:disabled
+  configure_cm network cluster-local-domain-tls:disabled
+
+  logger.info "Restart activator to unmount the certificates"
+  oc delete pod -n "${SERVING_NAMESPACE}" -l app=activator
+  oc wait --timeout=60s --for=condition=Available deployment  -n "${SERVING_NAMESPACE}" activator
+
+  logger.info "Restart controller to disable cert-manager integration"
+  oc delete pod -n "${SERVING_NAMESPACE}" -l app=controller
+  oc wait --timeout=60s --for=condition=Available deployment  -n "${SERVING_NAMESPACE}" controller
+  logger.info "cluster-local-domain-tls and system-internal-tls are DISABLED"
 }
 
 function downstream_eventing_e2e_tests {

--- a/test/servinge2e/encryption/encryption_test.go
+++ b/test/servinge2e/encryption/encryption_test.go
@@ -1,0 +1,69 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/openshift-knative/serverless-operator/serving/ingress/pkg/reconciler/ingress/resources"
+	"github.com/openshift-knative/serverless-operator/test"
+	"github.com/openshift-knative/serverless-operator/test/servinge2e"
+	routev1 "github.com/openshift/api/route/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/networking/pkg/apis/networking"
+	"knative.dev/networking/pkg/certificates"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/serving/pkg/apis/serving"
+)
+
+func TestExternalAccessWithEncryptionEnabled(t *testing.T) {
+	ctx := test.SetupClusterAdmin(t)
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, ctx) })
+	defer test.CleanupAll(t, ctx)
+
+	ksvc := test.Service("encryption-test", test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg), nil, nil)
+	ksvc = test.WithServiceReadyOrFail(ctx, ksvc)
+
+	// Check if the service is reachable.
+	servinge2e.WaitForRouteServingText(t, ctx, ksvc.Status.URL.URL(), servinge2e.HelloworldText)
+
+	// Verify the OCP route the operator created.
+	routes, err := ctx.Clients.Route.Routes(test.IngressNamespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", resources.OpenShiftIngressLabelKey, ksvc.Name),
+	})
+	if err != nil {
+		t.Fatalf("Failed to list routes: %v", err)
+	}
+	for _, r := range routes.Items {
+		if r.ObjectMeta.Labels[resources.OpenShiftIngressLabelKey] == ksvc.Name {
+			if !(r.Spec.TLS != nil && r.Spec.TLS.Termination == routev1.TLSTerminationPassthrough && r.Spec.TLS.InsecureEdgeTerminationPolicy == routev1.InsecureEdgeTerminationPolicyRedirect) {
+				t.Fatalf("Route %s does not have expected TLS termination and http redirects: %v", r.Name, r.Spec.TLS)
+			}
+			if r.Spec.Port.TargetPort.StrVal != "https" {
+				t.Fatalf("Route %s does not have expected https target port: %v", r.Name, r.Spec.Port.TargetPort)
+			}
+		}
+	}
+}
+
+func TestClusterLocalAccessWithEncryptionEnabled(t *testing.T) {
+	ctx := test.SetupClusterAdmin(t)
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, ctx) })
+	defer test.CleanupAll(t, ctx)
+
+	ksvc := test.Service("encryption-test", test.Namespace, pkgTest.ImagePath(test.HelloworldGoImg), nil, nil)
+	ksvc.ObjectMeta.Labels = map[string]string{networking.VisibilityLabelKey: serving.VisibilityClusterLocal}
+	ksvc = test.WithServiceReadyOrFail(ctx, ksvc)
+
+	// Get cert-manager CA cert that signed the cluster-local-domain certs
+	ca, err := getCertManagerCA(ctx.Clients)
+	if err != nil {
+		t.Fatalf("Could not get cert-manager CA: %v", err)
+	}
+
+	// Check if the service is reachable with https on cluster-local
+	httpProxy := test.WithServiceReadyOrFail(ctx, servinge2e.HTTPProxyService(ksvc.Name+"-proxy", test.Namespace,
+		"", ksvc.Status.URL.Host, string(ca.Data[certificates.CertName]), nil, nil))
+
+	servinge2e.WaitForRouteServingText(t, ctx, httpProxy.Status.URL.URL(), servinge2e.HelloworldText)
+}

--- a/test/servinge2e/encryption/helper.go
+++ b/test/servinge2e/encryption/helper.go
@@ -1,0 +1,41 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openshift-knative/serverless-operator/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/networking/pkg/certificates"
+)
+
+// this needs to match the ClusterIssuer in hack/lib/certmanager_resources/serving-ca-issuer.yaml.
+const (
+	certManagerCASecret  = "knative-selfsigned-ca"
+	certManagerNamespace = "cert-manager"
+)
+
+func getCertManagerCA(clients *test.Clients) (*corev1.Secret, error) {
+	var secret *corev1.Secret
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true, func(context.Context) (bool, error) {
+		caSecret, err := clients.Kube.CoreV1().Secrets(certManagerNamespace).Get(context.Background(), certManagerCASecret, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		// CA not yet populated
+		if len(caSecret.Data[certificates.CertName]) == 0 {
+			return false, nil
+		}
+
+		secret = caSecret
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error while waiting for cert-manager self-signed CA to be popluated: %w", err)
+	}
+
+	return secret, nil
+}

--- a/test/servinge2e/kourier/custom_route_test.go
+++ b/test/servinge2e/kourier/custom_route_test.go
@@ -85,7 +85,7 @@ func TestCustomOpenShiftRoute(t *testing.T) {
 		return caCtx.Clients.Route.Routes(route.Namespace).Delete(context.Background(), route.Name, metav1.DeleteOptions{})
 	})
 
-	servinge2e.WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
+	servinge2e.WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), servinge2e.HelloworldText)
 
 	// Create DomainMapping with disable Annotation.
 	dm := &servingv1beta1.DomainMapping{

--- a/test/servinge2e/kourier/helpers.go
+++ b/test/servinge2e/kourier/helpers.go
@@ -8,10 +8,6 @@ import (
 	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
-const (
-	helloworldText = "Hello World!"
-)
-
 func withDomainMappingReadyOrFail(ctx *test.Context, dm *servingv1beta1.DomainMapping) *servingv1beta1.DomainMapping {
 	dm, err := ctx.Clients.Serving.ServingV1beta1().DomainMappings(dm.Namespace).Create(context.Background(), dm, metav1.CreateOptions{})
 	if err != nil {

--- a/test/servinge2e/kourier/service_to_service_test.go
+++ b/test/servinge2e/kourier/service_to_service_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/servinge2e"
-	"github.com/openshift-knative/serverless-operator/test/servinge2e/servicemesh"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/networking/pkg/apis/networking"
 	pkgTest "knative.dev/pkg/test"
@@ -75,12 +74,12 @@ func testServiceToService(t *testing.T, ctx *test.Context, namespace string, tc 
 	// For cluster-local ksvc, we deploy an "HTTP proxy" service, and request that one instead
 	if service.GetLabels()[networking.VisibilityLabelKey] == serving.VisibilityClusterLocal {
 		// Deploy an "HTTP proxy" towards the ksvc (using an httpproxy image from knative-serving testsuite)
-		httpProxy := test.WithServiceReadyOrFail(ctx, servicemesh.HTTPProxyService(tc.name+"-proxy", namespace, "" /*gateway*/, service.Status.URL.Host, nil, nil))
+		httpProxy := test.WithServiceReadyOrFail(ctx, servinge2e.HTTPProxyService(tc.name+"-proxy", namespace, "", service.Status.URL.Host, "", nil, nil))
 		serviceURL = httpProxy.Status.URL.URL()
 	}
 
 	// Verify the service is actually accessible from the outside
-	servinge2e.WaitForRouteServingText(t, ctx, serviceURL, helloworldText)
+	servinge2e.WaitForRouteServingText(t, ctx, serviceURL, servinge2e.HelloworldText)
 
 	// Verify the expected istio-proxy is really there
 	podList, err := ctx.Clients.Kube.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "serving.knative.dev/service=" + service.Name})

--- a/test/servinge2e/kourier/servicemesh_test.go
+++ b/test/servinge2e/kourier/servicemesh_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	"github.com/openshift-knative/serverless-operator/test/servinge2e/servicemesh"
 	"knative.dev/serving/pkg/apis/autoscaling"
 
@@ -609,7 +610,7 @@ func TestKsvcWithServiceMeshJWTDefaultPolicy(t *testing.T) {
 
 				if scenario.valid {
 					// Verify the response is a proper "hello world" when the token is valid
-					if resp.StatusCode != 200 || !strings.Contains(string(resp.Body), helloworldText) {
+					if resp.StatusCode != 200 || !strings.Contains(string(resp.Body), servinge2e.HelloworldText) {
 						t.Fatalf("Unexpected response with a valid token: HTTP %d: %s", resp.StatusCode, string(resp.Body))
 					}
 				} else {

--- a/test/servinge2e/kourier/verify_http_and_https_test.go
+++ b/test/servinge2e/kourier/verify_http_and_https_test.go
@@ -21,7 +21,7 @@ func TestKnativeServiceHTTPRedirect(t *testing.T) {
 	ksvc = test.WithServiceReadyOrFail(caCtx, ksvc)
 
 	// Implicitly checks that HTTPS works.
-	servinge2e.WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), helloworldText)
+	servinge2e.WaitForRouteServingText(t, caCtx, ksvc.Status.URL.URL(), servinge2e.HelloworldText)
 
 	// Now check HTTP request.
 	httpURL := ksvc.Status.URL.DeepCopy()

--- a/test/servinge2e/kourier/verify_route_conflict_test.go
+++ b/test/servinge2e/kourier/verify_route_conflict_test.go
@@ -45,7 +45,7 @@ func TestRouteConflictBehavior(t *testing.T) {
 			t.Fatal("Knative Service not ready", err)
 		}
 
-		servinge2e.WaitForRouteServingText(t, caCtx, olderSvc.Status.URL.URL(), helloworldText)
+		servinge2e.WaitForRouteServingText(t, caCtx, olderSvc.Status.URL.URL(), servinge2e.HelloworldText)
 
 		_, err = test.CreateService(caCtx, newer.Name, newer.Namespace, pkgTest.ImagePath(test.HelloworldGoImg))
 		if err != nil {
@@ -74,7 +74,7 @@ func TestRouteConflictBehavior(t *testing.T) {
 		}
 
 		// Verify that the "older" service still works.
-		servinge2e.WaitForRouteServingText(t, caCtx, olderSvc.Status.URL.URL(), helloworldText)
+		servinge2e.WaitForRouteServingText(t, caCtx, olderSvc.Status.URL.URL(), servinge2e.HelloworldText)
 
 		for _, svc := range services {
 			if err := caCtx.Clients.Serving.ServingV1().Services(svc.Namespace).Delete(context.Background(), svc.Name, metav1.DeleteOptions{}); err != nil {

--- a/test/servinge2e/servicemesh/helpers.go
+++ b/test/servinge2e/servicemesh/helpers.go
@@ -1,11 +1,7 @@
 package servicemesh
 
 import (
-	"github.com/openshift-knative/serverless-operator/test"
-	corev1 "k8s.io/api/core/v1"
-	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
-	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 const (
@@ -24,21 +20,4 @@ type testCase struct {
 	gateway           string                // Value for gateway that's called by http proxy
 	usePrivateService bool                  // Whether http proxy should call target's service private service
 	checkResponseFunc spoof.ResponseChecker // Function to be used to check response
-}
-
-// HTTPProxyService returns a knative service acting as "http proxy", redirects requests towards a given "host". Used to test cluster-local services
-func HTTPProxyService(name, namespace, gateway, target string, serviceAnnotations, templateAnnotations map[string]string) *servingv1.Service {
-	proxy := test.Service(name, namespace, pkgTest.ImagePath(test.HTTPProxyImg), serviceAnnotations, templateAnnotations)
-	if gateway != "" {
-		proxy.Spec.Template.Spec.Containers[0].Env = append(proxy.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-			Name:  "GATEWAY_HOST",
-			Value: gateway,
-		})
-	}
-	proxy.Spec.Template.Spec.Containers[0].Env = append(proxy.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-		Name:  "TARGET_HOST",
-		Value: target,
-	})
-
-	return proxy
 }

--- a/test/servinge2e/servicemesh/multitenant_test.go
+++ b/test/servinge2e/servicemesh/multitenant_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/openshift-knative/serverless-operator/test"
+	"github.com/openshift-knative/serverless-operator/test/servinge2e"
 	"knative.dev/networking/pkg/apis/networking"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
@@ -146,7 +147,7 @@ func TestMultiTenancyWithServiceMesh(t *testing.T) {
 				targetHost = service.Status.URL.Host
 			}
 
-			httpProxy := test.WithServiceReadyOrFail(ctx, HTTPProxyService(tc.name+"-proxy", tc.sourceNamespace, gateway, targetHost, map[string]string{
+			httpProxy := test.WithServiceReadyOrFail(ctx, servinge2e.HTTPProxyService(tc.name+"-proxy", tc.sourceNamespace, gateway, targetHost, "", map[string]string{
 				ServingEnablePassthroughKey: "true",
 			}, tc.annotations))
 

--- a/test/servinge2e/tracing_test.go
+++ b/test/servinge2e/tracing_test.go
@@ -61,7 +61,7 @@ func tracingTest(t *testing.T, activatorInPath bool) {
 	}
 	ksvc := test.WithServiceReadyOrFail(ctx, test.Service(name, testNamespace, pkgTest.ImagePath(test.HelloworldGoImg), nil, annotations))
 
-	WaitForRouteServingText(t, ctx, ksvc.Status.URL.URL(), helloworldText)
+	WaitForRouteServingText(t, ctx, ksvc.Status.URL.URL(), HelloworldText)
 
 	doHelloWorldRequests(ctx, ksvc.Status.URL.URL(), requestCount)
 
@@ -93,7 +93,7 @@ func doHelloWorldRequests(ctx *test.Context, url *url.URL, count int) {
 			ctx.T.Errorf("Error GETing %s: %v", url, err)
 		}
 
-		if strings.TrimSpace(resp) != helloworldText {
+		if strings.TrimSpace(resp) != HelloworldText {
 			ctx.T.Errorf("Unexpected response: %s", resp)
 		}
 	}

--- a/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
+++ b/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
@@ -4,11 +4,13 @@ metadata:
   name: knative-serving
 spec:
   config:
-    network:
-      # we currently cannot run with encryption enabled
-      # as the net-certmanager stuff has not yet been integrated into Serving
-      # TODO: https://issues.redhat.com/browse/SRVKS-1198
-      internal-encryption: "false"
+    certmanager:
+      clusterLocalIssuerRef: |
+        kind: ClusterIssuer
+        name: knative-selfsigned-issuer
+      systemInternalIssuerRef: |
+        kind: ClusterIssuer
+        name: knative-selfsigned-issuer
     autoscaler:
       container-concurrency-target-default: "100"
       container-concurrency-target-percentage: "1.0"
@@ -37,8 +39,6 @@ spec:
       loglevel.queueproxy: "debug"
       loglevel.webhook: "debug"
       loglevel.hpaautoscaler: "debug"
-      loglevel.domainmapping: "debug"
-      loglevel.domainmapping-webhook: "debug"
     observability:
       logging.enable-var-log-collection: "false"
       metrics.backend-destination: "prometheus"

--- a/vendor/knative.dev/networking/pkg/certificates/certs.go
+++ b/vendor/knative.dev/networking/pkg/certificates/certs.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+var randReader = rand.Reader
+var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
+
+// Create template common to all certificates
+func createCertTemplate(expirationInterval time.Duration, sans []string) (*x509.Certificate, error) {
+	serialNumber, err := rand.Int(randReader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber:          serialNumber,
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(expirationInterval),
+		BasicConstraintsValid: true,
+		DNSNames:              sans,
+	}
+	return &tmpl, nil
+}
+
+// Create cert template suitable for CA and hence signing
+func createCACertTemplate(expirationInterval time.Duration) (*x509.Certificate, error) {
+	rootCert, err := createCertTemplate(expirationInterval, []string{})
+	if err != nil {
+		return nil, err
+	}
+	// Make it into a CA cert and change it so we can use it to sign certs
+	rootCert.IsCA = true
+	rootCert.KeyUsage = x509.KeyUsageCertSign
+	rootCert.Subject = pkix.Name{
+		Organization: []string{Organization},
+	}
+	return rootCert, nil
+}
+
+// Create cert template that we can use on the client/server for TLS
+func createTransportCertTemplate(expirationInterval time.Duration, sans []string) (*x509.Certificate, error) {
+	cert, err := createCertTemplate(expirationInterval, sans)
+	if err != nil {
+		return nil, err
+	}
+	cert.KeyUsage = x509.KeyUsageDigitalSignature
+	cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+	cert.Subject = pkix.Name{
+		Organization: []string{Organization},
+		CommonName:   "control-protocol-certificate",
+	}
+	return cert, err
+}
+
+func createCert(template, parent *x509.Certificate, pub, parentPriv interface{}) (certPEM *pem.Block, err error) {
+	certDER, err := x509.CreateCertificate(rand.Reader, template, parent, pub, parentPriv)
+	if err != nil {
+		return
+	}
+	_, err = x509.ParseCertificate(certDER)
+	if err != nil {
+		return
+	}
+	certPEM = &pem.Block{Type: "CERTIFICATE", Bytes: certDER}
+	return
+}
+
+// CreateCACerts generates the root CA cert
+func CreateCACerts(expirationInterval time.Duration) (*KeyPair, error) {
+	caKeyPair, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("error generating random key: %w", err)
+	}
+
+	rootCertTmpl, err := createCACertTemplate(expirationInterval)
+	if err != nil {
+		return nil, fmt.Errorf("error generating CA cert: %w", err)
+	}
+
+	caCertPem, err := createCert(rootCertTmpl, rootCertTmpl, &caKeyPair.PublicKey, caKeyPair)
+	if err != nil {
+		return nil, fmt.Errorf("error signing the CA cert: %w", err)
+	}
+	caPrivateKeyPem := &pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(caKeyPair),
+	}
+	return NewKeyPair(caPrivateKeyPem, caCertPem), nil
+}
+
+// Deprecated: CreateControlPlaneCert generates the certificate for the client
+func CreateControlPlaneCert(_ context.Context, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, expirationInterval time.Duration) (*KeyPair, error) {
+	return CreateCert(caKey, caCertificate, expirationInterval, LegacyFakeDnsName)
+}
+
+// Deprecated: CreateDataPlaneCert generates the certificate for the server
+func CreateDataPlaneCert(_ context.Context, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, expirationInterval time.Duration) (*KeyPair, error) {
+	return CreateCert(caKey, caCertificate, expirationInterval, LegacyFakeDnsName)
+}
+
+// CreateCert generates the certificate for use by client and server
+func CreateCert(caKey *rsa.PrivateKey, caCertificate *x509.Certificate, expirationInterval time.Duration, sans ...string) (*KeyPair, error) {
+
+	// Then create the private key for the serving cert
+	keyPair, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("error generating random key: %w", err)
+	}
+
+	certTemplate, err := createTransportCertTemplate(expirationInterval, sans)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the certificate template: %w", err)
+	}
+
+	// create a certificate which wraps the public key, sign it with the CA private key
+	certPEM, err := createCert(certTemplate, caCertificate, &keyPair.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("error signing certificate template: %w", err)
+	}
+
+	privateKeyPEM := &pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(keyPair),
+	}
+	return NewKeyPair(privateKeyPEM, certPEM), nil
+}
+
+// ParseCert parses a certificate/private key pair from serialized pem blocks
+func ParseCert(certPemBytes []byte, privateKeyPemBytes []byte) (*x509.Certificate, *rsa.PrivateKey, error) {
+	certBlock, _ := pem.Decode(certPemBytes)
+	if certBlock == nil {
+		return nil, nil, fmt.Errorf("decoding the cert block returned nil")
+	}
+	if certBlock.Type != "CERTIFICATE" {
+		return nil, nil, fmt.Errorf("bad pem block, expecting type 'CERTIFICATE', found %q", certBlock.Type)
+	}
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pkBlock, _ := pem.Decode(privateKeyPemBytes)
+	if pkBlock == nil {
+		return nil, nil, fmt.Errorf("decoding the pk block returned nil")
+	}
+	if pkBlock.Type != "RSA PRIVATE KEY" {
+		return nil, nil, fmt.Errorf("bad pem block, expecting type 'RSA PRIVATE KEY', found %q", pkBlock.Type)
+	}
+	pk, err := x509.ParsePKCS1PrivateKey(pkBlock.Bytes)
+	return cert, pk, err
+}
+
+// CheckExpiry checks the expiration of the certificate
+func CheckExpiry(cert *x509.Certificate, rotationThreshold time.Duration) error {
+	if time.Now().Add(rotationThreshold).After(cert.NotAfter) {
+		return fmt.Errorf("certificate is going to expire %v", cert.NotAfter)
+	}
+	return nil
+}

--- a/vendor/knative.dev/networking/pkg/certificates/constants.go
+++ b/vendor/knative.dev/networking/pkg/certificates/constants.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import "strings"
+
+const (
+	Organization = "knative.dev"
+
+	// nolint:all
+	LegacyFakeDnsName = "data-plane." + Organization
+
+	// nolint:all
+	// Deprecated: FakeDnsName is deprecated.
+	// Please use the DataPlaneRoutingSAN for calls to the Activator
+	// and the DataPlaneUserSAN function for calls to a Knative-Service via Queue-Proxy.
+	FakeDnsName = LegacyFakeDnsName
+
+	dataPlaneUserPrefix = "kn-user-"
+	DataPlaneRoutingSAN = "kn-routing"
+
+	// These keys are meant to line up with cert-manager, see
+	// https://cert-manager.io/docs/usage/certificate/#additional-certificate-output-formats
+	CaCertName     = "ca.crt"
+	CertName       = "tls.crt"
+	PrivateKeyName = "tls.key"
+
+	// These should be able to be deprecated some time in the future when the new names are fully adopted
+	// #nosec
+	// Deprecated: please use CaCertName instead.
+	SecretCaCertKey = "ca-cert.pem"
+	// #nosec
+	// Deprecated: please use CertName instead.
+	SecretCertKey = "public-cert.pem"
+	// #nosec
+	// Deprecated: please use PrivateKeyName instead.
+	SecretPKKey = "private-key.pem"
+)
+
+// DataPlaneUserSAN constructs a SAN for a data-plane-user certificate in the
+// target namespace of a Knative Service.
+func DataPlaneUserSAN(namespace string) string {
+	return dataPlaneUserPrefix + strings.ToLower(namespace)
+}

--- a/vendor/knative.dev/networking/pkg/certificates/key_pair.go
+++ b/vendor/knative.dev/networking/pkg/certificates/key_pair.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+)
+
+type KeyPair struct {
+	privateKeyBlock    *pem.Block
+	privateKeyPemBytes []byte
+
+	certBlock    *pem.Block
+	certPemBytes []byte
+}
+
+func NewKeyPair(privateKey *pem.Block, cert *pem.Block) *KeyPair {
+	return &KeyPair{
+		privateKeyBlock:    privateKey,
+		privateKeyPemBytes: pem.EncodeToMemory(privateKey),
+		certBlock:          cert,
+		certPemBytes:       pem.EncodeToMemory(cert),
+	}
+}
+
+func (kh *KeyPair) PrivateKey() *pem.Block {
+	return kh.privateKeyBlock
+}
+
+func (kh *KeyPair) PrivateKeyBytes() []byte {
+	return kh.privateKeyPemBytes
+}
+
+func (kh *KeyPair) Cert() *pem.Block {
+	return kh.certBlock
+}
+
+func (kh *KeyPair) CertBytes() []byte {
+	return kh.certPemBytes
+}
+
+func (kh *KeyPair) Parse() (*x509.Certificate, *rsa.PrivateKey, error) {
+	return ParseCert(kh.certPemBytes, kh.privateKeyPemBytes)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1619,6 +1619,7 @@ knative.dev/hack
 knative.dev/networking/pkg
 knative.dev/networking/pkg/apis/networking
 knative.dev/networking/pkg/apis/networking/v1alpha1
+knative.dev/networking/pkg/certificates
 knative.dev/networking/pkg/client/clientset/versioned
 knative.dev/networking/pkg/client/clientset/versioned/fake
 knative.dev/networking/pkg/client/clientset/versioned/scheme


### PR DESCRIPTION
Fixes JIRA https://issues.redhat.com/browse/SRVKS-1198

## Proposed Changes
- Install cert-manager always (as Downstream Serving tests now need it as well)
- Deploy Serving cert-manager issuers & certificates (aligned with upstream, we can't use the Eventing ones)
- Remove `internal-encryption` in favour of `system-internal-tls` and `cluster-local-domain-tls`
- Add a new test to make sure Serving encryption works
- Refactor test helpers to be shared

Please consider my comments for simpler review.


