### PR TITLE
Enable `eventtype-auto-create` feature flag for tests

### DIFF
--- a/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeeventing_cr.yaml
+++ b/test/v1beta1/resources/operator.knative.dev_v1beta1_knativeeventing_cr.yaml
@@ -6,6 +6,7 @@ spec:
   config:
     config-features:
       new-apiserversource-filters: "enabled"
+      eventtype-auto-create: "enabled"
     logging:
       loglevel.controller: "debug"
       loglevel.webhook: "debug"


### PR DESCRIPTION
Enable the `eventtype-auto-create` feature flag for tests to comply with https://github.com/openshift-knative/eventing-kafka-broker/pull/1028.

This should also help [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_serverless-operator/2659/pull-ci-openshift-knative-serverless-operator-main-415-upstream-e2e-kafka-aws-415/1790822616869638144) with:
```
test/e2e_new: TestBrokerEventTypeAutoCreate/AutoCreateEventTypesOnBroker/Assert/broker_create_event_type expand_less	8m0s
{Failed  === RUN   TestBrokerEventTypeAutoCreate/AutoCreateEventTypesOnBroker/Assert/broker_create_event_type
=== PAUSE TestBrokerEventTypeAutoCreate/AutoCreateEventTypesOnBroker/Assert/broker_create_event_type
=== CONT  TestBrokerEventTypeAutoCreate/AutoCreateEventTypesOnBroker/Assert/broker_create_event_type
    eventtype.go:76: failed to verify eventtype test EventTypes ready and test eventtypes match or not context deadline exceeded: client rate limiter Wait returned an error: context deadline exceeded
        &{TypeMeta:{Kind: APIVersion:} ListMeta:{SelfLink: ResourceVersion:163931 Continue: RemainingItemCount:<nil>} Items:[]}
--- FAIL: TestBrokerEventTypeAutoCreate/AutoCreateEventTypesOnBroker/Assert/broker_create_event_type (480.00s)
}
``` 
in #2659