### PR TITLE
Configure ingress certificate for downstream testing

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -150,6 +150,12 @@ function downstream_serving_e2e_tests {
       --imagetemplate "${IMAGE_TEMPLATE}" \
       "$@"
 
+    certName=$(oc get ingresscontroller.operator.openshift.io -n openshift-ingress-operator \
+      default -o=jsonpath='{.spec.defaultCertificate.name}')
+    if [[ "$certName" != "" ]]; then
+      configure_cm network openshift-ingress-default-certificate:"${certName}"
+    fi
+
     # Enable Serving encryption (only supported on Kourier - at least for now)
     configure_cm network system-internal-tls:enabled
     configure_cm network cluster-local-domain-tls:enabled
@@ -168,6 +174,10 @@ function downstream_serving_e2e_tests {
       --imagetemplate "${IMAGE_TEMPLATE}" \
       "$@"
 
+    # Put back default ingress certificate.
+    if [[ "$certName" != "" ]]; then
+      configure_cm network openshift-ingress-default-certificate:router-certs-default
+    fi
     # Disable Serving encryption for following tests
     configure_cm network system-internal-tls:disabled
     configure_cm network cluster-local-domain-tls:disabled


### PR DESCRIPTION
The cluster might have a specific ingress certificate and this needs to be set for the TLS tests to pass. Specifically, `test/servinge2e/encryption.TestExternalAccessWithEncryptionEnabled`

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

/hold

Pending downstream verification.
