### PR TITLE
:bug: Walkaround for OCPBUGS-38680

### DIFF
--- a/knative-operator/deploy/resources/knativekafka/controller/eventing-kafka-controller.yaml
+++ b/knative-operator/deploy/resources/knativekafka/controller/eventing-kafka-controller.yaml
@@ -1153,6 +1153,61 @@ metadata:
   labels:
     app.kubernetes.io/version: v1.14
     knative.dev/crd-install: "true"
+  name: consumers.internal.kafka.eventing.knative.dev
+spec:
+  group: internal.kafka.eventing.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: { }
+      schema:
+        openAPIV3Schema:
+          type: object
+          # this is a work around so we don't need to flesh out the
+          # schema for each version at this time
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+        - name: Subscriber
+          type: string
+          jsonPath: .status.subscriberUri
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  names:
+    kind: Consumer
+    plural: consumers
+    singular: consumer
+  scope: Namespaced
+---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/version: v1.14
+    knative.dev/crd-install: "true"
   name: consumergroups.internal.kafka.eventing.knative.dev
 spec:
   group: internal.kafka.eventing.knative.dev
@@ -1198,61 +1253,6 @@ spec:
     kind: ConsumerGroup
     plural: consumergroups
     singular: consumergroup
-  scope: Namespaced
----
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  labels:
-    app.kubernetes.io/version: v1.14
-    knative.dev/crd-install: "true"
-  name: consumers.internal.kafka.eventing.knative.dev
-spec:
-  group: internal.kafka.eventing.knative.dev
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      subresources:
-        status: { }
-      schema:
-        openAPIV3Schema:
-          type: object
-          # this is a work around so we don't need to flesh out the
-          # schema for each version at this time
-          x-kubernetes-preserve-unknown-fields: true
-      additionalPrinterColumns:
-        - name: Ready
-          type: string
-          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
-        - name: Reason
-          type: string
-          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
-        - name: Subscriber
-          type: string
-          jsonPath: .status.subscriberUri
-        - name: Age
-          type: date
-          jsonPath: .metadata.creationTimestamp
-  names:
-    kind: Consumer
-    plural: consumers
-    singular: consumer
   scope: Namespaced
 ---
 # Copyright 2022 The Knative Authors

--- a/test/ui/cypress/code/knative/serving/showcase.js
+++ b/test/ui/cypress/code/knative/serving/showcase.js
@@ -105,6 +105,18 @@ class ShowcaseKservice {
         .scrollIntoView()
         .uncheck()
     }
+    // FIXME: Remove after https://issues.redhat.com/browse/OCPBUGS-38680 is fixed.
+    if (environment.ocpVersion().satisfies('>=4.17')) {
+      const resourceSelect =
+        cy.get('button#form-select-input-resources-field')
+
+      resourceSelect
+        .scrollIntoView()
+        .click()
+      resourceSelect.siblings('ul[role=listbox]')
+        .get('li#select-option-resources-knative button')
+        .click()
+    }
     cy.get('button[type=submit]')
       .scrollIntoView()
       .click()


### PR DESCRIPTION
Selecting Serverless as resource type, as it ceased to be a default one for ODC 4.17+.

Walk around for https://issues.redhat.com/browse/OCPBUGS-38680

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Selecting Serverless as resource type, as it ceased to be a default one for ODC 4.17+

/kind bug