### PR TITLE
[release-1.32] Fix index image for patch release

### DIFF
--- a/hack/generate/dockerfile.sh
+++ b/hack/generate/dockerfile.sh
@@ -24,6 +24,9 @@ values[OCP_MAX_VERSION]="$(metadata.get 'requirements.ocpVersion.max')"
 values[PREVIOUS_VERSION]="$(metadata.get olm.replaces)"
 values[PREVIOUS_REPLACES]="$(metadata.get olm.previous.replaces)"
 
+prev_prev_channel="$(metadata.get 'olm.channels.list[*]' | head -n 4 | tail -n 1)"
+values[PREVIOUS_PREVIOUS_VERSION]="${prev_prev_channel#stable-}.0"
+
 # Start fresh
 cp "$template" "$target"
 

--- a/hack/generate/index.sh
+++ b/hack/generate/index.sh
@@ -18,6 +18,9 @@ values[LATEST_VERSIONED_CHANNEL]="$(metadata.get 'olm.channels.list[*]' | head -
 values[PREVIOUS_CHANNEL]="$(metadata.get 'olm.channels.list[*]' | head -n 3 | tail -n 1)"
 values[PREVIOUS_REPLACES_CHANNEL]="$(metadata.get 'olm.channels.list[*]' | head -n 4 | tail -n 1)"
 
+values[PREVIOUS_CHANNEL_HEAD]="${values[PREVIOUS_CHANNEL]#stable-}.0"
+values[PREVIOUS_REPLACES_CHANNEL_HEAD]="${values[PREVIOUS_REPLACES_CHANNEL]#stable-}.0"
+
 # Start fresh
 cp "$template" "$target"
 

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -8,10 +8,14 @@ COPY --from=opm /bin/opm /bin/opm
 COPY olm-catalog/serverless-operator/index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
-RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.31.0:serverless-bundle \
+RUN /bin/opm render --skip-tls-verify -o yaml \
+      registry.ci.openshift.org/knative/openshift-serverless-v1.30.0:serverless-bundle \
+      registry.ci.openshift.org/knative/openshift-serverless-v1.31.0:serverless-bundle \
       registry.ci.openshift.org/knative/release-1.32.0:serverless-bundle \
       registry.ci.openshift.org/knative/release-1.32.1:serverless-bundle >> /configs/index.yaml || \
-    /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v1.31.0:serverless-bundle \
+    /bin/opm render --skip-tls-verify -o yaml \
+      registry.ci.openshift.org/knative/openshift-serverless-v1.30.0:serverless-bundle \
+      registry.ci.openshift.org/knative/openshift-serverless-v1.31.0:serverless-bundle \
       registry.ci.openshift.org/knative/release-1.32.0:serverless-bundle \
       registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml
 

--- a/olm-catalog/serverless-operator/index/configs/index.yaml
+++ b/olm-catalog/serverless-operator/index/configs/index.yaml
@@ -27,13 +27,13 @@ schema: olm.channel
 name: stable-1.31
 package: serverless-operator
 entries:
+  - name: "serverless-operator.v1.30.0"
   - name: "serverless-operator.v1.31.0"
-  - name: "serverless-operator.v1.32.0"
-    replaces: "serverless-operator.v1.31.0"
-    skipRange: ">=1.31.0 <1.32.0"
+    replaces: "serverless-operator.v1.30.0"
+    skipRange: ">=1.30.0 <1.31.0"
 ---
 schema: olm.channel
 name: stable-1.30
 package: serverless-operator
 entries:
-  - name: "serverless-operator.v1.31.0"
+  - name: "serverless-operator.v1.30.0"

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -8,10 +8,14 @@ COPY --from=opm /bin/opm /bin/opm
 COPY olm-catalog/serverless-operator/index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=__DEFAULT_CHANNEL__ --output yaml >> /configs/index.yaml
-RUN /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
+RUN /bin/opm render --skip-tls-verify -o yaml \
+      registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_PREVIOUS_VERSION__:serverless-bundle \
+      registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
       registry.ci.openshift.org/knative/release-__PREVIOUS_VERSION__:serverless-bundle \
       registry.ci.openshift.org/knative/release-__VERSION__:serverless-bundle >> /configs/index.yaml || \
-    /bin/opm render --skip-tls-verify -o yaml registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
+    /bin/opm render --skip-tls-verify -o yaml \
+      registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_PREVIOUS_VERSION__:serverless-bundle \
+      registry.ci.openshift.org/knative/openshift-serverless-v__PREVIOUS_REPLACES__:serverless-bundle \
       registry.ci.openshift.org/knative/release-__PREVIOUS_VERSION__:serverless-bundle \
       registry.ci.openshift.org/knative/serverless-bundle:main >> /configs/index.yaml
 

--- a/templates/index.yaml
+++ b/templates/index.yaml
@@ -27,13 +27,13 @@ schema: olm.channel
 name: __PREVIOUS_CHANNEL__
 package: serverless-operator
 entries:
-  - name: "serverless-operator.v__PREVIOUS_REPLACES__"
-  - name: "serverless-operator.v__PREVIOUS_VERSION__"
-    replaces: "serverless-operator.v__PREVIOUS_REPLACES__"
-    skipRange: ">=__PREVIOUS_REPLACES__ <__PREVIOUS_VERSION__"
+  - name: "serverless-operator.v__PREVIOUS_REPLACES_CHANNEL_HEAD__"
+  - name: "serverless-operator.v__PREVIOUS_CHANNEL_HEAD__"
+    replaces: "serverless-operator.v__PREVIOUS_REPLACES_CHANNEL_HEAD__"
+    skipRange: ">=__PREVIOUS_REPLACES_CHANNEL_HEAD__ <__PREVIOUS_CHANNEL_HEAD__"
 ---
 schema: olm.channel
 name: __PREVIOUS_REPLACES_CHANNEL__
 package: serverless-operator
 entries:
-  - name: "serverless-operator.v__PREVIOUS_REPLACES__"
+  - name: "serverless-operator.v__PREVIOUS_REPLACES_CHANNEL_HEAD__"


### PR DESCRIPTION
This brings changes from https://github.com/openshift-knative/serverless-operator/commit/5decb52f6bdd9955c9af81b0eabc051884d0f449 and https://github.com/openshift-knative/serverless-operator/commit/c4e53de6ee0d820fcf34316131759240d21bcaf9 to 1.32