### PR TITLE
Update client midstream to 1.14

### DIFF
--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -929,9 +929,9 @@ spec:
                       - name: "IMAGE_KUBE_RBAC_PROXY"
                         value: "registry.ci.openshift.org/origin/4.15:kube-rbac-proxy"
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
-                        value: "registry.ci.openshift.org/knative/release-1.12:client-plugin-event-sender"
+                        value: "registry.ci.openshift.org/knative/release-1.14:client-plugin-event-sender"
                       - name: "IMAGE_KN_CLIENT"
-                        value: "registry.ci.openshift.org/openshift/knative-v1.12.0:knative-client"
+                        value: "registry.ci.openshift.org/openshift/knative-v1.14.0:knative-client"
                       - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
                         value: "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
                       - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"
@@ -975,7 +975,7 @@ spec:
                 serviceAccountName: knative-openshift
                 initContainers:
                   - name: cli-artifacts
-                    image: registry.ci.openshift.org/openshift/knative-v1.12.0:kn-cli-artifacts
+                    image: registry.ci.openshift.org/openshift/knative-v1.14.0:kn-cli-artifacts
                     imagePullPolicy: Always
                     command: ["sh", "-c", "rm -rf /cli-artifacts/* && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*"]
                     volumeMounts:
@@ -1099,9 +1099,9 @@ spec:
                       - name: "IMAGE_KUBE_RBAC_PROXY"
                         value: "registry.ci.openshift.org/origin/4.15:kube-rbac-proxy"
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
-                        value: "registry.ci.openshift.org/knative/release-1.12:client-plugin-event-sender"
+                        value: "registry.ci.openshift.org/knative/release-1.14:client-plugin-event-sender"
                       - name: "IMAGE_KN_CLIENT"
-                        value: "registry.ci.openshift.org/openshift/knative-v1.12.0:knative-client"
+                        value: "registry.ci.openshift.org/openshift/knative-v1.14.0:knative-client"
                       - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
                         value: "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
                       - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"
@@ -1372,9 +1372,9 @@ spec:
     - name: "IMAGE_KUBE_RBAC_PROXY"
       image: "registry.ci.openshift.org/origin/4.15:kube-rbac-proxy"
     - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
-      image: "registry.ci.openshift.org/knative/release-1.12:client-plugin-event-sender"
+      image: "registry.ci.openshift.org/knative/release-1.14:client-plugin-event-sender"
     - name: "IMAGE_KN_CLIENT"
-      image: "registry.ci.openshift.org/openshift/knative-v1.12.0:knative-client"
+      image: "registry.ci.openshift.org/openshift/knative-v1.14.0:knative-client"
     - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
       image: "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
     - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -51,7 +51,7 @@ dependencies:
     backstage_plugins: knative-v1.14
     # backstage-plugins midstream branch or commit
     backstage_plugins_artifacts_branch: release-v1.14
-    cli: 1.12.0
+    cli: 1.14.0
     func:
         util: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root
         tekton_s2i: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4


### PR DESCRIPTION

- Update client version 
- Dockerfiles are re-generated per latest tooling changes. Also fixed by #2842.
