### PR TITLE
[SRVKS-1288] Fix Kourier ns cleanup

### DIFF
--- a/hack/patches/022-serving-ingress-ns-filter.patch
+++ b/hack/patches/022-serving-ingress-ns-filter.patch
@@ -1,8 +1,61 @@
 diff --git a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
-index 4b8eca0b0..fb3c1a57c 100644
+index 4b8eca0b0..0398dfbf9 100644
 --- a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
 +++ b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
-@@ -117,6 +117,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServi
+@@ -19,14 +19,15 @@ package knativeserving
+ import (
+ 	"context"
+ 	"fmt"
++	"os"
+
+-	mf "github.com/manifestival/manifestival"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/client-go/kubernetes"
+
+ 	"knative.dev/pkg/logging"
+ 	pkgreconciler "knative.dev/pkg/reconciler"
+-
++	mf "github.com/manifestival/manifestival"
++	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+ 	"knative.dev/operator/pkg/apis/operator/base"
+ 	"knative.dev/operator/pkg/apis/operator/v1beta1"
+ 	clientset "knative.dev/operator/pkg/client/clientset/versioned"
+@@ -86,7 +87,12 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1beta1.Knative
+ 		logger.Error("Unable to fetch installed manifest; no cluster-scoped resources will be finalized", err)
+ 		return nil
+ 	}
+-
++	// we need this to apply the correct namespace to the resources otherwise it defaults to knative-serving
++	*manifest, err = manifest.Transform(overrideKourierNamespace(original))
++	if err != nil {
++		logger.Error("Unable to apply kourier namespace transform", err)
++		return nil
++	}
+ 	if manifest == nil {
+ 		return nil
+ 	}
+@@ -97,6 +103,20 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1beta1.Knative
+ 	return nil
+ }
+
++func overrideKourierNamespace(ks base.KComponent) mf.Transformer {
++	if ns, required := os.LookupEnv("REQUIRED_SERVING_INGRESS_NAMESPACE"); required {
++		nsInjector := mf.InjectNamespace(ns)
++		return func(u *unstructured.Unstructured) error {
++			provider := u.GetLabels()["networking.knative.dev/ingress-provider"]
++			if provider != "kourier" {
++				return nil
++			}
++			return nsInjector(u)
++		}
++	}
++	return nil
++}
++
+ // ReconcileKind compares the actual state with the desired, and attempts to
+ // converge the two.
+ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServing) pkgreconciler.Event {
+@@ -117,6 +137,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServi
  		security.AppendTargetSecurity,
  		common.AppendAdditionalManifests,
  		r.appendExtensionManifests,
@@ -13,3 +66,4 @@ index 4b8eca0b0..fb3c1a57c 100644
  		r.transform,
  		manifests.Install,
  		common.CheckDeployments,
+

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for must-gather.
-ARG CLI_ARTIFACTS=registry.ci.openshift.org/ocp/4.13:cli-artifacts
+ARG CLI_ARTIFACTS=registry.ci.openshift.org/ocp/4.14:cli-artifacts
 ARG RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 FROM $CLI_ARTIFACTS AS cli-artifacts
 

--- a/olm-catalog/serverless-operator-index/Dockerfile
+++ b/olm-catalog/serverless-operator-index/Dockerfile
@@ -15,7 +15,7 @@ registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
     /bin/opm render --skip-tls-verify -o yaml \
 registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
 registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
-      quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle@sha256:c1acc2634b31ed5daeeea716fb1095ef9bb2db2b8514da3397db4687871f24a9 >> /configs/index.yaml
+      quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle@sha256:7328625a0368cb770eb291e7b3f3f67a01ac463b6418058a43d49c719dd88bf4 >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe

--- a/olm-catalog/serverless-operator-index/v4.18/Dockerfile
+++ b/olm-catalog/serverless-operator-index/v4.18/Dockerfile
@@ -1,0 +1,12 @@
+ARG OPM_IMAGE=registry.ci.openshift.org/origin/4.18:operator-registry
+
+FROM $OPM_IMAGE
+
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+
+COPY catalog/ /configs
+
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -72,7 +72,7 @@ metadata:
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
     olm.skipRange: '>=1.34.0 <1.35.0'
-    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8@sha256:79dcd58e4aae42fa0f437fe43387d08c8be9f2e0a5460894a33b41e9151fb45e
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8@sha256:d2f1937b70c35d2f8f99afcf40432de31566f79ab8c573c3a39478c7d787ea3e
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
@@ -830,7 +830,7 @@ spec:
                 serviceAccountName: knative-operator
                 containers:
                   - name: knative-operator
-                    image: registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator@sha256:f77fb20bf90f0f1c3eb28934551f3a3ee5e4076ba9ef204afc3e20d951cb97e3
+                    image: registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator@sha256:d31bba5b4c61f65322f01f51a644c7e39f0ffc695dfdc17b522c864e8be692c4
                     readinessProbe:
                       periodSeconds: 1
                       httpGet:
@@ -899,11 +899,11 @@ spec:
                       - name: "IMAGE_kourier-gateway"
                         value: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:02b834fd74da71ec37f6a5c0d10aac9a679d1a0f4e510c4f77723ef2367e858a"
                       - name: "IMAGE_net-kourier-controller__controller"
-                        value: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:8e5a05f21f38f3a33ee96dd3ef6743e32ff16fc8fd6258f9d8aab7e9253ecb84"
+                        value: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:2e6c3736066757b04fafa2339faf109ea126d57d407f19998837ef10d8d4ff33"
                       - name: "IMAGE_net-istio-controller__controller"
-                        value: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:3a69adc9fddcd245b90c2e9ce4d17a385c8f5556e807b0e28e99b5cee28c8461"
+                        value: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:0dc5e69772a769725099ace39b9e53044dfdd183201dd56b16f3948078a4e3d5"
                       - name: "IMAGE_net-istio-webhook__webhook"
-                        value: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:aef829f6b62186f3bd7f8bf97d8ecba08207a4e9e279188d664c5a687500aa8e"
+                        value: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:26e57afe3ac2a9357b076122fbed60192a5107fd98f4d0a1f0d9967d39fcbc0b"
                       - name: "IMAGE_eventing-controller__eventing-controller"
                         value: "registry.redhat.io/openshift-serverless-1/kn-eventing-controller-rhel8@sha256:8f289d849927d90b429da58746273c7bfed65c14351e1797b9c9c148646a6aab"
                       - name: "IMAGE_eventing-istio-controller__eventing-istio-controller"
@@ -937,9 +937,9 @@ spec:
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
                         value: "registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@sha256:443162d16adcb0dbc5ddbff4de172b2e7e80cc17928e0d9bf0e723cb0e99ebaf"
                       - name: "IMAGE_KN_CLIENT"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:2e24f1085ed369597713dc6416e454d62add751c8c22a0531210e727f35b6502"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:d8877a35d4b9626155684e0146d64d6f9a0af3cbfd8a066bb27ea8a9973fb2c2"
                       - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:da3263b8d1961358ef384d35f152eb43260052bc0788f5f85cb101a492934117"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:49087b51e8b97d30ff7db67e1983d4ee63665092009af20a2598d7410eb781fb"
                       - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"
                         value: "registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4"
                       - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH"
@@ -981,7 +981,7 @@ spec:
                 serviceAccountName: knative-openshift
                 initContainers:
                   - name: cli-artifacts
-                    image: registry.redhat.io/openshift-serverless-1/kn-client-cli-artifacts-rhel8@sha256:82a41eaae2cd8b6004dcb663a2cd359c09fecf646bf5beaec330463abea0ea90
+                    image: registry.redhat.io/openshift-serverless-1/kn-client-cli-artifacts-rhel8@sha256:4396eed3408baea19fbe6617c637ec5542f515ee09f621a61fd1a4ae803fc98e
                     imagePullPolicy: Always
                     command: ["sh", "-c", "rm -rf /cli-artifacts/* && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*"]
                     volumeMounts:
@@ -995,7 +995,7 @@ spec:
                           - ALL
                 containers:
                   - name: knative-openshift
-                    image: registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8@sha256:9dadd3f0fe123d77cf4e759e445fe5bf67153de58bd322bfa9ad47cd5d476d7e
+                    image: registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8@sha256:e3f8b6a3b67ba8c05f28f387c4a1f3b38afad5d96622e74d728bf643725cd5c4
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -1073,11 +1073,11 @@ spec:
                       - name: "IMAGE_kourier-gateway"
                         value: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:02b834fd74da71ec37f6a5c0d10aac9a679d1a0f4e510c4f77723ef2367e858a"
                       - name: "IMAGE_net-kourier-controller__controller"
-                        value: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:8e5a05f21f38f3a33ee96dd3ef6743e32ff16fc8fd6258f9d8aab7e9253ecb84"
+                        value: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:2e6c3736066757b04fafa2339faf109ea126d57d407f19998837ef10d8d4ff33"
                       - name: "IMAGE_net-istio-controller__controller"
-                        value: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:3a69adc9fddcd245b90c2e9ce4d17a385c8f5556e807b0e28e99b5cee28c8461"
+                        value: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:0dc5e69772a769725099ace39b9e53044dfdd183201dd56b16f3948078a4e3d5"
                       - name: "IMAGE_net-istio-webhook__webhook"
-                        value: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:aef829f6b62186f3bd7f8bf97d8ecba08207a4e9e279188d664c5a687500aa8e"
+                        value: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:26e57afe3ac2a9357b076122fbed60192a5107fd98f4d0a1f0d9967d39fcbc0b"
                       - name: "IMAGE_eventing-controller__eventing-controller"
                         value: "registry.redhat.io/openshift-serverless-1/kn-eventing-controller-rhel8@sha256:8f289d849927d90b429da58746273c7bfed65c14351e1797b9c9c148646a6aab"
                       - name: "IMAGE_eventing-istio-controller__eventing-istio-controller"
@@ -1111,9 +1111,9 @@ spec:
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
                         value: "registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@sha256:443162d16adcb0dbc5ddbff4de172b2e7e80cc17928e0d9bf0e723cb0e99ebaf"
                       - name: "IMAGE_KN_CLIENT"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:2e24f1085ed369597713dc6416e454d62add751c8c22a0531210e727f35b6502"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:d8877a35d4b9626155684e0146d64d6f9a0af3cbfd8a066bb27ea8a9973fb2c2"
                       - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:da3263b8d1961358ef384d35f152eb43260052bc0788f5f85cb101a492934117"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:49087b51e8b97d30ff7db67e1983d4ee63665092009af20a2598d7410eb781fb"
                       - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"
                         value: "registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4"
                       - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH"
@@ -1177,7 +1177,7 @@ spec:
                 serviceAccountName: knative-openshift-ingress
                 containers:
                   - name: knative-openshift-ingress
-                    image: registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8@sha256:04f97b8594c2dfea4de468650c7771b1c7f42f27060ed34987502ee0ac87be33
+                    image: registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8@sha256:64e92116b0ff5c9b1776dfaf10d0710e3846192a741f55c37b6e5f476bde6d15
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -1328,11 +1328,11 @@ spec:
         - knativeeventings.operator.knative.dev
   relatedImages:
     - name: "knative-operator"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator@sha256:f77fb20bf90f0f1c3eb28934551f3a3ee5e4076ba9ef204afc3e20d951cb97e3"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator@sha256:d31bba5b4c61f65322f01f51a644c7e39f0ffc695dfdc17b522c864e8be692c4"
     - name: "knative-openshift"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8@sha256:9dadd3f0fe123d77cf4e759e445fe5bf67153de58bd322bfa9ad47cd5d476d7e"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8@sha256:e3f8b6a3b67ba8c05f28f387c4a1f3b38afad5d96622e74d728bf643725cd5c4"
     - name: "knative-openshift-ingress"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8@sha256:04f97b8594c2dfea4de468650c7771b1c7f42f27060ed34987502ee0ac87be33"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8@sha256:64e92116b0ff5c9b1776dfaf10d0710e3846192a741f55c37b6e5f476bde6d15"
     - name: "IMAGE_queue-proxy"
       image: "registry.redhat.io/openshift-serverless-1/kn-serving-queue-rhel8@sha256:f6f9208f8da20ea331d1d0062814d332931d059a8e7e811b6bc3b82d96ebb498"
     - name: "IMAGE_activator"
@@ -1350,11 +1350,11 @@ spec:
     - name: "IMAGE_kourier-gateway"
       image: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:02b834fd74da71ec37f6a5c0d10aac9a679d1a0f4e510c4f77723ef2367e858a"
     - name: "IMAGE_net-kourier-controller__controller"
-      image: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:8e5a05f21f38f3a33ee96dd3ef6743e32ff16fc8fd6258f9d8aab7e9253ecb84"
+      image: "registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:2e6c3736066757b04fafa2339faf109ea126d57d407f19998837ef10d8d4ff33"
     - name: "IMAGE_net-istio-controller__controller"
-      image: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:3a69adc9fddcd245b90c2e9ce4d17a385c8f5556e807b0e28e99b5cee28c8461"
+      image: "registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:0dc5e69772a769725099ace39b9e53044dfdd183201dd56b16f3948078a4e3d5"
     - name: "IMAGE_net-istio-webhook__webhook"
-      image: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:aef829f6b62186f3bd7f8bf97d8ecba08207a4e9e279188d664c5a687500aa8e"
+      image: "registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:26e57afe3ac2a9357b076122fbed60192a5107fd98f4d0a1f0d9967d39fcbc0b"
     - name: "IMAGE_eventing-controller__eventing-controller"
       image: "registry.redhat.io/openshift-serverless-1/kn-eventing-controller-rhel8@sha256:8f289d849927d90b429da58746273c7bfed65c14351e1797b9c9c148646a6aab"
     - name: "IMAGE_eventing-istio-controller__eventing-istio-controller"
@@ -1388,9 +1388,9 @@ spec:
     - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
       image: "registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@sha256:443162d16adcb0dbc5ddbff4de172b2e7e80cc17928e0d9bf0e723cb0e99ebaf"
     - name: "IMAGE_KN_CLIENT"
-      image: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:2e24f1085ed369597713dc6416e454d62add751c8c22a0531210e727f35b6502"
+      image: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:d8877a35d4b9626155684e0146d64d6f9a0af3cbfd8a066bb27ea8a9973fb2c2"
     - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
-      image: "registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:da3263b8d1961358ef384d35f152eb43260052bc0788f5f85cb101a492934117"
+      image: "registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:49087b51e8b97d30ff7db67e1983d4ee63665092009af20a2598d7410eb781fb"
     - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"
       image: "registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4"
     - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH"
@@ -1422,8 +1422,8 @@ spec:
     - name: "KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate"
       image: "registry.redhat.io/openshift-serverless-1/kn-eventing-migrate-rhel8@sha256:16628700b0b4ac8a079cc46750aefd829dc278e538a9f0d41473392f3896eaf2"
     - name: "IMAGE_MUST_GATHER"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8@sha256:79dcd58e4aae42fa0f437fe43387d08c8be9f2e0a5460894a33b41e9151fb45e"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8@sha256:d2f1937b70c35d2f8f99afcf40432de31566f79ab8c573c3a39478c7d787ea3e"
     - name: "IMAGE_KN_CLIENT_CLI_ARTIFACTS"
-      image: "registry.redhat.io/openshift-serverless-1/kn-client-cli-artifacts-rhel8@sha256:82a41eaae2cd8b6004dcb663a2cd359c09fecf646bf5beaec330463abea0ea90"
+      image: "registry.redhat.io/openshift-serverless-1/kn-client-cli-artifacts-rhel8@sha256:4396eed3408baea19fbe6617c637ec5542f515ee09f621a61fd1a4ae803fc98e"
   replaces: serverless-operator.v1.34.0
   version: 1.35.0

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -185,12 +185,10 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 	return monitoring.ReconcileMonitoringForServing(ctx, e.kubeclient, ks)
 }
 
