### PR TITLE
Update client images to release-v1.15

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -11,7 +11,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/metadata.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/images.bash"
 
 client_version="$(metadata.get dependencies.cli)"
-kn_event="${registry_host}/knative/release-${client_version%.*}:client-plugin-event"
+kn_event="${registry_host}/knative/release-${client_version#knative-v}:client-plugin-event"
 rbac_proxy="registry.ci.openshift.org/origin/$(metadata.get 'requirements.ocpVersion.max'):kube-rbac-proxy"
 
 default_serverless_operator_images
@@ -119,7 +119,7 @@ kafka_image "knative-kafka-storage-version-migrator__migrate"    "${KNATIVE_EVEN
 
 image 'KUBE_RBAC_PROXY'          "${rbac_proxy}"
 image 'KN_PLUGIN_EVENT_SENDER'   "${kn_event}-sender"
-image 'KN_CLIENT'              "${registry}/knative-v$(metadata.get dependencies.cli):knative-client"
+image 'KN_CLIENT'              "${registry}/$(metadata.get dependencies.cli):knative-client-kn"
 
 image 'KN_PLUGIN_FUNC_UTIL'           "$(metadata.get dependencies.func.util)"
 image 'KN_PLUGIN_FUNC_TEKTON_S2I'     "$(metadata.get dependencies.func.tekton_s2i)"
@@ -229,7 +229,7 @@ add_upstream_operator_deployment_env "$target" "KNATIVE_EVENTING_VERSION" "${eve
 add_upstream_operator_deployment_env "$target" "KNATIVE_EVENTING_KAFKA_BROKER_VERSION" "${ekb_version/knative-v/}" # Remove `knative-v` prefix if exists
 
 # Override the image for the CLI artifact deployment
-yq write --inplace "$target" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.initContainers(name==cli-artifacts).image" "${registry}/knative-v$(metadata.get dependencies.cli):kn-cli-artifacts"
+yq write --inplace "$target" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.initContainers(name==cli-artifacts).image" "${registry}/$(metadata.get dependencies.cli):knative-client-cli-artifacts"
 
 for name in "${!yaml_keys[@]}"; do
   echo "Value: ${name} -> ${yaml_keys[$name]}"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -931,9 +931,9 @@ spec:
                       - name: "IMAGE_KUBE_RBAC_PROXY"
                         value: "registry.ci.openshift.org/origin/4.15:kube-rbac-proxy"
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
-                        value: "registry.ci.openshift.org/knative/release-1.14:client-plugin-event-sender"
+                        value: "registry.ci.openshift.org/knative/release-1.15:client-plugin-event-sender"
                       - name: "IMAGE_KN_CLIENT"
-                        value: "registry.ci.openshift.org/openshift/knative-v1.14.0:knative-client"
+                        value: "registry.ci.openshift.org/openshift/knative-v1.15:knative-client-kn"
                       - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
                         value: "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
                       - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"
@@ -977,7 +977,7 @@ spec:
                 serviceAccountName: knative-openshift
                 initContainers:
                   - name: cli-artifacts
-                    image: registry.ci.openshift.org/openshift/knative-v1.14.0:kn-cli-artifacts
+                    image: registry.ci.openshift.org/openshift/knative-v1.15:knative-client-cli-artifacts
                     imagePullPolicy: Always
                     command: ["sh", "-c", "rm -rf /cli-artifacts/* && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*"]
                     volumeMounts:
@@ -1103,9 +1103,9 @@ spec:
                       - name: "IMAGE_KUBE_RBAC_PROXY"
                         value: "registry.ci.openshift.org/origin/4.15:kube-rbac-proxy"
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
-                        value: "registry.ci.openshift.org/knative/release-1.14:client-plugin-event-sender"
+                        value: "registry.ci.openshift.org/knative/release-1.15:client-plugin-event-sender"
                       - name: "IMAGE_KN_CLIENT"
-                        value: "registry.ci.openshift.org/openshift/knative-v1.14.0:knative-client"
+                        value: "registry.ci.openshift.org/openshift/knative-v1.15:knative-client-kn"
                       - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
                         value: "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
                       - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"
@@ -1378,9 +1378,9 @@ spec:
     - name: "IMAGE_KUBE_RBAC_PROXY"
       image: "registry.ci.openshift.org/origin/4.15:kube-rbac-proxy"
     - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
-      image: "registry.ci.openshift.org/knative/release-1.14:client-plugin-event-sender"
+      image: "registry.ci.openshift.org/knative/release-1.15:client-plugin-event-sender"
     - name: "IMAGE_KN_CLIENT"
-      image: "registry.ci.openshift.org/openshift/knative-v1.14.0:knative-client"
+      image: "registry.ci.openshift.org/openshift/knative-v1.15:knative-client-kn"
     - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
       image: "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
     - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -51,7 +51,7 @@ dependencies:
     backstage_plugins: knative-v1.14
     # backstage-plugins midstream branch or commit
     backstage_plugins_artifacts_branch: release-v1.14
-    cli: 1.14.0
+    cli: knative-v1.15
     func:
         util: quay.io/boson/alpine-socat:1.7.4.3-r1-non-root
         tekton_s2i: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Update client images to release-v1.15
- In addition, changed image format names related to enabling openshift-knative/hack CI generators for client repo.

/cc @ReToCode @skonto @pierDipi 
