### PR TITLE
[release-1.32] Generate CI supports patch versions (#2644)

### DIFF
--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -10,6 +10,9 @@ on:
       branch:
         required: true
         description: "SO branch"
+      tag:
+        required: true
+        description: "Promotion tag"
 
 jobs:
   generate-ci:
@@ -38,6 +41,10 @@ jobs:
         with:
           path: ./src/github.com/openshift-knative/serverless-operator
 
+      - name: Install yq
+        run: |
+          go install github.com/mikefarah/yq/v3@latest
+
       - name: Checkout openshift-knative/hack
         uses: actions/checkout@v4
         with:
@@ -60,12 +67,17 @@ jobs:
       - name: Generate CI (on workflow dispatch)
         if: github.event_name == 'workflow_dispatch'
         working-directory: ./src/github.com/openshift-knative/hack
-        run: go run ./cmd/prowcopy --branch ${{ inputs.branch }} --tag "${{ inputs.branch }}.0" --config config/serverless-operator.yaml
+        run: go run ./cmd/prowcopy --branch ${{ inputs.branch }} --tag ${{ inputs.tag }} --config config/serverless-operator.yaml
 
       - name: Generate CI (on branch created)
         if: github.event.created
         working-directory: ./src/github.com/openshift-knative/hack
-        run: go run ./cmd/prowcopy --branch ${{ github.ref_name }} --tag "${{ github.ref_name }}.0" --config config/serverless-operator.yaml
+        run: go run ./cmd/prowcopy --branch ${{ github.ref_name }} --tag "release-$(yq read ../serverless-operator/olm-catalog/serverless-operator/project.yaml 'project.version') --config config/serverless-operator.yaml
+
+      - name: Generate CI (on push)
+        if: github.event.created == false
+        working-directory: ./src/github.com/openshift-knative/hack
+        run: go run ./cmd/prowcopy --from-branch ${{ github.ref_name }} --branch ${{ github.ref_name }} --tag "release-$(yq read ../serverless-operator/olm-catalog/serverless-operator/project.yaml 'project.version') --config config/serverless-operator.yaml
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift-knative/serverless-operator/commit/d0f9ddf368f9c53d36da0842c0ce8826375ce442