### PR TITLE
Define project.tag in project.yaml

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -55,7 +55,7 @@ jobs:
         if: (github.event_name == 'pull_request' && github.base_ref != 'main') || ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name != 'main')
         run: |
           tag="release-$(yq read ./olm-catalog/serverless-operator/project.yaml 'project.version')"
-          echo "CURRENT_VERSION_IMAGES=${tag}" >> $GITHUB_ENV
+          yq write ./olm-catalog/serverless-operator/project.yaml 'project.tag' ${tag}
         shell: bash
 
       - name: Regenerate all generated files

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -19,7 +19,8 @@ function install_catalogsource {
   rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
 
   # Get current tag from openshift-knative image URL.
-  tag=$(yq read "$rootdir/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.containers(name==knative-openshift).image" | cut -d":" -f 1 | cut -d"/" -f 3)
+  csv="${rootdir}/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml"
+  tag=$(yq read "${csv}" "spec.install.spec.deployments(name==knative-openshift).spec.template.spec.containers(name==knative-openshift).image" | cut -d":" -f 1 | cut -d"/" -f 3)
 
   index_image=registry.ci.openshift.org/knative/serverless-index:${tag}
 
@@ -27,8 +28,6 @@ function install_catalogsource {
   # Otherwise the latest nightly build will be used for CatalogSource.
   if [ -n "$OPENSHIFT_CI" ] || [ -n "$DOCKER_REPO_OVERRIDE" ]; then
     index_image=image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-index:latest
-
-    csv="${rootdir}/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml"
 
     logger.debug "Create a backup of the CSV so we don't pollute the repository."
     mkdir -p "${rootdir}/_output"

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -16,14 +16,13 @@ function install_catalogsource {
 
   local rootdir csv index_image
 
-  rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
-
   index_image=registry.ci.openshift.org/knative/serverless-index:$(metadata.get project.tag)
 
   # Build bundle and index images only when running in CI or when DOCKER_REPO_OVERRIDE is defined.
   # Otherwise the latest nightly build will be used for CatalogSource.
   if [ -n "$OPENSHIFT_CI" ] || [ -n "$DOCKER_REPO_OVERRIDE" ]; then
     index_image=image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-index:latest
+    rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
 
     csv="${rootdir}/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml"
 

--- a/hack/lib/images.bash
+++ b/hack/lib/images.bash
@@ -5,7 +5,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/metadata.bash"
 
 registry_host='registry.ci.openshift.org'
 registry="${registry_host}/openshift"
-export CURRENT_VERSION_IMAGES=${CURRENT_VERSION_IMAGES:-"main"}
+export CURRENT_VERSION_IMAGES=${CURRENT_VERSION_IMAGES:-$(metadata.get project.tag)}
 
 function default_serverless_operator_images() {
   local serverless

--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -13,7 +13,7 @@ RUN go build -tags strictfipsruntime -o /usr/bin/main ./knative-operator/cmd/kna
 
 FROM $GO_RUNTIME
 
-ARG VERSION=
+ARG VERSION=main
 
 COPY --from=builder /usr/bin/main /usr/bin/knative-operator
 

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -5,6 +5,7 @@ project:
     # Otherwise, the upgrade tests will not pass, as we have a different SO version with the same bundle contents.
     # Also make sure to update values under `olm.previous` by copying from `olm.replaces` and `olm.skipRange`.
     version: 1.35.0
+    tag: main
 olm:
     replaces: 1.34.0
     skipRange: '>=1.34.0 <1.35.0'

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -13,7 +13,7 @@ RUN go build -tags strictfipsruntime -o /usr/bin/main ./openshift-knative-operat
 
 FROM $GO_RUNTIME
 
-ARG VERSION=
+ARG VERSION=main
 
 COPY --from=builder /usr/bin/main /usr/bin/openshift-knative-operator
 

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -13,7 +13,7 @@ RUN go build -tags strictfipsruntime -o /usr/bin/main ./serving/ingress/cmd/ingr
 
 FROM $GO_RUNTIME
 
-ARG VERSION=
+ARG VERSION=main
 
 COPY --from=builder /usr/bin/main /usr/bin/ingress
 

--- a/serving/metadata-webhook/Dockerfile
+++ b/serving/metadata-webhook/Dockerfile
@@ -13,7 +13,7 @@ RUN go build -tags strictfipsruntime -o /usr/bin/main ./serving/metadata-webhook
 
 FROM $GO_RUNTIME
 
-ARG VERSION=
+ARG VERSION=main
 
 COPY --from=builder /usr/bin/main /usr/bin/webhook
 


### PR DESCRIPTION
* Allows to run `make install` on release branches and it will us the right index image
* This change will also populate the VERSION arg properly in Dockerfiles as the version is read from `project.tag` which exists in other repositories but didn't exist in s-o so far ([example](https://github.com/openshift-knative/serverless-operator/blob/main/knative-operator/Dockerfile#L16))

[Slack thread](https://redhat-internal.slack.com/archives/CLUCMK7R6/p1727352333044709?thread_ts=1727347265.990459&cid=CLUCMK7R6)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->


