### PR TITLE
Workaround for OCPBUGS-35731 Repeat deleting service accounts

### DIFF
--- a/hack/patches/021-rekt-serviceaccounts-delete.patch
+++ b/hack/patches/021-rekt-serviceaccounts-delete.patch
@@ -1,0 +1,20 @@
+diff --git a/vendor/knative.dev/reconciler-test/pkg/feature/feature.go b/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
+index 0d454c517..9545093a0 100644
+--- a/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
++++ b/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
+@@ -249,6 +249,15 @@ func DeleteResources(ctx context.Context, t T, refs []corev1.ObjectReference) er
+ 				return false, fmt.Errorf("failed to get resource %+v %s/%s: %w", resource, ref.Namespace, ref.Name, err)
+ 			}
+ 
++			// Repeat deleting service accounts.
++			// Workaround for https://issues.redhat.com/browse/OCPBUGS-35731
++			if resource.Resource == "serviceaccounts" {
++				err = dc.Resource(resource).Namespace(ref.Namespace).Delete(ctx, ref.Name, metav1.DeleteOptions{})
++				if err != nil && !apierrors.IsNotFound(err) {
++					t.Logf("Warning, failed to delete %s/%s of GVR: %+v: %v", ref.Namespace, ref.Name, resource, err)
++				}
++			}
++
+ 			lastResource = ref
+ 			t.Logf("Resource %+v %s/%s still present", resource, ref.Namespace, ref.Name)
+ 			return false, nil

--- a/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
+++ b/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
@@ -249,6 +249,15 @@ func DeleteResources(ctx context.Context, t T, refs []corev1.ObjectReference) er
 				return false, fmt.Errorf("failed to get resource %+v %s/%s: %w", resource, ref.Namespace, ref.Name, err)
 			}
 
+			// Repeat deleting service accounts.
+			// Workaround for https://issues.redhat.com/browse/OCPBUGS-35731
+			if resource.Resource == "serviceaccounts" {
+				err = dc.Resource(resource).Namespace(ref.Namespace).Delete(ctx, ref.Name, metav1.DeleteOptions{})
+				if err != nil && !apierrors.IsNotFound(err) {
+					t.Logf("Warning, failed to delete %s/%s of GVR: %+v: %v", ref.Namespace, ref.Name, resource, err)
+				}
+			}
+
 			lastResource = ref
 			t.Logf("Resource %+v %s/%s still present", resource, ref.Namespace, ref.Name)
 			return false, nil


### PR DESCRIPTION
This is a workaround for https://issues.redhat.com/browse/OCPBUGS-35731
The bug description has references to CI runs that suffered this bug. It's pretty frequent.

The scope is as narrow as possible:
* Do this only downstream because the bug is on OCP
* Repeating deleting only service accounts, not other resources

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Delete ServiceAccount if the first attempt failed.

