### PR TITLE
Kitchensink upgrades - 1.33.0 supercedes 1.32.1

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -74,7 +74,5 @@ dependencies:
         image: quay.io/openshift-knative/must-gather
 upgrade_sequence:
     - csv: serverless-operator.v1.32.0
-    - csv: serverless-operator.v1.32.1
     - csv: serverless-operator.v1.33.0
-      source: serverless-operator
     - csv: serverless-operator.v1.34.0


### PR DESCRIPTION
* The version  1.32.1 is not offered anymore when upgrading from 1.32.0. The 1.33.0 InstallPlan is offered instead.
* It is not necessary to specify the source: serverless-operator. The upgrade tests first try redhat-operators catalog source and when it fails they try serverless-operator catalog source automatically.

Fixes Kitchensink upgrade test runs, e.g. [this run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-412-kitchensink-upgrade-aws-412-c/1805054153068646400)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
