### PR TITLE
Check in ImageContentSourcePolicy for nightly installations

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -26,6 +26,12 @@ jobs:
       - name: Setup Golang
         uses: openshift-knative/hack/actions/setup-go@main
 
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          # Installs the latest release of oc with the major version 4.
+          oc: "4"
+
       - name: Install yq
         run: |
           go install github.com/mikefarah/yq/v3@latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ users.htpasswd
 # certs created by hack/lib/mesh.bash
 example.com.*
 custom.example.com.*
+/iib-manifests

--- a/hack/generate/catalog.sh
+++ b/hack/generate/catalog.sh
@@ -155,4 +155,8 @@ EOF
   fi
 }
 
+logger.info "Generating ImageContextSourcePolicy"
+create_image_content_source_policy "registry.ci.openshift.org/knative/${CURRENT_VERSION_IMAGES}:serverless-index" "$registry_redhat_io" "$registry_quay" "olm-catalog/serverless-operator-index/image_content_source_policy.yaml"
+
+logger.info "Generating catalog"
 generate_catalog

--- a/olm-catalog/serverless-operator-index/image_content_source_policy.yaml
+++ b/olm-catalog/serverless-operator-index/image_content_source_policy.yaml
@@ -1,0 +1,74 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  labels:
+    operators.openshift.org/catalog: "true"
+  name: serverless-image-content-source-policy
+spec:
+  repositoryDigestMirrors:
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-backstage-plugins-eventmesh"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-backstage-plugins-eventmesh"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-dispatcher"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-kafka-controller"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-ekb-kafka-controller"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-post-install"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-ekb-post-install"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-receiver"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-webhook-kafka"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-ekb-webhook-kafka"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-apiserver-receive-adapter"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-apiserver-receive-adapter"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-channel-controller"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-channel-controller"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-channel-dispatcher"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-channel-dispatcher"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-controller"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-controller"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-filter"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-filter"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-ingress"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-ingress"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-istio-controller"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-istio-controller"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-jobsink"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-jobsink"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-migrate"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-migrate"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-mtchannel-broker"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-mtchannel-broker"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-mtping"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-mtping"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-webhook"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-eventing-webhook"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-plugin-func-func-util"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-activator"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-serving-activator"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-autoscaler"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-serving-autoscaler"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-autoscaler-hpa"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-serving-autoscaler-hpa"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-controller"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-serving-controller"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-queue"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-serving-queue"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-storage-version-migration"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-serving-storage-version-migration"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-webhook"]
+      source: "registry.redhat.io/openshift-serverless-1/kn-serving-webhook"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-istio-controller"]
+      source: "registry.redhat.io/openshift-serverless-1/net-istio-controller"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-istio-webhook"]
+      source: "registry.redhat.io/openshift-serverless-1/net-istio-webhook"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-kourier-kourier"]
+      source: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-ingress"]
+      source: "registry.redhat.io/openshift-serverless-1/serverless-ingress"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-kn-operator"]
+      source: "registry.redhat.io/openshift-serverless-1/serverless-kn-operator"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-openshift-kn-operator"]
+      source: "registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-operator"
+    - mirrors: ["quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle"]
+      source: "registry.redhat.io/openshift-serverless-1/serverless-bundle"


### PR DESCRIPTION
I need to apply this to install the nightly index with:
```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: openshift-serverless
---
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: serverless-operator
  namespace: openshift-marketplace
spec:
  displayName: Serverless Operator
  image: registry.ci.openshift.org/knative/main:serverless-index
  publisher: Red Hat
  sourceType: grpc
---
apiVersion: operators.coreos.com/v1
kind: OperatorGroup
metadata:
  name: serverless
  namespace: openshift-serverless
---
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: serverless-operator
  namespace: openshift-serverless
spec:
  channel: "stable"
  name: "serverless-operator"
  source: "serverless-operator"
  sourceNamespace: "openshift-marketplace"
  installPlanApproval: Automatic
```
