### PR TITLE
Fix grep for checking periodic runs

### DIFF
--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -83,7 +83,7 @@ function use_spot_instances {
     return
   fi
 
-  if ! echo "$JOB_SPEC" | grep -q "type:periodic"; then
+  if ! echo "$JOB_SPEC" | grep -q '"type":"periodic"'; then
     logger.info "Skipping spot instances. Not a periodic run."
     return
   fi


### PR DESCRIPTION
The value of the JOB_SPEC looks like this:
{"type":"periodic","job":"periodic-ci-openshift-knative-serverless-operator-main-415-operator-e2e-aws-415-c",...}


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
