### PR TITLE
[SRVCOM-3372] Allow to override labels in knative-serving-ingress ns

### DIFF
--- a/docs/gitops/README.md
+++ b/docs/gitops/README.md
@@ -19,6 +19,8 @@ oc apply -f docs/gitops/application.yaml
 
 # Grant admin permission to openshift gitops controller in knative-eventing
 oc adm policy add-role-to-user admin system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller -n knative-eventing
+oc adm policy add-role-to-user admin system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller -n knative-serving
+oc adm policy add-role-to-user admin system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller -n knative-serving-ingress
 
 # Access the Argo CD UI by navigating to the openshift-gitops-server route
 oc get routes -n openshift-gitops openshift-gitops-server
@@ -34,9 +36,11 @@ oc get routes -n openshift-gitops openshift-gitops-server
 ### Verify installation
 
 ```shell
-# Verify that KnativeEventing is ready and pods are present
+# Verify that KnativeEventing, KnativeServing are ready and pods are present
 oc get knativeeventing -n knative-eventing
 oc get pods -n knative-eventing
+oc get knativeserving -n knative-serving
+oc get pods -n knative-serving
 ```
 
 ### Reproduce SRVCOM-2200

--- a/docs/gitops/serverless/300-serving.yaml
+++ b/docs/gitops/serverless/300-serving.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops
+    knative.openshift.io/part-of: openshift-serverless
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/instance: openshift-serverless
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving-ingress
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops
+    knative.openshift.io/part-of: openshift-serverless
+    app.kubernetes.io/name: knative-serving-ingress
+    app.kubernetes.io/instance: openshift-serverless
+  annotations:
+    argocd.argoproj.io/sync-wave: "6"
+---
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+  annotations:
+    argocd.argoproj.io/sync-wave: "7"

--- a/hack/patches/022-serving-ingress-ns-filter.patch
+++ b/hack/patches/022-serving-ingress-ns-filter.patch
@@ -1,0 +1,15 @@
+diff --git a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
+index 4b8eca0b0..fb3c1a57c 100644
+--- a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
++++ b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
+@@ -117,6 +117,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServi
+ 		security.AppendTargetSecurity,
+ 		common.AppendAdditionalManifests,
+ 		r.appendExtensionManifests,
++		func(ctx context.Context, manifest *mf.Manifest, component base.KComponent) error {
++			*manifest = manifest.Filter(mf.Not(mf.All(mf.ByKind("Namespace"), mf.ByName("kourier-system"))))
++			return nil
++		},
+ 		r.transform,
+ 		manifests.Install,
+ 		common.CheckDeployments,

--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -4,6 +4,7 @@ ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder
 
+WORKDIR /go/src/knative-operator/cmd/knative-operator
 COPY . .
 
 ENV CGO_ENABLED=1

--- a/olm-catalog/serverless-operator-index/Dockerfile
+++ b/olm-catalog/serverless-operator-index/Dockerfile
@@ -15,7 +15,7 @@ registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
     /bin/opm render --skip-tls-verify -o yaml \
 registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
 registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
-      quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle@sha256:8274dbf41d54c14b2ce25781dbd959d89445ed56ba15038b5ebe55ce0e984e4d >> /configs/index.yaml
+      quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle@sha256:500de85cb1b20b39fa14ffdfb76419ad1776d841707bde5c8e2e4042dd542f47 >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -830,7 +830,7 @@ spec:
                 serviceAccountName: knative-operator
                 containers:
                   - name: knative-operator
-                    image: registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator@sha256:ad6761fe02d1bb12c9e677196e89e8e558e1773844f77dbdc77da47103daa864
+                    image: registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator@sha256:47822a7b95679ea90c1a953f7948c3e8d12e9bbdd002bcc67c86223ae57f0b52
                     readinessProbe:
                       periodSeconds: 1
                       httpGet:
@@ -899,11 +899,11 @@ spec:
                       - name: "IMAGE_kourier-gateway"
                         value: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:02b834fd74da71ec37f6a5c0d10aac9a679d1a0f4e510c4f77723ef2367e858a"
                       - name: "IMAGE_net-kourier-controller__controller"
-                        value: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:46c03eea11407071a3c933d3cfa6d83e82a452d15ce2e28cca4b408aeae46505"
+                        value: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:60e4e4219b70bea40bbdb6372c396d4560bf0e7457a6041fccab332c7956488e"
                       - name: "IMAGE_net-istio-controller__controller"
