### PR TITLE
[SRVCOM-3200] Bring up the hookserver

### DIFF
--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -135,6 +135,7 @@ func main() {
 
 	decoder := admission.NewDecoder(mgr.GetScheme())
 
+	// This call adds the server to the manager as a Runnable
 	_ = mgr.GetWebhookServer()
 	// Serving Webhooks
 	hookServer.Register("/mutate-knativeservings", &webhook.Admission{Handler: knativeserving.NewConfigurator(decoder)})

--- a/knative-operator/cmd/manager/main.go
+++ b/knative-operator/cmd/manager/main.go
@@ -135,6 +135,7 @@ func main() {
 
 	decoder := admission.NewDecoder(mgr.GetScheme())
 
+	_ = mgr.GetWebhookServer()
 	// Serving Webhooks
 	hookServer.Register("/mutate-knativeservings", &webhook.Admission{Handler: knativeserving.NewConfigurator(decoder)})
 	hookServer.Register("/validate-knativeservings", &webhook.Admission{Handler: knativeserving.NewValidator(mgr.GetClient(), decoder)})


### PR DESCRIPTION
Fixes JIRA #https://issues.redhat.com/browse/SRVCOM-3200

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- See discussion [here](https://redhat-internal.slack.com/archives/CD87JDUB0/p1721825624524249?thread_ts=1721816918.734599&cid=CD87JDUB0)
- Tested and now when trying to create a new CR it fails:

> $ oc apply ...
namespace/test4 created
Error from server (Forbidden): error when creating "wrong.yaml": admission webhook "validating.knativeservings.operator.serverless.openshift.io" denied the request: KnativeServing may only be created in knative-serving namespace

