### PR TITLE
Allow to pass opm image as a build arg

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -162,7 +162,7 @@ EOF
 # Dockerfiles might specify "FROM $XYZ" which fails OpenShift on-cluster
 # builds. Replace the references with real images.
 function replace_images() {
-  local dockerfile_path tmp_dockerfile go_runtime go_builder
+  local dockerfile_path tmp_dockerfile go_runtime go_builder opm_image
   dockerfile_path=${1:?Pass dockerfile path}
   tmp_dockerfile=$(mktemp /tmp/Dockerfile.XXXXXX)
   cp "${dockerfile_path}" "$tmp_dockerfile"
@@ -175,8 +175,13 @@ function replace_images() {
     go_builder=$(grep "GO_BUILDER=" "$tmp_dockerfile" | cut -d"=" -f 2)
   fi
 
+  if grep -q "OPM_IMAGE=" "$tmp_dockerfile"; then
+    opm_image=$(grep "OPM_IMAGE=" "$tmp_dockerfile" | cut -d"=" -f 2)
+  fi
+
   sed -e "s|\$GO_RUNTIME|${go_runtime:-}|" \
-      -e "s|\$GO_BUILDER|${go_builder:-}|" -i "$tmp_dockerfile"
+      -e "s|\$GO_BUILDER|${go_builder:-}|" \
+      -e "s|\$OPM_IMAGE|${opm_image:-}|" -i "$tmp_dockerfile"
 
   echo "$tmp_dockerfile"
 }

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -1,4 +1,6 @@
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17 AS opm
+ARG OPM_IMAGE=registry.ci.openshift.org/origin/4.17:operator-registry
+
+FROM $OPM_IMAGE AS opm
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 
@@ -19,7 +21,7 @@ registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17
+FROM $OPM_IMAGE
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs

--- a/olm-catalog/serverless-operator/index/Dockerfile
+++ b/olm-catalog/serverless-operator/index/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/origin/4.17:operator-registry AS opm
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17 AS opm
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 
@@ -19,7 +19,7 @@ registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.ci.openshift.org/origin/4.17:operator-registry
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -1,4 +1,6 @@
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v__OCP_MAX_VERSION__ AS opm
+ARG OPM_IMAGE=registry.ci.openshift.org/origin/__OCP_MAX_VERSION__:operator-registry
+
+FROM $OPM_IMAGE AS opm
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 
@@ -15,7 +17,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml \
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v__OCP_MAX_VERSION__
+FROM $OPM_IMAGE
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/origin/__OCP_MAX_VERSION__:operator-registry AS opm
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v__OCP_MAX_VERSION__ AS opm
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 
@@ -15,7 +15,7 @@ RUN /bin/opm render --skip-tls-verify -o yaml \
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.ci.openshift.org/origin/__OCP_MAX_VERSION__:operator-registry
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v__OCP_MAX_VERSION__
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs


### PR DESCRIPTION
Using `registry.ci.openshift.org/origin/4.15` as base image for the index, leads to the following FBC validation issue (e.g. [here](https://console.redhat.com/application-pipeline/workspaces/ocp-serverless/applications/serverless-operator-135/pipelineruns/serverless-index-main-on-pull-request-p6mgv/logs?task=fbc-validate))

```
serverless-index-main-on-pull-request-p6mgv-fbc-validate

...

[extract-and-check-binaries] Base image registry.ci.openshift.org/origin/4.15@sha256:eeaee7eb775236f9f0dcf959b5931af77b1c27ac32e1c60268540e64f4d94242 is not allowed for the file based catalog image. Allowed images: registry.redhat.io/openshift4/ose-operator-registry
[extract-and-check-binaries] {"result":"FAILURE","timestamp":"2024-10-02T09:16:05+00:00","note":"Task fbc-validation failed: Base image registry.ci.openshift.org/origin/4.15@sha256:eeaee7eb775236f9f0dcf959b5931af77b1c27ac32e1c60268540e64f4d94242 is not allowed for the file based catalog image. For details, check Tekton task logs","namespace":"default","successes":0,"failures":1,"warnings":0}
```

As using registry.redhat.io/openshift4/ose-operator-registry requires authentication, we allow to set the base image via a build arg, so we can set it for the Konflux builds (see https://github.com/openshift-knative/hack/pull/314)