### PR TITLE
Enable pprof support in ctrl runtime

### DIFF
--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis"
@@ -79,6 +80,17 @@ func main() {
 		WebhookMux: nil,
 	})
 
+	// If empty the pprof serving is disabled
+	pprofAddress := ""
+	enable := false
+
+	if enable, err = strconv.ParseBool(os.Getenv("ENABLE_PPROF")); err != nil {
+		log.Error(err, "unable to parse ENABLE_PPROF")
+		os.Exit(1)
+	} else if enable {
+		pprofAddress = fmt.Sprintf("%s:%d", pprofHost, pprofPort)
+	}
+
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
 		LeaderElection:   true,
@@ -88,7 +100,7 @@ func main() {
 		},
 		HealthProbeBindAddress: fmt.Sprintf(":%d", healthPort),
 		WebhookServer:          hookServer,
-		PprofBindAddress:       fmt.Sprintf("%s:%d", pprofHost, pprofPort),
+		PprofBindAddress:       pprofAddress,
 	})
 	if err != nil {
 		log.Error(err, "")

--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -44,6 +44,8 @@ var (
 	metricsHost       = "0.0.0.0"
 	metricsPort int32 = 8383
 	healthPort  int32 = 8687
+	pprofHost         = "127.0.0.1"
+	pprofPort   int32 = 8008
 	log               = logf.Log.WithName("cmd")
 )
 
@@ -86,6 +88,7 @@ func main() {
 		},
 		HealthProbeBindAddress: fmt.Sprintf(":%d", healthPort),
 		WebhookServer:          hookServer,
+		PprofBindAddress:       fmt.Sprintf("%s:%d", pprofHost, pprofPort),
 	})
 	if err != nil {
 		log.Error(err, "")

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -1038,6 +1038,8 @@ spec:
                         value: "true"
                       - name: SOURCES_GENERATE_SERVICE_MONITORS
                         value: "true"
+                      - name: ENABLE_PPROF
+                        value: "false"
                       - name: KUBERNETES_MIN_VERSION
                         value: "v1.0.0"
                       - name: "IMAGE_queue-proxy"

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -983,6 +983,8 @@ spec:
                         value: "true"
                       - name: SOURCES_GENERATE_SERVICE_MONITORS
                         value: "true"
+                      - name: ENABLE_PPROF
+                        value: "false"
                       - name: KUBERNETES_MIN_VERSION
                         value: "v1.0.0"
                     securityContext:


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- We recently had an issue that could have needed pprof support see [discussion](https://stackoverflow.com/questions/64057727/is-it-ok-to-use-golang-pprof-on-production-without-effecting-performance).
- Right now pprof is not configurable in knative-openshift deployment
- ctrl runtime is not configurable via a cm, there was a [design](https://github.com/kubernetes-sigs/controller-runtime/blob/main/designs/component-config.md) in the past but it seems not done. Ideally we would like to set up things the Knative way at some point: install a handler that depending on a cm value uses the pprof handler or some dummy that returns 403. The latter allows to dynamically switch on/off pprof support and get the data at the time of the issue without pod restart.
- Here we re-use the pprof support ctrl manager which is static thus we need a restart. That is ok for now given the low number of issues we have faced in practice and that pod restart would work for most cases (but would require some time for the issue to re-appear once a pod is restarted).
- [Probably it would be ok](https://stackoverflow.com/questions/64057727/is-it-ok-to-use-golang-pprof-on-production-without-effecting-performance) even to have it on by default but let's not be that brave for now.
- User can enable this temporarily by editing the csv in case of debugging a case.
- Pprof is exposed only locally for security reasons, available via port-forward (but could be open on ":8008" as Knative if we want to be less restrictive).
- See sample heap profile [here](https://github.com/openshift-knative/serverless-operator/assets/7945591/9910e314-91d5-4cbd-ae60-6ab990dd70d5). It shows that ctrl runtime `dynamicclient` consumes most part of memory during cache initialization.
-  Tested it locally by editing the csv (pod is restarted automatically with the right env var value set).