### PR TITLE
Tweak install of generate in Makefile & minor gh action fixes

### DIFF
--- a/.github/workflows/dependabot-deps.yaml
+++ b/.github/workflows/dependabot-deps.yaml
@@ -1,4 +1,4 @@
-name: depndabot - update-deps.sh
+name: Dependabot
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   generate_some_code:
-    name: Generate some code!
+    name: Update deps
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -109,9 +109,7 @@ jobs:
       GOPATH: ${{ github.workspace }}
     steps:
       - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.x
+        uses: openshift-knative/hack/actions/setup-go@main
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -316,9 +316,7 @@ release-files:
   	tenant-1,tenant-2,serving-tests,serverless-tests,eventing-e2e0,eventing-e2e1,eventing-e2e2,eventing-e2e3,eventing-e2e4
 
 generate-dockerfiles:
-	git clone https://github.com/openshift-knative/hack.git /tmp/hack
-	cd /tmp/hack && go install github.com/openshift-knative/hack/cmd/generate && cd - && rm -rf /tmp/hack
-	rm -rf /tmp/serverless-operator-generator
+	go install github.com/openshift-knative/hack/cmd/generate@latest
 	$(shell go env GOPATH)/bin/generate \
 		--generators dockerfile \
 		--includes knative-operator \


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Use plain go install to get generate 
- Fix Dependabot action name
- Use shared Go setup in validate.yaml