-                        value: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:a057123890677831815138c6edb2fc147c684c7793977e11d8946cd9062ba96d"
+                        value: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:7a3dd399d2e34b691f0001bc3f4ca57cf0d31002f6650803fbe4546f3e6a85da"
                       - name: "IMAGE_net-istio-webhook__webhook"
-                        value: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:eba2f14c1617419b3fac098d8c3da61e5542959cfd3f68a713b4a6c7c91dd052"
+                        value: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:f2e700a65cb081615b8424777541a13916ba8aed040d833c3e26c04f7d6ed525"
                       - name: "IMAGE_eventing-controller__eventing-controller"
                         value: "registry.redhat.io/openshift-serverless-1/kn-eventing-controller-rhel8@sha256:8f289d849927d90b429da58746273c7bfed65c14351e1797b9c9c148646a6aab"
                       - name: "IMAGE_eventing-istio-controller__eventing-istio-controller"
@@ -995,7 +995,7 @@ spec:
                           - ALL
                 containers:
                   - name: knative-openshift
-                    image: registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8@sha256:7fafde8a0d655fce200b04c945211b422c7d3087edde79b9835a6b6fb9078e0c
+                    image: registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8@sha256:5058e9c600d6f3f9553d8f4c6a4dc1f4a43049a3d93240ed505f2f5d3108658b
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -1073,11 +1073,11 @@ spec:
                       - name: "IMAGE_kourier-gateway"
                         value: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:02b834fd74da71ec37f6a5c0d10aac9a679d1a0f4e510c4f77723ef2367e858a"
                       - name: "IMAGE_net-kourier-controller__controller"
-                        value: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:46c03eea11407071a3c933d3cfa6d83e82a452d15ce2e28cca4b408aeae46505"
+                        value: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:60e4e4219b70bea40bbdb6372c396d4560bf0e7457a6041fccab332c7956488e"
                       - name: "IMAGE_net-istio-controller__controller"
-                        value: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:a057123890677831815138c6edb2fc147c684c7793977e11d8946cd9062ba96d"
+                        value: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:7a3dd399d2e34b691f0001bc3f4ca57cf0d31002f6650803fbe4546f3e6a85da"
                       - name: "IMAGE_net-istio-webhook__webhook"
-                        value: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:eba2f14c1617419b3fac098d8c3da61e5542959cfd3f68a713b4a6c7c91dd052"
+                        value: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:f2e700a65cb081615b8424777541a13916ba8aed040d833c3e26c04f7d6ed525"
                       - name: "IMAGE_eventing-controller__eventing-controller"
                         value: "registry.redhat.io/openshift-serverless-1/kn-eventing-controller-rhel8@sha256:8f289d849927d90b429da58746273c7bfed65c14351e1797b9c9c148646a6aab"
                       - name: "IMAGE_eventing-istio-controller__eventing-istio-controller"
@@ -1133,7 +1133,7 @@ spec:
                       - name: "KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher"
                         value: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:a67b1b1dcfef0f1e470db79dc74f636f9cfe47b747c958e9e5b175ea628d3a52"
                       - name: "KAFKA_IMAGE_kafka-controller__controller"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-kafka-controller-rhel8@sha256:a93a882daeed8135c5f9c235221961c473a34344f565021211190543e1841699"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-kafka-controller-rhel8@sha256:7c84244d62e8f4a3e3ab5c27b050b0cfb2c94c82b86f9af1c815048ddce43939"
                       - name: "KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver"
                         value: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:7fb3155f7b5292b784891fca026912ce64540104e3a27523976aa2054f72a8ee"
                       - name: "KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher"
@@ -1177,7 +1177,7 @@ spec:
                 serviceAccountName: knative-openshift-ingress
                 containers:
                   - name: knative-openshift-ingress