-func (e *extension) Finalize(ctx context.Context, comp base.KComponent) error {
+func (e *extension) Finalize(_ context.Context, comp base.KComponent) error {
 	ks := comp.(*operatorv1beta1.KnativeServing)
-
 	// Also default to Kourier here to pick the right manifest to uninstall.
 	defaultToKourier(ks)
-
 	return nil
 }
 

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -188,13 +188,6 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 func (e *extension) Finalize(ctx context.Context, comp base.KComponent) error {
 	ks := comp.(*operatorv1beta1.KnativeServing)
 
-	// Delete the ingress namespaces manually. Manifestival won't do it for us in upgrade cases.
-	// See: https://github.com/manifestival/manifestival/issues/85
-	err := e.kubeclient.CoreV1().Namespaces().Delete(ctx, kourierNamespace(ks.GetNamespace()), metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to remove ingress namespace: %w", err)
-	}
-
 	// Also default to Kourier here to pick the right manifest to uninstall.
 	defaultToKourier(ks)
 

--- a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
@@ -19,14 +19,15 @@ package knativeserving
 import (
 	"context"
 	"fmt"
+	"os"
 
-	mf "github.com/manifestival/manifestival"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
-
+	mf "github.com/manifestival/manifestival"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"knative.dev/operator/pkg/apis/operator/base"
 	"knative.dev/operator/pkg/apis/operator/v1beta1"
 	clientset "knative.dev/operator/pkg/client/clientset/versioned"
@@ -86,13 +87,32 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1beta1.Knative
 		logger.Error("Unable to fetch installed manifest; no cluster-scoped resources will be finalized", err)
 		return nil
 	}
-
+	// we need this to apply the correct namespace to the resources otherwise it defaults to knative-serving
+	*manifest, err = manifest.Transform(overrideKourierNamespace(original))
+	if err != nil {
+		logger.Error("Unable to apply kourier namespace transform", err)
+		return nil
+	}
 	if manifest == nil {
 		return nil
 	}
 
 	if err := common.Uninstall(manifest); err != nil {
 		logger.Error("Failed to finalize platform resources", err)
+	}
+	return nil
+}
+
+func overrideKourierNamespace(ks base.KComponent) mf.Transformer {
+	if ns, required := os.LookupEnv("REQUIRED_SERVING_INGRESS_NAMESPACE"); required {
+		nsInjector := mf.InjectNamespace(ns)
+		return func(u *unstructured.Unstructured) error {
+			provider := u.GetLabels()["networking.knative.dev/ingress-provider"]
+			if provider != "kourier" {
+				return nil
+			}
+			return nsInjector(u)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes JIRA # SRVKS-1288

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Removed the manual delete of the knative-serving-ingress ns
- Makes sure that the manifest used during deletion points to the right ns for the kourier resources.
So far we used a hack where we just deleted the ns.
- With this PR the behavior is made similar to Eventing, Serving namespaces. For the latter we keep the ns but delete the resources under it. The goal here is the same. This should fit better with gitops where the namespace is managed by the external tool, thus we should not delete it.
