### PR TITLE
Configure components to use custom build pipeline.

### DIFF
--- a/.konflux/manifests/components/knative-eventing-controller.yaml
+++ b/.konflux/manifests/components/knative-eventing-controller.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     image.redhat.com/generate: "true"
     appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/request: configure-pac
   name: knative-eventing-controller
 spec:
   componentName: knative-eventing-controller

--- a/.konflux/manifests/components/knative-eventing-controller.yaml
+++ b/.konflux/manifests/components/knative-eventing-controller.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     image.redhat.com/generate: "true"
     appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build","bundle":"latest"}'
     build.appstudio.openshift.io/request: configure-pac
   name: knative-eventing-controller
 spec:

--- a/.konflux/manifests/components/knative-serverless-operator-bundle.yaml
+++ b/.konflux/manifests/components/knative-serverless-operator-bundle.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     image.redhat.com/generate: "true"
     appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build","bundle":"latest"}'
     build.appstudio.openshift.io/request: configure-pac
   name: serverless-bundle
 spec:

--- a/.konflux/manifests/components/knative-serverless-operator-bundle.yaml
+++ b/.konflux/manifests/components/knative-serverless-operator-bundle.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     image.redhat.com/generate: "true"
     appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/request: configure-pac
   name: serverless-bundle
 spec:
   componentName: serverless-bundle

--- a/.konflux/manifests/components/knative-serverless-operator-index.yaml
+++ b/.konflux/manifests/components/knative-serverless-operator-index.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     image.redhat.com/generate: "true"
     appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/pipeline: '{"name":"fbc-builder","bundle":"latest"}'
     build.appstudio.openshift.io/request: configure-pac
   name: serverless-index
 spec:

--- a/.konflux/manifests/components/knative-serverless-operator-index.yaml
+++ b/.konflux/manifests/components/knative-serverless-operator-index.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     image.redhat.com/generate: "true"
     appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/request: configure-pac
   name: serverless-index
 spec:
   componentName: serverless-index

--- a/.konflux/manifests/components/knative-serverless-operator-openshift-knative-operator.yaml
+++ b/.konflux/manifests/components/knative-serverless-operator-openshift-knative-operator.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     image.redhat.com/generate: "true"
     appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/request: configure-pac
   name: serverless-openshift-knative-operator
 spec:
   componentName: serverless-openshift-knative-operator

--- a/.konflux/manifests/components/knative-serverless-operator-openshift-knative-operator.yaml
+++ b/.konflux/manifests/components/knative-serverless-operator-openshift-knative-operator.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     image.redhat.com/generate: "true"
     appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build","bundle":"latest"}'
     build.appstudio.openshift.io/request: configure-pac
   name: serverless-openshift-knative-operator
 spec:


### PR DESCRIPTION
Currently we have the issue, that Konflux does not run any build pipeline for a component, when the component CR gets applied directly in a new workspace. This PR addresses it and adds the `build.appstudio.openshift.io/request: configure-pac` annotation on components, to tell Konflux to use the custom build pipeline when components are configured via code. 

View [Configuration as Code](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/configuration-as-code/proc_configuration_as_code/#creating-your-base-component) (or [proc_configuration_as_code.adoc](https://github.com/redhat-appstudio/docs.appstudio.io/blob/ec0e3f3f7b9e79ae4d95fc232b348e90e3309f19/docs/modules/ROOT/pages/how-to-guides/configuration-as-code/proc_configuration_as_code.adoc?plain=1#L81)) for details.