### PR TITLE
SRVCOM-3200 test

### DIFF
--- a/test/e2e/allowed_namespaces.go
+++ b/test/e2e/allowed_namespaces.go
@@ -1,0 +1,33 @@
+package e2e
+
+import (
+	"context"
+	"github.com/openshift-knative/serverless-operator/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"testing"
+)
+
+func VerifyCRCannotBeInstalledInRandomNamespace(t *testing.T, caCtx *test.Context, namespace string, resource schema.GroupVersionResource, kind string, name string) {
+	dynamicClient := caCtx.Clients.Dynamic.Resource(resource).Namespace(namespace)
+
+	// Attempt to install the resource to the test namespace
+	_, err := dynamicClient.Create(context.Background(), &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": resource.GroupVersion().String(),
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+		},
+	}, metav1.CreateOptions{})
+
+	if err != nil {
+		t.Logf("actual error creating %s: %v", kind, err)
+	}
+
+	if err == nil {
+		t.Errorf("It should not be possible to install %s to a test namespace", kind)
+	}
+}

--- a/test/e2e/allowed_namespaces.go
+++ b/test/e2e/allowed_namespaces.go
@@ -2,11 +2,12 @@ package e2e
 
 import (
 	"context"
+	"testing"
+
 	"github.com/openshift-knative/serverless-operator/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"testing"
 )
 
 func VerifyCRCannotBeInstalledInRandomNamespace(t *testing.T, caCtx *test.Context, namespace string, resource schema.GroupVersionResource, kind string, name string) {

--- a/test/e2e/allowed_namespaces_test.go
+++ b/test/e2e/allowed_namespaces_test.go
@@ -12,12 +12,12 @@ func TestServingCannotBeInstalledInARandomNamespace(t *testing.T) {
 	caCtx := test.SetupClusterAdmin(t)
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
 
-	VerifyCRCannotBeInstalledInRandomNamespace(t, caCtx, test.Namespace, operator.KnativeServingResource.WithVersion(v1beta1.SchemaVersion), operator.KindKnativeServing, "knative-serving")
+	VerifyCRCannotBeInstalledInRandomNamespace(t, caCtx, test.Namespace, operator.KnativeServingResource.WithVersion(v1beta1.SchemaVersion), operator.KindKnativeServing, "knative-serving", "knative-serving")
 }
 
 func TestEventingCannotBeInstalledInARandomNamespace(t *testing.T) {
 	caCtx := test.SetupClusterAdmin(t)
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
 
-	VerifyCRCannotBeInstalledInRandomNamespace(t, caCtx, test.Namespace, operator.KnativeEventingResource.WithVersion(v1beta1.SchemaVersion), operator.KindKnativeEventing, "knative-eventing")
+	VerifyCRCannotBeInstalledInRandomNamespace(t, caCtx, test.Namespace, operator.KnativeEventingResource.WithVersion(v1beta1.SchemaVersion), operator.KindKnativeEventing, "knative-eventing", "knative-eventing")
 }

--- a/test/e2e/allowed_namespaces_test.go
+++ b/test/e2e/allowed_namespaces_test.go
@@ -1,10 +1,11 @@
 package e2e
 
 import (
+	"testing"
+
 	"github.com/openshift-knative/serverless-operator/test"
 	"knative.dev/operator/pkg/apis/operator"
 	"knative.dev/operator/pkg/apis/operator/v1beta1"
-	"testing"
 )
 
 func TestServingCannotBeInstalledInARandomNamespace(t *testing.T) {

--- a/test/e2e/allowed_namespaces_test.go
+++ b/test/e2e/allowed_namespaces_test.go
@@ -1,0 +1,22 @@
+package e2e
+
+import (
+	"github.com/openshift-knative/serverless-operator/test"
+	"knative.dev/operator/pkg/apis/operator"
+	"knative.dev/operator/pkg/apis/operator/v1beta1"
+	"testing"
+)
+
+func TestServingCannotBeInstalledInARandomNamespace(t *testing.T) {
+	caCtx := test.SetupClusterAdmin(t)
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
+
+	VerifyCRCannotBeInstalledInRandomNamespace(t, caCtx, test.Namespace, operator.KnativeServingResource.WithVersion(v1beta1.SchemaVersion), operator.KindKnativeServing, "knative-serving")
+}
+
+func TestEventingCannotBeInstalledInARandomNamespace(t *testing.T) {
+	caCtx := test.SetupClusterAdmin(t)
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
+
+	VerifyCRCannotBeInstalledInRandomNamespace(t, caCtx, test.Namespace, operator.KnativeEventingResource.WithVersion(v1beta1.SchemaVersion), operator.KindKnativeEventing, "knative-eventing")
+}

--- a/test/e2ekafka/allowed_namespaces_test.go
+++ b/test/e2ekafka/allowed_namespaces_test.go
@@ -1,0 +1,16 @@
+package e2ekafka
+
+import (
+	kafkav1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
+	"github.com/openshift-knative/serverless-operator/test"
+	"github.com/openshift-knative/serverless-operator/test/e2e"
+	"testing"
+)
+
+func TestKnativeKafkaCannotBeInstalledInARandomNamespace(t *testing.T) {
+	caCtx := test.SetupClusterAdmin(t)
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
+
+	knativeKafkaGvr := kafkav1alpha1.SchemeGroupVersion.WithResource("knativekafkas")
+	e2e.VerifyCRCannotBeInstalledInRandomNamespace(t, caCtx, test.Namespace, knativeKafkaGvr, "KnativeKafka", "knative-kafka")
+}

--- a/test/e2ekafka/allowed_namespaces_test.go
+++ b/test/e2ekafka/allowed_namespaces_test.go
@@ -13,5 +13,5 @@ func TestKnativeKafkaCannotBeInstalledInARandomNamespace(t *testing.T) {
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, caCtx) })
 
 	knativeKafkaGvr := kafkav1alpha1.SchemeGroupVersion.WithResource("knativekafkas")
-	e2e.VerifyCRCannotBeInstalledInRandomNamespace(t, caCtx, test.Namespace, knativeKafkaGvr, "KnativeKafka", "knative-kafka")
+	e2e.VerifyCRCannotBeInstalledInRandomNamespace(t, caCtx, test.Namespace, knativeKafkaGvr, "KnativeKafka", "knative-kafka", "knative-eventing")
 }

--- a/test/e2ekafka/allowed_namespaces_test.go
+++ b/test/e2ekafka/allowed_namespaces_test.go
@@ -1,10 +1,11 @@
 package e2ekafka
 
 import (
+	"testing"
+
 	kafkav1alpha1 "github.com/openshift-knative/serverless-operator/knative-operator/pkg/apis/operator/v1alpha1"
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/e2e"
-	"testing"
 )
 
 func TestKnativeKafkaCannotBeInstalledInARandomNamespace(t *testing.T) {


### PR DESCRIPTION
## Proposed Changes
- :gift: Test for SRVCOM-3200

verifies the operator CRs cannot be installed into the test namespace. 