### PR TITLE
fix KnativeKafka controller-autoscaler-keda enablement

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -412,7 +412,7 @@ EOF
   fi
 
   if [[ $ENABLE_KEDA == "true" ]]; then
-    yq write --inplace "$knativekafka_cr" 'spec.config-kafka-features."controller.autoscaler"' "enabled"
+    yq write --inplace "$knativekafka_cr" 'spec.config.kafka-features."controller-autoscaler-keda"' "enabled"
   fi
 
 


### PR DESCRIPTION
The documented way of activatinr keda autoscaling in KnativeKafka is `.spec.config.kafka-features.controller-autoscaler-keda`

## Proposed Changes
- :bug: knativekafka keda activation

https://docs.openshift.com/serverless/1.33/eventing/event-sources/serverless-kafka-developer-source.html#serverless-kafka-source-autoscale-keda_serverless-kafka-developer-source