### PR TITLE
Wait for imageStreamTag to be imported before build

### DIFF
--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -201,7 +201,7 @@ function replace_images() {
 }
 
 function build_image() {
-  local name from_dir dockerfile_path tmp_dockerfile
+  local name from_dir dockerfile_path tmp_dockerfile image_stream_tag
   name=${1:?Pass a name of image to be built as arg[1]}
   from_dir=${2:?Pass context dir}
   dockerfile_path=${3:?Pass dockerfile path}
@@ -214,11 +214,11 @@ function build_image() {
     oc -n "${OLM_NAMESPACE}" new-build \
       --strategy=docker --name "$name" --dockerfile "$(cat "${tmp_dockerfile}")"
 
-    imageStreamTag=$(oc get BuildConfig -n "${OLM_NAMESPACE}" "$name" -o json | \
+    image_stream_tag=$(oc get BuildConfig -n "${OLM_NAMESPACE}" "$name" -o json | \
       jq -r '.spec.strategy.dockerStrategy.from.name')
 
-    logger.info "Import the ${imageStreamTag} ImageStreamTag"
-    oc import-image -n "${OLM_NAMESPACE}" "$imageStreamTag"
+    logger.info "Wait for the ${image_stream_tag} ImageStreamTag to be imported"
+    timeout 60 "! oc get imagestreamtag -n \"${OLM_NAMESPACE}\" \"$image_stream_tag\" -o json | jq -re .image.dockerImageReference"
   else
     logger.info "${name} image build is already created"
   fi

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -201,7 +201,7 @@ function replace_images() {
 }
 
 function build_image() {
-  local name from_dir dockerfile_path tmp_dockerfile image_stream_tag
+  local name from_dir dockerfile_path tmp_dockerfile image_stream_tag from_kind
   name=${1:?Pass a name of image to be built as arg[1]}
   from_dir=${2:?Pass context dir}
   dockerfile_path=${3:?Pass dockerfile path}
@@ -214,11 +214,15 @@ function build_image() {
     oc -n "${OLM_NAMESPACE}" new-build \
       --strategy=docker --name "$name" --dockerfile "$(cat "${tmp_dockerfile}")"
 
-    image_stream_tag=$(oc get BuildConfig -n "${OLM_NAMESPACE}" "$name" -o json | \
-      jq -r '.spec.strategy.dockerStrategy.from.name')
+    from_kind=$(oc get BuildConfig -n "${OLM_NAMESPACE}" "$name" -o json | \
+      jq -r '.spec.strategy.dockerStrategy.from.kind')
+    if [ "ImageStreamTag" = "$from_kind" ]; then
+      image_stream_tag=$(oc get BuildConfig -n "${OLM_NAMESPACE}" "$name" -o json | \
+        jq -r '.spec.strategy.dockerStrategy.from.name')
 
-    logger.info "Wait for the ${image_stream_tag} ImageStreamTag to be imported"
-    timeout 60 "! oc get imagestreamtag -n \"${OLM_NAMESPACE}\" \"$image_stream_tag\" -o json | jq -re .image.dockerImageReference"
+      logger.info "Wait for the ${image_stream_tag} ImageStreamTag to be imported"
+      timeout 60 "! oc get imagestreamtag -n \"${OLM_NAMESPACE}\" \"$image_stream_tag\" -o json | jq -re .image.dockerImageReference"
+    fi
   else
     logger.info "${name} image build is already created"
   fi

--- a/hack/lib/catalogsource.bash
+++ b/hack/lib/catalogsource.bash
@@ -213,6 +213,12 @@ function build_image() {
     logger.info "Create an image build for ${name}"
     oc -n "${OLM_NAMESPACE}" new-build \
       --strategy=docker --name "$name" --dockerfile "$(cat "${tmp_dockerfile}")"
+
+    imageStreamTag=$(oc get BuildConfig -n "${OLM_NAMESPACE}" "$name" -o json | \
+      jq -r '.spec.strategy.dockerStrategy.from.name')
+
+    logger.info "Import the ${imageStreamTag} ImageStreamTag"
+    oc import-image -n "${OLM_NAMESPACE}" "$imageStreamTag"
   else
     logger.info "${name} image build is already created"
   fi


### PR DESCRIPTION
- :broom: Explicitly import the BuildConfig FROM imageStreamTag before starting the build

Sometimes we're getting errors like
> The ImageStreamTag "ubi-minimal:latest" is invalid: from: Error resolving ImageStreamTag ubi-minimal:latest in namespace openshift-marketplace: unable to find latest tagged image

let's see if explicitly importing the imagestream before running the "oc start-build" helps. 