-                    image: registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8@sha256:a14cb3b6189a39ee81c3514b69217d54e234e6453446d18cde8fcca5e89b8d06
+                    image: registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8@sha256:3eb9407f9505f4aa91158fcd432c03ceca26d8273fa1678cf304079049f0d9ed
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -1326,11 +1326,11 @@ spec:
         - knativeeventings.operator.knative.dev
   relatedImages:
     - name: "knative-operator"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator@sha256:ad6761fe02d1bb12c9e677196e89e8e558e1773844f77dbdc77da47103daa864"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator@sha256:47822a7b95679ea90c1a953f7948c3e8d12e9bbdd002bcc67c86223ae57f0b52"
     - name: "knative-openshift"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8@sha256:7fafde8a0d655fce200b04c945211b422c7d3087edde79b9835a6b6fb9078e0c"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8@sha256:5058e9c600d6f3f9553d8f4c6a4dc1f4a43049a3d93240ed505f2f5d3108658b"
     - name: "knative-openshift-ingress"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8@sha256:a14cb3b6189a39ee81c3514b69217d54e234e6453446d18cde8fcca5e89b8d06"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8@sha256:3eb9407f9505f4aa91158fcd432c03ceca26d8273fa1678cf304079049f0d9ed"
     - name: "IMAGE_queue-proxy"
       image: "registry.redhat.io/openshift-serverless-1/kn-serving-queue-rhel8@sha256:f6f9208f8da20ea331d1d0062814d332931d059a8e7e811b6bc3b82d96ebb498"
     - name: "IMAGE_activator"
@@ -1348,11 +1348,11 @@ spec:
     - name: "IMAGE_kourier-gateway"
       image: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:02b834fd74da71ec37f6a5c0d10aac9a679d1a0f4e510c4f77723ef2367e858a"
     - name: "IMAGE_net-kourier-controller__controller"
-      image: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:46c03eea11407071a3c933d3cfa6d83e82a452d15ce2e28cca4b408aeae46505"
+      image: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:60e4e4219b70bea40bbdb6372c396d4560bf0e7457a6041fccab332c7956488e"
     - name: "IMAGE_net-istio-controller__controller"
-      image: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:a057123890677831815138c6edb2fc147c684c7793977e11d8946cd9062ba96d"
+      image: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:7a3dd399d2e34b691f0001bc3f4ca57cf0d31002f6650803fbe4546f3e6a85da"
     - name: "IMAGE_net-istio-webhook__webhook"
-      image: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:eba2f14c1617419b3fac098d8c3da61e5542959cfd3f68a713b4a6c7c91dd052"
+      image: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:f2e700a65cb081615b8424777541a13916ba8aed040d833c3e26c04f7d6ed525"
     - name: "IMAGE_eventing-controller__eventing-controller"
       image: "registry.redhat.io/openshift-serverless-1/kn-eventing-controller-rhel8@sha256:8f289d849927d90b429da58746273c7bfed65c14351e1797b9c9c148646a6aab"
     - name: "IMAGE_eventing-istio-controller__eventing-istio-controller"
@@ -1408,7 +1408,7 @@ spec:
     - name: "KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher"
       image: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:a67b1b1dcfef0f1e470db79dc74f636f9cfe47b747c958e9e5b175ea628d3a52"
     - name: "KAFKA_IMAGE_kafka-controller__controller"
-      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-kafka-controller-rhel8@sha256:a93a882daeed8135c5f9c235221961c473a34344f565021211190543e1841699"
+      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-kafka-controller-rhel8@sha256:7c84244d62e8f4a3e3ab5c27b050b0cfb2c94c82b86f9af1c815048ddce43939"
     - name: "KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver"
       image: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:7fb3155f7b5292b784891fca026912ce64540104e3a27523976aa2054f72a8ee"
     - name: "KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher"

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -870,6 +870,8 @@ spec:
                         value: knative.dev/serving-operator
                       - name: REQUIRED_SERVING_NAMESPACE
                         value: "knative-serving"
+                      - name: REQUIRED_SERVING_INGRESS_NAMESPACE
+                        value: "knative-serving-ingress"
                       - name: REQUIRED_EVENTING_NAMESPACE
                         value: "knative-eventing"
                       - name: SERVICE_MONITOR_RBAC_MANIFEST_PATH
@@ -1026,6 +1028,8 @@ spec:
                         value: "knative-openshift"
                       - name: REQUIRED_SERVING_NAMESPACE
                         value: "knative-serving"
+                      - name: REQUIRED_SERVING_INGRESS_NAMESPACE
+                        value: "knative-serving-ingress"
                       - name: REQUIRED_EVENTING_NAMESPACE
                         value: "knative-eventing"
                       - name: REQUIRED_KAFKA_NAMESPACE

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -4,6 +4,7 @@ ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder
 
