### PR TITLE
Install Skopeo to get latest Konflux SHAs

### DIFF
--- a/templates/build-image.Dockerfile
+++ b/templates/build-image.Dockerfile
@@ -8,6 +8,7 @@ RUN yum install -y kubectl httpd-tools
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
+RUN GOFLAGS='' go install -tags="exclude_graphdriver_btrfs containers_image_openpgp" github.com/containers/skopeo/cmd/skopeo@v1.16.1
 RUN rm -rf $GOPATH/.cache
 
 # Allow runtime users to add entries to /etc/passwd


### PR DESCRIPTION
skopeo because, Podman doesn't work, Docker needs DinD in CI.

Related to https://github.com/openshift-knative/serverless-operator/pull/2827