### PR TITLE
Fix: call hack/generate by full path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ generate-dockerfiles:
 	git clone https://github.com/openshift-knative/hack.git /tmp/hack
 	cd /tmp/hack && go install github.com/openshift-knative/hack/cmd/generate && cd - && rm -rf /tmp/hack
 	rm -rf /tmp/serverless-operator-generator
-	generate \
+	$(shell go env GOPATH)/bin/generate \
 		--generators dockerfile \
 		--includes knative-operator \
 		--includes openshift-knative-operator \


### PR DESCRIPTION
Seeing the following error in https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing-kafka-broker/1166/pull-ci-openshift-knative-eventing-kafka-broker-release-v1.14-415-test-reconciler-keda-aws-415/1831213050431016960

```
cloning into '/tmp/hack'...
cd /tmp/hack && go install github.com/openshift-knative/hack/cmd/generate && cd - && rm -rf /tmp/hack
/tmp/serverless-operator
rm -rf /tmp/serverless-operator-generator
generate \
	--generators dockerfile \
	--includes knative-operator \
	--includes openshift-knative-operator \
	--includes serving/ingress \
	--project-file olm-catalog/serverless-operator/project.yaml \
	--output /tmp/serverless-operator-generator/
make[1]: generate: Command not found
make[1]: *** [Makefile:322: generate-dockerfiles] Error 127
```

This PR should fix it