### PR TITLE
Change kube rbac proxy's default log level to zero and make it configurable

### DIFF
--- a/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection.go
+++ b/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	RBACContainerName     = "kube-rbac-proxy"
-	rbacProxyImageEnvVar  = "IMAGE_KUBE_RBAC_PROXY"
-	KubeRbacProxyLogLevel = 0
+	RBACContainerName            = "kube-rbac-proxy"
+	rbacProxyImageEnvVar         = "IMAGE_KUBE_RBAC_PROXY"
+	DefaultKubeRbacProxyLogLevel = 0
 )
 
 var defaultKubeRBACProxyRequests = corev1.ResourceList{
@@ -33,7 +33,7 @@ func InjectRbacProxyContainer(deployments sets.Set[string], cfg base.ConfigMapDa
 		Requests: defaultKubeRBACProxyRequests,
 		Limits:   corev1.ResourceList{},
 	}
-	logLevel := KubeRbacProxyLogLevel
+	logLevel := DefaultKubeRbacProxyLogLevel
 	if cfg != nil {
 		if cfg["deployment"] != nil {
 			if cpuRequest, ok := cfg["deployment"]["kube-rbac-proxy-cpu-request"]; ok {
@@ -48,10 +48,10 @@ func InjectRbacProxyContainer(deployments sets.Set[string], cfg base.ConfigMapDa
 			if memLimit, ok := cfg["deployment"]["kube-rbac-proxy-memory-limit"]; ok {
 				resources.Limits["memory"] = resource.MustParse(memLimit)
 			}
-			if cfg["logging"] != nil {
-				if logLevelStr, ok := cfg["logging"]["loglevel.kube-rbac-proxy"]; ok {
-					logLevel, _ = strconv.Atoi(logLevelStr)
-				}
+		}
+		if cfg["logging"] != nil {
+			if logLevelStr, ok := cfg["logging"]["loglevel.kube-rbac-proxy"]; ok {
+				logLevel, _ = strconv.Atoi(logLevelStr)
 			}
 		}
 	}

--- a/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection.go
+++ b/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection.go
@@ -35,22 +35,22 @@ func InjectRbacProxyContainer(deployments sets.Set[string], cfg base.ConfigMapDa
 	}
 	logLevel := DefaultKubeRbacProxyLogLevel
 	if cfg != nil {
-		if cfg["deployment"] != nil {
-			if cpuRequest, ok := cfg["deployment"]["kube-rbac-proxy-cpu-request"]; ok {
+		if deploymentData := getCmDataforName(cfg, "config-deployment"); deploymentData != nil {
+			if cpuRequest, ok := deploymentData["kube-rbac-proxy-cpu-request"]; ok {
 				resources.Requests["cpu"] = resource.MustParse(cpuRequest)
 			}
-			if memRequest, ok := cfg["deployment"]["kube-rbac-proxy-memory-request"]; ok {
+			if memRequest, ok := deploymentData["kube-rbac-proxy-memory-request"]; ok {
 				resources.Requests["memory"] = resource.MustParse(memRequest)
 			}
-			if cpuLimit, ok := cfg["deployment"]["kube-rbac-proxy-cpu-limit"]; ok {
+			if cpuLimit, ok := deploymentData["kube-rbac-proxy-cpu-limit"]; ok {
 				resources.Limits["cpu"] = resource.MustParse(cpuLimit)
 			}
-			if memLimit, ok := cfg["deployment"]["kube-rbac-proxy-memory-limit"]; ok {
+			if memLimit, ok := deploymentData["kube-rbac-proxy-memory-limit"]; ok {
 				resources.Limits["memory"] = resource.MustParse(memLimit)
 			}
 		}
-		if cfg["logging"] != nil {
-			if logLevelStr, ok := cfg["logging"]["loglevel.kube-rbac-proxy"]; ok {
+		if loggingData := getCmDataforName(cfg, "config-logging"); loggingData != nil {
+			if logLevelStr, ok := loggingData["loglevel.kube-rbac-proxy"]; ok {
 				logLevel, _ = strconv.Atoi(logLevelStr)
 			}
 		}
@@ -140,4 +140,15 @@ func ExtensionDeploymentOverrides(overrides []base.WorkloadOverride, deployments
 		}
 	}
 	return operator.OverridesTransform(ovs, nil)
+}
+
+func getCmDataforName(cfg base.ConfigMapData, name string) map[string]string {
+	if cfg[name] != nil {
+		return cfg[name]
+	}
+	// The "config-" prefix is optional, so we try to find the config without it.
+	if cfg[name[len(`config-`):]] != nil {
+		return cfg[name[len(`config-`):]]
+	}
+	return nil
 }

--- a/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection.go
+++ b/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	mf "github.com/manifestival/manifestival"
 	appsv1 "k8s.io/api/apps/v1"
@@ -17,8 +18,9 @@ import (
 )
 
 const (
-	RBACContainerName    = "kube-rbac-proxy"
-	rbacProxyImageEnvVar = "IMAGE_KUBE_RBAC_PROXY"
+	RBACContainerName     = "kube-rbac-proxy"
+	rbacProxyImageEnvVar  = "IMAGE_KUBE_RBAC_PROXY"
+	KubeRbacProxyLogLevel = 0
 )
 
 var defaultKubeRBACProxyRequests = corev1.ResourceList{
@@ -31,18 +33,26 @@ func InjectRbacProxyContainer(deployments sets.Set[string], cfg base.ConfigMapDa
 		Requests: defaultKubeRBACProxyRequests,
 		Limits:   corev1.ResourceList{},
 	}
-	if cfg != nil && cfg["deployment"] != nil {
-		if cpuRequest, ok := cfg["deployment"]["kube-rbac-proxy-cpu-request"]; ok {
-			resources.Requests["cpu"] = resource.MustParse(cpuRequest)
-		}
-		if memRequest, ok := cfg["deployment"]["kube-rbac-proxy-memory-request"]; ok {
-			resources.Requests["memory"] = resource.MustParse(memRequest)
-		}
-		if cpuLimit, ok := cfg["deployment"]["kube-rbac-proxy-cpu-limit"]; ok {
-			resources.Limits["cpu"] = resource.MustParse(cpuLimit)
-		}
-		if memLimit, ok := cfg["deployment"]["kube-rbac-proxy-memory-limit"]; ok {
-			resources.Limits["memory"] = resource.MustParse(memLimit)
+	logLevel := KubeRbacProxyLogLevel
+	if cfg != nil {
+		if cfg["deployment"] != nil {
+			if cpuRequest, ok := cfg["deployment"]["kube-rbac-proxy-cpu-request"]; ok {
+				resources.Requests["cpu"] = resource.MustParse(cpuRequest)
+			}
+			if memRequest, ok := cfg["deployment"]["kube-rbac-proxy-memory-request"]; ok {
+				resources.Requests["memory"] = resource.MustParse(memRequest)
+			}
+			if cpuLimit, ok := cfg["deployment"]["kube-rbac-proxy-cpu-limit"]; ok {
+				resources.Limits["cpu"] = resource.MustParse(cpuLimit)
+			}
+			if memLimit, ok := cfg["deployment"]["kube-rbac-proxy-memory-limit"]; ok {
+				resources.Limits["memory"] = resource.MustParse(memLimit)
+			}
+			if cfg["logging"] != nil {
+				if logLevelStr, ok := cfg["logging"]["loglevel.kube-rbac-proxy"]; ok {
+					logLevel, _ = strconv.Atoi(logLevelStr)
+				}
+			}
 		}
 	}
 	return func(u *unstructured.Unstructured) error {
@@ -100,7 +110,7 @@ func InjectRbacProxyContainer(deployments sets.Set[string], cfg base.ConfigMapDa
 					"--tls-private-key-file=" + filepath.Join(mountPath, "tls.key"),
 					"--logtostderr=true",
 					"--http2-disable",
-					"--v=10",
+					fmt.Sprintf("--v=%d", logLevel),
 				},
 			}
 			podSpec.Containers = append(podSpec.Containers, rbacProxyContainer)

--- a/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection_test.go
+++ b/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection_test.go
@@ -134,7 +134,7 @@ func TestInjectRbacProxyContainerToDeployments(t *testing.T) {
 							"--tls-private-key-file=/etc/tls/private/tls.key",
 							"--logtostderr=true",
 							"--http2-disable",
-							fmt.Sprintf("--v=%d", KubeRbacProxyLogLevel),
+							fmt.Sprintf("--v=%d", DefaultKubeRbacProxyLogLevel),
 						},
 					}},
 				},

--- a/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection_test.go
+++ b/openshift-knative-operator/pkg/monitoring/rbac_proxy_injection_test.go
@@ -1,6 +1,7 @@
 package monitoring
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -133,7 +134,7 @@ func TestInjectRbacProxyContainerToDeployments(t *testing.T) {
 							"--tls-private-key-file=/etc/tls/private/tls.key",
 							"--logtostderr=true",
 							"--http2-disable",
-							"--v=10",
+							fmt.Sprintf("--v=%d", KubeRbacProxyLogLevel),
 						},
 					}},
 				},


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fixes #2740, similar issue to https://github.com/kubernetes-sigs/kubebuilder/issues/2434.
- User can inject the desired log level at the corresponding operator CR as follows:
```
spec:
  config:
    logging:
      loglevel.kube-rbac-proxy: "10"
```
