### PR TITLE
Fix testselect installation for Golang 1.22

### DIFF
--- a/hack/lib/testselect.bash
+++ b/hack/lib/testselect.bash
@@ -22,7 +22,7 @@ function run_testselect {
 
     # The testselect clones a repository. Make sure it's cloned into a temp dir.
     pushd "$clonedir" || return $?
-    "${go env GOPATH}/bin/testselect" --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
+    "$(go env GOPATH)/bin/testselect" --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
     popd || return $?
 
     logger.info 'Tests to be run:'

--- a/hack/lib/testselect.bash
+++ b/hack/lib/testselect.bash
@@ -2,9 +2,15 @@
 
 function run_testselect {
   if [[ -n "${ARTIFACT_DIR:-}" && -n "${CLONEREFS_OPTIONS:-}" ]]; then
-    GO111MODULE=off go get github.com/openshift-knative/hack/cmd/testselect
+    local clonedir rootdir hack_tmp_dir
 
-    local clonedir rootdir
+    hack_tmp_dir=$(mktemp -d)
+    git clone --branch main https://github.com/openshift-knative/hack "$hack_tmp_dir"
+    pushd "$hack_tmp_dir" || return $?
+    go install github.com/openshift-knative/hack/cmd/testselect
+    popd || return $?
+    rm -rf "$hack_tmp_dir"
+
     clonedir=$(mktemp -d)
 
     # CLONEREFS_OPTIONS var is set in CI
@@ -16,7 +22,7 @@ function run_testselect {
 
     # The testselect clones a repository. Make sure it's cloned into a temp dir.
     pushd "$clonedir" || return $?
-    "${GOPATH}/bin/testselect" --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
+    "${go env GOPATH}/bin/testselect" --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
     popd || return $?
 
     logger.info 'Tests to be run:'


### PR DESCRIPTION
Fixes errors such as:
[https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knat[…]operator-main-415-operator-e2e-aws-415/1820493721943150592](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_serverless-operator/2800/pull-ci-openshift-knative-serverless-operator-main-415-operator-e2e-aws-415/1820493721943150592)
```
 go: modules disabled by GO111MODULE=off; see 'go help modules'
17:17:54.138 ERROR:   🚨 Error (code: 1) occurred at /go/src/github.com/openshift-knative/serverless-operator/hack/lib/testselect.bash:5, with command: GO111MODULE=off go get github.com/openshift-knative/hack/cmd/testselect
```
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
