### PR TITLE
[RELEASE-1.34][SRVKS-1287] Allow to override the ha proxy default route timeout 1.34

### DIFF
--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -4,6 +4,7 @@ ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder
 
+WORKDIR /go/src/knative-operator/cmd/knative-operator
 COPY . .
 
 ENV CGO_ENABLED=1

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -1189,6 +1189,8 @@ spec:
                             fieldPath: metadata.namespace
                       - name: KUBERNETES_MIN_VERSION
                         value: "v1.0.0"
+                      - name: ROUTE_HAPROXY_TIMEOUT
+                        value: "600"
                     securityContext:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: true

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -4,6 +4,7 @@ ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder
 
+WORKDIR /go/src/openshift-knative-operator/cmd/openshift-knative-operator
 COPY . .
 
 ENV CGO_ENABLED=1

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -4,6 +4,7 @@ ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder
 
+WORKDIR /go/src/serving/ingress/cmd/ingress
 COPY . .
 
 ENV CGO_ENABLED=1

--- a/templates/csv.yaml
+++ b/templates/csv.yaml
@@ -1035,6 +1035,8 @@ spec:
                             fieldPath: metadata.namespace
                       - name: KUBERNETES_MIN_VERSION
                         value: "v1.0.0"
+                      - name: ROUTE_HAPROXY_TIMEOUT
+                        value: "600"
                     securityContext:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: true


### PR DESCRIPTION
Fixes JIRA #SRVKS-1287

- As per title, without this either you modify timeout globally or disable route generation and you bring your own. 
- This can be modified by editing the subscription (10 minutes is enough but some users may need more).

```
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
...
spec:
  channel: stable
  config:
    env:
      - name: ROUTE_HAPROXY_TIMEOUT
        value: '900'
```
- In the future we might want to migrate to a cm if there are enough properties that require exposure.
- Result after editing the subscription:
```
 oc get route -n knative-serving-ingress -ojson
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "route.openshift.io/v1",
            "kind": "Route",
            "metadata": {
                "annotations": {
                    "haproxy.router.openshift.io/timeout": "900s",
...

```
- We need this for 1.35 too.
