### PR TITLE
Use v2 endpoint for getting alerts

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -604,7 +604,7 @@ function check_serverless_alerts {
     jq -c 'map(select((.labels.service != "pingsource-mt-adapter") and (.labels.namespace == "'"${OPERATORS_NAMESPACE}"'" or .labels.namespace == "'"${EVENTING_NAMESPACE}"'" or .labels.namespace == "'"${SERVING_NAMESPACE}"'" or .labels.namespace == "'"${INGRESS_NAMESPACE}"'")))' > "${alerts_file}"
 
   num_alerts=$(jq 'length' "${alerts_file}")
-  num_apiremoved_alerts=$(jq '.[].labels.alertname=="APIRemovedInNextEUSReleaseInUse-quick"' "${alerts_file}" | wc -l)
+  num_apiremoved_alerts=$(jq 'map(select(.labels.alertname=="APIRemovedInNextEUSReleaseInUse-quick")) | length' "${alerts_file}")
   if [ "${num_apiremoved_alerts}" = "${num_alerts}" ]; then
     echo -e "\n\nSkip APIRemovedInNextEUSReleaseInUse-quick alerts. Please see SRVCOM-1857 and bz2079314\n"
     return 0

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -600,8 +600,8 @@ function check_serverless_alerts {
   monitoring_route=$(oc -n openshift-monitoring get routes alertmanager-main -oyaml -ojsonpath='{.spec.host}')
   # TODO(SRVKE-669) remove the filter for the pingsource-mt-adapter service once issue is fixed.
   curl -k -H "Authorization: Bearer $(oc -n openshift-monitoring create token prometheus-k8s)" \
-    "https://${monitoring_route}/api/v1/alerts" | \
-    jq -c '.data | map(select((.labels.service != "pingsource-mt-adapter") and (.labels.namespace == "'"${OPERATORS_NAMESPACE}"'" or .labels.namespace == "'"${EVENTING_NAMESPACE}"'" or .labels.namespace == "'"${SERVING_NAMESPACE}"'" or .labels.namespace == "'"${INGRESS_NAMESPACE}"'")))' > "${alerts_file}"
+    "https://${monitoring_route}/api/v2/alerts" | \
+    jq -c 'map(select((.labels.service != "pingsource-mt-adapter") and (.labels.namespace == "'"${OPERATORS_NAMESPACE}"'" or .labels.namespace == "'"${EVENTING_NAMESPACE}"'" or .labels.namespace == "'"${SERVING_NAMESPACE}"'" or .labels.namespace == "'"${INGRESS_NAMESPACE}"'")))' > "${alerts_file}"
 
   num_alerts=$(jq 'length' "${alerts_file}")
   num_apiremoved_alerts=$(jq '.[].labels.alertname=="APIRemovedInNextEUSReleaseInUse-quick"' "${alerts_file}" | wc -l)


### PR DESCRIPTION
Calling v1 endpoint on OCP 4.17 returns this:
{"status":"deprecated","error":"The Alertmanager v1 API was deprecated in version 0.16.0 and is removed as of version 0.28.0 - please use the equivalent route in the v2 API"}

The output of the v2 endpoint is an array of events while the v1 endpoint was a json object with .data element that included the array of events. Thus chanding the jq query a bit.

Related to https://github.com/openshift/release/pull/54230

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
