### PR TITLE
Add unit tests to GH actions

### DIFF
--- a/.github/workflows/go-unit-test.yaml
+++ b/.github/workflows/go-unit-test.yaml
@@ -1,0 +1,42 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release-*'
+  pull_request:
+    branches:
+      - 'main'
+      - 'release-*'
+
+jobs:
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go
+        uses: openshift-knative/hack/actions/setup-go@main
+
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Merge upstream
+        if: github.event_name == 'pull_request'
+        run: |
+          if ! git config user.name > /dev/null; then
+            git config user.name "John Doe"
+          fi
+          if ! git config user.email > /dev/null; then
+            git config user.email "johndoe@localhost"
+          fi
+          git remote add upstream https://github.com/${{ github.repository }}.git
+          git fetch upstream ${{ github.base_ref }}
+          git pull --no-rebase --no-commit upstream ${{ github.base_ref }}
+        shell: bash
+
+      - name: Test
+        run: make test-unit


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add unit tests to GH actions

Per chat with @ReToCode: an idea to substitute OpenShift CI unit test by executing it in GH action. Unit tests config is not regenerated based on openshift-knative/hack. Usually it's omitted from various common bumps, like Golang version. Moreover executing only Go unit tests doesn't require CI machinery like clusters etc. anyway.

We could drop this one: [ci-operator/config](https://github.com/openshift/release/blob/master/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-main.yaml)

Perhaps it would make sense to have shared action in `hack` repo for other components as well.

/cc @pierDipi @ReToCode 