### PR TITLE
Bump Golang version to 1.22 in CI image

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -20,9 +20,7 @@ jobs:
       GOPATH: ${{ github.workspace }}
     steps:
       - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.x
+        uses: openshift-knative/hack/actions/setup-go@main
 
       - name: Checkout openshift-knative/serverless-operator
         uses: actions/checkout@v4

--- a/.github/workflows/dependabot-deps.yaml
+++ b/.github/workflows/dependabot-deps.yaml
@@ -20,9 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.x
+        uses: openshift-knative/hack/actions/setup-go@main
 
       - name: Run ./hack/update-deps.sh
         working-directory: ./src/github.com/${{ github.repository }}

--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -22,9 +22,7 @@ jobs:
       GOPATH: ${{ github.workspace }}
     steps:
       - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.x
+        uses: openshift-knative/hack/actions/setup-go@main
 
       - name: Checkout openshift-knative/serverless-operator
         uses: actions/checkout@v4

--- a/.github/workflows/validate-release-promotion.yaml
+++ b/.github/workflows/validate-release-promotion.yaml
@@ -15,9 +15,7 @@ jobs:
     steps:
 
       - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.x
+        uses: openshift-knative/hack/actions/setup-go@main
 
       - name: Install yq
         run: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -24,9 +24,7 @@ jobs:
       GOPATH: ${{ github.workspace }}
     steps:
       - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.x
+        uses: openshift-knative/hack/actions/setup-go@main
 
       - name: Install yq
         run: |

--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.16 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -24,7 +24,7 @@ requirements:
         # is ignored as it is overridden by fake version via KUBERNETES_MIN_VERSION.
         # This value is used for CSV's min version validation.
         minVersion: 1.25.0
-    golang: '1.21'
+    golang: '1.22'
     nodejs: 20.x
     ocpVersion:
         min: '4.12'

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.16 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.16
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.16
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.16 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.16
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.17
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/

--- a/templates/knative-operator.Dockerfile
+++ b/templates/knative-operator.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.17 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/templates/openshift-knative-operator.Dockerfile
+++ b/templates/openshift-knative-operator.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.17 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}

--- a/templates/serving-ingress.Dockerfile
+++ b/templates/serving-ingress.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-__GOLANG_VERSION__-openshift-4.17 AS builder
 
 ENV BASE=github.com/openshift-knative/serverless-operator
 WORKDIR ${GOPATH}/src/${BASE}


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Bump Golang version to 1.22 in CI image

/cc @ReToCode @pierDipi @mgencur 
