### PR TITLE
Generate catalog for 4.17 with olm.csv.metadata

### DIFF
--- a/hack/generate/catalog.sh
+++ b/hack/generate/catalog.sh
@@ -38,8 +38,15 @@ function generate_catalog {
       add_channel "${catalog_template}" "$channel" "$(metadata.get 'olm.replaces')"
     done < <(metadata.get 'olm.channels.list[*]')
 
+    level=none
+    # For 4.17 and newer the olm.bundle.object must be converted to olm.csv.metadata
+    # See https://github.com/konflux-ci/build-definitions/blob/main/task/fbc-validation/0.1/USAGE.md#bundle-metadata-in-the-appropriate-format.
+    if versions.ge "$ocp_version" "4.17" ; then
+      level="bundle-object-to-csv-metadata"
+    fi
+
     # Generate full catalog
-    opm alpha render-template basic "${catalog_template}" -oyaml \
+    opm alpha render-template basic --migrate-level="$level" "${catalog_template}" -oyaml \
       > "${index_dir}/v${ocp_version}/catalog/serverless-operator/catalog.yaml"
 
     # Replace quay.io with registry.redhat.io for bundle image.


### PR DESCRIPTION
Fixes errors such as this one in Konflux pipeline:
```
!FAILURE! - olm.bundle.object bundle properties are not permitted in a FBC fragment for OCP version 4.17. Fragments must move to olm.csv.metadata bundle metadata.
!FAILURE! - every olm.bundle object in the fragment must have a corresponding olm.csv.metadata bundle property
```
Example: https://console.redhat.com/application-pipeline/workspaces/ocp-serverless/applications/serverless-operator-135-fbc-417/pipelineruns/serverless-index-135-fbc-417-on-pull-request-97tvx

There are already fbc-validation checks in Konflux pipeline that verify that: https://github.com/konflux-ci/build-definitions/blob/main/task/fbc-validation/0.1/USAGE.md#bundle-metadata-in-the-appropriate-format

The catalogs will be re-generated on the next "make generated-files" PR.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
