### PR TITLE
Replace FROM in Dockerfiles with real images

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -117,8 +117,10 @@ function replace_images() {
   dockerfile_path=${1:?Pass dockerfile path}
   tmp_dockerfile=$(mktemp /tmp/Dockerfile.XXXXXX)
   cp "${dockerfile_path}" "$tmp_dockerfile"
-  sed -e "s|\$GO_RUNTIME|$(metadata.get 'imageOverrides[name==GO_RUNTIME].pullSpec')|" -i "$tmp_dockerfile"
-  sed -e "s|\$GO_BUILDER|$(metadata.get 'imageOverrides[name==GO_BUILDER].pullSpec')|" -i "$tmp_dockerfile"
+
+  sed -e "s|\$GO_RUNTIME|$(grep "GO_RUNTIME=" "$tmp_dockerfile" | cut -d"=" -f 2)|" \
+      -e "s|\$GO_BUILDER|$(grep "GO_BUILDER=" "$tmp_dockerfile" | cut -d"=" -f 2)|" -i "$tmp_dockerfile"
+
   echo "$tmp_dockerfile"
 }
 

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -135,7 +135,8 @@ function build_image() {
   if ! oc get buildconfigs "$name" -n "$OLM_NAMESPACE" >/dev/null 2>&1; then
     logger.info "Create an image build for ${name}"
     oc -n "${OLM_NAMESPACE}" new-build \
-      --strategy=docker --name "$name" --dockerfile "$(cat "${tmp_dockerfile}")"
+      --strategy=docker --name "$name" --dockerfile "$(cat "${tmp_dockerfile}")" \
+      --image=$(metadata.get 'imageOverrides[name==GO_RUNTIME].pullSpec')
   else
     logger.info "${name} image build is already created"
   fi

--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -15,8 +15,7 @@ FROM $GO_RUNTIME
 
 ARG VERSION=
 
-# Install zoneinfo.
-RUN microdnf install tzdata
+RUN microdnf install tzdata 
 
 USER 65532
 

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -25,6 +25,11 @@ requirements:
         min: '4.12'
         max: '4.15'
         label: 'v4.12'
+imageOverrides:
+  - name: GO_BUILDER
+    pullSpec: "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17"
+  - name: GO_RUNTIME
+    pullSpec: "registry.access.redhat.com/ubi8/ubi-minimal"
 dependencies:
     serving: knative-v1.14
     # serving midstream branch name

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -25,11 +25,6 @@ requirements:
         min: '4.12'
         max: '4.15'
         label: 'v4.12'
-imageOverrides:
-  - name: GO_BUILDER
-    pullSpec: "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17"
-  - name: GO_RUNTIME
-    pullSpec: "registry.access.redhat.com/ubi8/ubi-minimal"
 dependencies:
     serving: knative-v1.14
     # serving midstream branch name

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -15,8 +15,7 @@ FROM $GO_RUNTIME
 
 ARG VERSION=
 
-# Install zoneinfo.
-RUN microdnf install tzdata
+RUN microdnf install tzdata 
 
 USER 65532
 

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -15,8 +15,7 @@ FROM $GO_RUNTIME
 
 ARG VERSION=
 
-# Install zoneinfo.
-RUN microdnf install tzdata
+RUN microdnf install tzdata 
 
 USER 65532
 


### PR DESCRIPTION
OpenShift (on cluster) Build cannot cope with using "FROM $GO_RUNTIME" in the Dockerfile and throws this error:
```
Create an image build for serverless-openshift-knative-operator error: unable to locate any images in image streams, local docker images with name "$GO_RUNTIME"
```
Example failure https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing-istio/290/pull-ci-openshift-knative-eventing-istio-release-v1.15-415-e2e-tests-aws-415/1831139316991004672


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Replace `FROM $GO_BUILDER` and `FROM $GO_RUNTIME` real images

