### PR TITLE
Adding image overrides for base image for Konflux

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -5,6 +5,11 @@ project:
     # Otherwise, the upgrade tests will not pass, as we have a different SO version with the same bundle contents.
     # Also make sure to update values under `olm.previous` by copying from `olm.replaces` and `olm.skipRange`.
     version: 1.35.0
+imageOverrides:
+  - name: GO_BUILDER
+    pullSpec: "brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.22"
+  - name: GO_RUNTIME
+    pullSpec: "registry.access.redhat.com/ubi8/ubi-minimal"
 olm:
     replaces: 1.34.0
     skipRange: '>=1.34.0 <1.35.0'


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVCOM-3350

Konflux will only read these overrides when the corresponding s-o branch exists (e.g. for midstream release-v1.15 the release-1.35 needs to exist in s-o). Maybe we'll want a fix for this in openshift-knative/hack.

Adding this according to instructions in https://github.com/openshift-knative/hack/pull/228

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Override both images GO_RUNTIME and GO_BUILDER. This will allow pinning the images with specific SHA

