### PR TITLE
Use spot instances for periodic runs in CI/AWS

### DIFF
--- a/hack/dependencies.sh
+++ b/hack/dependencies.sh
@@ -16,6 +16,5 @@ set -Eeuo pipefail
 
 debugging.setup
 
-use_spot_instances
 scale_up_workers
 create_namespaces "${SYSTEM_NAMESPACES[@]}"

--- a/hack/dependencies.sh
+++ b/hack/dependencies.sh
@@ -16,5 +16,6 @@ set -Eeuo pipefail
 
 debugging.setup
 
+use_spot_instances
 scale_up_workers
 create_namespaces "${SYSTEM_NAMESPACES[@]}"

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -16,6 +16,7 @@ set -Eeuo pipefail
 debugging.setup
 dump_state.setup
 
+use_spot_instances
 scale_up_workers
 create_namespaces "${SYSTEM_NAMESPACES[@]}"
 

--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -49,7 +49,7 @@ function scale_up_workers {
 function wait_until_machineset_scales_up {
   logger.info "Waiting until worker nodes scale up to $1 replicas"
   local available
-  for _ in {1..150}; do  # timeout after 15 minutes
+  for _ in {1..200}; do  # timeout after 20 minutes
     available=$(oc get machineconfigpool worker -o jsonpath='{.status.readyMachineCount}')
     if [[ ${available} -eq $1 ]]; then
       echo ''
@@ -119,6 +119,9 @@ function use_spot_instances {
 
   rm -f "$mset_file"
 
-  # Wait for at least the default number of workers to be up and running.
-  wait_until_machineset_scales_up 3
+  if [[ "${SCALE_UP}" -lt "0" ]]; then
+    wait_until_machineset_scales_up 3
+  else
+    wait_until_machineset_scales_up "${SCALE_UP}"
+  fi
 }

--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -84,7 +84,7 @@ function cluster_scalable {
   fi
 }
 
-# Convert existing machinesets to using spot instances
+# Convert existing machinesets to spot instances
 function use_spot_instances {
   if ! cluster_scalable; then
     logger.info 'Skipping spot instances, the cluster is not scalable.'
@@ -92,12 +92,12 @@ function use_spot_instances {
   fi
 
   if [[ $(oc get infrastructure cluster -ojsonpath='{.status.platform}') != AWS ]]; then
-    logger.info "Skipping spot instances. Spot instances only supported on AWS"
+    logger.info "Skipping spot instances. Spot instances only supported on AWS."
     return
   fi
 
   if [ -z "$OPENSHIFT_CI" ] ; then
-    logger.info "Skipping spot instances for non-CI runs"
+    logger.info "Skipping spot instances for non-CI runs."
     return
   fi
 

--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -83,10 +83,10 @@ function use_spot_instances {
     return
   fi
 
-#  if ! echo $JOB_SPEC | grep -q "type:periodic"; then
-#    logger.info "Skipping spot instances. Not a periodic run."
-#    return
-#  fi
+  if ! echo $JOB_SPEC | grep -q "type:periodic"; then
+    logger.info "Skipping spot instances. Not a periodic run."
+    return
+  fi
 
   if [[ $(oc get machineset -n openshift-machine-api -ojsonpath='{.items[*].spec.template.spec.providerSpec.value.spotMarketOptions}') != "" ]]; then
     logger.info "Spot instances already configured."

--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -83,7 +83,7 @@ function use_spot_instances {
     return
   fi
 
-  if ! echo $JOB_SPEC | grep -q "type:periodic"; then
+  if ! echo "$JOB_SPEC" | grep -q "type:periodic"; then
     logger.info "Skipping spot instances. Not a periodic run."
     return
   fi

--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -108,20 +108,20 @@ function use_spot_instances {
 
   logger.info "Convert MachineSets to spot instances"
 
-  for mset in $(oc get machineset -oname); do
-  	mset_name=$(oc get "${mset}" -ojsonpath='{.metadata.name}')
+  for mset in $(oc get machineset -n openshift-machine-api -oname); do
+  	mset_name=$(oc get "${mset}" -n openshift-machine-api -ojsonpath='{.metadata.name}')
 
   	# New machine set has a specific suffix
   	mset_name="${mset_name}-s"
 
   	# Create the new machineset with spotMarketOptions
-  	oc get "${mset}" -ojson | \
-  		jq '.metadata.name |= "'${mset_name}'"' | \
-  		jq '.spec.selector.matchLabels."machine.openshift.io/cluster-api-machineset" |= "'${mset_name}'"' | \
-  		jq '.spec.template.metadata.labels."machine.openshift.io/cluster-api-machineset" |= "'${mset_name}'"' | \
-  		jq '.spec.template.spec.providerSpec.value.spotMarketOptions |= {}' | oc create -f -
+  	oc get "${mset}" -n openshift-machine-api -ojson | \
+  		jq ".metadata.name |= \"${mset_name}\"" | \
+  		jq ".spec.selector.matchLabels.\"machine.openshift.io/cluster-api-machineset\" |= \"${mset_name}\"" | \
+  		jq ".spec.template.metadata.labels.\"machine.openshift.io/cluster-api-machineset\" |= \"${mset_name}\"" | \
+  		jq ".spec.template.spec.providerSpec.value.spotMarketOptions |= {}" | oc create -f -
 
   	# Delete the old machineset
-  	oc delete "${mset}"
+  	oc delete "${mset}" -n openshift-machine-api
   done
 }

--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -101,10 +101,10 @@ function use_spot_instances {
     return
   fi
 
-  if ! echo $JOB_SPEC | grep -q "type:periodic"; then
-    logger.info "Skipping spot instances. Not periodic runs."
-    return
-  fi
+#  if ! echo $JOB_SPEC | grep -q "type:periodic"; then
+#    logger.info "Skipping spot instances. Not periodic runs."
+#    return
+#  fi
 
   logger.info "Convert MachineSets to spot instances"
 

--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -118,10 +118,4 @@ function use_spot_instances {
   done
 
   rm -f "$mset_file"
-
-  if [[ "${SCALE_UP}" -lt "0" ]]; then
-    wait_until_machineset_scales_up 3
-  else
-    wait_until_machineset_scales_up "${SCALE_UP}"
-  fi
 }


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVCOM-2911

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Following the tutorial for setting up spot instances from https://docs.google.com/document/d/1qEQEggDJhJY9IzymwmbmekZZpbLtT2fK34L986QphRk/edit
- The goal is to use "spot" instances in CI only for periodic runs for now. If the stability is good enough we can think of using them for pre-submit phase as well.

> They cost 70-90% less than On-Demand VMs. (NB: Spot instances do not receive discounts from Savings Plans)
AWS may reclaim the capacity at any time (though in practice 95% of instances last at least 2 hours, and 90% last longer than 8 hours). AWS gives a 2-minute warning before an interruption happens, so that the instance may cleanly terminate/hibernate.
