### PR TITLE
Authenticate Podman with QCI registry

### DIFF
--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -54,6 +54,12 @@ jobs:
           git config --global user.email "serverless-support@redhat.com"
           git config --global user.name "OpenShift Serverless"
 
+      - name: Authenticate Podman to QCI
+        working-directory: ./src/github.com/openshift-knative/hack
+        env:
+          QCI_TOKEN: ${{ secrets.QCI_TOKEN }}
+        run: podman login -u=image-puller -p="${QCI_TOKEN}" quay-proxy.ci.openshift.org
+
       - name: Generate CI (on workflow dispatch)
         if: github.event_name == 'workflow_dispatch'
         working-directory: ./src/github.com/openshift-knative/hack


### PR DESCRIPTION
Required for running ./cmd/prowcopy which runs Make targets from openshift/relese repository.

Fixes https://issues.redhat.com/browse/SRVCOM-3166

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
