### PR TITLE
Force builder images to Golang 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ generate-dockerfiles:
 	rm -rf /tmp/serverless-operator-generator
 	$(shell go env GOPATH)/bin/generate \
 		--generators dockerfile \
-		--dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17%.0s"  \
+		--dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17"  \
 		--includes knative-operator \
 		--includes openshift-knative-operator \
 		--includes serving/ingress \

--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,7 @@ generate-dockerfiles:
 	rm -rf /tmp/serverless-operator-generator
 	$(shell go env GOPATH)/bin/generate \
 		--generators dockerfile \
+		--dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17%.0s"  \
 		--includes knative-operator \
 		--includes openshift-knative-operator \
 		--includes serving/ingress \

--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for knative-operator/cmd/knative-operator.
-ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for openshift-knative-operator/cmd/openshift-knative-operator.
-ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for serving/ingress/cmd/ingress.
-ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder


### PR DESCRIPTION

- Force builder images to Golang 1.22

/cc @pierDipi @mgencur 