### PR TITLE
Fix lint errors about grpc.Dial

### DIFF
--- a/test/servinge2e/tracing_test.go
+++ b/test/servinge2e/tracing_test.go
@@ -130,7 +130,7 @@ func verifyServicesArePresentInAllJaegerTraces(ctx *test.Context,
 	}
 	defer portForward.Close()
 
-	conn, err := grpc.Dial(fmt.Sprintf("127.0.0.1:%d", portForward.LocalPort),
+	conn, err := grpc.NewClient(fmt.Sprintf("127.0.0.1:%d", portForward.LocalPort),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("error dialing grpc to 127.0.0.1:%d: %w", portForward.LocalPort, err)


### PR DESCRIPTION
## Proposed Changes
- Fix lint errors about grpc.Dial
- See CI errors in https://github.com/openshift-knative/serverless-operator/pull/2680 and https://github.com/openshift-knative/serverless-operator/pull/2681

/assign @skonto 
/assign @pierDipi 
