### PR TITLE
Include 1.33.1 in upgrade sequence for kitchensink upgrade tests

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -75,4 +75,5 @@ dependencies:
 upgrade_sequence:
     - csv: serverless-operator.v1.32.0
     - csv: serverless-operator.v1.33.0
+    - csv: serverless-operator.v1.33.1
     - csv: serverless-operator.v1.34.0


### PR DESCRIPTION
This should fix the failure in periodic tests such as https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-415-kitchensink-upgrade-aws-415-c/1817757401651089408

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
