### PR TITLE
Support patch releases in index

### DIFF
--- a/hack/generate/dockerfile.sh
+++ b/hack/generate/dockerfile.sh
@@ -25,9 +25,13 @@ values[PREVIOUS_VERSION]="$(metadata.get olm.replaces)"
 values[PREVIOUS_REPLACES]="$(metadata.get olm.previous.replaces)"
 
 
-prev_prev_channel="$(metadata.get 'olm.channels.list[*]' | head -n 4 | tail -n 1)"
-if [[ "${values[PREVIOUS_REPLACES]}" == "$prev_prev_channel" ]]; then
-  values[PREVIOUS_PREVIOUS_VERSION]="registry.ci.openshift.org/knative/openshift-serverless-v${prev_prev_channel#stable-}.0:serverless-bundle"
+prev_prev_channel="$(metadata.get 'olm.channels.list[*]' | head -n 4 | tail -n 1)" # stable-1.32
+prev_prev_version="${prev_prev_channel#stable-}.0"
+
+echo "Comparing '${values[PREVIOUS_REPLACES]}' -- '$prev_prev_version'"
+
+if [[ "${values[PREVIOUS_REPLACES]}" != "$prev_prev_version" ]]; then
+  values[PREVIOUS_PREVIOUS_VERSION]="registry.ci.openshift.org/knative/openshift-serverless-v${prev_prev_version}:serverless-bundle"
 else
   values[PREVIOUS_PREVIOUS_VERSION]=""
 fi
@@ -37,5 +41,5 @@ cp "$template" "$target"
 
 for before in "${!values[@]}"; do
   echo "Value: ${before} -> ${values[$before]}"
-  sed --in-place "s/__${before}__/${values[${before}]}/" "$target"
+  sed --in-place "s|__${before}__|${values[${before}]}|" "$target"
 done

--- a/hack/generate/dockerfile.sh
+++ b/hack/generate/dockerfile.sh
@@ -24,6 +24,14 @@ values[OCP_MAX_VERSION]="$(metadata.get 'requirements.ocpVersion.max')"
 values[PREVIOUS_VERSION]="$(metadata.get olm.replaces)"
 values[PREVIOUS_REPLACES]="$(metadata.get olm.previous.replaces)"
 
+
+prev_prev_channel="$(metadata.get 'olm.channels.list[*]' | head -n 4 | tail -n 1)"
+if [[ "${values[PREVIOUS_REPLACES]}" == "$prev_prev_channel" ]]; then
+  values[PREVIOUS_PREVIOUS_VERSION]="registry.ci.openshift.org/knative/openshift-serverless-v${prev_prev_channel#stable-}.0:serverless-bundle"
+else
+  values[PREVIOUS_PREVIOUS_VERSION]=""
+fi
+
 # Start fresh
 cp "$template" "$target"
 

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -9,12 +9,12 @@ COPY olm-catalog/serverless-operator/index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml \
-      \
+       \
       registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
       registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
       registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle >> /configs/index.yaml || \
     /bin/opm render --skip-tls-verify -o yaml \
-      \
+       \
       registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
       registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
       registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -8,10 +8,14 @@ COPY --from=opm /bin/opm /bin/opm
 COPY olm-catalog/serverless-operator/index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
-RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
+RUN /bin/opm render --skip-tls-verify -o yaml \
+      \
+      registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
       registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
       registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle >> /configs/index.yaml || \
-    /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
+    /bin/opm render --skip-tls-verify -o yaml \
+      \
+      registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
       registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
       registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml
 

--- a/openshift-knative-operator/cmd/operator/kodata/ingress/1.14/kourier/1-net-kourier.yaml
+++ b/openshift-knative-operator/cmd/operator/kodata/ingress/1.14/kourier/1-net-kourier.yaml
@@ -546,6 +546,7 @@ spec:
 
       # to ensure a graceful drain, terminationGracePeriodSeconds must be greater than DRAIN_TIME_SECONDS environment variable
       terminationGracePeriodSeconds: 30
+
       volumes:
         - name: config-volume
           configMap:

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -8,10 +8,14 @@ COPY --from=opm /bin/opm /bin/opm
 COPY olm-catalog/serverless-operator/index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=__DEFAULT_CHANNEL__ --output yaml >> /configs/index.yaml
-RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
+RUN /bin/opm render --skip-tls-verify -o yaml \
+     __PREVIOUS_PREVIOUS_VERSION__ \
+      registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
       registry.ci.openshift.org/knative/release-__PREVIOUS_VERSION__:serverless-bundle \
       registry.ci.openshift.org/knative/release-__VERSION__:serverless-bundle >> /configs/index.yaml || \
-    /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
+    /bin/opm render --skip-tls-verify -o yaml \
+     __PREVIOUS_PREVIOUS_VERSION__ \
+      registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
       registry.ci.openshift.org/knative/release-__PREVIOUS_VERSION__:serverless-bundle \
       registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml
 

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -9,12 +9,12 @@ COPY olm-catalog/serverless-operator/index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=__DEFAULT_CHANNEL__ --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml \
-     __PREVIOUS_PREVIOUS_VERSION__ \
+      __PREVIOUS_PREVIOUS_VERSION__ \
       registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
       registry.ci.openshift.org/knative/release-__PREVIOUS_VERSION__:serverless-bundle \
       registry.ci.openshift.org/knative/release-__VERSION__:serverless-bundle >> /configs/index.yaml || \
     /bin/opm render --skip-tls-verify -o yaml \
-     __PREVIOUS_PREVIOUS_VERSION__ \
+      __PREVIOUS_PREVIOUS_VERSION__ \
       registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
       registry.ci.openshift.org/knative/release-__PREVIOUS_VERSION__:serverless-bundle \
       registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml


### PR DESCRIPTION
This will avoid errors in https://github.com/openshift-knative/serverless-operator/pull/2748 for patch releases on `release-*` branches

Tested by changing `olm.previous.replaces: 1.32.1` in `project.yaml`

we would get the following update to the index Dockerfile

```
RUN /bin/opm render --skip-tls-verify -o yaml \
      registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
      registry.ci.openshift.org/knative/openshift-serverless-v1.32.1:serverless-bundle \
      registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
      registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle >> /configs/index.yaml || \
    /bin/opm render --skip-tls-verify -o yaml \
      registry.ci.openshift.org/knative/openshift-serverless-v1.32.0:serverless-bundle \
      registry.ci.openshift.org/knative/openshift-serverless-v1.32.1:serverless-bundle \
      registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
      registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml
```