### PR TITLE
Run validate GH action only on main and release branches

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -4,12 +4,14 @@ name: Validate
 on:
   push:
     branches:
-      - '**'
+      - 'main'
+      - 'release-*'
     tags:
       - 'v*.*.*'
   pull_request:
     branches:
-      - '**'
+      - 'main'
+      - 'release-*'
   schedule:
     - cron: "0 6 * * *" # Daily at 06:00.
   workflow_dispatch: # Manual workflow trigger


### PR DESCRIPTION
Currently the [validate github action](https://github.com/openshift-knative/serverless-operator/actions/workflows/validate.yaml) runs on every branch. This should be limited to "main" and release branches to limit the noise.