### PR TITLE
Use longer poll timeout for REKT tests

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -235,7 +235,7 @@ function downstream_eventing_e2e_rekt_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  RUN_FLAGS=(-failfast -timeout=30m -parallel=10)
+  RUN_FLAGS=(-failfast -timeout=30m -parallel=10 --poll.timeout=8m)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi
@@ -244,7 +244,6 @@ function downstream_eventing_e2e_rekt_tests {
     # Need to specify a namespace that is in Mesh.
     go_test_e2e "${RUN_FLAGS[@]}" ./test/eventinge2erekt ./test/eventinge2erekt/servicemesh \
       --images.producer.file="${images_file}" \
-      --poll.timeout="8m" \
       --environment.namespace=serverless-tests \
       --istio.enabled="$MESH" \
       "$@"
@@ -307,7 +306,7 @@ function downstream_knative_kafka_e2e_rekt_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  RUN_FLAGS=(-failfast -timeout=30m -parallel=10)
+  RUN_FLAGS=(-failfast -timeout=30m -parallel=10 --poll.timeout=8m)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi
@@ -317,7 +316,6 @@ function downstream_knative_kafka_e2e_rekt_tests {
     go_test_e2e "${RUN_FLAGS[@]}" ./test/extensione2erekt ./test/extensione2erekt/servicemesh \
       --images.producer.file="${images_file}" \
       --environment.namespace=serverless-tests \
-      --poll.timeout="8m" \
       --istio.enabled="$MESH" \
       "$@"
 

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -235,7 +235,7 @@ function downstream_eventing_e2e_rekt_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  RUN_FLAGS=(-failfast -timeout=30m -parallel=10 --poll.timeout=8m)
+  RUN_FLAGS=(-failfast -timeout=30m -parallel=10)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi
@@ -244,12 +244,14 @@ function downstream_eventing_e2e_rekt_tests {
     # Need to specify a namespace that is in Mesh.
     go_test_e2e "${RUN_FLAGS[@]}" ./test/eventinge2erekt ./test/eventinge2erekt/servicemesh \
       --images.producer.file="${images_file}" \
+      --poll.timeout=8m \
       --environment.namespace=serverless-tests \
       --istio.enabled="$MESH" \
       "$@"
   else
     go_test_e2e "${RUN_FLAGS[@]}" ./test/eventinge2erekt \
       --images.producer.file="${images_file}" \
+      --poll.timeout=8m \
       "$@"
   fi
 }
@@ -306,7 +308,7 @@ function downstream_knative_kafka_e2e_rekt_tests {
   SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-eventing"}"
   export SYSTEM_NAMESPACE
 
-  RUN_FLAGS=(-failfast -timeout=30m -parallel=10 --poll.timeout=8m)
+  RUN_FLAGS=(-failfast -timeout=30m -parallel=10)
   if [ -n "${OPERATOR_TEST_FLAGS:-}" ]; then
     IFS=" " read -r -a RUN_FLAGS <<< "$OPERATOR_TEST_FLAGS"
   fi
@@ -315,6 +317,7 @@ function downstream_knative_kafka_e2e_rekt_tests {
     # Need to specify a namespace that is in Mesh.
     go_test_e2e "${RUN_FLAGS[@]}" ./test/extensione2erekt ./test/extensione2erekt/servicemesh \
       --images.producer.file="${images_file}" \
+      --poll.timeout=8m \
       --environment.namespace=serverless-tests \
       --istio.enabled="$MESH" \
       "$@"
@@ -325,6 +328,7 @@ function downstream_knative_kafka_e2e_rekt_tests {
   else
     go_test_e2e "${RUN_FLAGS[@]}" ./test/extensione2erekt \
       --images.producer.file="${images_file}" \
+      --poll.timeout=8m \
       "$@"
   fi
 }


### PR DESCRIPTION
For both downstream Eventing and EKB.

The default poll timeout is 2 minutes which is too short and might cause flaky tests.

Some examples:
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-ocp4.16-lp-interop-operator-e2e-interop-aws-ocp416/1800046364940308480
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-ocp4.16-lp-interop-operator-e2e-interop-aws-ocp416/1798549188200370176

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
