### PR TITLE
Drop OSSM 2.x dependencies and cleanup scripts

### DIFF
--- a/hack/lib/mesh_resources/namespace.yaml
+++ b/hack/lib/mesh_resources/namespace.yaml
@@ -6,6 +6,11 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: knative-serving-ingress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: knative-eventing
 ---
 apiVersion: v1

--- a/hack/lib/mesh_resources/subscription.yaml
+++ b/hack/lib/mesh_resources/subscription.yaml
@@ -1,27 +1,27 @@
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: jaeger-product
-  namespace: openshift-operators
-spec:
-  channel: stable
-  name: jaeger-product
-  installPlanApproval: Automatic
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: kiali-ossm
-  namespace: openshift-operators
-spec:
-  channel: stable
-  name: kiali-ossm
-  installPlanApproval: Automatic
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
----
+#apiVersion: operators.coreos.com/v1alpha1
+#kind: Subscription
+#metadata:
+#  name: jaeger-product
+#  namespace: openshift-operators
+#spec:
+#  channel: stable
+#  name: jaeger-product
+#  installPlanApproval: Automatic
+#  source: redhat-operators
+#  sourceNamespace: openshift-marketplace
+#---
+#apiVersion: operators.coreos.com/v1alpha1
+#kind: Subscription
+#metadata:
+#  name: kiali-ossm
+#  namespace: openshift-operators
+#spec:
+#  channel: stable
+#  name: kiali-ossm
+#  installPlanApproval: Automatic
+#  source: redhat-operators
+#  sourceNamespace: openshift-marketplace
+#---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/hack/lib/mesh_resources/subscription.yaml
+++ b/hack/lib/mesh_resources/subscription.yaml
@@ -1,27 +1,3 @@
-#apiVersion: operators.coreos.com/v1alpha1
-#kind: Subscription
-#metadata:
-#  name: jaeger-product
-#  namespace: openshift-operators
-#spec:
-#  channel: stable
-#  name: jaeger-product
-#  installPlanApproval: Automatic
-#  source: redhat-operators
-#  sourceNamespace: openshift-marketplace
-#---
-#apiVersion: operators.coreos.com/v1alpha1
-#kind: Subscription
-#metadata:
-#  name: kiali-ossm
-#  namespace: openshift-operators
-#spec:
-#  channel: stable
-#  name: kiali-ossm
-#  installPlanApproval: Automatic
-#  source: redhat-operators
-#  sourceNamespace: openshift-marketplace
-#---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -476,6 +476,9 @@ function teardown_serverless {
   fi
   logger.info 'Ensure no ingress pods running'
   timeout 600 "[[ \$(oc get pods -n ${INGRESS_NAMESPACE} --field-selector=status.phase!=Succeeded -o jsonpath='{.items}') != '[]' ]]"
+  if oc get namespace "${INGRESS_NAMESPACE}" &>/dev/null; then
+    oc delete namespace "${INGRESS_NAMESPACE}"
+  fi
   timeout 600 "[[ \$(oc get ns ${INGRESS_NAMESPACE} --no-headers | wc -l) == 1 ]]"
   logger.info 'Ensure no knative eventing or knative kafka pods running'
   timeout 700 "[[ \$(oc get pods -n ${EVENTING_NAMESPACE} --field-selector=status.phase!=Succeeded -o jsonpath='{.items}') != '[]' ]]"

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -166,8 +166,6 @@ function deploy_knativeserving_cr {
 
   if [[ $MESH == "true" ]]; then
     enable_istio "$serving_cr"
-    # Disable internal encryption.
-    yq delete --inplace "$serving_cr" spec.config.network.internal-encryption
   fi
 
   if [[ $ENABLE_TRACING == "true" ]]; then

--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -127,13 +127,9 @@ EOF
 }
 
 function install_opentelemetry_tracing {
-  logger.info "Install OpenTelemetry Tracing"
-  if [[ $(oc get crd servicemeshcontrolplanes.maistra.io --no-headers | wc -l) != 1 ]]; then
-    # The following components are installed with Service Mesh.
-    logger.info "Install Distributed Tracing Platform (Jaeger) Operator"
-    install_jaeger_operator
-    install_jaeger_cr
-  fi
+  logger.info "Install Distributed Tracing Platform (Jaeger) Operator"
+  install_jaeger_operator
+  install_jaeger_cr
   logger.info "Install Distributed Tracing Data Collection Operator"
   install_opentelemetry_operator
   install_opentelemetrycollector

--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -10,8 +10,6 @@ function install_tracing {
     install_zipkin_tracing
   elif [[ "${TRACING_BACKEND}" == "tempo" ]]; then
     install_tempo_tracing
-  elif [[ "${TRACING_BACKEND}" == "otel" ]]; then
-    install_opentelemetry_tracing
   else
     echo "Unknown TRACING_BACKEND \"$TRACING_BACKEND\""
     return 1
@@ -124,15 +122,6 @@ EOF
 
   logger.info "Waiting until Zipkin is available"
   oc wait deployment --all --timeout=600s --for=condition=Available -n "${TRACING_NAMESPACE}"
-}
-
-function install_opentelemetry_tracing {
-  logger.info "Install Distributed Tracing Platform (Jaeger) Operator"
-  install_jaeger_operator
-  install_jaeger_cr
-  logger.info "Install Distributed Tracing Data Collection Operator"
-  install_opentelemetry_operator
-  install_opentelemetrycollector
 }
 
 function install_tempo_tracing {

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -51,8 +51,8 @@ export OPERATORS_NAMESPACE="${OPERATORS_NAMESPACE:-openshift-serverless}"
 export SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
 export INGRESS_NAMESPACE="${INGRESS_NAMESPACE:-knative-serving-ingress}"
 export EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-knative-eventing}"
-# eventing e2e and conformance tests use a container for tracing tests that has hardcoded `istio-system` in it
-export TRACING_NAMESPACE="${TRACING_NAMESPACE:-istio-system}"
+# eventing e2e and conformance tests use a container for tracing tests that has hardcoded to `knative-tracing` in it
+export TRACING_NAMESPACE="${TRACING_NAMESPACE:-knative-tracing}"
 export TRACING_BACKEND="${TRACING_BACKEND:-tempo}"
 
 declare -a SYSTEM_NAMESPACES

--- a/test/servinge2e/tracing_test.go
+++ b/test/servinge2e/tracing_test.go
@@ -27,7 +27,7 @@ import (
 const (
 	testNamespace              = "serverless-tests"
 	requestCount               = 100
-	tracingNamespace           = "istio-system"
+	tracingNamespace           = "knative-tracing"
 	jaegerQueryFrontedSelector = "app=jaeger"
 	tempoQueryFrontedSelector  = "app.kubernetes.io/component=query-frontend"
 	jaegerQueryPort            = 16685


### PR DESCRIPTION
Fixes JIRA https://issues.redhat.com/browse/SRVKS-1280

## Proposed Changes
- Drop OSSM 2.x dependent operators
- Change default tracing namespace to `knative-tracing` instead of `istio-system`
- Prepares for OSSM 3.x
  - Create and teardown knative-serving-ingress (will be needed for istio-ingressgateway in OSSM 3.x)
- Drop old internal-encryption config for mesh
- Drop unused OTEL tracing



