### PR TITLE
Add rpms.lock file

### DIFF
--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -1,0 +1,77 @@
+# url="<arches[].packages[].url>"; curl $url -o my-rpm.rpm; stat my-rpm.rpm; sha256sum my-rpm.rpm;
+
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+  - arch: x86_64
+    packages:
+      - repoid: ubi-8-appstream-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/s/socat-1.7.4.1-1.el8.x86_64.rpm"
+        size: 330744
+        checksum: "sha256:b03b86ac05bd5871f14e00400a6ddd30d8e9ed97b93e56e96789706c36e2f379"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/t/tar-1.30-9.el8.x86_64.rpm"
+        size: 858812
+        checksum: "sha256:6b0dc7341d743c89fa038292a7e04761ebb6cc98208ebc26dee9f01e2c1a9529"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/r/rsync-3.1.3-19.el8_7.1.x86_64.rpm"
+        size: 420156
+        checksum: "sha256:7aef9de61fbf590995b07d92f99a3f3478d6c0543d7a6e1ebb6f4b1c02334283"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/t/tzdata-2024a-1.el8.noarch.rpm"
+        size: 486452
+        checksum: "sha256:a82ef1ce1668f326097a682dc125733ffc47b00fd5deb8076c98e87a331a23b7"
+  - arch: aarch64
+    packages:
+      - repoid: ubi-8-appstream-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/s/socat-1.7.4.1-1.el8.aarch64.rpm"
+        size: 324364
+        checksum: "sha256:eb27326c2f3f7c813f0f21e15177ab3f4c74778e2ef8029de51aafb09445c515"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/t/tar-1.30-9.el8.aarch64.rpm"
+        size: 849892
+        checksum: "sha256:3ba95ecab30f49ecf168ee37e6bc332b626bde62ef7bf61801613f93e2126d8e"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/r/rsync-3.1.3-19.el8_7.1.aarch64.rpm"
+        size: 410088
+        checksum: "sha256:d700d21063ae2b609031a3a8772012aff012899062e952ca43370c495f7e40ff"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/t/tzdata-2024a-1.el8.noarch.rpm"
+        size: 486452
+        checksum: "sha256:a82ef1ce1668f326097a682dc125733ffc47b00fd5deb8076c98e87a331a23b7"
+  - arch: s390x
+    packages:
+      - repoid: ubi-8-appstream-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/s/socat-1.7.4.1-1.el8.s390x.rpm"
+        size: 320544
+        checksum: "sha256:4e8380ed4b4570663136b8b499bfe343b688bda676028ef5172d2155ac80e6ae"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/t/tar-1.30-9.el8.s390x.rpm"
+        size: 853548
+        checksum: "sha256:1efadfc1d2113503b8b0e95939c4cb98a7e0095fb383dec2ac4bf652822a8d87"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/r/rsync-3.1.3-19.el8_7.1.s390x.rpm"
+        size: 413364
+        checksum: "sha256:8819079e4ea1236eab315348584007918798776c6ea23dae5725544148316cfb"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/t/tzdata-2024a-1.el8.noarch.rpm"
+        size: 486452
+        checksum: "sha256:a82ef1ce1668f326097a682dc125733ffc47b00fd5deb8076c98e87a331a23b7"
+  - arch: ppc64le
+    packages:
+      - repoid: ubi-8-appstream-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/s/socat-1.7.4.1-1.el8.ppc64le.rpm"
+        size: 337076
+        checksum: "sha256:51f267ce6469e7967815e1f202b8afa84010717ff24fbff30c7c1bc9ee15d1d1"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/t/tar-1.30-9.el8.ppc64le.rpm"
+        size: 878620
+        checksum: "sha256:c34619440c83b785306420d9ae4a21ccbafe09815e5631510cccb6433f435a47"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/r/rsync-3.1.3-19.el8_7.1.ppc64le.rpm"
+        size: 442696
+        checksum: "sha256:698ca98abf03ab4dcc3d4d1795f4a392d33a2e84f0b1b1f4b9856b38e8ef0b77"
+      - repoid: ubi-8-baseos-rpms
+        url: "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/t/tzdata-2024a-1.el8.noarch.rpm"
+        size: 486452
+        checksum: "sha256:a82ef1ce1668f326097a682dc125733ffc47b00fd5deb8076c98e87a331a23b7"


### PR DESCRIPTION
must-gather Konflux build fails due to:

```
Build will be executed with network isolation
Adding the entitlement to the build
[1/2] STEP 1/1: FROM brew.registry.redhat.io/rh-osbs/openshift-ose-must-gather:latest AS builder
--> cfd5af5e8cfe
[2/2] STEP 1/8: FROM registry.access.redhat.com/ubi8/ubi-minimal
[2/2] STEP 2/8: COPY --from=builder /usr/bin/oc /usr/bin/oc
[2/2] STEP 3/8: COPY --from=builder /usr/bin/gather /usr/bin/gather_original
[2/2] STEP 4/8: COPY must-gather/bin/* /usr/bin/
[2/2] STEP 5/8: RUN microdnf install -y rsync tar

(microdnf:518): librhsm-WARNING **: 20:20:50.780: Found 0 entitlement certificates

(microdnf:518): librhsm-WARNING **: 20:20:50.782: Found 0 entitlement certificates
Downloading metadata...
error: cannot update repo 'ubi-8-baseos-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried; Last error: Curl error (6): Couldn't resolve host name for https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/repodata/repomd.xml [Could not resolve host: cdn-ubi.redhat.com]
subprocess exited with status 1
subprocess exited with status 1
Error: building at STEP "RUN microdnf install -y rsync tar": exit status 1
```

This is because the builds run hermetic and we don't have the rpms.lock file.

Requires https://github.com/openshift-knative/hack/pull/405, to generate the Konflux pipelines afterwards correctly