### PR TITLE
Update must-gather Dockerfile and script to use env for logs dir

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -14,6 +14,12 @@ COPY must-gather/bin/* /usr/bin/
 
 RUN microdnf install -y rsync tar
 
+ENV LOGS_DIR="/must-gather"
+RUN mkdir -p $LOGS_DIR && \
+    chown -R 65532:65532 $LOGS_DIR
+
+USER 65532
+
 LABEL \
       com.redhat.component="openshift-serverless-1-must-gather-rhel8-container" \
       name="openshift-serverless-1/svls-must-gather-rhel8" \

--- a/must-gather/bin/gather
+++ b/must-gather/bin/gather
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-export LOGS_DIR="/must-gather"
-
 /usr/bin/gather_knative
 
 exit 0


### PR DESCRIPTION
Updates the must-gather Dockerfile and gather script according to https://github.com/openshift-knative/hack/pull/420