### PR TITLE
Remove redundant `eventing` suffix from Eventing jobs

### DIFF
--- a/hack/patches/018-remove_eventing_suffix_from_jobs.patch
+++ b/hack/patches/018-remove_eventing_suffix_from_jobs.patch
@@ -1,0 +1,13 @@
+diff --git a/vendor/knative.dev/operator/pkg/reconciler/common/job.go b/vendor/knative.dev/operator/pkg/reconciler/common/job.go
+index bdaf62807..c049ea850 100644
+--- a/vendor/knative.dev/operator/pkg/reconciler/common/job.go
++++ b/vendor/knative.dev/operator/pkg/reconciler/common/job.go
+@@ -40,7 +40,7 @@ func JobTransform(obj base.KComponent) mf.Transformer {
+ 
+ 			component := "serving"
+ 			if _, ok := obj.(*v1beta1.KnativeEventing); ok {
+-				component = "eventing"
++				component = ""
+ 			}
+ 			if job.GetName() == "" {
+ 				job.SetName(fmt.Sprintf("%s%s-%s", job.GetGenerateName(), component, TargetVersion(obj)))

--- a/vendor/knative.dev/operator/pkg/reconciler/common/job.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/common/job.go
@@ -40,7 +40,7 @@ func JobTransform(obj base.KComponent) mf.Transformer {
 
 			component := "serving"
 			if _, ok := obj.(*v1beta1.KnativeEventing); ok {
-				component = "eventing"
+				component = ""
 			}
 			if job.GetName() == "" {
 				job.SetName(fmt.Sprintf("%s%s-%s", job.GetGenerateName(), component, TargetVersion(obj)))


### PR DESCRIPTION
Avoid having Job names longer than 63 chars.

Fixes issue found in https://github.com/openshift-knative/eventing-kafka-broker/pull/1132#issuecomment-2260243019