### PR TITLE
SRVCOM-3398 must-gather collects logs for all namespaces with Knative resources

### DIFF
--- a/must-gather/bin/gather_knative
+++ b/must-gather/bin/gather_knative
@@ -11,26 +11,34 @@ LOGS_DIR=${LOGS_DIR:-must-gather-logs}
 
 APIRESOURCES=$(${BIN} get crds -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep -e knative.dev -e serverless.openshift.io)
 
+COLLECT_NAMESPACES=()
+
 for APIRESOURCE in ${APIRESOURCES[@]}
 do
   NAMESPACES=$(${BIN} get ${APIRESOURCE} --all-namespaces=true -o jsonpath='{range .items[*]}{@.metadata.namespace}{"\n"}{end}' | uniq)
   for NAMESPACE in ${NAMESPACES[@]}
   do
+    COLLECT_NAMESPACES+=("${NAMESPACE}")
     mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
     ${BIN} describe ${APIRESOURCE} -n ${NAMESPACE} > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/describe.log
     ${BIN} get ${APIRESOURCE} -n ${NAMESPACE} -o=yaml > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/get.yaml
   done
 done
 
+SYSTEM_NAMESPACES=(knative-eventing knative-serving knative-serving-ingress)
 
-# Collect oc adm inspect and extra resources in knative system namespaces.
-
-NAMESPACES=(knative-eventing knative-serving knative-serving-ingress)
-APIRESOURCES=(roles rolebindings serviceaccounts leases)
-
-for NAMESPACE in ${NAMESPACES[@]}
+# Collect oc adm inspect in all namespaces with Serverless resources.
+COLLECT_NAMESPACES+=("${SYSTEM_NAMESPACES[@]}")
+for NAMESPACE in $(echo "${COLLECT_NAMESPACES[@]}" | tr " " "\n" | sort --unique)
 do
   ${BIN} adm inspect namespace ${NAMESPACE} --dest-dir=${LOGS_DIR}
+done
+
+# Collect extra resources in knative system namespaces.
+APIRESOURCES=(roles rolebindings serviceaccounts leases)
+
+for NAMESPACE in ${SYSTEM_NAMESPACES[@]}
+do
   for APIRESOURCE in ${APIRESOURCES[@]}
   do
     mkdir -p ${LOGS_DIR}/namespaces/${NAMESPACE}/extra/${APIRESOURCE}
@@ -38,7 +46,6 @@ do
     ${BIN} get ${APIRESOURCE} -n ${NAMESPACE} -o=yaml > ${LOGS_DIR}/namespaces/${NAMESPACE}/extra/${APIRESOURCE}/get.yaml
   done
 done
-
 
 # Collect clusterroles and clusterrolebindings
 


### PR DESCRIPTION
Previously, logs were collected only for system-namespaces through oc adm inspect. However, it is useful to have logs and additional resources for all namespaces that have Knative resources.

[Slack discussion](https://redhat-internal.slack.com/archives/CKR568L8G/p1730889416377289?thread_ts=1730883580.226309&cid=CKR568L8G)

Fixes https://issues.redhat.com/browse/SRVCOM-3398

This is the directory structure that is created when running the must-gather (see the "test" namespace which has one Knative service deployed):
https://gist.github.com/mgencur/849c8065863aa82aa9755c1f80d29880

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Since `oc adm inspect` takes a longer time, make sure each namespace is collected only once.

