### PR TITLE
Apply OpenShift Ingress certificate to Kourier system-internal-tls is…

### DIFF
--- a/openshift-knative-operator/pkg/serving/kourier.go
+++ b/openshift-knative-operator/pkg/serving/kourier.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
+	networking "knative.dev/networking/pkg/config"
 	"knative.dev/operator/pkg/apis/operator/base"
 	"knative.dev/pkg/network"
 )
@@ -17,10 +18,6 @@ const (
 	providerLabel           = "networking.knative.dev/ingress-provider"
 	kourierIngressClassName = "kourier.ingress.networking.knative.dev"
 	networkCMName           = "network"
-
-	// TODO: Use "knative.dev/networking/pkg/config" once the repo pulled Knative 1.6.
-	// Backport messes up the dependencies.
-	InternalEncryptionKey = "internal-encryption"
 
 	// IngressDefaultCertificateKey is the OpenShift Ingress default certificate name.
 	// The default cert name is different when users changed the default ingress certificate name via IngressController CR (SRVKS-955).
@@ -101,7 +98,8 @@ func addKourierEnvValues(ks base.KComponent) mf.Transformer {
 	}
 
 	networkCM := ks.GetSpec().GetConfig()[networkCMName]
-	if encrypt := networkCM[InternalEncryptionKey]; strings.ToLower(encrypt) == "true" {
+	if strings.ToLower(networkCM[networking.SystemInternalTLSKey]) == "true" ||
+		strings.ToLower(networkCM[networking.InternalEncryptionKey]) == "true" {
 		if certName := networkCM[IngressDefaultCertificateKey]; certName != "" {
 			envVars = append(envVars,
 				corev1.EnvVar{Name: "CERTS_SECRET_NAMESPACE", Value: ingressDefaultCertificateNameSpace},

--- a/openshift-knative-operator/pkg/serving/kourier_test.go
+++ b/openshift-knative-operator/pkg/serving/kourier_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
+	networking "knative.dev/networking/pkg/config"
 	"knative.dev/operator/pkg/apis/operator/base"
 	operatorv1beta1 "knative.dev/operator/pkg/apis/operator/v1beta1"
 )
@@ -155,7 +156,7 @@ func TestKourierEnvValue(t *testing.T) {
 			CommonSpec: base.CommonSpec{
 				Config: base.ConfigMapData{
 					"network": map[string]string{
-						InternalEncryptionKey: "true",
+						networking.SystemInternalTLSKey: "true",
 					},
 				},
 			},
@@ -229,8 +230,8 @@ func TestKourierInternalEncryptionOverrideCertName(t *testing.T) {
 			CommonSpec: base.CommonSpec{
 				Config: base.ConfigMapData{
 					"network": map[string]string{
-						InternalEncryptionKey:        "true",
-						IngressDefaultCertificateKey: "custom-cert",
+						networking.SystemInternalTLSKey: "true",
+						IngressDefaultCertificateKey:    "custom-cert",
 					},
 				},
 			},


### PR DESCRIPTION
… used

Key "internal-encryption" is deprecated as part of https://github.com/knative/networking/pull/858

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Apply OpenShift Ingress certificate when system-internal-tls key is defined in KnativeServing:
```
spec:
  config:
    network:
      system-internal-tls: Enabled
```
