### PR TITLE
Add https port on knative-local-gateway (sync with upstream)

### DIFF
--- a/hack/lib/mesh_resources/gateway.yaml
+++ b/hack/lib/mesh_resources/gateway.yaml
@@ -50,3 +50,6 @@ spec:
     - name: http2
       port: 80
       targetPort: 8081
+    - name: https
+      port: 443
+      targetPort: 8444


### PR DESCRIPTION
## Proposed Changes
- Add https port on knative-local-gateway (sync with upstream https://github.com/knative-extensions/net-istio/blob/main/config/203-local-gateway.yaml#L58)
- Needed if we want to enable `cluster-local-domain-tls` for istio at some point

/assign @skonto 