+WORKDIR /go/src/openshift-knative-operator/cmd/openshift-knative-operator
 COPY . .
 
 ENV CGO_ENABLED=1

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -4,6 +4,7 @@ ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder
 
+WORKDIR /go/src/serving/ingress/cmd/ingress
 COPY . .
 
 ENV CGO_ENABLED=1

--- a/serving/metadata-webhook/Dockerfile
+++ b/serving/metadata-webhook/Dockerfile
@@ -4,6 +4,7 @@ ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder
 
+WORKDIR /go/src/serving/metadata-webhook/cmd/webhook
 COPY . .
 
 ENV CGO_ENABLED=1

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -878,6 +878,8 @@ spec:
                         value: knative.dev/serving-operator
                       - name: REQUIRED_SERVING_NAMESPACE
                         value: "knative-serving"
+                      - name: REQUIRED_SERVING_INGRESS_NAMESPACE
+                        value: "knative-serving-ingress"
                       - name: REQUIRED_EVENTING_NAMESPACE
                         value: "knative-eventing"
                       - name: SERVICE_MONITOR_RBAC_MANIFEST_PATH
@@ -963,6 +965,8 @@ spec:
                         value: "knative-openshift"
                       - name: REQUIRED_SERVING_NAMESPACE
                         value: "knative-serving"
+                      - name: REQUIRED_SERVING_INGRESS_NAMESPACE
+                        value: "knative-serving-ingress"
                       - name: REQUIRED_EVENTING_NAMESPACE
                         value: "knative-eventing"
                       - name: REQUIRED_KAFKA_NAMESPACE

--- a/test/e2e/dashboards.go
+++ b/test/e2e/dashboards.go
@@ -21,6 +21,12 @@ var (
 		"grafana-dashboard-definition-knative-eventing-channel",
 		"grafana-dashboard-definition-knative-eventing-kafka-sink",
 	}
+
+	ServingDashboards = []string{
+		"grafana-dashboard-knative-serving-queue-proxy",
+		"grafana-dashboard-definition-knative-serving-resources",
+		"grafana-dashboard-definition-knative-serving-scaling-debugging",
+	}
 )
 
 func VerifyDashboards(t *testing.T, caCtx *test.Context, dashboards []string) {

--- a/test/e2e/knative_serving_test.go
+++ b/test/e2e/knative_serving_test.go
@@ -97,4 +97,10 @@ func TestKnativeServing(t *testing.T) {
 	t.Run("make sure no gcr.io references are there", func(t *testing.T) {
 		VerifyNoDisallowedImageReference(t, caCtx, servingNamespace)
 	})
+
+	VerifyDashboards(t, caCtx, ServingDashboards)
+	VerifyNamespaceMetadata(t, caCtx, servingNamespace)
+	if os.Getenv("MESH") != "true" {
+		VerifyNamespaceMetadata(t, caCtx, servingNamespace+"-ingress")
+	}
 }

--- a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
@@ -117,6 +117,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServi
 		security.AppendTargetSecurity,
 		common.AppendAdditionalManifests,
 		r.appendExtensionManifests,
+		func(ctx context.Context, manifest *mf.Manifest, component base.KComponent) error {
+			*manifest = manifest.Filter(mf.Not(mf.All(mf.ByKind("Namespace"), mf.ByName("kourier-system"))))
+			return nil
+		},
 		r.transform,
 		manifests.Install,
 		common.CheckDeployments,


### PR DESCRIPTION
Fixes JIRA: SRVCOM-3372

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- As per title. As with knative-{eventing, serving} ns we create the ns upfront.  To test this use this [branch](https://github.com/openshift-knative/serverless-operator/compare/main...skonto:serverless-operator:support_argo_knative_ingress_simple?expand=1).
With this patch all ns stay in-sync even if all pods in openshift-serverless are deleted:

![Screenshot from 2024-11-05 13-04-33](https://github.com/user-attachments/assets/2c1583a1-ce07-4e2c-b5bb-dc0cf0cc1468)

- An alternative approach is to mark a ns to be filtered from manifests when the argo annotation is detected on an existing ns. See this approach [here](https://github.com/openshift-knative/serverless-operator/compare/main...skonto:serverless-operator:support_argo_knative_ingress?expand=1). For now we go with the simple approach in this patch unless users eg. deploying only Istio, see this resource created as redundant. In general though `knative-serving-ingress` will be the ns where the ingress gateway will be installed with SM 3 support, so we see no harm to have this resource pre-created.

