### PR TITLE
[release-1.34] Bump to latest upstream operator 1.14.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	knative.dev/eventing-kafka-broker v0.37.0
 	knative.dev/hack v0.0.0-20240404013450-1133b37da8d7
 	knative.dev/networking v0.0.0-20240418213116-979f63728302
-	knative.dev/operator v0.41.2
+	knative.dev/operator v0.41.9
 	knative.dev/pkg v0.0.0-20240416145024-0f34a8815650
 	knative.dev/serving v0.41.0
 	sigs.k8s.io/controller-runtime v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -1716,8 +1716,8 @@ knative.dev/hack v0.0.0-20240404013450-1133b37da8d7 h1:fkWYWvdHm1mVHevKW2vVJnZtx
 knative.dev/hack v0.0.0-20240404013450-1133b37da8d7/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
 knative.dev/networking v0.0.0-20240418213116-979f63728302 h1:TQwoh8K7RgPXU+5Z5SX385vYjgvQ0OzdFLHRRCeF5K4=
 knative.dev/networking v0.0.0-20240418213116-979f63728302/go.mod h1:bb3B1eNMNO827kErNDGKYYiBgtlaR6T1DEDnfEad3q4=
-knative.dev/operator v0.41.2 h1:TtlQ8XgTAw4IzTTPu/90trXwexq+5S2yT5GrFi/M5hU=
-knative.dev/operator v0.41.2/go.mod h1:8eejRUmwF2sG+s+RmQcjYIqJ1NMEM2bovpz3PlGRNmE=
+knative.dev/operator v0.41.9 h1:+4Usbu8r1LICNmipUB3RCtxhGqcKYnWMvFwRGK3s/Fk=
+knative.dev/operator v0.41.9/go.mod h1:8eejRUmwF2sG+s+RmQcjYIqJ1NMEM2bovpz3PlGRNmE=
 knative.dev/pkg v0.0.0-20240416145024-0f34a8815650 h1:m2ahFUO0L2VrgGDYdyOUFdE6xBd3pLXAJozLJwqLRQM=
 knative.dev/pkg v0.0.0-20240416145024-0f34a8815650/go.mod h1:soFw5ss08G4PU3JiFDKqiZRd2U7xoqcfNpJP1coIXkY=
 knative.dev/reconciler-test v0.0.0-20240503125949-8fd5ae6217a3 h1:kndnO/h0hG+M/sVqGysZHL9P4qXHzQ7ZmgzKXk0k8fg=

--- a/hack/patches/022-keep-kafka-channel-replica-override.patch
+++ b/hack/patches/022-keep-kafka-channel-replica-override.patch
@@ -1,0 +1,12 @@
+diff --git a/vendor/knative.dev/operator/pkg/reconciler/common/hpa.go b/vendor/knative.dev/operator/pkg/reconciler/common/hpa.go
+index 09518fb99..c2af7a3d3 100644
+--- a/vendor/knative.dev/operator/pkg/reconciler/common/hpa.go
++++ b/vendor/knative.dev/operator/pkg/reconciler/common/hpa.go
+@@ -33,7 +33,6 @@ func hasHorizontalPodOrCustomAutoscaler(name string) bool {
+ 		"mt-broker-filter",
+ 		"kafka-broker-dispatcher",
+ 		"kafka-source-dispatcher",
+-		"kafka-channel-dispatcher",
+ 	).Has(name)
+ }
+ 

--- a/vendor/knative.dev/operator/pkg/reconciler/common/ha.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/common/ha.go
@@ -50,7 +50,7 @@ func HighAvailabilityTransform(obj base.KComponent) mf.Transformer {
 		replicas := int64(*ha.Replicas)
 
 		// Transform deployments that support HA.
-		if u.GetKind() == "Deployment" && !haUnSupported(u.GetName()) && !hasHorizontalPodAutoscaler(u.GetName()) {
+		if u.GetKind() == "Deployment" && !haUnSupported(u.GetName()) && !hasHorizontalPodOrCustomAutoscaler(u.GetName()) {
 			if err := unstructured.SetNestedField(u.Object, replicas, "spec", "replicas"); err != nil {
 				return err
 			}

--- a/vendor/knative.dev/operator/pkg/reconciler/common/hpa.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/common/hpa.go
@@ -21,9 +21,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// When a Podspecable has HPA, the replicas should be controlled by HPAs minReplicas instead of operator.
+// When a Podspecable has HPA or a custom autoscaling, the replicas should be controlled by it instead of operator.
 // Hence, skip changing the spec.replicas for these Podspecables.
-func hasHorizontalPodAutoscaler(name string) bool {
+func hasHorizontalPodOrCustomAutoscaler(name string) bool {
 	return sets.NewString(
 		"webhook",
 		"activator",
@@ -31,6 +31,9 @@ func hasHorizontalPodAutoscaler(name string) bool {
 		"eventing-webhook",
 		"mt-broker-ingress",
 		"mt-broker-filter",
+		"kafka-broker-dispatcher",
+		"kafka-source-dispatcher",
+		"kafka-channel-dispatcher",
 	).Has(name)
 }
 

--- a/vendor/knative.dev/operator/pkg/reconciler/common/hpa.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/common/hpa.go
@@ -33,7 +33,6 @@ func hasHorizontalPodOrCustomAutoscaler(name string) bool {
 		"mt-broker-filter",
 		"kafka-broker-dispatcher",
 		"kafka-source-dispatcher",
-		"kafka-channel-dispatcher",
 	).Has(name)
 }
 

--- a/vendor/knative.dev/operator/pkg/reconciler/common/workload_override.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/common/workload_override.go
@@ -49,7 +49,7 @@ func OverridesTransform(overrides []base.WorkloadOverride, log *zap.SugaredLogge
 				ps = &deployment.Spec.Template
 
 				// Do not set replicas, if this resource is controlled by a HPA
-				if override.Replicas != nil && !hasHorizontalPodAutoscaler(override.Name) {
+				if override.Replicas != nil && !hasHorizontalPodOrCustomAutoscaler(override.Name) {
 					deployment.Spec.Replicas = override.Replicas
 				}
 			}
@@ -62,7 +62,7 @@ func OverridesTransform(overrides []base.WorkloadOverride, log *zap.SugaredLogge
 				ps = &ss.Spec.Template
 
 				// Do not set replicas, if this resource is controlled by a HPA
-				if override.Replicas != nil && !hasHorizontalPodAutoscaler(override.Name) {
+				if override.Replicas != nil && !hasHorizontalPodOrCustomAutoscaler(override.Name) {
 					ss.Spec.Replicas = override.Replicas
 				}
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1633,7 +1633,7 @@ knative.dev/networking/pkg/http/proxy
 knative.dev/networking/pkg/http/stats
 knative.dev/networking/pkg/ingress
 knative.dev/networking/pkg/k8s
-# knative.dev/operator v0.41.2
+# knative.dev/operator v0.41.9
 ## explicit; go 1.21
 knative.dev/operator/pkg/apis/operator
 knative.dev/operator/pkg/apis/operator/base


### PR DESCRIPTION
Fixes JIRA #SRVKE-1655

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- bump to latest upstream with ignores _all_ dispatchers. Adding a patch to keep the kafka-channel-dispatcher configurable, since that is not yet "autoscaled". Adding tmp patch _only_ for this release branch 
