### PR TITLE
Workflow for building multiarch serving/metadata-webhook

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -1,0 +1,20 @@
+name: Multiarch builds
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release-[0-9]+'
+
+jobs:
+  build-image:
+    name: Build image
+    uses: openshift-knative/hack/.github/workflows/multiarch-containerfile-build.yaml@main
+    secrets: inherit
+    strategy:
+      matrix:
+        image:
+        - metadata-webhook
+    with:
+      image: ${{ matrix.image }}
+      containerfile: serving/${{ matrix.image }}/Dockerfile


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVCOM-3198

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- This is to allow running upgrade-tests downstream on arm64. The metadata-webhook is used to inject Istio annotations and must be multiarch.
- After pushing to quay.io, the image should be available at `podman pull quay.io/openshift-knative/serverless-operator/metadata-webhook:main`

