### PR TITLE
Align key for features CM in KnativeEventing CR

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -240,7 +240,7 @@ function enable_istio_eventing {
   cat - << EOF > "${istio_patch}"
 spec:
   config:
-    features:
+    config-features:
       istio: "enabled"
       delivery-timeout: "enabled"
   workloads:


### PR DESCRIPTION
Currently we use different keys for the eventing config-features configmap in the KnativeEventing CR. E.g. `features` ([here](https://github.com/openshift-knative/serverless-operator/blob/565620d716d72f3458c839b40de41c50a7471f56/hack/lib/serverless.bash#L243)) or `config-features` in #2660.
This leads to patches like the following, which are problematic as only one is considered:

```
apiVersion: operator.knative.dev/v1beta1
kind: KnativeEventing
metadata:
  name: knative-eventing
spec:
  config:
    config-features:
      new-apiserversource-filters: "enabled"
      eventtype-auto-create: "enabled"
    logging:
      ...
    features:
      istio: "enabled"
      delivery-timeout: "enabled"
```

This PR addresses it and updates the key for the CM accordingly.

This should help with https://github.com/openshift-knative/eventing-istio/pull/265#issuecomment-2111972249 and https://github.com/openshift-knative/serverless-operator/pull/2659