### PR TITLE
[SRVKS-1264] Remove deprecated TLS secret

### DIFF
--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -37,8 +37,7 @@ const (
 	controlProtocolCertificatesReconcilerLease = "controller.knative.dev.control-protocol.pkg.certificates.reconciler.reconciler"
 )
 
-var isDomainMappingRemoved atomic.Bool
-var isSecretRemoved atomic.Bool
+var oldResourceRemoved atomic.Bool
 
 // NewExtension creates a new extension for a Knative Serving controller.
 func NewExtension(ctx context.Context, impl *controller.Impl) operator.Extension {
@@ -170,18 +169,11 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 		common.ConfigureIfUnset(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")
 	}
 
-	if !isDomainMappingRemoved.Load() {
+	if !oldResourceRemoved.Load() {
 		if err := e.cleanupOldResources(ctx, ks.GetNamespace()); err != nil {
 			return err
 		}
-		isDomainMappingRemoved.Store(true)
-	}
-
-	if !isSecretRemoved.Load() {
-		if err := e.cleanupOldSecrets(ctx, ks.GetNamespace()); err != nil {
-			return err
-		}
-		isSecretRemoved.Store(true)
+		oldResourceRemoved.Store(true)
 	}
 
 	return monitoring.ReconcileMonitoringForServing(ctx, e.kubeclient, ks)
@@ -222,8 +214,10 @@ func (e *extension) fetchLoggingHost(ctx context.Context) string {
 	return route.Status.Ingress[0].Host
 }
 
+// cleanupOldResources util function to clean up old, deprecated or dangling resources from Serving features.
 func (e *extension) cleanupOldResources(ctx context.Context, ns string) error {
 	client := e.kubeclient
+	// DomainMapping related resources
 	for _, dep := range []string{"domain-mapping", "domainmapping-webhook"} {
 		if err := client.AppsV1().Deployments(ns).Delete(ctx, dep, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete deployment %s: %w", dep, err)
@@ -257,14 +251,12 @@ func (e *extension) cleanupOldResources(ctx context.Context, ns string) error {
 	if err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, "validation.webhook.domainmapping.serving.knative.dev", metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete validating webhook configuration validation.webhook.domainmapping.serving.knative.dev: %w", err)
 	}
-	return nil
-}
+	// --DomainMapping related resources
 
-// SRVKS-1264 - cleanup of old internal TLS secrets
-func (e *extension) cleanupOldSecrets(ctx context.Context, ns string) error {
-	client := e.kubeclient
+	// SRVKS-1264 - deprecated TLS secret
 	if err := client.CoreV1().Secrets(ns).Delete(ctx, "control-serving-certs", metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete old internal TLS secret: %w", err)
 	}
+
 	return nil
 }

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -233,7 +233,6 @@ func (e *extension) cleanupOldResources(ctx context.Context, ns string) error {
 	if err != nil {
 		return err
 	}
-	// Leases - DomainMapping and CertManager related
 	for _, lease := range leases.Items {
 		if strings.HasPrefix(lease.Name, "domainmapping") ||
 			strings.HasPrefix(lease.Name, "net-certmanager") ||

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -233,6 +233,7 @@ func (e *extension) cleanupOldResources(ctx context.Context, ns string) error {
 	if err != nil {
 		return err
 	}
+	// Leases - DomainMapping and CertManager related
 	for _, lease := range leases.Items {
 		if strings.HasPrefix(lease.Name, "domainmapping") ||
 			strings.HasPrefix(lease.Name, "net-certmanager") ||
@@ -251,7 +252,6 @@ func (e *extension) cleanupOldResources(ctx context.Context, ns string) error {
 	if err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, "validation.webhook.domainmapping.serving.knative.dev", metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete validating webhook configuration validation.webhook.domainmapping.serving.knative.dev: %w", err)
 	}
-	// --DomainMapping related resources
 
 	// SRVKS-1264 - deprecated TLS secret
 	if err := client.CoreV1().Secrets(ns).Delete(ctx, "control-serving-certs", metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {

--- a/test/servinge2e/deprecated_resources_test.go
+++ b/test/servinge2e/deprecated_resources_test.go
@@ -52,3 +52,15 @@ func TestDomainMappingResource(t *testing.T) {
 		}
 	})
 }
+
+// SRVKS-1264 - cleanup of old internal TLS secrets
+func TestOldTLSSecret(t *testing.T) {
+	ctx := test.SetupClusterAdmin(t)
+	t.Run("Secret", func(t *testing.T) {
+		if _, err := ctx.Clients.Kube.CoreV1().Secrets(test.ServingNamespace).Get(context.Background(), "control-serving-certs", metav1.GetOptions{}); err != nil {
+			if !apierrors.IsNotFound(err) {
+				t.Fatalf("Failed to verify secret is deprecated & removed %s: %v", "control-serving-certs", err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Fixes JIRA #SRVKS-1264

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- [SRVKS-1264] Remove deprecated TLS secret


Meanwhile, I'm waiting for OCP cluster to spin up. I'm trying very naive approach to remove the dangling secret.

/cc @skonto 