### PR TITLE
[release-1.34] Configure ingress certificate for downstream testing

### DIFF
--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -28,6 +28,8 @@ LABEL \
       summary="Red Hat OpenShift Serverless 1 Knative Operator" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Knative Operator" \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1 Knative Operator"
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Knative Operator" \
+      io.k8s.description="Red Hat OpenShift Serverless Knative Operator" \
+      io.openshift.tags="knative-operator"
 
 ENTRYPOINT ["/usr/bin/knative-operator"]

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -29,6 +29,8 @@ LABEL \
       summary="Red Hat OpenShift Serverless 1 Openshift Knative Operator" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Openshift Knative Operator" \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1 Openshift Knative Operator"
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Openshift Knative Operator" \
+      io.k8s.description="Red Hat OpenShift Serverless Openshift Knative Operator" \
+      io.openshift.tags="openshift-knative-operator"
 
 ENTRYPOINT ["/usr/bin/openshift-knative-operator"]

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -26,6 +26,8 @@ LABEL \
       summary="Red Hat OpenShift Serverless 1 Ingress" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Ingress" \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1 Ingress"
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Ingress" \
+      io.k8s.description="Red Hat OpenShift Serverless Ingress" \
+      io.openshift.tags="ingress"
 
 ENTRYPOINT ["/usr/bin/ingress"]

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -150,6 +150,12 @@ function downstream_serving_e2e_tests {
       --imagetemplate "${IMAGE_TEMPLATE}" \
       "$@"
 
+    certName=$(oc get ingresscontroller.operator.openshift.io -n openshift-ingress-operator \
+      default -o=jsonpath='{.spec.defaultCertificate.name}')
+    if [[ "$certName" != "" ]]; then
+      configure_cm network openshift-ingress-default-certificate:"${certName}"
+    fi
+
     # Enable Serving encryption (only supported on Kourier - at least for now)
     configure_cm network system-internal-tls:enabled
     configure_cm network cluster-local-domain-tls:enabled
@@ -168,6 +174,10 @@ function downstream_serving_e2e_tests {
       --imagetemplate "${IMAGE_TEMPLATE}" \
       "$@"
 
+    # Put back default ingress certificate.
+    if [[ "$certName" != "" ]]; then
+      configure_cm network openshift-ingress-default-certificate:router-certs-default
+    fi
     # Disable Serving encryption for following tests
     configure_cm network system-internal-tls:disabled
     configure_cm network cluster-local-domain-tls:disabled


### PR DESCRIPTION
Same as https://github.com/openshift-knative/serverless-operator/pull/2882. Verified downstream.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
