### PR TITLE
Support console unmanaged mode

### DIFF
--- a/knative-operator/pkg/controller/knativeserving/consoleutil/util.go
+++ b/knative-operator/pkg/controller/knativeserving/consoleutil/util.go
@@ -25,7 +25,7 @@ func IsConsoleInstalled() bool {
 // and checks if it is available.
 func IsClusterOperatorAvailable(status configv1.ClusterOperatorStatus) bool {
 	for _, cond := range status.Conditions {
-		if cond.Type == configv1.OperatorAvailable && cond.Status == configv1.ConditionTrue {
+		if cond.Type == configv1.OperatorAvailable && (cond.Status == configv1.ConditionTrue || cond.Reason == "Unmanaged") {
 			return true
 		}
 	}


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- User install its own console in "Umanaged" mode, see possible values for managementState [here](https://docs.openshift.com/container-platform/4.17/web_console/disabling-web-console.html). This will stop deploying the dashboards as the cluster operator status becomes:
```
  - lastTransitionTime: "2024-10-16T05:47:10Z"
    reason: Unmanaged
    status: Unknown
    type: Available
```
We currently expect this to be true.
- See discussion [here](https://redhat-internal.slack.com/archives/CD87JDUB0/p1729069847509779?thread_ts=1729064787.346979&cid=CD87JDUB0).