### PR TITLE
Bump OCP versions to minVersion: 4.14, maxVersion 4.18

### DIFF
--- a/knative-operator/deploy/resources/quickstart/serverless-application-quickstart.yaml
+++ b/knative-operator/deploy/resources/quickstart/serverless-application-quickstart.yaml
@@ -46,7 +46,7 @@ spec:
       review:
         failedTaskHelp: >-
           This task isn’t verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.17/applications/odc-viewing-application-composition-using-topology-view.html)
+          more](https://docs.openshift.com/container-platform/4.18/applications/odc-viewing-application-composition-using-topology-view.html)
           about this topic.
         instructions: >-
           #### To verify the application was successfully created:
@@ -83,7 +83,7 @@ spec:
       review:
         failedTaskHelp: >-
           This task isn’t verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.17/applications/odc-viewing-application-composition-using-topology-view.html#odc-scaling-application-pods-and-checking-builds-and-routes_viewing-application-composition-using-topology-view)
+          more](https://docs.openshift.com/container-platform/4.18/applications/odc-viewing-application-composition-using-topology-view.html#odc-scaling-application-pods-and-checking-builds-and-routes_viewing-application-composition-using-topology-view)
           about this topic.
         instructions: >-
           #### To verify the application scaled down:
@@ -124,7 +124,7 @@ spec:
       review:
         failedTaskHelp: >-
           This task isn’t verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.17/serverless/eventing/event-sources/serverless-pingsource.html#serverless-pingsource-odc_serverless-pingsource)
+          more](https://docs.openshift.com/container-platform/4.18/serverless/eventing/event-sources/serverless-pingsource.html#serverless-pingsource-odc_serverless-pingsource)
           about this topic.
         instructions: >-
           #### To verify that the event connected to your Knative service:
@@ -176,7 +176,7 @@ spec:
       review:
         failedTaskHelp: >-
           This task isn’t verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.17/serverless/knative-serving/traffic-splitting/traffic-splitting-revisions.html#odc-splitting-traffic-between-revisions-using-developer-perspective_traffic-splitting-revisions)
+          more](https://docs.openshift.com/container-platform/4.18/serverless/knative-serving/traffic-splitting/traffic-splitting-revisions.html#odc-splitting-traffic-between-revisions-using-developer-perspective_traffic-splitting-revisions)
           about this topic.
         instructions: >-
           #### To verify that you forced a new revision and set traffic
@@ -204,7 +204,7 @@ spec:
       review:
         failedTaskHelp: >-
           This task is not verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.17/applications/odc-deleting-applications.html)
+          more](https://docs.openshift.com/container-platform/4.18/applications/odc-deleting-applications.html)
           about this topic.
         instructions: |-
           #### To verify you deleted your application:          :

--- a/olm-catalog/serverless-operator-index/Dockerfile
+++ b/olm-catalog/serverless-operator-index/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/origin/4.17:operator-registry AS opm
+FROM registry.ci.openshift.org/origin/4.18:operator-registry AS opm
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 
@@ -19,7 +19,7 @@ registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.ci.openshift.org/origin/4.17:operator-registry
+FROM registry.ci.openshift.org/origin/4.18:operator-registry
 
 # Copy declarative config root into image at /configs
 COPY --from=builder /configs /configs

--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -19,7 +19,7 @@ LABEL \
       description="Red Hat OpenShift Serverless Bundle" \
       io.k8s.description="Red Hat OpenShift Serverless Bundle" \
       io.k8s.display-name="Red Hat OpenShift Serverless Bundle" \
-      com.redhat.openshift.versions="v4.13" \
+      com.redhat.openshift.versions="v4.14" \
       com.redhat.delivery.operator.bundle=true \
       com.redhat.delivery.backport=false \
       distribution-scope="authoritative-source-only" \

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -191,7 +191,7 @@ spec:
     - kafka
   links:
     - name: Documentation
-      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/serverless/index
+      url: https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.35/html/installing_openshift_serverless/index
     - name: Source Repository
       url: https://github.com/openshift-knative/serverless-operator
   maintainers:

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -23,14 +23,14 @@ requirements:
   nodejs: 20.x
   ocpVersion:
     list:
-      - "4.13"
       - "4.14"
       - "4.15"
       - "4.16"
       - "4.17"
-    min: '4.13'
-    max: '4.17'
-    label: 'v4.13'
+      - "4.18"
+    min: '4.14'
+    max: '4.18'
+    label: 'v4.14'
 dependencies:
   serving: knative-v1.15
   # serving midstream branch name

--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.17:cli-artifacts AS oc-image
+FROM registry.ci.openshift.org/ocp/4.18:cli-artifacts AS oc-image
 
 FROM src
 

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -190,7 +190,7 @@ spec:
     - kafka
   links:
     - name: Documentation
-      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/__OCP_TARGET__/html/serverless/index
+      url: https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/__VERSION_MAJOR_MINOR__/html/installing_openshift_serverless/index
     - name: Source Repository
       url: https://github.com/openshift-knative/serverless-operator
   maintainers:


### PR DESCRIPTION
OCP 4.13 will be unsupported soon.
We also need 4.18 Catalog for pre-release testing.


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

