### PR TITLE
SRVKE-1626 Run cleanup uperations for EKB during downgrades

### DIFF
--- a/test/upgrade/installation/triggerv2_downgrade.go
+++ b/test/upgrade/installation/triggerv2_downgrade.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package installation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/system"
+	pkgupgrade "knative.dev/pkg/test/upgrade"
+
+	internalsclient "knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/client"
+
+	"knative.dev/reconciler-test/pkg/environment"
+)
+
+// This file is copied from Eventing Kafka Broker repo.
+
+func CleanupTriggerv2ConsumerGroups(c pkgupgrade.Context, glob environment.GlobalEnvironment) {
+	ctx, _ := glob.Environment()
+	client := kubeclient.Get(ctx)
+
+	err := deleteConsumerGroups(ctx, client)
+	if err != nil {
+		c.T.Fatal("failed to downgrade from triggerv2", err.Error())
+	}
+}
+
+func CleanupTriggerv2Deployments(c pkgupgrade.Context, glob environment.GlobalEnvironment) {
+	ctx, _ := glob.Environment()
+	client := kubeclient.Get(ctx)
+
+	err := deleteStatefulSet(ctx, client, "kafka-broker-dispatcher", system.Namespace())
+	if err != nil {
+		c.T.Fatal("failed to downgrade from triggerv2", err.Error())
+	}
+}
+
+func deleteStatefulSet(ctx context.Context, client kubernetes.Interface, name string, namespace string) error {
+	err := waitDeploymentExists(ctx, client, name, namespace)
+	if err != nil {
+		return err
+	}
+
+	err = client.AppsV1().StatefulSets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete statefulset: %w", err)
+	}
+
+	return nil
+}
+
+func waitDeploymentExists(ctx context.Context, client kubernetes.Interface, name string, namespace string) error {
+	return wait.PollUntilContextTimeout(ctx, time.Second*10, time.Minute*3, true, func(ctx context.Context) (bool, error) {
+		_, err := client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		if err != nil {
+			return false, fmt.Errorf("failed to get deployment: %w", err)
+		}
+
+		return true, nil
+	})
+}
+
+func deleteConsumerGroups(ctx context.Context, client kubernetes.Interface) error {
+	namespaces, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	internalClient := internalsclient.Get(ctx)
+
+	for _, ns := range namespaces.Items {
+		cgClient := internalClient.InternalV1alpha1().ConsumerGroups(ns.Name)
+		cgList, err := cgClient.List(ctx, metav1.ListOptions{})
+
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+
+		for _, cg := range cgList.Items {
+			for _, owner := range cg.OwnerReferences {
+				if owner.Kind == "Trigger" {
+					err := cgClient.Delete(ctx, cg.Name, metav1.DeleteOptions{})
+					if err != nil && !errors.IsNotFound(err) {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/test/upgrade/installation/triggerv2_downgrade.go
+++ b/test/upgrade/installation/triggerv2_downgrade.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift-knative/serverless-operator/test"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	"knative.dev/pkg/system"
 	pkgupgrade "knative.dev/pkg/test/upgrade"
 
 	internalsclient "knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/client"
@@ -51,7 +51,7 @@ func CleanupTriggerv2Deployments(c pkgupgrade.Context, glob environment.GlobalEn
 	ctx, _ := glob.Environment()
 	client := kubeclient.Get(ctx)
 
-	err := deleteStatefulSet(ctx, client, "kafka-broker-dispatcher", system.Namespace())
+	err := deleteStatefulSet(ctx, client, "kafka-broker-dispatcher", test.EventingNamespace)
 	if err != nil {
 		c.T.Fatal("failed to downgrade from triggerv2", err.Error())
 	}

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/upgrade/installation"
 	pkgupgrade "knative.dev/pkg/test/upgrade"
+	"knative.dev/reconciler-test/pkg/environment"
 )
 
 func ServerlessUpgradeOperations(ctx *test.Context) []pkgupgrade.Operation {
@@ -16,12 +17,14 @@ func ServerlessUpgradeOperations(ctx *test.Context) []pkgupgrade.Operation {
 	}
 }
 
-func ServerlessDowngradeOperations(ctx *test.Context) []pkgupgrade.Operation {
+func ServerlessDowngradeOperations(ctx *test.Context, glob environment.GlobalEnvironment) []pkgupgrade.Operation {
 	return []pkgupgrade.Operation{
 		pkgupgrade.NewOperation("DowngradeServerless", func(c pkgupgrade.Context) {
 			if err := installation.DowngradeServerless(ctx); err != nil {
 				c.T.Error("Serverless downgrade failed:", err)
 			}
+			installation.CleanupTriggerv2ConsumerGroups(c, glob)
+			installation.CleanupTriggerv2Deployments(c, glob)
 		}),
 	}
 }

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -75,7 +75,7 @@ func TestServerlessUpgradePrePost(t *testing.T) {
 		},
 		Installations: pkgupgrade.Installations{
 			UpgradeWith:   upgrade.ServerlessUpgradeOperations(ctx),
-			DowngradeWith: upgrade.ServerlessDowngradeOperations(ctx),
+			DowngradeWith: upgrade.ServerlessDowngradeOperations(ctx, global),
 		},
 	}
 	suite.Execute(pkgupgrade.Configuration{T: t})
@@ -97,7 +97,7 @@ func TestServerlessUpgradeContinual(t *testing.T) {
 		},
 		Installations: pkgupgrade.Installations{
 			UpgradeWith:   upgrade.ServerlessUpgradeOperations(ctx),
-			DowngradeWith: upgrade.ServerlessDowngradeOperations(ctx),
+			DowngradeWith: upgrade.ServerlessDowngradeOperations(ctx, global),
 		},
 	}
 	suite.Execute(pkgupgrade.Configuration{T: t})


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVKE-1626

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Run cleanup operations for EKB to fix downgrade tests from: https://github.com/openshift-knative/eventing-kafka-broker/blob/release-v1.14/test/upgrade/installation/stable.go#L28-L29. This is to fix https://issues.redhat.com/browse/SRVKE-1626 . The code is copied from EKB repository because it's just a one time fix. It will be removed with next version.
- Remove workaround for webhook strategy in downgrades. The minimum supported version if now OCP 4.12
