### PR TITLE
Support building operator with any dependencies artifacts and tag

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -18,11 +18,11 @@ default_serverless_operator_images
 default_knative_ingress_images
 
 if [[ ${USE_RELEASE_NEXT:-} == "true" ]]; then
-  knative_eventing_images_release_next
-  knative_eventing_istio_images_release_next
-  knative_eventing_kafka_broker_images_release_next
-  knative_backstage_plugins_images_release_next
-  knative_serving_images_release_next
+  knative_eventing_images_release
+  knative_eventing_istio_images_release
+  knative_eventing_kafka_broker_images_release
+  knative_backstage_plugins_images_release
+  knative_serving_images_release
 else
   default_knative_eventing_images
   default_knative_eventing_istio_images

--- a/hack/lib/images.bash
+++ b/hack/lib/images.bash
@@ -15,8 +15,8 @@ function default_serverless_operator_images() {
   export SERVERLESS_INGRESS=${SERVERLESS_INGRESS:-"${serverless}-ingress"}
 }
 
-function knative_serving_images_release_next() {
-  knative_serving_images "knative-nightly"
+function knative_serving_images_release() {
+  knative_serving_images "${USE_IMAGE_RELEASE_TAG}"
 }
 
 function default_knative_serving_images() {
@@ -36,8 +36,8 @@ function knative_serving_images() {
   export KNATIVE_SERVING_STORAGE_VERSION_MIGRATION=${KNATIVE_SERVING_STORAGE_VERSION_MIGRATION:-"${serving}-storage-version-migration:${tag}"}
 }
 
-function knative_eventing_images_release_next() {
-  knative_eventing_images "knative-nightly"
+function knative_eventing_images_release() {
+  knative_eventing_images "${USE_IMAGE_RELEASE_TAG}"
 }
 
 function default_knative_eventing_images() {
@@ -91,8 +91,8 @@ function default_knative_eventing_test_images() {
   export KNATIVE_EVENTING_TEST_WATHOLA_SENDER=${KNATIVE_EVENTING_TEST_WATHOLA_SENDER:-"${eventing}/wathola-sender:${tag}"}
 }
 
-function knative_eventing_istio_images_release_next() {
-  knative_eventing_istio_images "knative-nightly"
+function knative_eventing_istio_images_release() {
+  knative_eventing_istio_images "${USE_IMAGE_RELEASE_TAG}"
 }
 
 function default_knative_eventing_istio_images() {
@@ -106,8 +106,8 @@ function knative_eventing_istio_images() {
   export KNATIVE_EVENTING_ISTIO_CONTROLLER=${KNATIVE_EVENTING_ISTIO_CONTROLLER:-"${eventing_istio}-controller:${tag}"}
 }
 
-function knative_eventing_kafka_broker_images_release_next() {
-  knative_eventing_kafka_broker_images "knative-nightly"
+function knative_eventing_kafka_broker_images_release() {
+  knative_eventing_kafka_broker_images "${USE_IMAGE_RELEASE_TAG}"
 }
 
 function default_knative_eventing_kafka_broker_images() {
@@ -143,8 +143,8 @@ function knative_backstage_plugins_images() {
   export KNATIVE_BACKSTAGE_PLUGINS_EVENTMESH=${KNATIVE_BACKSTAGE_PLUGINS_EVENTMESH:-"${backstage_plugins}-eventmesh:${tag}"}
 }
 
-function knative_backstage_plugins_images_release_next() {
-  knative_backstage_plugins_images "knative-nightly"
+function knative_backstage_plugins_images_release() {
+  knative_backstage_plugins_images "${USE_IMAGE_RELEASE_TAG}"
 }
 
 function default_knative_backstage_plugins_images() {


### PR DESCRIPTION
This is a follow up to https://github.com/openshift-knative/serverless-operator/pull/2528 for arbitrary branch and tag

Tested with 2 options and it looks like creates the correct manifests and CSV:

```
USE_IMAGE_RELEASE_TAG=knative-v1.14 make generated-files
USE_IMAGE_RELEASE_TAG=knative-nightly make generated-files
```

### Notes

#### net-istio and net-kourier don't support release-next, so we can't add support for the two ingress yet
```
Files: net-istio-core
--2024-07-30 12:38:31--  https://raw.githubusercontent.com/openshift-knative/net-istio/release-next/openshift/release/artifacts/net-istio-core.yaml
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.109.133, 185.199.108.133, 185.199.111.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.109.133|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2024-07-30 12:38:31 ERROR 404: Not Found.

️ERROR   12:38:31.556 🚨 Error (code: 8) occurred at ./hack/update-manifests.sh:196, with command: wget --no-check-certificate "$url" -O "$ingress_target_file"
/home/pierdipi/redhat/knative/serverless-operator/hack/lib/ui.bash: line 39: ERROR_HANDLERS: unbound variable
make: *** [Makefile:326: generated-files] Error 1
```

#### Backstage plugins doesn't support release-next, so we can't add support for it

```
Files: backstage-plugins-eventmesh-backend.yaml
Downloading file from https://raw.githubusercontent.com/openshift-knative/backstage-plugins/release-next/openshift/release/artifacts/backstage-plugins-eventmesh-backend.yaml
--2024-07-30 12:40:45--  https://raw.githubusercontent.com/openshift-knative/backstage-plugins/release-next/openshift/release/artifacts/backstage-plugins-eventmesh-backend.yaml
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.111.133, 185.199.109.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2024-07-30 12:40:45 ERROR 404: Not Found.

️ERROR   12:40:45.753 🚨 Error (code: 8) occurred at ./hack/update-manifests.sh:160, with command: wget --no-check-certificate "$url" -O "$target_file"
/home/pierdipi/redhat/knative/serverless-operator/hack/lib/ui.bash: line 39: ERROR_HANDLERS: unbound variable
make: *** [Makefile:326: generated-files] Error 1
```

This enabled fixing errors in https://github.com/openshift-knative/eventing-kafka-broker/pull/1132