### PR TITLE
stabilise kitchensink e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ test-kitchensink-e2e-setup:
 # Runs all subsets of kitchensink tests. Runs tests separately so `go test` doesn't take too much memory in CI
 kitchensink-e2e:
 	UNINSTALL_STRIMZI="false" ./hack/strimzi.sh
-	SCALE_UP=4 INSTALL_KAFKA="true" ./hack/install.sh
+	SCALE_UP=5 INSTALL_KAFKA="true" ./hack/install.sh
 	./test/kitchensink-e2e-tests.sh -run TestBrokerReadinessBrokerDLS
 	./test/kitchensink-e2e-tests.sh -run TestBrokerReadinessTriggerDLS
 	./test/kitchensink-e2e-tests.sh -run TestChannelReadiness


### PR DESCRIPTION
Trying to stabilise kitchensink e2e

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-415-kitchensink-e2e-aws-415-c/1816701570553745408

seeing 

Pod \"kafka-broker-dispatcher-4\" is in phase \"Pending\" with conditions [PodScheduled=False]

suggest insufficient resources  (likely, as we now have scalable kafka-broker dispatchers, not only kafkasource ones with 1.34)

## Proposed Changes
- :broom: Increase kitchensink e2e cluster size