### PR TITLE
Explicitly specify OCP stream for kube-rbac-proxy

### DIFF
--- a/hack/generate/catalog.sh
+++ b/hack/generate/catalog.sh
@@ -160,7 +160,7 @@ function upgrade_service_mesh_proxy_image() {
 function upgrade_kube_rbac_proxy_image() {
   local image image_stream
   image=$(metadata.get 'dependencies.kube_rbac_proxy')
-  image_stream=$(metadata.get 'requirements.ocpVersion.list[-1]')
+  image_stream=$(metadata.get 'requirements.ocpVersion.kube-rbac-proxy')
   image=$(latest_konflux_image_sha "${image}" "v${image_stream}")
   yq w --inplace olm-catalog/serverless-operator/project.yaml 'dependencies.kube_rbac_proxy' "${image}"
 }

--- a/hack/lib/images.bash
+++ b/hack/lib/images.bash
@@ -40,7 +40,7 @@ function default_serverless_operator_images() {
     ocp_version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}')
     ocp_version=$(versions.major_minor "$ocp_version")
   else
-    ocp_version=$(metadata.get 'requirements.ocpVersion.list[-1]')
+    ocp_version=$(metadata.get 'requirements.ocpVersion.min')
   fi
   ocp_version=${ocp_version/./} # 4.17 -> 417
 

--- a/olm-catalog/serverless-operator-index/v4.18/Dockerfile
+++ b/olm-catalog/serverless-operator-index/v4.18/Dockerfile
@@ -1,0 +1,12 @@
+ARG OPM_IMAGE=registry.ci.openshift.org/origin/4.18:operator-registry
+
+FROM $OPM_IMAGE
+
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+
+COPY catalog/ /configs
+
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/olm-catalog/serverless-operator-index/v4.18/catalog-template.yaml
+++ b/olm-catalog/serverless-operator-index/v4.18/catalog-template.yaml
@@ -1,0 +1,444 @@
+entries:
+  - defaultChannel: stable
+    icon:
+      base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij48ZGVmcz48c3R5bGU+LmF7ZmlsbDojZmZmO30uYntmaWxsOiNlMDA7fTwvc3R5bGU+PC9kZWZzPjxwYXRoIGNsYXNzPSJhIiBkPSJNMjgsMUgxMGE5LDksMCwwLDAtOSw5VjI4YTksOSwwLDAsMCw5LDlIMjhhOSw5LDAsMCwwLDktOVYxMGE5LDksMCwwLDAtOS05WiIvPjxwYXRoIGQ9Ik0yOCwyLjI1QTcuNzU4Nyw3Ljc1ODcsMCwwLDEsMzUuNzUsMTBWMjhBNy43NTg3LDcuNzU4NywwLDAsMSwyOCwzNS43NUgxMEE3Ljc1ODcsNy43NTg3LDAsMCwxLDIuMjUsMjhWMTBBNy43NTg3LDcuNzU4NywwLDAsMSwxMCwyLjI1SDI4TTI4LDFIMTBhOSw5LDAsMCwwLTksOVYyOGE5LDksMCwwLDAsOSw5SDI4YTksOSwwLDAsMCw5LTlWMTBhOSw5LDAsMCwwLTktOVoiLz48cGF0aCBjbGFzcz0iYiIgZD0iTTE0LDIzLjQ3NjZIMTBhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwxNCwyMy40NzY2Wm0tMy4zNzUtMS4yNWgyLjc1di0yLjc1aC0yLjc1WiIvPjxwYXRoIGNsYXNzPSJiIiBkPSJNMjEsMjMuNDc2NkgxN2EuNjI1My42MjUzLDAsMCwxLS42MjUtLjYyNXYtNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUtLjYyNWg0YS42MjUyLjYyNTIsMCwwLDEsLjYyNS42MjV2NEEuNjI1My42MjUzLDAsMCwxLDIxLDIzLjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0xNy41LDE2LjQ3NjZoLTRhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwxNy41LDE2LjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0yNC41LDE2LjQ3NjZoLTRhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwyNC41LDE2LjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0yOCwyMy40NzY2SDI0YS42MjUzLjYyNTMsMCwwLDEtLjYyNS0uNjI1di00YS42MjUyLjYyNTIsMCwwLDEsLjYyNS0uNjI1aDRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LjYyNXY0QS42MjUzLjYyNTMsMCwwLDEsMjgsMjMuNDc2NlptLTMuMzc1LTEuMjVoMi43NXYtMi43NWgtMi43NVoiLz48cGF0aCBkPSJNMjksMjYuNDc2Nkg5YS42MjUuNjI1LDAsMCwxLDAtMS4yNUgyOWEuNjI1LjYyNSwwLDAsMSwwLDEuMjVaIi8+PC9zdmc+
+      mediatype: image/svg+xml
+    name: serverless-operator
+    schema: olm.package
+  - entries:
+      - name: serverless-operator.v1.20.0
+        replaces: serverless-operator.v1.19.0
+        skipRange: '>=1.19.0 <1.20.0'
+      - name: serverless-operator.v1.21.0
+        replaces: serverless-operator.v1.20.0
+        skipRange: '>=1.20.0 <1.21.0'
+      - name: serverless-operator.v1.22.0
+        replaces: serverless-operator.v1.21.0
+        skipRange: '>=1.21.0 <1.22.0'
+      - name: serverless-operator.v1.23.0
+        replaces: serverless-operator.v1.22.0
+        skipRange: '>=1.22.0 <1.23.0'
+      - name: serverless-operator.v1.24.0
+        replaces: serverless-operator.v1.23.0
+        skipRange: '>=1.23.0 <1.24.0'
+      - name: serverless-operator.v1.25.0
+        replaces: serverless-operator.v1.24.0
+        skipRange: '>=1.24.0 <1.25.0'
+      - name: serverless-operator.v1.26.0
+        replaces: serverless-operator.v1.25.0
+        skipRange: '>=1.25.0 <1.26.0'
+      - name: serverless-operator.v1.27.0
+        replaces: serverless-operator.v1.26.0
+        skipRange: '>=1.26.0 <1.27.0'
+      - name: serverless-operator.v1.27.1
+        replaces: serverless-operator.v1.27.0
+        skipRange: '>=1.26.0 <1.27.1'
+      - name: serverless-operator.v1.28.0
+        replaces: serverless-operator.v1.27.1
+        skipRange: '>=1.27.0 <1.28.0'
+      - name: serverless-operator.v1.29.0
+        replaces: serverless-operator.v1.28.0
+        skipRange: '>=1.28.0 <1.29.0'
+      - name: serverless-operator.v1.30.0
+        replaces: serverless-operator.v1.29.0
+        skipRange: '>=1.29.0 <1.30.0'
+      - name: serverless-operator.v1.31.0
+        replaces: serverless-operator.v1.30.0
+        skipRange: '>=1.30.0 <1.31.0'
+      - name: serverless-operator.v1.32.0
+        replaces: serverless-operator.v1.31.0
+        skipRange: '>=1.31.0 <1.32.0'
+      - name: serverless-operator.v1.33.0
+        replaces: serverless-operator.v1.32.0
+        skipRange: '>=1.32.0 <1.33.0'
+      - name: serverless-operator.v1.34.0
+        replaces: serverless-operator.v1.33.0
+        skipRange: '>=1.33.0 <1.34.0'
+      - name: serverless-operator.v1.35.0
+        replaces: serverless-operator.v1.34.0
+        skipRange: '>=1.34.0 <1.35.0'
+    name: stable
+    package: serverless-operator
+    schema: olm.channel
+  - entries:
+      - name: serverless-operator.v1.20.0
+        replaces: serverless-operator.v1.19.0
+        skipRange: '>=1.19.0 <1.20.0'
+      - name: serverless-operator.v1.21.0
+        replaces: serverless-operator.v1.20.0
+        skipRange: '>=1.20.0 <1.21.0'
+      - name: serverless-operator.v1.22.0
+        replaces: serverless-operator.v1.21.0
+        skipRange: '>=1.21.0 <1.22.0'
+      - name: serverless-operator.v1.23.0
+        replaces: serverless-operator.v1.22.0
+        skipRange: '>=1.22.0 <1.23.0'
+      - name: serverless-operator.v1.24.0
+        replaces: serverless-operator.v1.23.0
+        skipRange: '>=1.23.0 <1.24.0'
+      - name: serverless-operator.v1.25.0
+        replaces: serverless-operator.v1.24.0
+        skipRange: '>=1.24.0 <1.25.0'
+      - name: serverless-operator.v1.26.0
+        replaces: serverless-operator.v1.25.0
+        skipRange: '>=1.25.0 <1.26.0'
+      - name: serverless-operator.v1.27.0
+        replaces: serverless-operator.v1.26.0
+        skipRange: '>=1.26.0 <1.27.0'
+      - name: serverless-operator.v1.27.1
+        replaces: serverless-operator.v1.27.0
+        skipRange: '>=1.26.0 <1.27.1'
+      - name: serverless-operator.v1.28.0
+        replaces: serverless-operator.v1.27.1
+        skipRange: '>=1.27.0 <1.28.0'
+      - name: serverless-operator.v1.29.0
+        replaces: serverless-operator.v1.28.0
+        skipRange: '>=1.28.0 <1.29.0'
+      - name: serverless-operator.v1.29.1
+        replaces: serverless-operator.v1.29.0
+        skipRange: '>=1.29.0 <1.29.1'
+    name: stable-1.29
+    package: serverless-operator
+    schema: olm.channel
+  - entries:
+      - name: serverless-operator.v1.20.0
+        replaces: serverless-operator.v1.19.0
+        skipRange: '>=1.19.0 <1.20.0'
+      - name: serverless-operator.v1.21.0
+        replaces: serverless-operator.v1.20.0
+        skipRange: '>=1.20.0 <1.21.0'
+      - name: serverless-operator.v1.22.0
+        replaces: serverless-operator.v1.21.0
+        skipRange: '>=1.21.0 <1.22.0'
+      - name: serverless-operator.v1.23.0
+        replaces: serverless-operator.v1.22.0
+        skipRange: '>=1.22.0 <1.23.0'
+      - name: serverless-operator.v1.24.0
+        replaces: serverless-operator.v1.23.0
+        skipRange: '>=1.23.0 <1.24.0'
+      - name: serverless-operator.v1.25.0
+        replaces: serverless-operator.v1.24.0
+        skipRange: '>=1.24.0 <1.25.0'
+      - name: serverless-operator.v1.26.0
+        replaces: serverless-operator.v1.25.0
+        skipRange: '>=1.25.0 <1.26.0'
+      - name: serverless-operator.v1.27.0
+        replaces: serverless-operator.v1.26.0
+        skipRange: '>=1.26.0 <1.27.0'
+      - name: serverless-operator.v1.27.1
+        replaces: serverless-operator.v1.27.0
+        skipRange: '>=1.26.0 <1.27.1'
+      - name: serverless-operator.v1.28.0
+        replaces: serverless-operator.v1.27.1
+        skipRange: '>=1.27.0 <1.28.0'
+      - name: serverless-operator.v1.29.0
+        replaces: serverless-operator.v1.28.0
+        skipRange: '>=1.28.0 <1.29.0'
+      - name: serverless-operator.v1.30.0
+        replaces: serverless-operator.v1.29.0
+        skipRange: '>=1.29.0 <1.30.0'
+      - name: serverless-operator.v1.30.2
+        replaces: serverless-operator.v1.30.0
+        skipRange: '>=1.30.0 <1.30.2'
+    name: stable-1.30
+    package: serverless-operator
+    schema: olm.channel
+  - entries:
+      - name: serverless-operator.v1.20.0
+        replaces: serverless-operator.v1.19.0
+        skipRange: '>=1.19.0 <1.20.0'
+      - name: serverless-operator.v1.21.0
+        replaces: serverless-operator.v1.20.0
+        skipRange: '>=1.20.0 <1.21.0'
+      - name: serverless-operator.v1.22.0
+        replaces: serverless-operator.v1.21.0
+        skipRange: '>=1.21.0 <1.22.0'
+      - name: serverless-operator.v1.23.0
+        replaces: serverless-operator.v1.22.0
+        skipRange: '>=1.22.0 <1.23.0'
+      - name: serverless-operator.v1.24.0
+        replaces: serverless-operator.v1.23.0
+        skipRange: '>=1.23.0 <1.24.0'
+      - name: serverless-operator.v1.25.0
+        replaces: serverless-operator.v1.24.0
+        skipRange: '>=1.24.0 <1.25.0'
+      - name: serverless-operator.v1.26.0
+        replaces: serverless-operator.v1.25.0
+        skipRange: '>=1.25.0 <1.26.0'
+      - name: serverless-operator.v1.27.0
+        replaces: serverless-operator.v1.26.0
+        skipRange: '>=1.26.0 <1.27.0'
+      - name: serverless-operator.v1.27.1
+        replaces: serverless-operator.v1.27.0
+        skipRange: '>=1.26.0 <1.27.1'
+      - name: serverless-operator.v1.28.0
+        replaces: serverless-operator.v1.27.1
+        skipRange: '>=1.27.0 <1.28.0'
+      - name: serverless-operator.v1.29.0
+        replaces: serverless-operator.v1.28.0
+        skipRange: '>=1.28.0 <1.29.0'
+      - name: serverless-operator.v1.30.0
+        replaces: serverless-operator.v1.29.0
+        skipRange: '>=1.29.0 <1.30.0'
+      - name: serverless-operator.v1.31.0
+        replaces: serverless-operator.v1.30.0
+        skipRange: '>=1.30.0 <1.31.0'
+      - name: serverless-operator.v1.31.1
+        replaces: serverless-operator.v1.31.0
+        skipRange: '>=1.31.0 <1.31.1'
+    name: stable-1.31
+    package: serverless-operator
+    schema: olm.channel
+  - entries:
+      - name: serverless-operator.v1.20.0
+        replaces: serverless-operator.v1.19.0
+        skipRange: '>=1.19.0 <1.20.0'
+      - name: serverless-operator.v1.21.0
+        replaces: serverless-operator.v1.20.0
+        skipRange: '>=1.20.0 <1.21.0'
+      - name: serverless-operator.v1.22.0
+        replaces: serverless-operator.v1.21.0
+        skipRange: '>=1.21.0 <1.22.0'
+      - name: serverless-operator.v1.23.0
+        replaces: serverless-operator.v1.22.0
+        skipRange: '>=1.22.0 <1.23.0'
+      - name: serverless-operator.v1.24.0
+        replaces: serverless-operator.v1.23.0
+        skipRange: '>=1.23.0 <1.24.0'
+      - name: serverless-operator.v1.25.0
+        replaces: serverless-operator.v1.24.0
+        skipRange: '>=1.24.0 <1.25.0'
+      - name: serverless-operator.v1.26.0
+        replaces: serverless-operator.v1.25.0
+        skipRange: '>=1.25.0 <1.26.0'
+      - name: serverless-operator.v1.27.0
+        replaces: serverless-operator.v1.26.0
+        skipRange: '>=1.26.0 <1.27.0'
+      - name: serverless-operator.v1.27.1
+        replaces: serverless-operator.v1.27.0
+        skipRange: '>=1.26.0 <1.27.1'
+      - name: serverless-operator.v1.28.0
+        replaces: serverless-operator.v1.27.1
+        skipRange: '>=1.27.0 <1.28.0'
+      - name: serverless-operator.v1.29.0
+        replaces: serverless-operator.v1.28.0
+        skipRange: '>=1.28.0 <1.29.0'
+      - name: serverless-operator.v1.30.0
+        replaces: serverless-operator.v1.29.0
+        skipRange: '>=1.29.0 <1.30.0'
+      - name: serverless-operator.v1.31.0
+        replaces: serverless-operator.v1.30.0
+        skipRange: '>=1.30.0 <1.31.0'
+      - name: serverless-operator.v1.32.0
+        replaces: serverless-operator.v1.31.0
+        skipRange: '>=1.31.0 <1.32.0'
+      - name: serverless-operator.v1.32.2
+        replaces: serverless-operator.v1.32.0
+        skipRange: '>=1.32.0 <1.32.2'
+    name: stable-1.32
+    package: serverless-operator
+    schema: olm.channel
+  - entries:
+      - name: serverless-operator.v1.20.0
+        replaces: serverless-operator.v1.19.0
+        skipRange: '>=1.19.0 <1.20.0'
+      - name: serverless-operator.v1.21.0
+        replaces: serverless-operator.v1.20.0
+        skipRange: '>=1.20.0 <1.21.0'
+      - name: serverless-operator.v1.22.0
+        replaces: serverless-operator.v1.21.0
+        skipRange: '>=1.21.0 <1.22.0'
+      - name: serverless-operator.v1.23.0
+        replaces: serverless-operator.v1.22.0
+        skipRange: '>=1.22.0 <1.23.0'
+      - name: serverless-operator.v1.24.0
+        replaces: serverless-operator.v1.23.0
+        skipRange: '>=1.23.0 <1.24.0'
+      - name: serverless-operator.v1.25.0
+        replaces: serverless-operator.v1.24.0
+        skipRange: '>=1.24.0 <1.25.0'
+      - name: serverless-operator.v1.26.0
+        replaces: serverless-operator.v1.25.0
+        skipRange: '>=1.25.0 <1.26.0'
+      - name: serverless-operator.v1.27.0
+        replaces: serverless-operator.v1.26.0
+        skipRange: '>=1.26.0 <1.27.0'
+      - name: serverless-operator.v1.27.1
+        replaces: serverless-operator.v1.27.0
+        skipRange: '>=1.26.0 <1.27.1'
+      - name: serverless-operator.v1.28.0
+        replaces: serverless-operator.v1.27.1
+        skipRange: '>=1.27.0 <1.28.0'
+      - name: serverless-operator.v1.29.0
+        replaces: serverless-operator.v1.28.0
+        skipRange: '>=1.28.0 <1.29.0'
+      - name: serverless-operator.v1.30.0
+        replaces: serverless-operator.v1.29.0
+        skipRange: '>=1.29.0 <1.30.0'
+      - name: serverless-operator.v1.31.0
+        replaces: serverless-operator.v1.30.0
+        skipRange: '>=1.30.0 <1.31.0'
+      - name: serverless-operator.v1.32.0
+        replaces: serverless-operator.v1.31.0
+        skipRange: '>=1.31.0 <1.32.0'
+      - name: serverless-operator.v1.33.0
+        replaces: serverless-operator.v1.32.0
+        skipRange: '>=1.32.0 <1.33.0'
+      - name: serverless-operator.v1.33.2
+        replaces: serverless-operator.v1.33.0
+        skipRange: '>=1.33.0 <1.33.2'
+    name: stable-1.33
+    package: serverless-operator
+    schema: olm.channel
+  - entries:
+      - name: serverless-operator.v1.20.0
+        replaces: serverless-operator.v1.19.0
+        skipRange: '>=1.19.0 <1.20.0'
+      - name: serverless-operator.v1.21.0
+        replaces: serverless-operator.v1.20.0
+        skipRange: '>=1.20.0 <1.21.0'
+      - name: serverless-operator.v1.22.0
+        replaces: serverless-operator.v1.21.0
+        skipRange: '>=1.21.0 <1.22.0'
+      - name: serverless-operator.v1.23.0
+        replaces: serverless-operator.v1.22.0
+        skipRange: '>=1.22.0 <1.23.0'
+      - name: serverless-operator.v1.24.0
+        replaces: serverless-operator.v1.23.0
+        skipRange: '>=1.23.0 <1.24.0'
+      - name: serverless-operator.v1.25.0
+        replaces: serverless-operator.v1.24.0
+        skipRange: '>=1.24.0 <1.25.0'
+      - name: serverless-operator.v1.26.0
+        replaces: serverless-operator.v1.25.0
+        skipRange: '>=1.25.0 <1.26.0'
+      - name: serverless-operator.v1.27.0
+        replaces: serverless-operator.v1.26.0
+        skipRange: '>=1.26.0 <1.27.0'
+      - name: serverless-operator.v1.27.1
+        replaces: serverless-operator.v1.27.0
+        skipRange: '>=1.26.0 <1.27.1'
+      - name: serverless-operator.v1.28.0
+        replaces: serverless-operator.v1.27.1
+        skipRange: '>=1.27.0 <1.28.0'
+      - name: serverless-operator.v1.29.0
+        replaces: serverless-operator.v1.28.0
+        skipRange: '>=1.28.0 <1.29.0'
+      - name: serverless-operator.v1.30.0
+        replaces: serverless-operator.v1.29.0
+        skipRange: '>=1.29.0 <1.30.0'
+      - name: serverless-operator.v1.31.0
+        replaces: serverless-operator.v1.30.0
+        skipRange: '>=1.30.0 <1.31.0'
+      - name: serverless-operator.v1.32.0
+        replaces: serverless-operator.v1.31.0
+        skipRange: '>=1.31.0 <1.32.0'
+      - name: serverless-operator.v1.33.0
+        replaces: serverless-operator.v1.32.0
+        skipRange: '>=1.32.0 <1.33.0'
+      - name: serverless-operator.v1.34.0
+        replaces: serverless-operator.v1.33.0
+        skipRange: '>=1.33.0 <1.34.0'
+    name: stable-1.34
+    package: serverless-operator
+    schema: olm.channel
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:003a5c5c3682db69aa57da4c05ed3ccbaf94fb80a4972c8ddcf91eb3d5e299b9
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:1905984e13c9d165aad06f954904fc33d3f3a6e2f0041f98bc5840d05a87abaf
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:0d73e731e7defc5d1da1aa3a347b419ce5d6f2b6b880403cb2e0871a8b3bb240
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:8da1dda3de163dc82927ad732d560e9c5c7daca3a8d3b46110b561441c483af9
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:0422f8843fc62c2b72e01ffefd33db912a1ad3d70ac297882d3663c9b7299f10
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:edb6116289b3c722aca7614eb06b655e2081ebda74a9b7a82261ae1fa1e76408
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:0516545990ec466969730d43136016c10e7dc34f633bf2646463d12145d9f917
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:832677abddada05258b4610b6584d442dd20c5bdd55ae8fbddb83ac133b3f12e
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:2f82fcdc9a5424a2e195fda62ce0a018970e0211f253eb0d5ae47a72dd0bb6fc
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:91b90a9ba578595836772b4f7ecccebf77d1dcaf04c62e3f532d9beed90eb465
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:12373623440b5b1aaea228550674ee69fe926ac6f12e7adffb5592afe1b98fca
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:16b39335e97bcc7c970a8ba385c61d8333e9912faaee813ccf8520d434b7bb7a
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:ffcf75e33c5bf527488fc196bd94bf615ac06ba5735d87cf568777f27817d214
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:51ac9aced282f62c8fb2d3696da3696b8496d8f877e9846fe3a4a743ccd63bea
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:469ae5fc8a478d6d06b13e218a000f34dd988eb69a9488a6349d67c76bda5b49
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:a82288782b61ea46d068cc09ee10608d3201c136abfc767e4d37734775101390
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:b84351200cba437c323f7f21d0cb58e0a443d772376a9ea6de1278a68d1c2c7d
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:828d31bf8a441091b8aed03da213a6b4ffae260070eff58c3319156f9bf04f5a
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:9bee3204d9fafe46f9f188e7ea10ac4843eaaf72a5f9dda68f6d8d7a92310218
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:d96f2a6e9bdd2540c5c7b0ffe6a8e610b43ba227420892586a46fbdb9a3caef3
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:82b9bfb8b83701db1a9b891d1ffc1e782d4b0f971fc9a53525942845c2602934
+    schema: olm.bundle
+  - schema: olm.bundle
+    image: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle@sha256:7328625a0368cb770eb291e7b3f3f67a01ac463b6418058a43d49c719dd88bf4
+  - entries:
+      - name: serverless-operator.v1.20.0
+        replaces: serverless-operator.v1.19.0
+        skipRange: '>=1.19.0 <1.20.0'
+      - name: serverless-operator.v1.21.0
+        replaces: serverless-operator.v1.20.0
+        skipRange: '>=1.20.0 <1.21.0'
+      - name: serverless-operator.v1.22.0
+        replaces: serverless-operator.v1.21.0
+        skipRange: '>=1.21.0 <1.22.0'
+      - name: serverless-operator.v1.23.0
+        replaces: serverless-operator.v1.22.0
+        skipRange: '>=1.22.0 <1.23.0'
+      - name: serverless-operator.v1.24.0
+        replaces: serverless-operator.v1.23.0
+        skipRange: '>=1.23.0 <1.24.0'
+      - name: serverless-operator.v1.25.0
+        replaces: serverless-operator.v1.24.0
+        skipRange: '>=1.24.0 <1.25.0'
+      - name: serverless-operator.v1.26.0
+        replaces: serverless-operator.v1.25.0
+        skipRange: '>=1.25.0 <1.26.0'
+      - name: serverless-operator.v1.27.0
+        replaces: serverless-operator.v1.26.0
+        skipRange: '>=1.26.0 <1.27.0'
+      - name: serverless-operator.v1.27.1
+        replaces: serverless-operator.v1.27.0
+        skipRange: '>=1.26.0 <1.27.1'
+      - name: serverless-operator.v1.28.0
+        replaces: serverless-operator.v1.27.1
+        skipRange: '>=1.27.0 <1.28.0'
+      - name: serverless-operator.v1.29.0
+        replaces: serverless-operator.v1.28.0
+        skipRange: '>=1.28.0 <1.29.0'
+      - name: serverless-operator.v1.30.0
+        replaces: serverless-operator.v1.29.0
+        skipRange: '>=1.29.0 <1.30.0'
+      - name: serverless-operator.v1.31.0
+        replaces: serverless-operator.v1.30.0
+        skipRange: '>=1.30.0 <1.31.0'
+      - name: serverless-operator.v1.32.0
+        replaces: serverless-operator.v1.31.0
+        skipRange: '>=1.31.0 <1.32.0'
+      - name: serverless-operator.v1.33.0
+        replaces: serverless-operator.v1.32.0
+        skipRange: '>=1.32.0 <1.33.0'
+      - name: serverless-operator.v1.34.0
+        replaces: serverless-operator.v1.33.0
+        skipRange: '>=1.33.0 <1.34.0'
+      - name: serverless-operator.v1.35.0
+        replaces: serverless-operator.v1.34.0
+        skipRange: '>=1.34.0 <1.35.0'
+    name: stable-1.35
+    package: serverless-operator
+    schema: olm.channel
+schema: olm.template.basic

--- a/olm-catalog/serverless-operator-index/v4.18/catalog/serverless-operator/catalog.yaml
+++ b/olm-catalog/serverless-operator-index/v4.18/catalog/serverless-operator/catalog.yaml
@@ -1,0 +1,8068 @@
+---
+defaultChannel: stable
+icon:
+  base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij48ZGVmcz48c3R5bGU+LmF7ZmlsbDojZmZmO30uYntmaWxsOiNlMDA7fTwvc3R5bGU+PC9kZWZzPjxwYXRoIGNsYXNzPSJhIiBkPSJNMjgsMUgxMGE5LDksMCwwLDAtOSw5VjI4YTksOSwwLDAsMCw5LDlIMjhhOSw5LDAsMCwwLDktOVYxMGE5LDksMCwwLDAtOS05WiIvPjxwYXRoIGQ9Ik0yOCwyLjI1QTcuNzU4Nyw3Ljc1ODcsMCwwLDEsMzUuNzUsMTBWMjhBNy43NTg3LDcuNzU4NywwLDAsMSwyOCwzNS43NUgxMEE3Ljc1ODcsNy43NTg3LDAsMCwxLDIuMjUsMjhWMTBBNy43NTg3LDcuNzU4NywwLDAsMSwxMCwyLjI1SDI4TTI4LDFIMTBhOSw5LDAsMCwwLTksOVYyOGE5LDksMCwwLDAsOSw5SDI4YTksOSwwLDAsMCw5LTlWMTBhOSw5LDAsMCwwLTktOVoiLz48cGF0aCBjbGFzcz0iYiIgZD0iTTE0LDIzLjQ3NjZIMTBhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwxNCwyMy40NzY2Wm0tMy4zNzUtMS4yNWgyLjc1di0yLjc1aC0yLjc1WiIvPjxwYXRoIGNsYXNzPSJiIiBkPSJNMjEsMjMuNDc2NkgxN2EuNjI1My42MjUzLDAsMCwxLS42MjUtLjYyNXYtNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUtLjYyNWg0YS42MjUyLjYyNTIsMCwwLDEsLjYyNS42MjV2NEEuNjI1My42MjUzLDAsMCwxLDIxLDIzLjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0xNy41LDE2LjQ3NjZoLTRhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwxNy41LDE2LjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0yNC41LDE2LjQ3NjZoLTRhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwyNC41LDE2LjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0yOCwyMy40NzY2SDI0YS42MjUzLjYyNTMsMCwwLDEtLjYyNS0uNjI1di00YS42MjUyLjYyNTIsMCwwLDEsLjYyNS0uNjI1aDRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LjYyNXY0QS42MjUzLjYyNTMsMCwwLDEsMjgsMjMuNDc2NlptLTMuMzc1LTEuMjVoMi43NXYtMi43NWgtMi43NVoiLz48cGF0aCBkPSJNMjksMjYuNDc2Nkg5YS42MjUuNjI1LDAsMCwxLDAtMS4yNUgyOWEuNjI1LjYyNSwwLDAsMSwwLDEuMjVaIi8+PC9zdmc+
+  mediatype: image/svg+xml
+name: serverless-operator
+schema: olm.package
+---
+entries:
+- name: serverless-operator.v1.20.0
+  replaces: serverless-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
+- name: serverless-operator.v1.21.0
+  replaces: serverless-operator.v1.20.0
+  skipRange: '>=1.20.0 <1.21.0'
+- name: serverless-operator.v1.22.0
+  replaces: serverless-operator.v1.21.0
+  skipRange: '>=1.21.0 <1.22.0'
+- name: serverless-operator.v1.23.0
+  replaces: serverless-operator.v1.22.0
+  skipRange: '>=1.22.0 <1.23.0'
+- name: serverless-operator.v1.24.0
+  replaces: serverless-operator.v1.23.0
+  skipRange: '>=1.23.0 <1.24.0'
+- name: serverless-operator.v1.25.0
+  replaces: serverless-operator.v1.24.0
+  skipRange: '>=1.24.0 <1.25.0'
+- name: serverless-operator.v1.26.0
+  replaces: serverless-operator.v1.25.0
+  skipRange: '>=1.25.0 <1.26.0'
+- name: serverless-operator.v1.27.0
+  replaces: serverless-operator.v1.26.0
+  skipRange: '>=1.26.0 <1.27.0'
+- name: serverless-operator.v1.27.1
+  replaces: serverless-operator.v1.27.0
+  skipRange: '>=1.26.0 <1.27.1'
+- name: serverless-operator.v1.28.0
+  replaces: serverless-operator.v1.27.1
+  skipRange: '>=1.27.0 <1.28.0'
+- name: serverless-operator.v1.29.0
+  replaces: serverless-operator.v1.28.0
+  skipRange: '>=1.28.0 <1.29.0'
+- name: serverless-operator.v1.30.0
+  replaces: serverless-operator.v1.29.0
+  skipRange: '>=1.29.0 <1.30.0'
+- name: serverless-operator.v1.31.0
+  replaces: serverless-operator.v1.30.0
+  skipRange: '>=1.30.0 <1.31.0'
+- name: serverless-operator.v1.32.0
+  replaces: serverless-operator.v1.31.0
+  skipRange: '>=1.31.0 <1.32.0'
+- name: serverless-operator.v1.33.0
+  replaces: serverless-operator.v1.32.0
+  skipRange: '>=1.32.0 <1.33.0'
+- name: serverless-operator.v1.34.0
+  replaces: serverless-operator.v1.33.0
+  skipRange: '>=1.33.0 <1.34.0'
+- name: serverless-operator.v1.35.0
+  replaces: serverless-operator.v1.34.0
+  skipRange: '>=1.34.0 <1.35.0'
+name: stable
+package: serverless-operator
+schema: olm.channel
+---
+entries:
+- name: serverless-operator.v1.20.0
+  replaces: serverless-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
+- name: serverless-operator.v1.21.0
+  replaces: serverless-operator.v1.20.0
+  skipRange: '>=1.20.0 <1.21.0'
+- name: serverless-operator.v1.22.0
+  replaces: serverless-operator.v1.21.0
+  skipRange: '>=1.21.0 <1.22.0'
+- name: serverless-operator.v1.23.0
+  replaces: serverless-operator.v1.22.0
+  skipRange: '>=1.22.0 <1.23.0'
+- name: serverless-operator.v1.24.0
+  replaces: serverless-operator.v1.23.0
+  skipRange: '>=1.23.0 <1.24.0'
+- name: serverless-operator.v1.25.0
+  replaces: serverless-operator.v1.24.0
+  skipRange: '>=1.24.0 <1.25.0'
+- name: serverless-operator.v1.26.0
+  replaces: serverless-operator.v1.25.0
+  skipRange: '>=1.25.0 <1.26.0'
+- name: serverless-operator.v1.27.0
+  replaces: serverless-operator.v1.26.0
+  skipRange: '>=1.26.0 <1.27.0'
+- name: serverless-operator.v1.27.1
+  replaces: serverless-operator.v1.27.0
+  skipRange: '>=1.26.0 <1.27.1'
+- name: serverless-operator.v1.28.0
+  replaces: serverless-operator.v1.27.1
+  skipRange: '>=1.27.0 <1.28.0'
+- name: serverless-operator.v1.29.0
+  replaces: serverless-operator.v1.28.0
+  skipRange: '>=1.28.0 <1.29.0'
+- name: serverless-operator.v1.29.1
+  replaces: serverless-operator.v1.29.0
+  skipRange: '>=1.29.0 <1.29.1'
+name: stable-1.29
+package: serverless-operator
+schema: olm.channel
+---
+entries:
+- name: serverless-operator.v1.20.0
+  replaces: serverless-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
+- name: serverless-operator.v1.21.0
+  replaces: serverless-operator.v1.20.0
+  skipRange: '>=1.20.0 <1.21.0'
+- name: serverless-operator.v1.22.0
+  replaces: serverless-operator.v1.21.0
+  skipRange: '>=1.21.0 <1.22.0'
+- name: serverless-operator.v1.23.0
+  replaces: serverless-operator.v1.22.0
+  skipRange: '>=1.22.0 <1.23.0'
+- name: serverless-operator.v1.24.0
+  replaces: serverless-operator.v1.23.0
+  skipRange: '>=1.23.0 <1.24.0'
+- name: serverless-operator.v1.25.0
+  replaces: serverless-operator.v1.24.0
+  skipRange: '>=1.24.0 <1.25.0'
+- name: serverless-operator.v1.26.0
+  replaces: serverless-operator.v1.25.0
+  skipRange: '>=1.25.0 <1.26.0'
+- name: serverless-operator.v1.27.0
+  replaces: serverless-operator.v1.26.0
+  skipRange: '>=1.26.0 <1.27.0'
+- name: serverless-operator.v1.27.1
+  replaces: serverless-operator.v1.27.0
+  skipRange: '>=1.26.0 <1.27.1'
+- name: serverless-operator.v1.28.0
+  replaces: serverless-operator.v1.27.1
+  skipRange: '>=1.27.0 <1.28.0'
+- name: serverless-operator.v1.29.0
+  replaces: serverless-operator.v1.28.0
+  skipRange: '>=1.28.0 <1.29.0'
+- name: serverless-operator.v1.30.0
+  replaces: serverless-operator.v1.29.0
+  skipRange: '>=1.29.0 <1.30.0'
+- name: serverless-operator.v1.30.2
+  replaces: serverless-operator.v1.30.0
+  skipRange: '>=1.30.0 <1.30.2'
+name: stable-1.30
+package: serverless-operator
+schema: olm.channel
+---
+entries:
+- name: serverless-operator.v1.20.0
+  replaces: serverless-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
+- name: serverless-operator.v1.21.0
+  replaces: serverless-operator.v1.20.0
+  skipRange: '>=1.20.0 <1.21.0'
+- name: serverless-operator.v1.22.0
+  replaces: serverless-operator.v1.21.0
+  skipRange: '>=1.21.0 <1.22.0'
+- name: serverless-operator.v1.23.0
+  replaces: serverless-operator.v1.22.0
+  skipRange: '>=1.22.0 <1.23.0'
+- name: serverless-operator.v1.24.0
+  replaces: serverless-operator.v1.23.0
+  skipRange: '>=1.23.0 <1.24.0'
+- name: serverless-operator.v1.25.0
+  replaces: serverless-operator.v1.24.0
+  skipRange: '>=1.24.0 <1.25.0'
+- name: serverless-operator.v1.26.0
+  replaces: serverless-operator.v1.25.0
+  skipRange: '>=1.25.0 <1.26.0'
+- name: serverless-operator.v1.27.0
+  replaces: serverless-operator.v1.26.0
+  skipRange: '>=1.26.0 <1.27.0'
+- name: serverless-operator.v1.27.1
+  replaces: serverless-operator.v1.27.0
+  skipRange: '>=1.26.0 <1.27.1'
+- name: serverless-operator.v1.28.0
+  replaces: serverless-operator.v1.27.1
+  skipRange: '>=1.27.0 <1.28.0'
+- name: serverless-operator.v1.29.0
+  replaces: serverless-operator.v1.28.0
+  skipRange: '>=1.28.0 <1.29.0'
+- name: serverless-operator.v1.30.0
+  replaces: serverless-operator.v1.29.0
+  skipRange: '>=1.29.0 <1.30.0'
+- name: serverless-operator.v1.31.0
+  replaces: serverless-operator.v1.30.0
+  skipRange: '>=1.30.0 <1.31.0'
+- name: serverless-operator.v1.31.1
+  replaces: serverless-operator.v1.31.0
+  skipRange: '>=1.31.0 <1.31.1'
+name: stable-1.31
+package: serverless-operator
+schema: olm.channel
+---
+entries:
+- name: serverless-operator.v1.20.0
+  replaces: serverless-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
+- name: serverless-operator.v1.21.0
+  replaces: serverless-operator.v1.20.0
+  skipRange: '>=1.20.0 <1.21.0'
+- name: serverless-operator.v1.22.0
+  replaces: serverless-operator.v1.21.0
+  skipRange: '>=1.21.0 <1.22.0'
+- name: serverless-operator.v1.23.0
+  replaces: serverless-operator.v1.22.0
+  skipRange: '>=1.22.0 <1.23.0'
+- name: serverless-operator.v1.24.0
+  replaces: serverless-operator.v1.23.0
+  skipRange: '>=1.23.0 <1.24.0'
+- name: serverless-operator.v1.25.0
+  replaces: serverless-operator.v1.24.0
+  skipRange: '>=1.24.0 <1.25.0'
+- name: serverless-operator.v1.26.0
+  replaces: serverless-operator.v1.25.0
+  skipRange: '>=1.25.0 <1.26.0'
+- name: serverless-operator.v1.27.0
+  replaces: serverless-operator.v1.26.0
+  skipRange: '>=1.26.0 <1.27.0'
+- name: serverless-operator.v1.27.1
+  replaces: serverless-operator.v1.27.0
+  skipRange: '>=1.26.0 <1.27.1'
+- name: serverless-operator.v1.28.0
+  replaces: serverless-operator.v1.27.1
+  skipRange: '>=1.27.0 <1.28.0'
+- name: serverless-operator.v1.29.0
+  replaces: serverless-operator.v1.28.0
+  skipRange: '>=1.28.0 <1.29.0'
+- name: serverless-operator.v1.30.0
+  replaces: serverless-operator.v1.29.0
+  skipRange: '>=1.29.0 <1.30.0'
+- name: serverless-operator.v1.31.0
+  replaces: serverless-operator.v1.30.0
+  skipRange: '>=1.30.0 <1.31.0'
+- name: serverless-operator.v1.32.0
+  replaces: serverless-operator.v1.31.0
+  skipRange: '>=1.31.0 <1.32.0'
+- name: serverless-operator.v1.32.2
+  replaces: serverless-operator.v1.32.0
+  skipRange: '>=1.32.0 <1.32.2'
+name: stable-1.32
+package: serverless-operator
+schema: olm.channel
+---
+entries:
+- name: serverless-operator.v1.20.0
+  replaces: serverless-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
+- name: serverless-operator.v1.21.0
+  replaces: serverless-operator.v1.20.0
+  skipRange: '>=1.20.0 <1.21.0'
+- name: serverless-operator.v1.22.0
+  replaces: serverless-operator.v1.21.0
+  skipRange: '>=1.21.0 <1.22.0'
+- name: serverless-operator.v1.23.0
+  replaces: serverless-operator.v1.22.0
+  skipRange: '>=1.22.0 <1.23.0'
+- name: serverless-operator.v1.24.0
+  replaces: serverless-operator.v1.23.0
+  skipRange: '>=1.23.0 <1.24.0'
+- name: serverless-operator.v1.25.0
+  replaces: serverless-operator.v1.24.0
+  skipRange: '>=1.24.0 <1.25.0'
+- name: serverless-operator.v1.26.0
+  replaces: serverless-operator.v1.25.0
+  skipRange: '>=1.25.0 <1.26.0'
+- name: serverless-operator.v1.27.0
+  replaces: serverless-operator.v1.26.0
+  skipRange: '>=1.26.0 <1.27.0'
+- name: serverless-operator.v1.27.1
+  replaces: serverless-operator.v1.27.0
+  skipRange: '>=1.26.0 <1.27.1'
+- name: serverless-operator.v1.28.0
+  replaces: serverless-operator.v1.27.1
+  skipRange: '>=1.27.0 <1.28.0'
+- name: serverless-operator.v1.29.0
+  replaces: serverless-operator.v1.28.0
+  skipRange: '>=1.28.0 <1.29.0'
+- name: serverless-operator.v1.30.0
+  replaces: serverless-operator.v1.29.0
+  skipRange: '>=1.29.0 <1.30.0'
+- name: serverless-operator.v1.31.0
+  replaces: serverless-operator.v1.30.0
+  skipRange: '>=1.30.0 <1.31.0'
+- name: serverless-operator.v1.32.0
+  replaces: serverless-operator.v1.31.0
+  skipRange: '>=1.31.0 <1.32.0'
+- name: serverless-operator.v1.33.0
+  replaces: serverless-operator.v1.32.0
+  skipRange: '>=1.32.0 <1.33.0'
+- name: serverless-operator.v1.33.2
+  replaces: serverless-operator.v1.33.0
+  skipRange: '>=1.33.0 <1.33.2'
+name: stable-1.33
+package: serverless-operator
+schema: olm.channel
+---
+entries:
+- name: serverless-operator.v1.20.0
+  replaces: serverless-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
+- name: serverless-operator.v1.21.0
+  replaces: serverless-operator.v1.20.0
+  skipRange: '>=1.20.0 <1.21.0'
+- name: serverless-operator.v1.22.0
+  replaces: serverless-operator.v1.21.0
+  skipRange: '>=1.21.0 <1.22.0'
+- name: serverless-operator.v1.23.0
+  replaces: serverless-operator.v1.22.0
+  skipRange: '>=1.22.0 <1.23.0'
+- name: serverless-operator.v1.24.0
+  replaces: serverless-operator.v1.23.0
+  skipRange: '>=1.23.0 <1.24.0'
+- name: serverless-operator.v1.25.0
+  replaces: serverless-operator.v1.24.0
+  skipRange: '>=1.24.0 <1.25.0'
+- name: serverless-operator.v1.26.0
+  replaces: serverless-operator.v1.25.0
+  skipRange: '>=1.25.0 <1.26.0'
+- name: serverless-operator.v1.27.0
+  replaces: serverless-operator.v1.26.0
+  skipRange: '>=1.26.0 <1.27.0'
+- name: serverless-operator.v1.27.1
+  replaces: serverless-operator.v1.27.0
+  skipRange: '>=1.26.0 <1.27.1'
+- name: serverless-operator.v1.28.0
+  replaces: serverless-operator.v1.27.1
+  skipRange: '>=1.27.0 <1.28.0'
+- name: serverless-operator.v1.29.0
+  replaces: serverless-operator.v1.28.0
+  skipRange: '>=1.28.0 <1.29.0'
+- name: serverless-operator.v1.30.0
+  replaces: serverless-operator.v1.29.0
+  skipRange: '>=1.29.0 <1.30.0'
+- name: serverless-operator.v1.31.0
+  replaces: serverless-operator.v1.30.0
+  skipRange: '>=1.30.0 <1.31.0'
+- name: serverless-operator.v1.32.0
+  replaces: serverless-operator.v1.31.0
+  skipRange: '>=1.31.0 <1.32.0'
+- name: serverless-operator.v1.33.0
+  replaces: serverless-operator.v1.32.0
+  skipRange: '>=1.32.0 <1.33.0'
+- name: serverless-operator.v1.34.0
+  replaces: serverless-operator.v1.33.0
+  skipRange: '>=1.33.0 <1.34.0'
+name: stable-1.34
+package: serverless-operator
+schema: olm.channel
+---
+entries:
+- name: serverless-operator.v1.20.0
+  replaces: serverless-operator.v1.19.0
+  skipRange: '>=1.19.0 <1.20.0'
+- name: serverless-operator.v1.21.0
+  replaces: serverless-operator.v1.20.0
+  skipRange: '>=1.20.0 <1.21.0'
+- name: serverless-operator.v1.22.0
+  replaces: serverless-operator.v1.21.0
+  skipRange: '>=1.21.0 <1.22.0'
+- name: serverless-operator.v1.23.0
+  replaces: serverless-operator.v1.22.0
+  skipRange: '>=1.22.0 <1.23.0'
+- name: serverless-operator.v1.24.0
+  replaces: serverless-operator.v1.23.0
+  skipRange: '>=1.23.0 <1.24.0'
+- name: serverless-operator.v1.25.0
+  replaces: serverless-operator.v1.24.0
+  skipRange: '>=1.24.0 <1.25.0'
+- name: serverless-operator.v1.26.0
+  replaces: serverless-operator.v1.25.0
+  skipRange: '>=1.25.0 <1.26.0'
+- name: serverless-operator.v1.27.0
+  replaces: serverless-operator.v1.26.0
+  skipRange: '>=1.26.0 <1.27.0'
+- name: serverless-operator.v1.27.1
+  replaces: serverless-operator.v1.27.0
+  skipRange: '>=1.26.0 <1.27.1'
+- name: serverless-operator.v1.28.0
+  replaces: serverless-operator.v1.27.1
+  skipRange: '>=1.27.0 <1.28.0'
+- name: serverless-operator.v1.29.0
+  replaces: serverless-operator.v1.28.0
+  skipRange: '>=1.28.0 <1.29.0'
+- name: serverless-operator.v1.30.0
+  replaces: serverless-operator.v1.29.0
+  skipRange: '>=1.29.0 <1.30.0'
+- name: serverless-operator.v1.31.0
+  replaces: serverless-operator.v1.30.0
+  skipRange: '>=1.30.0 <1.31.0'
+- name: serverless-operator.v1.32.0
+  replaces: serverless-operator.v1.31.0
+  skipRange: '>=1.31.0 <1.32.0'
+- name: serverless-operator.v1.33.0
+  replaces: serverless-operator.v1.32.0
+  skipRange: '>=1.32.0 <1.33.0'
+- name: serverless-operator.v1.34.0
+  replaces: serverless-operator.v1.33.0
+  skipRange: '>=1.33.0 <1.34.0'
+- name: serverless-operator.v1.35.0
+  replaces: serverless-operator.v1.34.0
+  skipRange: '>=1.34.0 <1.35.0'
+name: stable-1.35
+package: serverless-operator
+schema: olm.channel
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:003a5c5c3682db69aa57da4c05ed3ccbaf94fb80a4972c8ddcf91eb3d5e299b9
+name: serverless-operator.v1.20.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.20.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2022-01-26T07:00:42Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.19.0 <1.20.0'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/serverless/index#serverless-getting-started).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications
+         * without modifying producer or consumer, and
+         * with the ability to select a specific subset of events from a particular producer
+
+      ## Serverless functions
+      Serverless functions extend Knative allowing developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Serverless functions bring greater efficiency, more scalability and faster development that facilitate rapid go-to-market.
+
+      Other features include:
+      - Based on Buildpacks
+      - Quarkus, Node and Go support
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Support for creating, building and deploying serverless functions for multiple runtimes (Node, Quarkus, Golang)
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/serverless/administration-guide#installing-openshift-serverless)
+      - [Getting
+      started](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/serverless/serverless-getting-started)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-controller-rhel8@sha256:e7af2251f613b58c9661b9822942226a16c722b95bed4ca661fbd2fd84916272
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-dispatcher-rhel8@sha256:53f63604e0557a1f0936c0fdb8484e8c41555ea6c36bd7813b74a83a56fbe7aa
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-receiver-rhel8@sha256:c4138cb979dc9b1ce7d890aa25fdc194f1d6669df17e9ee564c321986bc75895
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-webhook-rhel8@sha256:a2c3e8d41578a2236125c3e5a949e2b6c82139cb033db4a457577aeeebe562c5
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:b61ae07d5e3dc7483e050e311962b85d91d9481ca1962dc0c57f62ba13b54c35
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:18b03a7e7a698fd1507c1082d7013d4a254a1852280718b2c63f864ea7000c56
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:8df9c7d974607b2bc51dccf9205621323b4d7cfa9fd5a6bc5997dd10d9d24461
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:90aaad80d64f19c37c5ae4af73af1bd6236429742edb9b902219531ea2484fa0
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:655cfaaed21a8a021a1c5c79cd4dcc5f1e5c39b59804b510a51d0adfbb98e5fc
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:655cfaaed21a8a021a1c5c79cd4dcc5f1e5c39b59804b510a51d0adfbb98e5fc
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-channel-cleanup-rhel8@sha256:7a7e2f6fa568d5dc39d702c2b95a9a2a389533c7fcd3c881399e4c9ce3a1813e
+  name: KAFKA_IMAGE_v0.26-eventing-kafka-channel-post-install-job__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-channel-controller-rhel8@sha256:3ae993986aad5cf3d6ab0764883d888973708805d9e2eed5029938217dded1e8
+  name: KAFKA_IMAGE_kafka-ch-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-channel-dispatcher-rhel8@sha256:8c2ffee91216f1473a2a83c4c7da79e5aec2b6e27f7d2e080313b52ec9210dcc
+  name: KAFKA_IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-channel-webhook-rhel8@sha256:593c8dd85b72fc61c544a2a80c14e76ba8a80bae289859f9901d027fd8789e34
+  name: KAFKA_IMAGE_kafka-webhook__kafka-webhook
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-source-controller-rhel8@sha256:9678fba882afd9b3a694f5e7963dc8288848d8732bbc64324d563038447887d8
+  name: KAFKA_IMAGE_kafka-controller-manager__manager
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-source-receive-adapter-rhel8@sha256:d827b639bed34b01017a0e285dfb1d82a7735fcd77c4d3451fad653571b5bc8a
+  name: KAFKA_IMAGE_KAFKA_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:3edf6e507eb078b2222308cc6eed252ce5eda16e64260590646c28bcf911305a
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:3243beab3e944a62ce3f696a2701908343c7d9b57694e9d27d6e8063a47bcd51
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:3d27912976ee6c6d24e0ba09d18008f7d8b26198700595be29ccb6183d271467
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:fd094c5fe1b03b2dcb02c03c5a6110845040ba3f28d9e7462e9c9d1d07d8af72
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:27dee9e0ca2a5578bee9d777190c35570bb141a6910a5b97b439148d7699faa5
+  name: IMAGE_storage-version-migration-eventing-eventing-0.26.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-sugar-controller-rhel8@sha256:d9949b5ca998775677f1ded9f9e69ed8d97794c979e0d3cfcd2cb5aa21b14c56
+  name: IMAGE_sugar-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:286591b2d982d0f7596644bd634fc4c363b6426c1d8f3a983ec1c9677436a309
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:9e9439eeaaefd0367879717305c98ecba2a83ed6558d526246b4157d0660a574
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:c21e94f825242a1d6adfc8073fee29ba13ae4a6d31bd2cae0954ae5d27f3309e
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:0ce21db1875e2e7f7c58c5510d434722ca0bb02fd9ce39e3e0a554988d8aacd6
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:430744d0e8d108f1cdacc41d8c020d4b3869cae1158abb361bfa893077cbef85
+  name: IMAGE_kourier-control
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:430744d0e8d108f1cdacc41d8c020d4b3869cae1158abb361bfa893077cbef85
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:ff83481b41f502ae6c7e629ed0aae8692fc7efc180034890650d93784dea0a0a
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:f24348abc22959bd0e378121181098ebd8ee27d22498c4fc3a4ff5f6f93424c1
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:003a5c5c3682db69aa57da4c05ed3ccbaf94fb80a4972c8ddcf91eb3d5e299b9
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:b38e0446549dcde3ff960b4c6b660304017501094f1542e7b65b89dea296d7f7
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:c4da32d3ba28a571f90fe7c1608c27b60539d22f22e49be2b7ccf39456f01e12
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:8af9752db1b374d2ab7e937430783246c9bfa21208d737cdf3b506624ca34fb3
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:f7a947f4e4307307e9d978645181d9421c7bf78921cb802b184e5ef540e3501b
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:61029ddfcd2d6817bc967cf893a66fc9d64ef161918eb275e09ce9fafbb35f8b
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:f2893793ca05047bf11ce6c89ace163dbee0ef0c20f605cab860eb7eb8978c4a
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:f510e34ca5d46e728e0c5f58b8df51994955dfe75752e6df092825d86ac6069b
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:ebd14b9efd29d15b09ebab14f3615cea477db47feca37afeeca475f548cd45af
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:7b1010d1a250a04c82f74eea92f2eb2e889c6a2acbc892d7e8c7b603cd8f5c48
+  name: IMAGE_storage-version-migration-serving-serving-0.26.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:79df0772b7dbaac2443a03390a71c54e325a0c2d425758caa3c611d9844c9add
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:13f566dca713189e5bdb4c67c1754fafc1ebc3f8b9696ccb2093f927d186737f
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:7a7145e20786d051ce14f0b566481ffe5dc71324acc1dffae31dca84dcbf0e24
+  name: IMAGE_KUBE_RBAC_PROXY
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:1905984e13c9d165aad06f954904fc33d3f3a6e2f0041f98bc5840d05a87abaf
+name: serverless-operator.v1.21.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.21.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2022-03-21T05:26:13Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.20.0 <1.21.0'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/install#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Serverless functions
+      Serverless functions extend Knative allowing developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Serverless functions bring greater efficiency, more scalability and faster development that facilitate rapid go-to-market.
+
+      Other features include:
+      - Based on Buildpacks
+      - Quarkus, Node and Go support
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Support for creating, building and deploying serverless functions for multiple runtimes (Node, Quarkus, Golang)
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/install)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/develop)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-controller-rhel8@sha256:9a426067df621818911d18aa8bcf9662bc9bebed5f7a85cbd1d087fcacf41987
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-dispatcher-rhel8@sha256:598ac6d11807e022b3126d465e142ac582853becf788666016b6dc3e506c3047
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-receiver-rhel8@sha256:63595f749af167a3bfa771d6e8314db1a5068d77ac39a487c73b32c55c07f02d
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-receiver-rhel8@sha256:63595f749af167a3bfa771d6e8314db1a5068d77ac39a487c73b32c55c07f02d
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-webhook-rhel8@sha256:54c127c7a886a3ec752c834324b42a6a949ddc14561a40701aa83079851bd2b8
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:c425ae9064a28818a0e0516fd267d35fc9868f88efa0bf58306809ddfda34598
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:cadf52f5ff038e71389712b1486dd9a8855bb96ea31f50555475d3086c9ae835
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:82018fde6f1aac486061ad4ed3f4cb903e06907b4be7262ca03b787dd366ff8b
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:a1205e7ac1be07bfc249d8fbbc0dcae6d0271c23e159740527ceecff40c2cd94
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:2692bc167f42d9b62a2ee9b8f0777c20d25d93585c74620e093ab6929d64dcdf
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:2692bc167f42d9b62a2ee9b8f0777c20d25d93585c74620e093ab6929d64dcdf
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-channel-controller-rhel8@sha256:489919a8e4dafb302263382dbfe3502403ebddb5c73b28a1c1af9d2056b75c56
+  name: KAFKA_IMAGE_kafka-ch-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-channel-dispatcher-rhel8@sha256:19c0bcd6dca80e63a142e0c8c507f83bb1d990ddf09e066a129ccff231fd6a83
+  name: KAFKA_IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-channel-webhook-rhel8@sha256:3ad823512c58e09627e9f1be57726b13f1874e62f08faf50611d2d8e502f38e7
+  name: KAFKA_IMAGE_kafka-webhook__kafka-webhook
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-source-controller-rhel8@sha256:8e8f76359c2a82284edd853aac0b979ad0711edb5f0790731f664043bfe92a26
+  name: KAFKA_IMAGE_kafka-controller-manager__manager
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-source-receive-adapter-rhel8@sha256:bf62394ad8558f5723bddc2193de4ff185c45c1c64e3527491a939aa3f585ce9
+  name: KAFKA_IMAGE_KAFKA_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-storage-version-migration-rhel8@sha256:01a691af2aff77b065443f92c8d2c07f4c2f40b570852dcc5cd15147ee8dde01
+  name: KAFKA_IMAGE_storage-version-migration-kafka-source-1.0.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-storage-version-migration-rhel8@sha256:01a691af2aff77b065443f92c8d2c07f4c2f40b570852dcc5cd15147ee8dde01
+  name: KAFKA_IMAGE_storage-version-migration-kafka-channel-1.0.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:29567865d535c2f3b16db3e1581d20c3530df101c8432629f52530799cd748ee
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:91e45fd99b82de8fd1cc2f56fcc428e2106de041b0986a405c7ca150f72ffa11
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:fe3c0770c875a9406c569e551635b1deb669e7daabd1bc541aa4cba1305603f2
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:369f58813fda9fe3c4ca8ead6b05cc750ce7437d5afb8f915192da3cf405c269
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:961a0612e2cade3a3312364ea33bd176d34a1a56acf74fd7ea28133793399e65
+  name: IMAGE_storage-version-migration-eventing-eventing-1.0.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-sugar-controller-rhel8@sha256:8d40f49954e9bb1f1235da4a0ed17a5fdd01fad7943791e56ec47fe99812cf88
+  name: IMAGE_sugar-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:3a2b6a5fe33746b6a2cb0577ddb3beef95d72491ffb64a3e7e8b33e370312544
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:8f85446e458fe5953541dfa99294672c498cf5091e3c13b2d0b5b34678741d2f
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:ff0e4fcdb5c92f434714f33c844761c5f909b481ff17cd73fa53338c789455cc
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:3becb8b067c1b9393df2b7d81604b0b06f4753f81dd25b7dfd2f7c392554c1a3
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:0bfbfdcf1cf7f0d00f1bd45496b301eb47f8d4c9ee71df9fd5e26c98d71913b7
+  name: IMAGE_kourier-control
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:0bfbfdcf1cf7f0d00f1bd45496b301eb47f8d4c9ee71df9fd5e26c98d71913b7
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:3200aa708b9f2424e208b5f4761a8500ce381887c313f9ead1381232e1d608c8
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:6e0a1b6060b2f054e24749f9cd527e434d15bf8486f8787ded87acafc68b0ad5
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:1905984e13c9d165aad06f954904fc33d3f3a6e2f0041f98bc5840d05a87abaf
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:f6a9cfb08f922881159020394c7cceaf54366541012313975a250667e7fa6e54
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:6498db836688f86bf46f19d42e5dab4afb7d8d35b6fa88daa6d6ce415a33e435
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:3b0d42654df1608b930a5fee5cd48c56a58e82fdbf9f1165cb12e9a33e5b53b9
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:ba0981152ab8ba266559e36076cfa3a75ac69cb4f817d082ae029dfc30f58962
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:63f8bf89831e96053ac53a7982b936ea3ea0f1706aeed87491e650f0ea06855e
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:c656083c3d58fe1cb4921c91b0591fb9c41437745d092a4cc4070f7b4be1ed7d
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:7014a0e70839ce87a46b3756aaa2872ace35fbf37b212731aece2f0e8e02bae1
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:f4c86c2e1f72495c6ab9ae024c58ef7e38d838e437ea955627fffbc0fc3e41ad
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:30ea9ae3223fcff9c6c91febe8063739971e1ef4618872a470729f1477d3637b
+  name: IMAGE_storage-version-migration-serving-serving-1.0.1__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:d8cbca46df62c13cae6888a5ab7f8e3e301341d0f291362eaa427610955a1a78
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:13f566dca713189e5bdb4c67c1754fafc1ebc3f8b9696ccb2093f927d186737f
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:b6fde43491c2e0733c8fe6ee8660f7f6435fe20c0b6d435cfc7f86eeab8b4748
+  name: IMAGE_KUBE_RBAC_PROXY
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:0d73e731e7defc5d1da1aa3a347b419ce5d6f2b6b880403cb2e0871a8b3bb240
+name: serverless-operator.v1.22.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.22.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2022-05-04T11:53:23Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.21.0 <1.22.0'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/install#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Serverless functions
+      Serverless functions extend Knative allowing developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Serverless functions bring greater efficiency, more scalability and faster development that facilitate rapid go-to-market.
+
+      Other features include:
+      - Based on Buildpacks
+      - Quarkus, Node and Go support
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Support for creating, building and deploying serverless functions for multiple runtimes (Node, Quarkus, Golang)
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/install)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/develop)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-receiver-rhel8@sha256:0ba3bc18aeacb366815f99db3371ef79cf27b5badfdd2b3833fbb6eb58f4d3c0
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-receiver-rhel8@sha256:0ba3bc18aeacb366815f99db3371ef79cf27b5badfdd2b3833fbb6eb58f4d3c0
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:3df500df58f86ea07ffae63b2d12de6a4dc22c344a2b582d985fa0135c3c7f70
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:13d8a81640c7ba42212de65878274627e8502446c5278dad3bc2f12743e5ed22
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:7c7c2fc45b9263a6e5d6113b62a0048df1250a5d884473d7c9776deb7124207a
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:bca473cfef83b56ff4b67346134540c4e3ce39f43068fb8ad5084f51740efeb6
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:d7214756a96c61323f388289ff3abeb791c0b14d19e5f13b188f4b9fe6d2dd19
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:d7214756a96c61323f388289ff3abeb791c0b14d19e5f13b188f4b9fe6d2dd19
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:1f5df72484aa89af08c3933490aceffcfde0bb59eacb52aa862da09769d89f0d
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:6642dae76e63b0386d18b9550e4e0ce6b5496eb4b143f2f4825c6c8811b7e422
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:6642dae76e63b0386d18b9550e4e0ce6b5496eb4b143f2f4825c6c8811b7e422
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:a13e6f5797dd89186af1703e802f74197cfd81bd158642981219907117d105c4
+  name: KAFKA_IMAGE_kafka-controller-post-install-__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:e50e677af16d8ba684c768cda44c15e8a7435988598ad97af2127d531f80d0d7
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-channel-controller-rhel8@sha256:ed4fc85d182d8a09f1e883db12cd90fd73a701d46693c9623388c7b0cb2850f3
+  name: KAFKA_IMAGE_kafka-ch-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-channel-dispatcher-rhel8@sha256:2001e3462b8579a918297dbe54cc7ea92ccf129df38a415e154ea854a6b63f0d
+  name: KAFKA_IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-channel-webhook-rhel8@sha256:3712279fffdf370dfa77ab64721e923379e936e1e2a53b20ad8f5719d4a9f692
+  name: KAFKA_IMAGE_kafka-webhook__kafka-webhook
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-storage-version-migration-rhel8@sha256:f04e0cbeab7aaee730693817727807ebed55b951c757bf6affed1ce7ff267dc2
+  name: KAFKA_IMAGE_storage-version-migration-kafka-channel-__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:10f042c5a9334b768a915dd2c06a931744f448c331bf825d0bd53ea62c5cd2e8
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:1fb1fe631c26a4908c64cdada9526baa4eb7d75e9ad8c2b56f9d2ce0104afc3b
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:39cf5e7f70fc396f861d7f1e9d17ad0d98b8c7606797bdcf930ee8119d3f183b
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:118a8a4af60c990185df3e971908c82101472505cf99a140e0480e2e78fa1fb0
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:ab3213e9d1c03771688fa0f44459a398d071223f62d07a6789ae11a5e2bef20c
+  name: IMAGE_storage-version-migration-eventing-eventing-1.1.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:ab3213e9d1c03771688fa0f44459a398d071223f62d07a6789ae11a5e2bef20c
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator-__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-sugar-controller-rhel8@sha256:933f27804297123f249baa4b176fdc2189fe70629d2a508219a9c35507235282
+  name: IMAGE_sugar-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:c47c5c6214695ead9887e35bf0634f5f928dd548fa45c092e2eaa5cad3a4b8f9
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:d1a41da96d8a07a7d2961cc2f222263f160e9b0975f103c1a3bc61df8280b15b
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:a6cada4d400f4326054c84d3fd367aa7ff60938361ca9b2489e3592954892f5f
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:8125cb05c705bb0f6b900478be95a1ba0b867a9bdf61385d67ca377fb7a68599
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:af0441be17265705e52829a44e6f0bdde7c6ccce8fde331a2328ed0926fb5da7
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:af0441be17265705e52829a44e6f0bdde7c6ccce8fde331a2328ed0926fb5da7
+  name: IMAGE_kourier-control
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:87fb543636775c8ff059e6388806ca36b4c6e4f2c08ae2d45593ded6b700dfa1
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:d9d17b7ef4143069b299db8eef5cad9d85370da041461a39341beafc6552940d
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:0d73e731e7defc5d1da1aa3a347b419ce5d6f2b6b880403cb2e0871a8b3bb240
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:d0ada53609f8ce3e0d159ecf505aede131a120a93a03168f3be410f75cbf8d46
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:a18734393eb160a4b8594f41b8df0b4077bc898f24c3090ab60dbfdd26b9cc64
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:0f89451821a861d6f4b39d5e031fd6eecd348d3546aec9a24aa91625c8469135
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:24422240c308d79f282ecab1fb706252eef8b2a379af2fb86aba582f24606b6d
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:780ccc1c9de02f70513b564e021118186e7ccd8de2d011250436aefccbc412aa
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:354cbace2e2e46ec28cd8bfc4014d4033de71ddc040bf6904851a43576de3c19
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:a7923535848df7ac0ce6fea6710a1867cdd25a5b68e5bbb17b53e84d26285cfc
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:1197add615c859ed1744a44e6088c203be1d09ba66a7eea45eeab022fc4bb2d0
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:101e5f57ee6ba9748e716d21fe420343a44be65738109a6dc27e79c80f121d98
+  name: IMAGE_storage-version-migration-serving-serving-1.1.2__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:61bcf2402ca520ef3bcbdc60fd347ba8996e6708ef6e221366ad2b8516e5f863
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:1d0b1923f82a06c1c318cb73bee362eaf396b66205e541509f36bea90a7a12aa
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:20954f1fd9c2bac5cabaedbeec25d60b31546ffc05f3e4c38ffcf45e2ed41be9
+  name: IMAGE_KUBE_RBAC_PROXY
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:8da1dda3de163dc82927ad732d560e9c5c7daca3a8d3b46110b561441c483af9
+name: serverless-operator.v1.23.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.23.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2022-06-21T13:42:32Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.22.0 <1.23.0'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/serverless/install#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Serverless functions
+      Serverless functions extend Knative allowing developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Serverless functions bring greater efficiency, more scalability and faster development that facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Support for creating, building and deploying serverless functions for multiple runtimes (Node, Quarkus, Golang)
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/serverless/install)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/serverless/develop)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-receiver-rhel8@sha256:2db5d5a0378f448ed3e81ce7bccd5be24b65f2cd0b8a2d9a65afb6e57d39250d
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-receiver-rhel8@sha256:2db5d5a0378f448ed3e81ce7bccd5be24b65f2cd0b8a2d9a65afb6e57d39250d
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-receiver-rhel8@sha256:2db5d5a0378f448ed3e81ce7bccd5be24b65f2cd0b8a2d9a65afb6e57d39250d
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:1f287e16ac996cff369875c17051425ca8f318b1548c20c3bbdf6600f1abaff6
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:40fd82ffd4078cd0055cd5819b2a093e836dafb1198f2e58a9343c227ed1d4a2
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:a9e75c271d547b060ad33661611c0a4fdf4ae6dde492fbd354c62a9cb1e5df48
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:0f725852e7f283f2cd6007fc8ccd6916c77a47507b9e386d8224de770f923ffe
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:0d6e607f3c8207a87d75179353276454d4200127b4378c847e7821e09c2da3df
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:0d6e607f3c8207a87d75179353276454d4200127b4378c847e7821e09c2da3df
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:64528a4adb9b34aa76bc65227c0a842157f56f53fc872e4637bd219823bff175
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:342278266de8cc110eb23cc67fb9dddca1040c400926955a433487db16a1ac51
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:342278266de8cc110eb23cc67fb9dddca1040c400926955a433487db16a1ac51
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:342278266de8cc110eb23cc67fb9dddca1040c400926955a433487db16a1ac51
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:6eed6f3ac3261d0e2887249f233d5a3bb25f244b80166f4a99a3f5e44929091c
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:df0b6708c4ae46dd63d143f5fb94907157ed8c9801eb1cd5d743ad80d88a6e1b
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:a6d7ac8008a443f5938273b9b9351f2a67641d59c320d53a2fdca4bdb6608d01
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:b00b0ac71e5dc3d125db4bec3940a08db8944a8a1853fca48c62b65acb18236d
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:35eea866f3b7ded420fe79c1c89049cc4cfed3698c55f4581ce92fcd5d36fa72
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:f7d6a87f4592ebaefccd8700642961313ceab45579ad03856675cff53af16389
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:7e3515f6eeebb68e45bbbcd61e99084a8f2846112394adbc58ef6d03cc6d51d1
+  name: IMAGE_storage-version-migration-eventing-eventing-1.2.1__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:7e3515f6eeebb68e45bbbcd61e99084a8f2846112394adbc58ef6d03cc6d51d1
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-sugar-controller-rhel8@sha256:6349679a04029235ba4ac7106c99e1f5923f69d79bbe1b264f04bb88b58fc67d
+  name: IMAGE_sugar-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:c10b26e3d90f65a1c98a5e2b701dec433d3e525de6a22e90567e4af29b8b59a8
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:16a0f18d6855e266b88045c690d37833f8f9a0d22c17cbaa5f69f39979c7572b
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:6ea5f88b9348dbbc50556ee98042f7cb976d69917ac5bbf387cf3ef3caf799e8
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:f1ecfc5e51805266b0c3818a6d4557cd169fdcc65ba719da42a4057ffa9150c9
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:dcc9a1a064b51fa7741db9511d57a122c11c0c8056d0c86ce29d5df026164afb
+  name: IMAGE_kourier-control
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:dcc9a1a064b51fa7741db9511d57a122c11c0c8056d0c86ce29d5df026164afb
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:2c18de609b0ad5fb440102fac85f3080357f3a684fca995a6389d668c51bc05f
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:b8b38dbe130129ea3b2429c9dfc08e945b788984be6724fa1c959e3d7ba9ff7c
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:8da1dda3de163dc82927ad732d560e9c5c7daca3a8d3b46110b561441c483af9
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:6ec8368c6a59ced3e127b8a70e493e5a2cf8397eb148dfccc2f89bc758e08598
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:f4da0f4dd3d1599e591cb315068cb45ed86d6a0788131225a9be16bc4c00ab78
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:8c5765c7844590649153644b5a6db01725d436cadc158452bb511e295e4b353a
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:6b951c909628ddfcba163258e7e9bb22748fd046f9f340ac32b808ad927325f1
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:02d7e39b138576988f6eafc78132a0b4b7fed475294953dbd86391ed4c9b1d0e
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:93d17e83146300a982d12182acc12610ccb9095ba95ca3059905ea533496a418
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:8f0aab28c5d01f80dd84a16b6cb7cee12eba14ba65cfeb5702d6e103fc7193d1
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:d0c793aa1d3886403c5f96b66422cb5a7ff93db4c418c63d554d8f829f2e15a6
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:925435f60deb19e6c4d477964d0fa9ccc8b53972d72f656cb37528e7ab1c8dfd
+  name: IMAGE_storage-version-migration-serving-serving-1.2.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:c55310ccc61bc428c0d0f9b785678f9324b93cb2b396434d8a59c7d689befeab
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:887b747cc1586def69e88536d18bfeda1b2d5b81947291633244af11dac7dc68
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:3658954f199040b0f244945c94955f794ee68008657421002e1b32962e7c30fc
+  name: IMAGE_KUBE_RBAC_PROXY
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:0422f8843fc62c2b72e01ffefd33db912a1ad3d70ac297882d3663c9b7299f10
+name: serverless-operator.v1.24.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.24.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2022-08-01T13:31:56Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.23.0 <1.24.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/serverless/install#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Serverless functions
+      Serverless functions extend Knative allowing developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Serverless functions bring greater efficiency, more scalability and faster development that facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Support for creating, building and deploying serverless functions for multiple runtimes (Node, Quarkus, Golang)
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/serverless/install)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/serverless/develop)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-receiver-rhel8@sha256:7531d998167d4bf14e03d6a8c341b3e24c2e1d28b56e9aebbe5564ecba828b78
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-receiver-rhel8@sha256:7531d998167d4bf14e03d6a8c341b3e24c2e1d28b56e9aebbe5564ecba828b78
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-kafka-broker-receiver-rhel8@sha256:7531d998167d4bf14e03d6a8c341b3e24c2e1d28b56e9aebbe5564ecba828b78
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:11bc8c74fb9132baf29121ecb788a4a6b650c6a758174b61e47b5ae5727dfefc
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:ccba05cf3fe0d17b45395ab086aa9917656b40afe70dccb8b9a0f29505be0c62
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:87cc64d7ed8a02d7f6ea22c02fd23b7a55a74c0a10d82d07e3b6424744f036a3
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:f1c17bc51adc70a8f6f5c27791d57d3d63d90564f4f19baa5b68a77c983591f0
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:8a6248c2dbeefec570e818d20c8120842ae7d00f221c2efc243f046155424d95
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:8a6248c2dbeefec570e818d20c8120842ae7d00f221c2efc243f046155424d95
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:683d005feabef8c2831f02f2f3343d507d87457a576fb180cf0e104e8b74df8b
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:623bbb3c17ff50b1d11188451e4cbf0fab265c844dfdba30517ad20788877c42
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:623bbb3c17ff50b1d11188451e4cbf0fab265c844dfdba30517ad20788877c42
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:623bbb3c17ff50b1d11188451e4cbf0fab265c844dfdba30517ad20788877c42
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:c0b95510de68fe33a0a3f547d0d2e15deda3119f708ab0a452c65c3641ed615b
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:7d0e31b39c479f3e82a76dfa200bec7de33b5347b742731ef452c13e763faf32
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:eb922a129932eb2013694bcd751664229510e1fb709c49545df39b922daa10dd
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:6c1e232ce55470d3cfd5761c19dc47b3d4a24ca40384e4f9441319e6fba6a02c
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:445365c0305f2b2abebb6941345b8f89d649449a63bdd771ecdd22c3e7897095
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:4494bf6284aac462fab1b82c131807b7a5efdc9faf474dcd20e6734aac27ea8f
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:f1972b264ebf651979efa081af696adfce05f6b342aa572c40c0c4b66f147809
+  name: IMAGE_storage-version-migration-eventing-eventing-1.3.2__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:f1972b264ebf651979efa081af696adfce05f6b342aa572c40c0c4b66f147809
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-sugar-controller-rhel8@sha256:d4bed4c01ea8ad184c025aead4af42e25a68605363b95c334fbf1a5daead720e
+  name: IMAGE_sugar-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:f09ffc0a1b71d4c2fa9a70a74bcd1be74869a29c15751517a946c493e6b1566e
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:1cc2fed7d8696fccd7b73421e2b7214331ee5bef73abc1ebc63678fc1493998e
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:41d54f9d694d67f276c09092a12fe597aad19dabb047cd401db76276a933468a
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:176ad63e537cae9cff8e520d717bd3567a7859e513c2cadb2eb568ca8abc5a82
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:f2d478b9bb9f61d3b2b750e9066d7c19cc443c717dd02332e75d816dc676964e
+  name: IMAGE_kourier-control
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:f2d478b9bb9f61d3b2b750e9066d7c19cc443c717dd02332e75d816dc676964e
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:c9369227de2cbee0f460bbe3e060a276b5ff8e763d83a282c3d10142e8d0bad3
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:953c79b292a6ea4e4b887e5a58303f6716301a3e93d5443fdf4c86d0e3258acb
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:0422f8843fc62c2b72e01ffefd33db912a1ad3d70ac297882d3663c9b7299f10
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:9f08813bb45fc5e06885b5c01c734b8b70476b19114cdc8a2a45a2b4dff9aefd
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:4b18d81ac9e3a1958710d231856476c32515930a3a85ed369425355df0918800
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:c70990baebcbe4a389c3329ad66bdc35c642b4c4894b3ec148437367a918b1ed
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:0ec7529dbcfbb3a89b711fa87c876a2034ec564122b506550ed77f9c3c20d7cb
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:efe7427e8f15c8824730ee4a1c0bec9005c7b9294651f0feb3d5ff5f3b14e29d
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:110572383be118d5a7693594bf3400547d0b428e548af27ea9ae609599b8e1c8
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:5d677b0b1aa62084522224b96b9736c8b35559e703980aede049159bd13f3578
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:710e97c7d8f063ed1a26e86feec1668d4d8ed0388c3d2490453411f7bd5c1f50
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:d41af9b3dbd86d00027972d2c284dfb9a7eab00c01e34293fc0b80ca6e98da3c
+  name: IMAGE_storage-version-migration-serving-serving-1.3.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:d8ac03626fd046388e6a6ac9e4e49c24974ca222dcddf56301f946c22987a7b0
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:1485769b50bf20c413d44840a5df955ad7a7979978937affe462fe7090ef61bd
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:011909289ad5a6e6dd012fafaab83117777073febb15536ee7e66a4d5830f303
+  name: IMAGE_KUBE_RBAC_PROXY
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:edb6116289b3c722aca7614eb06b655e2081ebda74a9b7a82261ae1fa1e76408
+name: serverless-operator.v1.25.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.25.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2022-10-14T11:09:08Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.24.0 <1.25.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/serverless/install#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Serverless functions
+      Serverless functions extend Knative allowing developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Serverless functions bring greater efficiency, more scalability and faster development that facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Support for creating, building and deploying serverless functions for multiple runtimes (Node, Quarkus, Golang)
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/serverless/install)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/serverless/develop)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:ddec439321826f4d627639348b984c88236b70d991300090acc3268de8026cd2
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:8ef9539d11a14d19bdf2fa86704adcf9d8c59d613a4ecbb19c0b2475f33f4fa1
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:6a8da8b816824bc0f21cd47c307cd107b5f9e73721bd1febe46a9cd5c9587db6
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:f58450c254f1b99f4c43d57747777341993da42e85381dc958cc1b7683671032
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:2806145ae552b0d3e3d15eee04ce3932459c21b70b121af6e401e6b699974dd2
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:24d2df044804d5a6db2577e4c1c88b4c874dcaeec61a7d4c0d40ab6247ad87e2
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:24d2df044804d5a6db2577e4c1c88b4c874dcaeec61a7d4c0d40ab6247ad87e2
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:a01dffffd4d9098983293adb8492c8fbcd371ddd968bfa8447d08ad96f38d829
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:4841553c3fa69d92737b3627fccf46f77b0f5b54b0e062edd3b0577ca9684910
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:4841553c3fa69d92737b3627fccf46f77b0f5b54b0e062edd3b0577ca9684910
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:4841553c3fa69d92737b3627fccf46f77b0f5b54b0e062edd3b0577ca9684910
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:41e6b33e2c7661bd1e3f08bcb2592c4a43e5267135e06c2f10d8f969bb099975
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:6a8678ebd3b28c1c489de394499f62391911ffdbef581bbf8046eef6b2a8c416
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:6a8678ebd3b28c1c489de394499f62391911ffdbef581bbf8046eef6b2a8c416
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:6a8678ebd3b28c1c489de394499f62391911ffdbef581bbf8046eef6b2a8c416
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:6fcb506428b99e8770e00b9e68493cdb1015027cf3959297adc098e0c9b1d5ee
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:0fb4de1518783693b034bce98547c1290b50bf5944d1fb7abbb38e06c793f539
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:0d99d244e2f48834fbb853facb3029fe41313e84cd2190aa705bc5199740ca73
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:8bcb51ec7b4f729fe6d8a7a63a8403efa6f4883bef86acbb1706d7521348f98b
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:8bc831dfde37a3e6456728939337fd25ddadd1ce6fff8aeddc9208f424050b30
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:94dae9f5090ec109fcb43a288dd37abcf0e979b132914f2d5cb4d3d225fd583e
+  name: IMAGE_storage-version-migration-eventing-eventing-1.4__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:94dae9f5090ec109fcb43a288dd37abcf0e979b132914f2d5cb4d3d225fd583e
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:8b8a67d1a9a3dae95dbe2cf03a1c0d7acc8d39aee718ba393143546623d90fd9
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-socat-rhel8@sha256:395f5f2dc8995c014f64636494193414ca9f24a5b4a80e03ad280832580086ba
+  name: IMAGE_KN_PLUGIN_FUNC_SOCAT
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:2cb82235a069754855104cfcc985abdca49cb153d95043b962c4a2cffc071add
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:ed1afd32c625a6c4d3547176d0f6e7badbcd25f65ed2b1fa061a1b107e2e00bc
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:1364b19dd4810a9d5d40033b7baee9782bde4c16a838631404e62834d1851abd
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:5a38d84de56ac35ac0c3e68902cca47b496bc872065d48f0460aa24f0e968059
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:5a38d84de56ac35ac0c3e68902cca47b496bc872065d48f0460aa24f0e968059
+  name: IMAGE_kourier-control
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:a1f64d821efd9920c53af817182edf64bbe4a0829a163a4ad13bd58689c4ca19
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:55eeaf581d342a8535b09553d4bd0f0db46eacf3034d6269003fb5cbe0a0680c
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:edb6116289b3c722aca7614eb06b655e2081ebda74a9b7a82261ae1fa1e76408
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:ea7b81a32147d88b0ae100797b5d82dd4e564c79f26fcced799af79ef138f6c5
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:ded01f6a071237bf108bf143f1f401b2f0d0f975fd6de7cca0506a88e975a3c9
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:5c84d3931586acc1e67109a580ecca8d67361561ec2fa50e9b318c702cc1491b
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:589d49eb5d0f33ef462b7dc25e94423bb37986ac6f89a407e5165e1fdc30af1c
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:5e630b8121acd1d4cd2a8a85aa2adcfad35b61845bc66a0b065ba8658bcf75b6
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:c03f4d11790c91d679b234040436524efad6f27847a9bf2cd5191b62c9991363
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:b3cbfa4ece5eceaf80adb115ccfe9a666d4ce9c31643903b6589b5b646959237
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:1759aa4dc630d0d15882d570bd2b3abeec1628d6aeb012049bfd5b4839d05232
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:ac9bd799a6a70e51f4d605c365cb5a32e0f223f0daf3e0d01ef99d9c7c02708a
+  name: IMAGE_storage-version-migration-serving-serving-1.4.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:efee462eee82b83534fed2a1f038eee30d1f7c1313ad961a02660f18f977eeda
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:3589029ad53c303102cc08aabd8d8395eadb28cf503249aed22c41e129375a2a
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:ef2c41fb899228a64cf2f61d7606a980a5f8fcae820da246d25c4f17faa0da3d
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:0516545990ec466969730d43136016c10e7dc34f633bf2646463d12145d9f917
+name: serverless-operator.v1.26.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.26.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2022-12-01T16:39:45Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.25.0 <1.26.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/serverless/install#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/serverless/install)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/serverless/develop)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:b1b1f4e0306297dbc5c1e87abbd9892bfd800d23d148651209db2f09ed30d9ca
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:89fb53858bb93ada958faff761915f45d01e3364b5e5df4ba05b01c4b8cde587
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:3391e74bd8a9337f553726039869c1ae24a861ecb8337eabbb5c3844a0cbc52b
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:8d2da1c16df8766618cf7e6ca49f017272591c97f1d88c639aab6de77c757333
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:7feef3d3ec3ac5072d41f7ba93ee666ab1a20b84e034cddf56e0f3e9de31622a
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:23df9575999bf3fd29f278595ae2f36a31a87b5c4a58b61627cf8f717da8673f
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:23df9575999bf3fd29f278595ae2f36a31a87b5c4a58b61627cf8f717da8673f
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:3e12866ab3c8e521cd31349a7e592e23c45f5e0433fb31849ed73d2c341842b5
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:eea487578add89cd52a31f3a7913fc6c03cd03f0cc0aa285df01a00d2525c38e
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:eea487578add89cd52a31f3a7913fc6c03cd03f0cc0aa285df01a00d2525c38e
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:eea487578add89cd52a31f3a7913fc6c03cd03f0cc0aa285df01a00d2525c38e
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:427c142384a4820bb7c46fc47631b8b6eb99b26194e6ac3e5331bed8330aacd2
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:9caecb2e4066bf88acceb73f87d1b17ac1dffdb4264a3b358abf4b563c4e9b67
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:9caecb2e4066bf88acceb73f87d1b17ac1dffdb4264a3b358abf4b563c4e9b67
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:9caecb2e4066bf88acceb73f87d1b17ac1dffdb4264a3b358abf4b563c4e9b67
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:b4eeaaef3d99f9d4f597152065fa19184c76c49642fef693093bba9f13c0f36a
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:b0416d01035debe4c528580b92cb5d94adb2b16007dda3d818b24f798e7e2892
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:57236a569f76f6a3b17e6867c5d3dea31eb0ab017f4dbc01042681cb6f4e5ca2
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:9bda943aa7b34206990a48f51694a5cb386a99eb730037ce6350f8c681566702
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:d0576e3ce7c50efd708c7d46fb05d050d7756cd8e95f6a12e1b62fb8cc6ab8c6
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:29349cbf4f5716933fcc86e7dea1e70fb08afa0c35a436253229e367caf325cc
+  name: IMAGE_storage-version-migration-eventing-eventing-1.5__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:29349cbf4f5716933fcc86e7dea1e70fb08afa0c35a436253229e367caf325cc
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:7cbdcafe8ade1f4f656081bc2f62faa78f1d75328d6db7946b421f534889db51
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:3ab4b3b60e5818eb46ea28a3d649c1fbde86d9d23b727ba96da717b83164a49f
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:20d49ca2d48e0f5d12dedc042fa6791d5b05fb6d5dec3e1b72788391d1b6368f
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:39b7b9449a82e04ed49fd6fe5e31f91a79b7b9cd3e7c01340953ecc334da33f3
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:b7fc21abe0ead718056af5d6da041ac6de0d3e6dff88b962861392dc6d026dc9
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:b4c680970661373b003e15a5c5f899041a4dface6079395b3c90334027630f92
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:b4c680970661373b003e15a5c5f899041a4dface6079395b3c90334027630f92
+  name: IMAGE_kourier-control
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:6509429d95956bac73bd2531b262136bc121780aa245200f986b3437f061cb93
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:c317e8815afc35c8e8a800bd1c9a127126359b954beddf54a196db66c7f1a8f3
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:0516545990ec466969730d43136016c10e7dc34f633bf2646463d12145d9f917
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:928c2b33631fef0cda1c1d3b241c2dfb897042e47b22434b220b0f9a2a806c3c
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:aa6a3ee558c19b9dc2b13bbd351843a7bdb12b40c6b94b9e5312578e0e4db6b4
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:507798c908336173ab0d302e37edf48f39ebb827f42d3e8ee0932d0bf7f07fa3
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:010bbd4fd08f134f7971c56c5c47d6eff487949bf4f7bb60cd4e511a65ae7c9c
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:bbe6d81eb3ce97d961d686a077e49f69ea26f8fa9746c2f04c9e6cfd3100ac67
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:787657127dbde83cfcfd97c013743cafda13601af72546d3afd43e0492e0c280
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:b8e97763348ac558178247c67c7fd8e84f0e6ddd5d324f3a6927d1436b85c3f7
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:8c34803cb97f69f51d92987f06ffcf14c4bd5f47a81b7fb3f6d9d11eba0bba96
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:8304e4aad026ccef7151a69e70482ade0d75b0fdfbb3854617b30443ddd437c9
+  name: IMAGE_storage-version-migration-serving-serving-1.5.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:d619de7f9a0c63905a6073f9a508082084be1930ee110afc274438ad949af499
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:e6d403896601c748075ef9849a799ff63a44f0a80ddc1e7070055061e2608004
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:f7993b7a5458679621f6686bdc4ab818659e051ef6cdf6a8e107f627adf5f178
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:832677abddada05258b4610b6584d442dd20c5bdd55ae8fbddb83ac133b3f12e
+name: serverless-operator.v1.27.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.27.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2023-02-07T09:25:21Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.26.0 <1.27.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/install#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/install)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/develop)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.21.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:85e146835a88a42f54dabefe93b1bbfb1873a7374da9570e621569e96342767f
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:f4ac62e81c1dfcee845a1f8fe69d456311f68d638b20cefe73875a27ec32fd17
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:4f4cdfa688cae53f24a05892ce247aff903d53a21cc79190505f881ede4396d2
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:8e827fd94a764739d28fd29a525e98851e16d3ecf1d211a7d87bd468e456e700
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:7fb39f514539657b68b273738e3d5e17772896c836b32202299466befea1e26d
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:ee6f0d2d4ad329f7514e2a2d1f9ac67904719ceba8cec14caf3844f85c8eacf8
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:ee6f0d2d4ad329f7514e2a2d1f9ac67904719ceba8cec14caf3844f85c8eacf8
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:0a0805c28de8fe7e7a42f014083372addcebe6bd2001bce4fcc75c06fa6919b5
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:f33f7550bb5e1a715e105da68b5ba3433e03e50d379c2a68effac58a6e6db9d4
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:f33f7550bb5e1a715e105da68b5ba3433e03e50d379c2a68effac58a6e6db9d4
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:f33f7550bb5e1a715e105da68b5ba3433e03e50d379c2a68effac58a6e6db9d4
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:613b62031fe34d2a7ba37d1fa15932fbd902dcc786579264a2b89f42f29f1430
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:ee776e1783f52b8f8c2b37b7ef67bd65d442924253cb9e6904031e41b86b6b1f
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:ee776e1783f52b8f8c2b37b7ef67bd65d442924253cb9e6904031e41b86b6b1f
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:ee776e1783f52b8f8c2b37b7ef67bd65d442924253cb9e6904031e41b86b6b1f
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:17bc9a39e2b5233fe03510b913e7d16c8d1f870b806de83f3d8fce72d8e122a2
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:d43fcd7c3ed01f514d70b100e61c93f398c81aaea12eff3837bb1083533a0c95
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:f1b2bded98dfeacd9fd71790eeadfdd5ff950f48bd376845d5a235ca5853952b
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:835f65fcda74c58095f4a93ba24b4f9cfe5a1c70b9f10a2d2dd3cbd5e2b6a85a
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:e162d4c1ebed80fbc7e53bec0ada38a2ed36ef48ca19bd239a6248a0ac630979
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:6fbf126bf8be98c78a2870c84632dcf0be1970178be4fe4127621738a5360589
+  name: IMAGE_storage-version-migration-eventing-eventing-1.6__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:6fbf126bf8be98c78a2870c84632dcf0be1970178be4fe4127621738a5360589
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:f7681878ec377fc3c33055c5cacc38da5492be2c00adfc3dbd8ca5ecd0dede48
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:d2d9d27673552434a5830b036bda6c914e75a21d6b2f922a886769d4e666955e
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:8b886c4e94a44e38adbf9d830af9021461b984cd3d843ae8835264a7b009dac0
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:ad1425a1ad0b04e6ae10966dc3eb9068501d6a99d07a70e32e185aa066188540
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:c411b61db246650168d7b7e063016ae3b6df689fd87bb370b08e65c0cab59c0a
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:632f3a063915b009bcab43fe6a5d0543a719ded272ac177676597b6292e1493f
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:632f3a063915b009bcab43fe6a5d0543a719ded272ac177676597b6292e1493f
+  name: IMAGE_kourier-control
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:c02d1acf24840976b22fcdff1590f276865aac9b86b220d207d464363f776327
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:02f3809347fa5ef54187b1124e5f45bb94e98e75ce972b0bc998cfab6910422c
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:832677abddada05258b4610b6584d442dd20c5bdd55ae8fbddb83ac133b3f12e
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:9fad0741b9c4688eabbc835d4271c5b5f81766fdfdd7de683234652f14d8cb52
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:3451cca764bac1ef9dd5ce72a2f4e68ce0de9c79bef15bcb44989ef889c0949f
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:8ed60064b6d8d149458f8e48d2babd5ba82d352b6097ace590cf9dbf98eae1e7
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:8fa33e18eb145cc10a6ea1516efdcfd6e46f1a452806a2bc887eaa6906f0570e
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:78677b684e2c628ed4f6a23fa4861880c40b31143ed4dce4ba8b87a04b77552f
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:4037e7e1eac9c7a3ec9ed7c3b48ff26b620e215f2de47697371a796fda9abc5c
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:5ca024d3da31d9f5d0ca125a32c682dd7a6ba817cc342bb3a6a3b022756bc974
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:4c1df3f2856e90a9b5791848683481f3cfd09fc42c41dafa321e18dadd8ab4d2
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:129dfab42f0da0e91e9f467b1e888cb2c2834c27b771277d3f5f69274cb52f7f
+  name: IMAGE_storage-version-migration-serving-serving-1.6.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:9ad60e16951116c277509937b39d80d9b7a4d9c1f0c7f32770e5225312652a0a
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:5716a22874c9afa06159da127caf28809ae4f3c18a58605ee662021eb8c9099a
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:cb836456974e510eb4bccbffadbc6d99d5f57c36caec54c767a158ffd8a025d5
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:2f82fcdc9a5424a2e195fda62ce0a018970e0211f253eb0d5ae47a72dd0bb6fc
+name: serverless-operator.v1.27.1
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.27.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2023-03-07T09:16:58Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.26.0 <1.27.1'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/install#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/install)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/develop)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.21.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:7737e1e634f361b944fcd7fa01f2418fd9f661695be08c82d27d9d222784410c
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:75bf624c04517248e3a5c85ed4fb24ffcea778b883e5ffdd3528ef427750eea4
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:1a14f606c07f241a4f3242c2c54e5dcb29de55809d8c54e1adc015b2e24543f3
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:6850e988c1159bbd70732116df950824e63da1bd767637b8a136b0a9ea2354dc
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:8593f2cba314c8fba265e3b00e27fd7219ae0aa80290058ba7395fc2ae2c2a3d
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:12973e2731757c7995b21b9c0b84f463ad201e8838f95c57d0db92b3c8c31b7b
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:12973e2731757c7995b21b9c0b84f463ad201e8838f95c57d0db92b3c8c31b7b
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:228cc2f9b7486c5ed9dc9e75e662f2f5262bcfa522d83d0bcdd549d3286b6b6a
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:48dc3b40cf4c242da984dd34e40502ccc90065adafd26bad5e4401e3286ace6c
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:48dc3b40cf4c242da984dd34e40502ccc90065adafd26bad5e4401e3286ace6c
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:48dc3b40cf4c242da984dd34e40502ccc90065adafd26bad5e4401e3286ace6c
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:ae6e6aa0dc4615957e20530d092f8cbc1ecfa164cc44ffa7207b962894a36821
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:58b1539c97fb4d0a7133d0deef4bc45476e160731b34fd373e84f74e4721b3b9
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:58b1539c97fb4d0a7133d0deef4bc45476e160731b34fd373e84f74e4721b3b9
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:58b1539c97fb4d0a7133d0deef4bc45476e160731b34fd373e84f74e4721b3b9
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:726f553c9fa4f9940744cbb4ec53dfe7877d0ecfb512df0e57b970cc29409919
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:d97615b61a68c857a879ca07b904ed336d6082ba9cac6b78f209c2c543dcd8e5
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:4e0e44d2f535942651e365324e54d9397896663c05176d0ac90d98cab6feec18
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:73274df850f3a91c269e1c208c6ab3355b827c6465f3f2a50f2913df150c340f
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:8a30dbbab33f1a3f39d3448b26640fbde02db6af12dc05736f3c62a57f007450
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:0c05e72e2e9befb32d04e28d5ed498b508a23386edfcd27aa13c517dd2f45b91
+  name: IMAGE_storage-version-migration-eventing-eventing-1.6__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:0c05e72e2e9befb32d04e28d5ed498b508a23386edfcd27aa13c517dd2f45b91
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:aa8e7b374a0febc002088a7e3b2bb73b6883606caceeabf086a6df83393855b6
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:2e03f00602b6632635599b5689c598cba8739f838b76a05b5e3105f3b32f7cb2
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:41fe34ae69d7e67d0c413062aa173f81d1d6840e6166124d37434ccd280c0f66
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:0cb9e1f1dbb767d717d62978ffaf34af4c654ec3848b09729c69e87626b4924e
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:82a04e3a25c3ba9b5b1c3644f93ed2ef1534d54c6e19b781737270bae5a8598e
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:439ed5e378e9b23f3fc1294b3d18c4ceeb07d36215456f4a9edcfdac7905da19
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:439ed5e378e9b23f3fc1294b3d18c4ceeb07d36215456f4a9edcfdac7905da19
+  name: IMAGE_kourier-control
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:158301e7ab506ccfc3672182857ee798860d423d20619d9ef77d7a9125aa901e
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:5c39ee5d621432b2705d02dbe23b116b6874c989ea0d2211680ce16dd20cf2ce
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:2f82fcdc9a5424a2e195fda62ce0a018970e0211f253eb0d5ae47a72dd0bb6fc
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:3c5dec9531b316a539aea17e1f26cf8175693cf22c38c74b0b7a7ad8802c9497
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:0f8e6dc4e68fcdc249079f125c0fb790c8c8d31fc1553d3d28294f2314e42639
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:1304101d99492a0c2ebb147476d6a5431376f95a591a8bf3f68418069840dacd
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:75d24253847dbebf152f1be9905f344f121215143dff4f6561db1a6365047fc9
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:c3d0556347feea15e8499da84e21fc2d7cad612e5f7ac5ee21a9d1c5d067546d
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:30cbd7d8dba86c31cd9b4c720ef55dd87fa117bd11c8bd2898a3b6496550a212
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:4ebff3c09f1dc0db6d02691c96db2e58fe4e5913acc9851dd7f00b416905ac66
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:d35f063d640e85c620073e1d8fe0de299175fb05bfee2e9152ff5a2c5b2e5d90
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:c271b6fc5f2b44e7225983183ed6a64762bfbd9a0797c28c71ee09381b363772
+  name: IMAGE_storage-version-migration-serving-serving-1.6.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:c1316ef1b31940520f96aa48f4df4b8d9cabfc930b8b8bf6565d828fa24d0369
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:5716a22874c9afa06159da127caf28809ae4f3c18a58605ee662021eb8c9099a
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:5df77deac108236c8d3fc84bfaae9f86439557ccb9a08b9cd4fac7ce4e918485
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:91b90a9ba578595836772b4f7ecccebf77d1dcaf04c62e3f532d9beed90eb465
+name: serverless-operator.v1.28.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.28.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1alpha1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2023-03-29T10:35:00Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.27.0 <1.28.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/installing-serverless#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/installing-serverless)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/knative-serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.21.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:b15416de07b28ddf806030ccf0fdcc1e533fdeb06a57e644fd2f44c2ad59a5a7
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:3fcf747549ad9a8957291f1e943316230112f2d87b2fcc050342f5c9a58889fc
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:9590533eebf9eb8df3b844379018a4c72954ec15649af60a4dd930aaabd1288c
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:fe4fe36ac711e920e7c16b3c988f1d7fae2f14a15ffa02d1429a138b491fdca5
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:b92ebec07483cdbc040b26937f2e9e783222608996a0274af4eaafcd2c4cce1d
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:cdc6036077fd7a00eec8430f7d6f477766c19dc481da698c31bb742600420f95
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:cdc6036077fd7a00eec8430f7d6f477766c19dc481da698c31bb742600420f95
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:b298c043507ec2dffc4174b69944212da8c93ca576f7396540d1218375823c11
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:32b3441c900f1a5cddf5b6da1d9a1c64dbb90ec4528007ac74e7cf5a7c15fb48
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:32b3441c900f1a5cddf5b6da1d9a1c64dbb90ec4528007ac74e7cf5a7c15fb48
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:32b3441c900f1a5cddf5b6da1d9a1c64dbb90ec4528007ac74e7cf5a7c15fb48
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:ceec2bd7b6110e1ed600a1fb073199169b43f419af2001be72aacd5b919f2f45
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:1b54b9cc6e09c13bcd66a579d016ca0bed1d4ff730da590aa84e9d34768a6559
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:1b54b9cc6e09c13bcd66a579d016ca0bed1d4ff730da590aa84e9d34768a6559
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:1b54b9cc6e09c13bcd66a579d016ca0bed1d4ff730da590aa84e9d34768a6559
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:35595da04b43c8d89240d94febf5d7422347c29965ff0285384d302c295f8879
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:babfeffcd42a1868f16a83020c971557308dbc3c9d50603e79e9ff90f4d0db8e
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:fc206d5c18392591312a44117ba3f618e97d11774acd8bdd614825fb8a58ac72
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:73bfef3b4cc7cdce717d6cefdc8fdcf03c80def1670d4902fc82784bb4a138cf
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:ed4892179cf33d26c8fc8f760fd18b1a845a7cf801efeaee01ff38392ac8743f
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:090e33ff15d33e84fc631d1f8b758d527b92e9231b9a01e73779d7a3e3cc08eb
+  name: IMAGE_storage-version-migration-eventing-eventing-1.7__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:090e33ff15d33e84fc631d1f8b758d527b92e9231b9a01e73779d7a3e3cc08eb
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:93a16a4e4797c1296c7ec2541e02514b3ec605fdc1585b564de3e532da619e03
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:d1d5a3d77fc0b11141bede9fc69a736b39ec23c7767e5d905868e56837c3ad1a
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:a2f977de2d1ff2b252e45700a736635011d19ec3ac1ad919f0f1ee02eeee372d
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:42060246462ea021644d56988883ba09c78e9c79b2e71e7a2cb544be4e60a2cb
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:9f630f77301d720acd4692271171f7b21240f894c3ee3db70d885fd902192b70
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:c6910cd4596eeb1c45ad622a18a58a1d8d104f427b917cbec07453a6bebe5292
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:c6910cd4596eeb1c45ad622a18a58a1d8d104f427b917cbec07453a6bebe5292
+  name: IMAGE_kourier-control
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:0e8e9f227b9018c8325f6357f2001b9c12861a56918501ba7d62b381ecd88add
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:0ac571deaaa4e8a210cf7198caafea5ea628dbe8f18fa132c24ba12de80eb1da
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:91b90a9ba578595836772b4f7ecccebf77d1dcaf04c62e3f532d9beed90eb465
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:7cf16d2803e7117c2668dec4e0ca107057a72c27e58a61e3b1764750a46715aa
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:6259b6caa2ef106577b5d8fb86d85bfa242125f1a211e986d685e344dca8a5fb
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:82e3a8de0c7659b2ae6ad4af17f9a650e47c10ed5403dc4b31b8e2b30909788c
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:ca017304d3aa55dd19dd1670551dd09da195fdb53afcc8fdc22222443d7759b5
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:697e5b6c08df999a70b751bc7dd96738eb632b21502bdaf241c962d37a97e273
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:59470c6eaf1bb4988a954cd7fbc569f4a7ad2291ce08f21ec90990db0306230f
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:6d8d5d17b72cebbc5fcce39726cc1a5fd3a700270c4df3a719dcabf7d006fe96
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:c797d1c797b1edad00fb33b2372f5907eb5b8454138c3c5dc11996de24c70906
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:f9fd6a01b827dc78754f2b3af6df6ac5484a2a5bbd778865f0ee54382dd50219
+  name: IMAGE_storage-version-migration-serving-serving-1.7.0__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:8d1a5e189e38d38989ea8ae93336687104ac2b2b9a992d84734a1024bb128208
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:15444e6b93a05d88c6fc6ce1d1e7744635141291b86a7c3abb57758849a5d19e
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:d291e0d38bd95eb2731a10bd5ff06bfa07c6621528d3c2bbe888397d87b3feaa
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:12373623440b5b1aaea228550674ee69fe926ac6f12e7adffb5592afe1b98fca
+name: serverless-operator.v1.29.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.29.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2023-05-31T10:23:02Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.28.0 <1.29.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:df1a644da964be5d5098c0662cfa8c8a285d5af7c98fb01588f84cf2845f038c
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:1700137a4ae6e5c0642faef6b3e037952f985dbe4e9a66916c9a27511833d776
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:6bd37a794e0c14bed33a421d0b7ab14f29e27a05fceda818794180871a8b37ec
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:0cf9c79d1e92cc75464a5d21cda692b244a9348747c429af99d51017cee54f06
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:23b13a5f5df99757fd2d02031e7bde4994eb278100c7b3be1d79524133fdf35a
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:31233e08d7c40039a3a379a6417e308547588b298c20ef7480045cc73bac4abd
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:31233e08d7c40039a3a379a6417e308547588b298c20ef7480045cc73bac4abd
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:017c9fb76405200f475ece40dc6a941e01bf8571e1da7b9e112678d259703727
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:14355efa9ce4d9de8c2bbcd76e7b53adcfdea1f9914a9079c828ed000906b9fd
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:14355efa9ce4d9de8c2bbcd76e7b53adcfdea1f9914a9079c828ed000906b9fd
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:14355efa9ce4d9de8c2bbcd76e7b53adcfdea1f9914a9079c828ed000906b9fd
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:4d5b8d55c70a7a2fcd77f34748478e730e86c28df8372dadb683bdf197107a5f
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:de75ad6eabfa70a72ca097df12ced4d5c08d5d1638c0cb9979311631ae4980e4
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:de75ad6eabfa70a72ca097df12ced4d5c08d5d1638c0cb9979311631ae4980e4
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:de75ad6eabfa70a72ca097df12ced4d5c08d5d1638c0cb9979311631ae4980e4
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:680ecea2dd076df19b9381e36d6528a079281c7eccbaea7d14a4d037ae6f9da0
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:ff60dc234bf57c8b22da8619d637393f5644d7ba6fff2628b0c74284461aaf44
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:ee52c61446dfef920a841d45305b3db3cca1dfe58e1d88657714f920985af85b
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:255b065e6de2ede0e4aabe23314119286c5c6f30ba09aa342a58b782f909d3c7
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:b8bc97832af9159720eaf76a924dc2b994c8c79a8dc41cc6b52a39a95843ea22
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:e39303ff0e9b0b01693335474ea6e1650ef4ff24593b82edde84795d3f127289
+  name: IMAGE_storage-version-migration-eventing-eventing-1.8__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:e39303ff0e9b0b01693335474ea6e1650ef4ff24593b82edde84795d3f127289
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:2427735ced81c716796cbc6b0faca1fa9001be4f0eeca88162fd27c36cb96992
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:ea379133ea27686942d28a4a64599a01bde226a573e2b52195cda02971a33c7d
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:954e21ce48e71d442786606a7243e18cace48857198a514cc72eb167541696a6
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:5be90fad0e2c55673e78daa8b34b91e9d49a4989273c7e22daf4d76eff119de4
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:97d0f08bf187bf08d96f759b0c2730657985aa559833a42d02406f3de66ed4d3
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:d7544ab550f10248e936a05a7e08c14138ceffbfcdd246d716162cfb49576f2b
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:e1b2ef1088bd13a383e5081785f1774c6d661b8a9ee9018f206f045b220a916c
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:25c1b3a826a52ac32ccb99d7eec5af50aaa239f75f2cd431b55a215642a56018
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:12373623440b5b1aaea228550674ee69fe926ac6f12e7adffb5592afe1b98fca
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:6053cbc47c2b593b706a9746d1fcd804e17980ba86888ff1a8afaf8df5ce24c5
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:54824ae3fc2ed73e1b248d9963bb67ee0baa8039c30979b82f3ed419de8dc88b
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:b32016322fa03d65e1fe7b975935b2a1ce797c4ef1cc19d0a001544cebaee37f
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:070622ae01f756d10ecb0372ac29542f088e483cbac52aba73f777a70432a289
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:3f7386e99d2d42db1d674bfe2f06365ce13073d2f7b86c5ab3fca132452c6d09
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:521b3d612adfe63e63f7f62a76a7ab55795b4bf54f21b3d71920ca2f4757080d
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:1b63f829cde13dba494299df20277347662080d9552479bede58b01180ddc916
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:a73df9030d510897c831b7dedd218b7c8fe5f065fa286257261aa7991e6a5aaa
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:528a4ca8ed4e5215854a1be80a1e462a32ea9719626133c6b9e4a5825b37fbe7
+  name: IMAGE_storage-version-migration-serving-serving-1.8__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:336357410ff9faf580d2ec788b6590425b816c15171448ce6a96c5a5ad63231a
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:b6281e8ca3553e745edc914cd76ede5ec85e2717cf0a67c235275a026b90ba48
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:16b39335e97bcc7c970a8ba385c61d8333e9912faaee813ccf8520d434b7bb7a
+name: serverless-operator.v1.29.1
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.29.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2023-07-28T05:42:31Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.29.0 <1.29.1'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:3aab995872336e6ccb590ef6488c097cff38a91348055031145427a00aa6b732
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:8273842d8e1714fa03c7e0809924b1ffc5ef282f79b9606bd8ac88c03e7a16bd
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:a4943c0563c45ceccfda0a01e26be3a01c1437c89d927714c577bf6060495958
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:7dd11d385b3d5a178566d901650ecd45e4af395faec2141d57b98af8fc1e5151
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:b780634fffe2257eb845f8c1d25498d9c654d0327c1f8841b40d90c176a2bfe0
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:61fb98802490323bb03ff4a7060334d8fbda9e9f95cd6366b29b1b6494e4ef8b
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:61fb98802490323bb03ff4a7060334d8fbda9e9f95cd6366b29b1b6494e4ef8b
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:216f58dc8c8166c0c69fc0312b667daad14cf39b7aeb7bc0fe1e313376f1a5fd
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:3d7801f7ffe6420595779673a170235921a9090333f8ca51d5b7f664e19c82b2
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:3d7801f7ffe6420595779673a170235921a9090333f8ca51d5b7f664e19c82b2
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:3d7801f7ffe6420595779673a170235921a9090333f8ca51d5b7f664e19c82b2
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:fe916630003194dbcd3894dd880cad8b15a041a5e534cd8f76fde6296db00797
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:56e48afb1dcbf4e266ace944105f3c45042550d8d4a0528c982225a793d26d56
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:56e48afb1dcbf4e266ace944105f3c45042550d8d4a0528c982225a793d26d56
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:56e48afb1dcbf4e266ace944105f3c45042550d8d4a0528c982225a793d26d56
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:c4cff5ad5b0ac79e71a16b88640a312ab320817041317f50caf575f7e12a864e
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:397eb425f383c1273c7976bea69a603530676a00a61f461ceb5f48d67901c4cd
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:04866e16881f64ff2b5edd379eab0731c9d66a47c25ebfe79c8d8ad33d8116e6
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:f37f494956adf0892ffca34d2a4c9b839ce28dc9f2779ca32e8801fb4f0e9105
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:4408d1fcf34c0ffe9327d4c9c0bc772afa969d831bc5de1097164d10b4e8d900
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:594c3ac24bf59802e2d3fa127e4051277bc07b6444f934f535fddeb668ccc144
+  name: IMAGE_storage-version-migration-eventing-eventing-1.8__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:594c3ac24bf59802e2d3fa127e4051277bc07b6444f934f535fddeb668ccc144
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:a3c5d5fd8014c432830be912aedebbc58f9c60a8cabd87ae6c42c7b8d27db8f9
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:fd86ea2a34de43014dea3ba2b8d705a3d94347d3a24a370a8bfd032ed239dc56
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:a59ba5aeb8e66db3d8ba9074b8e553603c59e6b0e35b57b82c4ce3de589b94cc
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:c12c471902b8e2596588d9e553ad59b501d979dd04f301d45f7d45e794737a8c
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:ab90ec9b3cd9203fdcdd7c43abf95f48c9d7479a9c7af479eb1e4b6599ba9642
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:de0634d14962bdb8701a8c29e80b7b70684824462bc5203e5fa7f139839cb73b
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:557e73127326be051aa6257e7daeb9721e2af04d2f06cc26cfc7a1073666b989
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:3b7449287adf98f0cf0a1dc74e03b69218be3bcf5538327bc34ef776cc1c69c4
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:16b39335e97bcc7c970a8ba385c61d8333e9912faaee813ccf8520d434b7bb7a
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:bd134e64c156dc5c81d14522c9c9efcc1f56b2e972ac8ecb1bb1b130c76adc60
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:10788ca67809e5a2d76d6d72df7dd64ea4407773999707a7681e0cf1b5c4695f
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:c2cb80bce34a74afa76151d2b44dc25ece73fb274cdfc6fdf243b1b0cb7d989f
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:6342358e6aed2339333ebf37fc223a41a0a3e199a0e4a840f3f66e5accf8f233
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:e5db11a0adb889f907cad797dad9cf2de09c433e5522fa333193cb35575802d8
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:03a3d6f0314acf4da4f3d3d85f1e273a3ef25828d28f5b22f394441d55a645f3
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:b520305189c7567b2f8ac867b20468259fb22cd3edc5b4576af2bfcdb0c11855
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:0229a0a4f026f04f8fa0a1cd8e7afea10117fe3f12e21986ec6089769c8afcaf
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:ad399867cbb712111db6affaf5c9e3573699ed0eb0def8ce6057de02054ced4f
+  name: IMAGE_storage-version-migration-serving-serving-1.8__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:aea5f200a845e1d4dc718d76465fdbb1eeac2b20ecae224d5d20a98214ad0357
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:a10e76aa15707e708f82c8d9e8b5179bf67780d99f3c3e2e99b84ae2a0aa4ecb
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:31d45f10a8519addec9aac115c5edc8a2e14f9621c875d95f123d1291776ef4b
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:ffcf75e33c5bf527488fc196bd94bf615ac06ba5735d87cf568777f27817d214
+name: serverless-operator.v1.30.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.30.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2023-09-13T06:42:20Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.29.0 <1.30.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-istio-controller-rhel8@sha256:878b6636ab69fe91f25536b7156b0c428bfefb0ab6a544a53221f78593b6372b
+  name: IMAGE_eventing-istio-controller__eventing-istio-controller
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:f3f2be68d83efc82d98500f4a87fa75f36a0823109222ef3f9ebef4ff8caa1e5
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:6b0b0edbdaf491daeaca4bd88a01f2faca9ba677fdfba7f09ec799ed49e81fd1
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:55a362bf408f7767eee8a7cc66aa42173edeb227007f5fb946cc98d72a27a46d
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:d90602d0ca6bc53be0a7c5ac918e20ad8a785c6c80a5295dd975fcf9acd582a1
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:94e60d27f23fdb0c7b831104e4dee8c32a9f689102073a98e5f463b796705924
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:d3d6f17d4147067c6a01e386478746d17093daca6b569242c7cfd6cd9a97b604
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:d3d6f17d4147067c6a01e386478746d17093daca6b569242c7cfd6cd9a97b604
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:c2e593e3782b4edfe94e4b044870d980efa71d2b857838ae5cbab04b0fd428b3
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:4ed88a1283de6d44ef715e9d0b352080eae6ba3a2565f3be1626b9df4b6b4355
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:4ed88a1283de6d44ef715e9d0b352080eae6ba3a2565f3be1626b9df4b6b4355
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:4ed88a1283de6d44ef715e9d0b352080eae6ba3a2565f3be1626b9df4b6b4355
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:e2a4df5572c4a79871beaf1adfc3a6968d6fb9f94c0ecaf60f81e1df6be589d7
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:0193f98cf23564b1b3b8c09f9ce18e606a4c1e4127dfad36c6dfc88601c854b6
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:0193f98cf23564b1b3b8c09f9ce18e606a4c1e4127dfad36c6dfc88601c854b6
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:0193f98cf23564b1b3b8c09f9ce18e606a4c1e4127dfad36c6dfc88601c854b6
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:b44b0285c86dd690205205c70ee3b95944f7ec5a8a184e8cbece8696b7ba8397
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:d27ae2a488c47def76ab73fa090732bf00da491c805b2c03f56fec5baaef523c
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:54466fffdeee09c7b844a1b4bfbcffb234c31c0da71f8d699ed04d7b0228d72f
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:9f288b29136a38af904f4a575c4f7fc3cfd0732381046aacf2d5b72bb0ef4f29
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:434dfaccd8b3023d7c4a2995906e4c1d0626f3214e368795b15212ba612b1a9b
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:c31e65263eec89259a34156aa1c70f5f6c20023d6e716dc6f8cde420a16d736c
+  name: IMAGE_storage-version-migration-eventing-eventing-1.9__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:c31e65263eec89259a34156aa1c70f5f6c20023d6e716dc6f8cde420a16d736c
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:ef34d78cd8857e9202b1bf2e1f28797153fbf27852d5e9d59b3b0d70c744eae6
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:c6ecea4da8e0e72a8b58e25e681faa151343d03dc02f8fe698a4ba66d8b3e62e
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:e4175b5314225a97831f6319bfec12f1ecde62b3529ce2a13eb13f1145385819
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:38e46284de2046c14a1c1580a6a2d10ccf5f2eb946a572eaf0ce497975d9a130
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:52deb374b370a2c45282d5081936420803211a982558a0ccee9adbab1c48d8fe
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:6af80c73d02572686404d0277e5d55ccff336fbc16c83469366e980c096cf50f
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:384300fa3d5a1deaae9d3a83c344b8aa245f8148a189c667f81d328fd9785530
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:d26586495d610c2ec4822d67207bd3c3ec706ac6df09d9d92c15fb0d10be3f4b
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:ffcf75e33c5bf527488fc196bd94bf615ac06ba5735d87cf568777f27817d214
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:af9befc10f19ffae5048cf1f5d2ccefb2bdfd52a5490bc7acb0da6491313ea7b
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:8cb0aa4114c6f7810f44df3ea5930e33d3e06869baeb70b7d4160d3b2d5eacd8
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:5c1cd0dc1e36cf2c21456e84213479bb5f1193b1e909efb08ef3ccf78ce64c98
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:bf58a62d055902b69b448b920b5f4c8ac40361a610bb92b656adda9118a0f5f0
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:2100246675d771ab1304dd4d289985777ee23b145dc816a2461288b4b2f77dae
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:663064adbeeb19c247a6a5ba6d35f2d5bd29736b55bd291f9b2d0c2a4557bfd1
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:e6853dfc59520ab918e979c30fea9ee2c8293ac59d03d52a0e2185c035ade314
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:96f096660fdfbe8a319dc2653b503bdb2c7f226837ace099658c895f8f36a207
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:4ca203b721bc789c81e8bfe4734640b0533d0361d9bb2ad284ffa8e143512eea
+  name: IMAGE_storage-version-migration-serving-serving-1.9__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:e65b92e13e55027dc070ed2d0acd2f7e6749359b4bc82263302b9ba6444d07e3
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:2b5cb346d61deb35083fab97ffbda6d2f6e04aed7e10403b995b654c1d0ea393
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:e5091cc36ac7bb8c776c16891cbfc12e3b7810d9003ce034a6a8697267666a7b
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+- image: registry.redhat.io/ubi8/nodejs-16@sha256:3116913de59e6d17e40282a7924104ef835a1868cc142dd6cbb0d93f6b268bb1
+  name: IMAGE_KN_PLUGIN_FUNC_NODEJS_16
+- image: registry.redhat.io/ubi8/openjdk-17@sha256:7942acf43a41b8fd202de7c5f7745d9732fae00a401b3da06e1ac988ac26ba4d
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_17
+- image: registry.redhat.io/ubi8/python-39@sha256:547b3c90f95b53e2ab2a839b6187df54931ec84bfe4ebb9d2e053112b7bc511f
+  name: IMAGE_KN_PLUGIN_FUNC_PYTHON_39
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:51ac9aced282f62c8fb2d3696da3696b8496d8f877e9846fe3a4a743ccd63bea
+name: serverless-operator.v1.30.2
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.30.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2023-10-30T14:03:25Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.30.0 <1.30.2'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Represents an installation of a particular version of Knative
+          Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: Represents an installation of a particular version of Knative
+          Kafka components
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-istio-controller-rhel8@sha256:b6ef281fca2b80d379b1e28fe3f23119df8ff765fb2cca291d514053fb512da6
+  name: IMAGE_eventing-istio-controller__eventing-istio-controller
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:a0c5a91348ec71697747113990652feb024143fbbd0cdd67e8ae672730383a79
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:92a39ca90984cebb1938447a31c9170b52994ae98f83caa860acdb2c3ebb75c7
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:66149df8549380673c24e1487d0c2c8eb638b7e502455671ca64ed6f32ff82c3
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:96c135ced2e3bff434addb012368d96d0778ef1d294ba507ae7e624811e20d46
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:cd1abeb2067afa44a0f1eca301cce37307582d56c1147820ff86b9b64a40588b
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:a5154f9d13a1c373b8ba47e2bcfb9d4474fd03e08db4134c92aa4f049536f1a8
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:a5154f9d13a1c373b8ba47e2bcfb9d4474fd03e08db4134c92aa4f049536f1a8
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:e97eb2bb7eb529cbfe67c14e823ffa1269d614e2d35723896e89efa12a499c6a
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:06e9e073f092dce67d4227e282fd8eea6dc9f38b90a8d444cf448d80d027b616
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:06e9e073f092dce67d4227e282fd8eea6dc9f38b90a8d444cf448d80d027b616
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:06e9e073f092dce67d4227e282fd8eea6dc9f38b90a8d444cf448d80d027b616
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:e9505aba7c44cffc3f261a5dc7617a0e54ed98e78f73ea3c9c7a508560b792ed
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:96d6f52711ba433ab2f273be8080840a88e626e989027480424d19c2fe1e9454
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:96d6f52711ba433ab2f273be8080840a88e626e989027480424d19c2fe1e9454
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:96d6f52711ba433ab2f273be8080840a88e626e989027480424d19c2fe1e9454
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:3c8bf480dbb05e09e8d07cab12e4736643f61bf9b5d98efa6bc0557eb31887bc
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:a9c95fc208cc03625cf49bcebdaac73da823d1fa3bfae4239d7db20d3a0b8723
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:124087e6402caa375b24b976c3b9fd7d53890e20ac3b0b57ba3ac646e352c7ce
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:1f7e65009168383cdcb6b2caa22fe4db49e03c71574973a8086f6c332dc5e26e
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:1455606c8edf611d996a48e29ead53e0bb4078f55384b7689058bb25fc59fb2c
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:69ea22c646c09208ca68345d4b3508453d8c49f7f7fd9a4ff4c4cb78be7bff43
+  name: IMAGE_storage-version-migration-eventing-eventing-1.9__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:69ea22c646c09208ca68345d4b3508453d8c49f7f7fd9a4ff4c4cb78be7bff43
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:9a28cb1d4c4f4dd7d494829eeeb7122db2174a27747f915244672c95dc8f9d12
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:4800c85e8de031bf77f6fae0e4c8e6c1a9912ccdfb77799cc2ea574c37d870ac
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:5c933641efc6bf919b1945be5a01dfb7774ae865975b1bb1f44653b3e4ca9f1f
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:16939b802f4c16a3d9d941917d0363325f40cdef28f6e1a982bc95401117674c
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:3fb6e7626d2b0c92c2a2fef35e9b8171382b4bdf54393f2ab1281ae7ab441761
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:e8c756b659f6187790bc1a5115e0f71791bff96630859a905bc5b75d14596e0e
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:3508434d5ab6b38c8a7466256f1158ebcd75e8b751afcc5255da8c21566804f0
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:6057a2d18406e00b0b7b1731870f707844e39193d4cce6de50137b77f17d220b
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:51ac9aced282f62c8fb2d3696da3696b8496d8f877e9846fe3a4a743ccd63bea
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:32445e4a73bc7c1e8007775adeb147175d934b17e7d3d4dcf422104dbe80a52b
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:2d3e314a6584fc6974517c1a992fb59f5133f54c2f6cfaa42f579c0d332e0300
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:c9353a022e6f883b7c0b2d87b1bc4653172feb13806ebf0aa075d6f9f43c264e
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:21a638b481639c3c58e8b026d875917c30a5874b08fa4ceac40d447076b2bfa4
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:01c8fee92889a84a19136b0843e4fed5db31c1f2a6d997669f103373fd995e36
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:12bc62246142a605f4efed0f6bb8843aa2df7699cc1c5ab53debb94b0682e9d1
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:85a369d5696771d0932b61760336e52ae3f7c66f9a3def5312aefcac03ba516e
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:ce4b36c90955a356a5774410356aafdac2b60795526a3488b0b76ac2ec1a018c
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:ef116868c9c60e5ee246060688da49832571ff6a7901cfe143a42d048743736e
+  name: IMAGE_storage-version-migration-serving-serving-1.9__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:2264d2cd4ee2a720667d625ff42b6f8be4f2cd65b57a91eb6044da086a110740
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:d03f2bf8f5e7cba47102ba26ea0149ae6719076c645d5e451058392d6044b738
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:53d3620bb0490d83aaf6a356bb7d3b9e7147222d1a2017f8317f05fa90cd3de9
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:a1e5cc0fb334e333e5eab69689223e8bd1f0c060810d260603b26cf8c0da2023
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+- image: registry.redhat.io/ubi8/nodejs-16@sha256:8abeddc6ccfffbe313f87e5e069e18cb7047f2c7880ad63cf15bcd0a79ba71ff
+  name: IMAGE_KN_PLUGIN_FUNC_NODEJS_16
+- image: registry.redhat.io/ubi8/openjdk-17@sha256:af305e087061cbaa4107ce0b304a1ef987f6b54bae3f75bfd529cfd084cba9b5
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_17
+- image: registry.redhat.io/ubi8/python-39@sha256:0ff58549041d32b685cc850aaa85da32d1ef73f99cd4b6e0f6882dad5f0399bf
+  name: IMAGE_KN_PLUGIN_FUNC_PYTHON_39
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:469ae5fc8a478d6d06b13e218a000f34dd988eb69a9488a6349d67c76bda5b49
+name: serverless-operator.v1.31.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.31.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2023-11-10T13:49:39Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.30.0 <1.31.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A platform for streamlined application deployment, traffic-based
+          auto-scaling from zero to N, and traffic-split rollouts
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: An event-driven application platform that leverages CloudEvents
+          with a simple HTTP interface
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: An extension to Knative Eventing, merging HTTP accessibility
+          with Apache Kafka's proven efficiency and reliability
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.24.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-istio-controller-rhel8@sha256:799442ad945fc58d456544870b8c93ed678de861523a4c4459a1f61e601fe1f2
+  name: IMAGE_eventing-istio-controller__eventing-istio-controller
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:81983437cfbe05cc1cc13e98a91937d6e4bdba6cd40b1cdcf9a4ed3da4bbea84
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:e36d4a92e03d35be45d34036a4c0aa3b4ffbe606280ca6bcb43cfa89dbe67abd
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:d5efaddd8b952f2db4f0b772c065959db0ad468d6e228c3a04c90313299591b1
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:6b9b0f30d83449e27d93053974cca4a4c9b88e2452cb1c6fd60060b7fe2e59cf
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:aba60380667304288108e8aea038ba78e5722f526467c008e870598cc7aabb89
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:d6f30d4fd44f27abb5879e08ba3c62bdd61b238d3013543a006d7fabe30ece6d
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:d6f30d4fd44f27abb5879e08ba3c62bdd61b238d3013543a006d7fabe30ece6d
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:e3073ad3a1087122dac854b64fd0393cf75570832ea4f687a97233a95abac1ab
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:44770cb87f6640896047e74d50cb4f58acf453d2c5f468ac1a5a60c0cbb7cb0f
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:44770cb87f6640896047e74d50cb4f58acf453d2c5f468ac1a5a60c0cbb7cb0f
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:44770cb87f6640896047e74d50cb4f58acf453d2c5f468ac1a5a60c0cbb7cb0f
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:d3913d9fd4319bc4a35404c1b6ee3ee3842780303a577041f870b0e1cdfa4935
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:7357cb94fdfac229440c1cc8b48c9e239905b56d092b5908d417674303e3985f
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:7357cb94fdfac229440c1cc8b48c9e239905b56d092b5908d417674303e3985f
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:7357cb94fdfac229440c1cc8b48c9e239905b56d092b5908d417674303e3985f
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:8b063807c2d5f119490af349c3be7c0d9c4ed08e8b003c850e644da92a38ec32
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:f192775d31ef1310283bf6f4dc55bcc706d8ad7c76f511ee5533ffdcf7234ef5
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:7c819b725f73e7a5eaa8bc570b5493dbbdf362bd67c301054a85cdbd042a2dde
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:a5e16256bf52ac39b825e672087f0b62b4e21fc754b8d858ed4026d33bf77ff7
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:02ee04425ad07e1e7bad676ff0c6cb701a0ca4902f4161c1daba468c7d040cfd
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:1ee87b158f4999d122eddd4aee57532abf6e5da36b37091aafcf7bb0cbecf6bf
+  name: IMAGE_storage-version-migration-eventing-eventing-1.10__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:1ee87b158f4999d122eddd4aee57532abf6e5da36b37091aafcf7bb0cbecf6bf
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:3400b67d44b8083aaaa63e0c0215cb6faf07961f8f4b5bbe2f7eac4d33bb794b
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:61ff3f22c1c4cda4af6513da52ca3e818e88b96cc07eb015ea22dc95dce682f8
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:b8ef03e0fda4ae02ddb6528edffff4ecdd701a28c3e24a2c36c4b17172b06bf4
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:8dc7b63d51530858e09c1d90e7007498a84766263927ebbecb3508b12cc3e788
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:7fe03e661ebdcedba5db5aa9fdca0ad5a2769816b9469f867a0465339dcfc1d7
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:d70493c2bd8060414133c356ac1487604adb370207bc9f33080fd17c47f75951
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:7f49b246dc8a9a37cb319d74ce558958a641a352298a26ce19b82003d22ff464
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:b95f4530f0fb78a995948c095b8e935ce3a55b5326bc2d790d42cd8773df3b7a
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:469ae5fc8a478d6d06b13e218a000f34dd988eb69a9488a6349d67c76bda5b49
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:33a2515591d765cce475f8612e281ba1d15c6fad5de7f5c49f6c2b1da3c8347a
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:91807aaf7647d301be03f29ee675b909cfa72c7720cd32f8c7f804cec113d9fc
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:fa4cb861898d02d1620877e28ea5069780e7e9e7b2cb59ccb8f38d9171cebf67
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:c15bbdf5bc0f0da8361e41e684c6c9c35c628c3e8a80cfe40a1fb0600be941ab
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:3600df5efe06496da2918e865d8fe43c26bc3061204a10a4cdad4e267d19014c
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:eaeb93ec6fea66614dc3e923f16df87b65320d23060c52de7f7b222ee2c043f8
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:18dc68d847d8591f1d6842dd43350c6d1e6c898a7c16afd42841e629e159480f
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:1dec256cf8b51aea56b3dd92d9da6fa10e8ab12b888eb85d2d411d2a7c7736f8
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:0753f7da3aaef223753dd87078f3c84199981c5fd5af346cb0fb2cec00c324bb
+  name: IMAGE_storage-version-migration-serving-serving-1.10__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:ef800c728bdba35b8e5df203a8efe3f519b628f1f8c2b461fa90cb71995b7365
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:d03f2bf8f5e7cba47102ba26ea0149ae6719076c645d5e451058392d6044b738
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:53d3620bb0490d83aaf6a356bb7d3b9e7147222d1a2017f8317f05fa90cd3de9
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:55f5c7d88c77e1ab5a2ab8e877172b2b66cb196e21f10dc45148470d0ee8bbae
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+- image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/ubi8/nodejs-16@sha256:8abeddc6ccfffbe313f87e5e069e18cb7047f2c7880ad63cf15bcd0a79ba71ff
+  name: IMAGE_KN_PLUGIN_FUNC_NODEJS_16
+- image: registry.redhat.io/ubi8/openjdk-17@sha256:af305e087061cbaa4107ce0b304a1ef987f6b54bae3f75bfd529cfd084cba9b5
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_17
+- image: registry.redhat.io/ubi8/python-39@sha256:0ff58549041d32b685cc850aaa85da32d1ef73f99cd4b6e0f6882dad5f0399bf
+  name: IMAGE_KN_PLUGIN_FUNC_PYTHON_39
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:a82288782b61ea46d068cc09ee10608d3201c136abfc767e4d37734775101390
+name: serverless-operator.v1.31.1
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.31.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2024-02-01T19:15:42Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      olm.skipRange: '>=1.31.0 <1.31.1'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A platform for streamlined application deployment, traffic-based
+          auto-scaling from zero to N, and traffic-split rollouts
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: An event-driven application platform that leverages CloudEvents
+          with a simple HTTP interface
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: An extension to Knative Eventing, merging HTTP accessibility
+          with Apache Kafka's proven efficiency and reliability
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/installing-serverless)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.24.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/eventing-istio-controller-rhel8@sha256:5b38e5c71e422161e40f9c37dd2f46212cb80e8e37b00247767276b957080397
+  name: IMAGE_eventing-istio-controller__eventing-istio-controller
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:433821e6c7f43da5ca2e38c0550722feb179a0bab021decd9a97ad020cb78b76
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:3181ad775ead55f317f96466c2719b2b73c5b35d31933733da21273955d160c4
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:3dab790fa845ed7eda088e5abdc87799da1354884a53ff1ff728739b8e278418
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:565becc77dbe3bf03d89b1399d6e1853253276a71e80b6b14069285d03cb14b2
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:9e120ecdbea54eecbc5e0412c1774f8a2ee70d7fca682ecd0757b8627f70680b
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:df1aee67a161fa19d7f49ba56d53e0682cc1996436e985a12a2068fa419b54ea
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:df1aee67a161fa19d7f49ba56d53e0682cc1996436e985a12a2068fa419b54ea
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:2572d98363cca2dd94984d6cefa573c5054fc206ee70048f901ad4b846d8dd52
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:af5c30fc9f631d9ed110641b815315d8b4aef539f687277a3821d9939ca5dd46
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:af5c30fc9f631d9ed110641b815315d8b4aef539f687277a3821d9939ca5dd46
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:af5c30fc9f631d9ed110641b815315d8b4aef539f687277a3821d9939ca5dd46
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:3be4fc173b489d0beb768739f60274e07d95ffee86d70a8423e1f59678c805ea
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:eacdad8db61b23634c3f89bffa3f1c30ac5c7bbb5e938c6208003ff00f9595f1
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:eacdad8db61b23634c3f89bffa3f1c30ac5c7bbb5e938c6208003ff00f9595f1
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:eacdad8db61b23634c3f89bffa3f1c30ac5c7bbb5e938c6208003ff00f9595f1
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:ef7d28580e75d746449a90cc0e5343ef3f4ddd75bd9fb866d97836bfbc3b314d
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:677be039353b2cee51d5faa5d5a2abd6a7bd46992ffe9521eb033eea9925c785
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:7941b421b3e18bda8c565305241621fcdf1212cbbe0dc02f38f4ab0565d2bfcb
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:9221a833ecc66fe2354aee7aaec2a2470b21e2d89cb6ed287ece32edab2a2edb
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:486bf60d17a5d265ebd65d590a6ee1a7e13bf3953ea797b2f6c2b5910789858f
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:1fcecc11b55007b9c6969a24940a391968378e4102eebf7ceabbe7efda138575
+  name: IMAGE_storage-version-migration-eventing-eventing-1.10__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:1fcecc11b55007b9c6969a24940a391968378e4102eebf7ceabbe7efda138575
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:80361e052d366ffffe9a99893cd83965bd69a9ff81d8c9262976de145bbc6184
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:cda04e3b7c2c1f37164733ad162ea0c4e52f14fdc8eb8bdef8507f0ed5454640
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:de62762efa0df95ed23df56f5520490d8a231e47ce13c433c512254ceff81844
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:d8bdd96c6a9b31f48c961ca438c254511db785fd34bd10b98084b702baf0ebab
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:d2a34100f6309c3cbac7c9ccd452b7bdab2a533afc99463bfbf91e3ba2706d54
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:1ee675125f7141e91f4ee57ebce082967834bbdabe1a870c221f31aeb8750be4
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:0a2989f688b966277652957b312df736ada43fff78fd89b17f60b2137e38f115
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:dbd9c0cac86f79b8d91ab65ae7543854144781d4cb17ef16183931ec9bc234a7
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:a82288782b61ea46d068cc09ee10608d3201c136abfc767e4d37734775101390
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:3a4e7412322755b4c278540c965a403f9e178f138bd4ad7929c1c24a8036dd14
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:e49220eaf3143a8958f0cb1f22115b2e834fb7177755433bdc592b753a54a8ec
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:63e08279d2852d494d4f8836c54e2ce942a342f452a23ef437df9640bb2f5bc9
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:3b01ebdb0704dc6a1a993ac076819489495ab3fe32e3c14609e42d1358856be2
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:b37dd2cf4b459fecb6d681cac36918e486c3bd22501df50b90e20b15fe164d56
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-rhel8@sha256:22ffe08d6a0d5461158613f2b2a2ac6936025357e282a09197a750c42b5e6922
+  name: IMAGE_domain-mapping
+- image: registry.redhat.io/openshift-serverless-1/serving-domain-mapping-webhook-rhel8@sha256:99f5dcb92a33c047f0b68236a3a42ffaec78037dd0a5eb79d1144d62d6bfcf43
+  name: IMAGE_domainmapping-webhook
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:8353ccb4f0d70597d61e4fd1f799d4bb74e5bc038f6b9916059e712aa70b97c1
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:887480662b1bfe09626fbca8ec7c5da879d097c46dca11764ea98474ec78ab5d
+  name: IMAGE_storage-version-migration-serving-serving-1.10__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:b2480154951109a159acfb88c5472a312a515d6a6b060d832b3f7bfc16f90ac5
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:bf693eaa845373e1a06041626a9314ec00519a6fd2437b12f7f4f3f104864039
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:c078071cd51c7fd5584039b54a2004331c05a897ee8b0689bfcb9204a8ebae80
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:b48f410efa0ff8ab0db6ead420a5d8d866d64af846fece5efb185230d7ecf591
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+- image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/ubi8/nodejs-16@sha256:f90b28179d1d5de68d42ef1a9166d70a9dfea85a1c6a4bf12dce2c59eeb2fbb1
+  name: IMAGE_KN_PLUGIN_FUNC_NODEJS_16
+- image: registry.redhat.io/ubi8/openjdk-17@sha256:a8165bc2cd5051a96d6937e25ed03155bbd4b731da6e58cebfe2ea83209c16d8
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_17
+- image: registry.redhat.io/ubi8/python-39@sha256:4f35cbcc6f4e108c69f7d2b70cce5afb138741b0c961506376d524e001b922f4
+  name: IMAGE_KN_PLUGIN_FUNC_PYTHON_39
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:b84351200cba437c323f7f21d0cb58e0a443d772376a9ea6de1278a68d1c2c7d
+name: serverless-operator.v1.32.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.32.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2024-03-11T19:05:23Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.31.0 <1.32.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8@sha256:faaa1ecd0b2b7a37f6e603435b0417d13693662c4bc85a6753f770a14a545ff9
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A platform for streamlined application deployment, traffic-based
+          auto-scaling from zero to N, and traffic-split rollouts
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: An event-driven application platform that leverages CloudEvents
+          with a simple HTTP interface
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: An extension to Knative Eventing, merging HTTP accessibility
+          with Apache Kafka's proven efficiency and reliability
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/installing-serverless#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/installing-serverless)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:f23587c78cecb9c09b7beb8e572a662cf4dba7844c08abebd583f205a993c435
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:5121f1657645c4932fb2cf1e85810e5e135dca3a297138c687d827a9e493557d
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:bbf27adc281e3b5e573f7cc11abcfc03e6a50adf6c7160d1e7d427077d288b1c
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:b01e8aa83f81b130aaafb4b29434bfd9057f6b84f9aa1cd3bc229b6c8207ae26
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:4d156ad90ade221eca5f6ac174245554984b710e39005a7bfd57ce2590800d08
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:4565dd8737c1e84950fa482ef06c6e11084b7873a2272d3a317ac0687a97193d
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:4565dd8737c1e84950fa482ef06c6e11084b7873a2272d3a317ac0687a97193d
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-istio-controller-rhel8@sha256:15af188d02f524da32c0122c3a02b5ce58bbfb6b729abed8c04def9f0ff0b04d
+  name: IMAGE_eventing-istio-controller__eventing-istio-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:9876c845fe0f94fd53d48a862eb44d219d852b506715c8763934efee30e44475
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:b9bf9288f5008269624b2a3c592d32d8943b9ae536a6b4a65799a7847c051a4d
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:b9bf9288f5008269624b2a3c592d32d8943b9ae536a6b4a65799a7847c051a4d
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:b9bf9288f5008269624b2a3c592d32d8943b9ae536a6b4a65799a7847c051a4d
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:443d5cd21bc2721ae6203cc1bfc6310478c604ea060dfb4496c1f25c5f1b4543
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:b443a4f71e0c479026c37f268cebf05e811dff589f1d69e2d353ae20612356af
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:b443a4f71e0c479026c37f268cebf05e811dff589f1d69e2d353ae20612356af
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:b443a4f71e0c479026c37f268cebf05e811dff589f1d69e2d353ae20612356af
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:5c7f98c061bf856c298a14bba2e4e3117ca3883c5be1697b4ca6b4750dade719
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:c86aa26e00a2248a051470e7811623dcab6d1ffac6b6831551294dbd13a937a1
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:b2e3f71858b44053be240c28955574338e006e7a70d650429575333a1fe52a8d
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:1c8931df351e1df76ebd32e2a7891d4b242c4f9304c511e8df04fbc23623b4b6
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:6f999e5dd1bb415ca53c4c8fd8a3e4a032ca5cbebb3354e44d620f1d83a8d489
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:4a5e8233812053808fbf4d26dae6cb512027c872f93ccb09a54bd0065d4720f4
+  name: IMAGE_storage-version-migration-eventing-__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:4a5e8233812053808fbf4d26dae6cb512027c872f93ccb09a54bd0065d4720f4
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:ef0a507ae9676f4cd27ef56e81cc2e6b14ec40004e2b6500f7351f5a9e3eae69
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:fa4009b583229378dd3ba0348297fd0762aea352895728c648d98e7b34f1be13
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:58f6b6ec4f46b76cc3a25b3896f0c544486f6a9ebdf8bf8ca1974c90cd885b6a
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:73f0e84235a401319734ab3dd0074533e2364d5043e7afa711ce0c40ca3d71bb
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:764bb6c4d2b86c723e5641f8390ac6aa7d28289b8eb982fd2985399274f910f6
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:cff8c78f5539343b44f20b464bb7848973c94b17b91fde02d0d6c126a4df0a06
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:bb93b5d5a33e10b6e836f338199b9ae563501af1a5ce9840967ef00009f2a07b
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:854358e190dff1de84327877fbb9f61fb177a1f46cb2cc0ae79b62af3c252e7f
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:b84351200cba437c323f7f21d0cb58e0a443d772376a9ea6de1278a68d1c2c7d
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:fdc073804608d432ffe2875cad548bc5bcc44475fa413aed62a33b33d0d6d822
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:bad92005f90f01c0e088ad55ce159c3823cdae233125651879379abeb34c7a60
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:68767264f30604fb950cb29b8f6d4da653d2cedd82a1c637a5bc04d80b21560a
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:3d6f35b63c546c6fd3de5af79f8402f4a27a7d7274a5f0e64478a4e015c3e805
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:f0fa22afae2d140496f64e5e24f418a3ab75be80b0b6e4710d44ca493d1f6628
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:6494a92d822a6ae4ff730a0f0010a78f94b4f632b2a00f712870678c3688df4e
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:1c66deb5e98e8c28741d87dd3cb181b478c7ffaf97e92cfd81abf538200c6e52
+  name: IMAGE_storage-version-migration-serving-__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:0010a994ab96d55f29be56819629b9925cb607ab5981171a6e45c08df62045b0
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:bf693eaa845373e1a06041626a9314ec00519a6fd2437b12f7f4f3f104864039
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:ecbe2c0919df429655d90d0d0a6a795b5ddc5b27984e800555a8fbc2958d4342
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:55f5c7d88c77e1ab5a2ab8e877172b2b66cb196e21f10dc45148470d0ee8bbae
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+- image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/ubi8/nodejs-16@sha256:82cbcd71ab2ae4852e87411682f0cbccdda8aa9f3edf40445d8969f77b453287
+  name: IMAGE_KN_PLUGIN_FUNC_NODEJS_16
+- image: registry.redhat.io/ubi8/openjdk-17@sha256:7016a0c5ce878211a8b82fbeb6619f82a97a35acdba6773be1c5f92f4e85aec8
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_17
+- image: registry.redhat.io/ubi8/openjdk-21@sha256:86e499efaa15b1ad6221aa4d4fe26e514a8bb721aa3bf7575293b7101eb0e128
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_21
+- image: registry.redhat.io/ubi8/python-39@sha256:6b0a73679bad8510b017bb95e411bd4a7d3ee7d3515d030bba3b710254921f23
+  name: IMAGE_KN_PLUGIN_FUNC_PYTHON_39
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:828d31bf8a441091b8aed03da213a6b4ffae260070eff58c3319156f9bf04f5a
+name: serverless-operator.v1.32.2
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.32.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2024-08-01T10:56:58Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.32.0 <1.32.2'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8@sha256:16c026f09b377c44253cdb902b9a5fa0ae766fd0185cca1863798a212e0daee1
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A platform for streamlined application deployment, traffic-based
+          auto-scaling from zero to N, and traffic-split rollouts
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: An event-driven application platform that leverages CloudEvents
+          with a simple HTTP interface
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: An extension to Knative Eventing, merging HTTP accessibility
+          with Apache Kafka's proven efficiency and reliability
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/installing-serverless#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/installing-serverless)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:0507ea8745267fdb53329a5274d59d23c387225d2594af51dd2603b4ad99db0f
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:a5a7b2be50f211d4d9d555b2a2e2302096c139ff5011d984cc386f1530007f16
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:14ca32e999767776c3e585ff5eb1aa568f7d76fd3e5ae24cae05ce7564678080
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:e7e6cbb46720eeca3f0f4b9829dfeeb3db373a83c89cd808b667ded4d5e139a4
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:1a1de677297525c0c5d317fe8a7a42684fe3f1b422a7d6bea1f70f0924653b08
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:8033b7c1e903ba313134645c626eb3bf7ab1a0d68dc2575bc8e26884ad4f805f
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:8033b7c1e903ba313134645c626eb3bf7ab1a0d68dc2575bc8e26884ad4f805f
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-istio-controller-rhel8@sha256:9b6524f9c0e7f78e6ffb372a8587eaf5f4f1281eaf64f93dd00b63be84a4c21e
+  name: IMAGE_eventing-istio-controller__eventing-istio-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:990962ad245a6d62cd11551bd4e1f8b14dc08abbebe47beddb2f4874f78d4f47
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:e1e2273fdf6384d95e1128e54c0794d7d620291a272bfb1f91e0c2723be7f1b7
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:e1e2273fdf6384d95e1128e54c0794d7d620291a272bfb1f91e0c2723be7f1b7
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:e1e2273fdf6384d95e1128e54c0794d7d620291a272bfb1f91e0c2723be7f1b7
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:ab9a1b952e9603b4ecc5f197715a1d871abc25ebb0c5e6470d4f0b365ae94276
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:e70dd3a9e067075eb56e5f2772642545e308348cd49b89357c02de3979b1a5be
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:e70dd3a9e067075eb56e5f2772642545e308348cd49b89357c02de3979b1a5be
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:e70dd3a9e067075eb56e5f2772642545e308348cd49b89357c02de3979b1a5be
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:b008da825ee2429f04cf39258389740c68056f82cf4bde0cbd3db850b6256885
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:7c8cefd5823ad953f112b905c651f12a97491aafc008b2ba0111f0c9e83e50ae
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:46b8dc1c8ea6c40401d4d1a9868ab3edbe8b9e92364a43add6722489e2eefa04
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:da5f813dea324ffe9679524ea7f3801536fa48f7dbbd8da56a8492b916b15fc3
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:04e5b3882223d45a5f5383ce6481efb7b2cbedea57ebd894caafb1454ad8c09d
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:4933b76d95d411d597d4dc460fc46c92875d28e107cda661946206a9d934b8b5
+  name: IMAGE_storage-version-migration-eventing-__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:4933b76d95d411d597d4dc460fc46c92875d28e107cda661946206a9d934b8b5
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:22b4d47725ed8cdd663ee26a03f31198fff9e71dc703532e70c42bdfb4840811
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:0551f1657dc158bd41eb2338dd6514d55c39fc77300cdf1744d8f5ab14e9ed1b
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:e55c70591c0498b6b85f0d68e304e88b830ea0b35219ba8881143555757be4b7
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:1befc9969edd2062b3df69f45aee9771b33a2659c3a14db0aaaf5c3df985af58
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:3ffcf746df914f0949477b46f90cb2992bb63f8198d73ffd54208e7a777a9cb1
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:2a30ae808d5c32d812406ff4ac9b472e82b6bb0555e62eee4c2c6a972f8750c2
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:25cbdf78b67e7f5a360313ccfbe3b6e2c98873b4e9ddee46c115a623e77c7abb
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:70c26c7ac48d1eaaf1f95ca5c5b8ba8ee6b047a3c9c4a2c2db9c49a506bb2205
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:828d31bf8a441091b8aed03da213a6b4ffae260070eff58c3319156f9bf04f5a
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:2f0f84767f7d76dbbf4387ca2e272766267a2c46b5bc29f5d01f05dfa39cb944
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:9d36cde68bd822016e967148eebd2ef3e7ffab9dcdd37d17f33017e9b703d9b2
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:ab09a1710aa2331e24df9e7283f3909fdb104c1b314dea88e919d0a396f334d3
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:42f31eb8f12dd36541c8c0b6572d942c62e2064d5418428482d676d117a6c426
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:0729de0f3f03ed220216c6cb718fc34beece0ceacd926b5e2480bdfcf44df5cd
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:3be20d63d7e82f35ac88274532d6ab7839f9a7306ca272e7d532ac03215faea9
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:b0db9f0fc85fcdcd5da980633a3a44be2bbabae068f89d0965263de38789e812
+  name: IMAGE_storage-version-migration-serving-__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:5930caa25ea875d29dff0ec5e235eaa13cb6dc98980d8045335eba1a09ae761d
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:4c9faea6fd162db3340aee8c11af11a08c9d79bbed104967c25df26c4933c8ae
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:20566173a8e907980e603d82fae4d96fcdfd5c43d9004c2e506cf0e09a47b91e
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:55f5c7d88c77e1ab5a2ab8e877172b2b66cb196e21f10dc45148470d0ee8bbae
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+- image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/ubi8/nodejs-16@sha256:69439fe83fa957089cb6fd3c1042ab71d719f81dd457a5d1fbc56c1e3ea600da
+  name: IMAGE_KN_PLUGIN_FUNC_NODEJS_16
+- image: registry.redhat.io/ubi8/openjdk-17@sha256:a166bd2fedb99cb62ebf4695ab46e19c7e451f887940cdf0b8245c81e403aea2
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_17
+- image: registry.redhat.io/ubi8/openjdk-21@sha256:bb95ea866269ac8652f666ee1587d71f4f43da33493c2be7f6a9548bcfd2407c
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_21
+- image: registry.redhat.io/ubi8/python-39@sha256:8c96e8648cc6651d0cefbd20496a89f208621601f9664554d3fdeef8ced25453
+  name: IMAGE_KN_PLUGIN_FUNC_PYTHON_39
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:9bee3204d9fafe46f9f188e7ea10ac4843eaaf72a5f9dda68f6d8d7a92310218
+name: serverless-operator.v1.33.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.33.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2024-06-17T13:54:19Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.32.0 <1.33.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
+      operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8@sha256:dde324446b8a4dd9c30edbaaf7bd8ec8c17b53608208bc26b55327749841bb5d
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A platform for streamlined application deployment, traffic-based
+          auto-scaling from zero to N, and traffic-split rollouts
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: An event-driven application platform that leverages CloudEvents
+          with a simple HTTP interface
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: An extension to Knative Eventing, merging HTTP accessibility
+          with Apache Kafka's proven efficiency and reliability
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/serverless/installing-serverless#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/serverless/installing-serverless)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/serverless/serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/backstage-plugins-eventmesh-rhel8@sha256:7890efb64ea5bdadc6ee97f9675feefdffb7dae2702ead9ff50ec00fb928eb24
+  name: IMAGE_eventmesh-backend__controller
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:702b867a588e1b3c85bf75952f0b39b691ac2e59b0119e9c8e01ad4f606c0147
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:8c7b9a60a344a7302b5f1089ddde71a39b5642af16737977828f11598865186a
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:9962ec37be9e8c968102519812854b2366db4007c582eb088bfcc0988051e067
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:7d5798a50d72d9e721c66b51e9f071f542fa640f91a4456ec7131f06d6965dab
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:ad50dcb62e88bf3543ad9d508bd6bf0f70946eb1a729cdb225bc709dbfde9e60
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:3361f71390529b1a8c6a424068d63d984ccbb94179241a1718d7e2a93fae1dd0
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:3361f71390529b1a8c6a424068d63d984ccbb94179241a1718d7e2a93fae1dd0
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-istio-controller-rhel8@sha256:bbf183890ed46556b367e34a968fb7bd0d0c630988695b8d1d58055bff664a94
+  name: IMAGE_eventing-istio-controller__eventing-istio-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:8ece7c775831227a198c4e86325a21c8b98e2f54f599219c044033327fd52c08
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:395cd27d93a9ee948e84e9f38c33143bd17a997a78b2844ce6b9aac18410b3d0
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:395cd27d93a9ee948e84e9f38c33143bd17a997a78b2844ce6b9aac18410b3d0
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:395cd27d93a9ee948e84e9f38c33143bd17a997a78b2844ce6b9aac18410b3d0
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:b4fb6c083958c9dfefdc73ace52c67c678d2bc80ae7499b9db3583c1d2d3b6a3
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:e9c1a21a802092cc5b4a78f1449a49391e50c2a487d331c2e6de6fdd3fa1d1f1
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:e9c1a21a802092cc5b4a78f1449a49391e50c2a487d331c2e6de6fdd3fa1d1f1
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:e9c1a21a802092cc5b4a78f1449a49391e50c2a487d331c2e6de6fdd3fa1d1f1
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:601ff5b3615c1d86b5ec7479568c4c6817aeca049b6e745c43be22844dc13d4e
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:83321b6ba12b0e64cb370702396fbbbbab4b2c8201dd235b4a2094f2317497e3
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:f0e85df2dbb1791e0c062cc55f5d90d005fbd742a942a8cdf237be44c633553e
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:7949087ff89604fd77a0fd5aa06489991462d82a48da224b2b98abb8d69acd27
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:b6add9e1d55f3cc0e32f779f083fdd889daea68b4e247f31b2f69574db5ca4bf
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:9dd214dd2ecb7095bed6f19d8ee85d965d4a081a4afa597962a301bfea49f9fd
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:9dd214dd2ecb7095bed6f19d8ee85d965d4a081a4afa597962a301bfea49f9fd
+  name: IMAGE_storage-version-migration-eventing-__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:bff9e09435cc1ea41825996d0e8529b37275c9f9d57a245736fc463ac14a4024
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:aaec9703d03eda1fc1828ea3c9a921790f16715936cbcaa8c474165d26917ff7
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:4ba91436c643f21c51b9906443fadac92cdb6c4643778452bcb38e0703ffb0e3
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:4973d87f9ce0447e2d8e8a54eddd936e9b7cd99fff4e5490ff21b750d2acf706
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:8fe56a80db8aa1130c5731a383ecfe74db4f1babaf4c067d4a7a1600f2f82cf3
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:d9e1f407aa32520a116d51bd5439c534cf61da11355b831d398a238974c77fdd
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:88a0da51e7507bdf81acf705f636e77a10f2fbdcbe0c6ffe97c312c8570a63f8
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:2c6e04124bc7c9f44be4c41ec4db60aad64192b40a1b69fdf5b918a5de74bbce
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:9bee3204d9fafe46f9f188e7ea10ac4843eaaf72a5f9dda68f6d8d7a92310218
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:78077131691f4685f4f36e785147920090cd9a138969979e3c46c7ca2b100220
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:7eb52ae2fd87f4a89133e706b4a2993527a88dfd55ca7266f518d7ade669d978
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:c8da043cdf66907cbb2370e5f8593fd3cbfcc85948d6f72a266993bd22cbd358
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:a7eb1df20577cfb908a9d2f84888fe7b6674b9c4946957e7a9933d290248aa2c
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:e279b15f22194425ea46b8c58ea5b5e195afe78d550ff68151d4ccf99205f316
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:20fa7da4753f888dbb495950cf1c946cbbf7c7fddc23ee3a58c8160687198428
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:dc3524e16a1164205429637ad8820032bc3184176b8e5e9beeaa781e4e3bfe00
+  name: IMAGE_storage-version-migration-serving-__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:749b263095fd585f3fe4d6e3b925d1f76a843bd54b6b385b435b1e8bced1ad4b
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8@sha256:dde324446b8a4dd9c30edbaaf7bd8ec8c17b53608208bc26b55327749841bb5d
+  name: IMAGE_MUST_GATHER
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:c4f08d86c2f17e2b265322d17e626fa1f7eff0074275de0cc48ce651f0602ca7
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:309843a1347643ed7f6d3d74bd5673aa1eee52356a8c1b25b53706181d0f3f0d
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:3d505d9c0f5d4cd5a4ec03b8d038656c6cdbdf5191e00ce6388f7e0e4d2f1b74
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+- image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/ubi8/nodejs-20-minimal@sha256:52124a2ed45a97ed5fd73662b1f557407d4fcd7a10caa57d6d121e7c3f2af3d0
+  name: IMAGE_KN_PLUGIN_FUNC_NODEJS_20_MINIMAL
+- image: registry.redhat.io/ubi8/openjdk-21@sha256:69090c70cc88587ff10c39be263332e276bc8868d1b9cd507239a42fd036c098
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_21
+- image: registry.redhat.io/ubi8/python-39@sha256:78f4d1a6528fde88dd8aaee321d3fadceccb52ad1c8781eb13370a5933bd1ba0
+  name: IMAGE_KN_PLUGIN_FUNC_PYTHON_39
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:d96f2a6e9bdd2540c5c7b0ffe6a8e610b43ba227420892586a46fbdb9a3caef3
+name: serverless-operator.v1.33.2
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.33.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2024-07-31T15:02:32Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.33.0 <1.33.2'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
+      operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8@sha256:929ae7631e0dbb5f2a9d17de58809819723db9c5e430215ff9e9d3301e33ff70
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A platform for streamlined application deployment, traffic-based
+          auto-scaling from zero to N, and traffic-split rollouts
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: An event-driven application platform that leverages CloudEvents
+          with a simple HTTP interface
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: An extension to Knative Eventing, merging HTTP accessibility
+          with Apache Kafka's proven efficiency and reliability
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/serverless/installing-serverless#install-serverless-operator).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/serverless/installing-serverless)
+      - [Develop Serverless Applications](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/serverless/serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/backstage-plugins-eventmesh-rhel8@sha256:10336fc398e4c412008cc8a756b7d90eea160f5fa37cc0f05a5e66819aee730d
+  name: IMAGE_eventmesh-backend__controller
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:30cb695872e6fd85ec594fa90f8f438216064b3b82b6ca697aa79a2a2ea6ee53
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:cd45a8677dbcddbb38ad7da155f5b11fc850430b975a3ef8fde53cc6273279cf
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:bf3b27d10bcf500d9000a08e1000ca1c832e413d0ac80f4e3ef611c542431422
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:2ab4604a66bde5194283695b8105e9b979d0650b320acaf07cb4d54f573d650a
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:19469540919f7bbde6cf7a1e4bda758e447289490ba3d57d68f28364a4b2d0ff
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:2b2fecf40319c390856b0db93f564c6591cce890ce104ea70753f7d97b31a766
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:2b2fecf40319c390856b0db93f564c6591cce890ce104ea70753f7d97b31a766
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-istio-controller-rhel8@sha256:d64998228046ddd6a85d7a38b1ca92101a669561f14dedfd0b59002a9703f9a1
+  name: IMAGE_eventing-istio-controller__eventing-istio-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:e437e19ebf399a4228b65a8b90abf7669aacc614255c434526a82060341bb8d2
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:d161ae7577f114fbc02d6bc9e604165a045ec7c5c56f090e0c7cf8c131558e0a
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:d161ae7577f114fbc02d6bc9e604165a045ec7c5c56f090e0c7cf8c131558e0a
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:d161ae7577f114fbc02d6bc9e604165a045ec7c5c56f090e0c7cf8c131558e0a
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:42b44d946f953a207b4c1f25acd57d28c1e185fc582ec81296cb3a3d21f44368
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:e98a230a20959e39183eef3eb10c36775e4cae744ed114fce4b6633cc4d5bed2
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:e98a230a20959e39183eef3eb10c36775e4cae744ed114fce4b6633cc4d5bed2
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:e98a230a20959e39183eef3eb10c36775e4cae744ed114fce4b6633cc4d5bed2
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:858c32c459ff901db48073c192e96d6c4f104bd8ef04ad5fd66c6482f3c42482
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:77a563d1fe018d41f58d3c4cbefcc5c080f795fdb399d4bea4d51ac26e6f11dd
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:f6ad71487e8fc051891812cec8641f5ac60efe8c5e67535dff84f2df71756151
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:195edd3ef2967d184299bab8a421c31b74520b18a73d23acbb07f012d2dd1dff
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:be36230faa5439ec17f0f51238324955ef8d4122c678491ed4a32cfa2455ecd6
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:1081373beb89fdfbe3bf6b918a253a2be2d8083fb2fae5df3a7ed27b814774b3
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:1081373beb89fdfbe3bf6b918a253a2be2d8083fb2fae5df3a7ed27b814774b3
+  name: IMAGE_storage-version-migration-eventing-__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:2110cbe054d18a3f77ef3f294bbe8526b92fbf3b3d963cbf2bc32dd161da87ed
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:2ea14055cc04d47a85435043dd95c575dead1e6f551639da07ff38569de6a593
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:36a5393aee3f0293a86a53498ecfd6fff8a70c203127f67404e71d81ec7001fd
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:fde888f5308d0fc45871e014e283cf09850a74ecaaa4d14a6152dffbb406b65c
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:3697676f4938093e725bb7b64b9b5286b87f571040d3d91f9d3fff32d46d79cf
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:b5dfbe6aea3b615d1e0d212134c18c70dfb2adae10b1aab8f27fc32326413d56
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:3cd67dc6b12e265e0d415c153695ddca319fefc505496feb00bc41999cca933b
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:2909964f85863aa078fd2252b2f408bd3a2387b9c96c8949b262f4ef932d6fa8
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:d96f2a6e9bdd2540c5c7b0ffe6a8e610b43ba227420892586a46fbdb9a3caef3
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:d919b019c9cc2a8385162a1760e1289f259c11a32fa02a17f7f7f34ceb1cc591
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:ffb3c5d774e6b46ddad066e5efee76a65d0bdd1b18c87fad025c3e504cc2e222
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:1eeb36098def12e24717046ea282ce86c38330f2fa4e238403ad7e9500e6b44b
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:d9db13c5c0fb44ee072c86b9513dd7ea07bb3c54892e2d4658cce099a27ebc28
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:960841bc7e2643a0848b20c2f673c4a411bd813d5d8b7dc66832a92d8a8bd2f0
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:2f4e2426b335998d1cf131f799a62696cb3ad46ee513c524ac1e50ac1609822c
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:886b4a68cbd003c9fcc77b0dc966b0e4cd87477049744a9e4ee1a0c7d42df6bb
+  name: IMAGE_storage-version-migration-serving-__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:cdabac2c35853fb7cc6fa018f68d0c52c82001be31c4a93f7ebccf5914d3ca9c
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8@sha256:929ae7631e0dbb5f2a9d17de58809819723db9c5e430215ff9e9d3301e33ff70
+  name: IMAGE_MUST_GATHER
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:c4f08d86c2f17e2b265322d17e626fa1f7eff0074275de0cc48ce651f0602ca7
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:77df668a9591bbaae675d0553f8dca5423c0f257317bc08fe821d965f44ed019
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:3d505d9c0f5d4cd5a4ec03b8d038656c6cdbdf5191e00ce6388f7e0e4d2f1b74
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+- image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/ubi8/nodejs-20-minimal@sha256:87c3f21682b71688753b1b5d4fa854082ac719416e9268fe4928822a760e229f
+  name: IMAGE_KN_PLUGIN_FUNC_NODEJS_20_MINIMAL
+- image: registry.redhat.io/ubi8/openjdk-21@sha256:bb95ea866269ac8652f666ee1587d71f4f43da33493c2be7f6a9548bcfd2407c
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_21
+- image: registry.redhat.io/ubi8/python-39@sha256:8c96e8648cc6651d0cefbd20496a89f208621601f9664554d3fdeef8ced25453
+  name: IMAGE_KN_PLUGIN_FUNC_PYTHON_39
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:82b9bfb8b83701db1a9b891d1ffc1e782d4b0f971fc9a53525942845c2602934
+name: serverless-operator.v1.34.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.34.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2024-10-08T12:30:03Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.33.0 <1.34.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
+      operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8@sha256:c7ea3d26e4220fcfde67b840b1cdb135bd9774ff84eb2e4673de81c9f3696d11
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A platform for streamlined application deployment, traffic-based
+          auto-scaling from zero to N, and traffic-split rollouts
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: An event-driven application platform that leverages CloudEvents
+          with a simple HTTP interface
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: An extension to Knative Eventing, merging HTTP accessibility
+          with Apache Kafka's proven efficiency and reliability
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.34/html/serving/getting-started-with-knative-serving#serverless-applications).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.34/html/installing_openshift_serverless/index)
+      - [Develop Serverless Applications](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.34/html/serving/getting-started-with-knative-serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/backstage-plugins-eventmesh-rhel8@sha256:5e28ee6c57a52b7f144bca484216562585e1b593c20ed155009f35568ae44df7
+  name: IMAGE_eventmesh-backend__controller
+- image: registry.redhat.io/openshift-serverless-1-tech-preview/knative-client-plugin-event-sender-rhel8@sha256:615c1659509869b87d1e1944f2b7bde8683b99e5c6828f98dd1066ef2be2cf99
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:735a6918003f933af603363f6db7f3688cbb6224af838b1cb6f5fcca9e2c51f6
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/eventing-apiserver-receive-adapter-rhel8@sha256:9da2f46278867e2d5e2e680f1f90c6bec46c283ef7bada24091bc6c42311f968
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-controller-rhel8@sha256:040cd6cd7f4de080515a5386a61b7ae4f0c5a035bdb6243e9769d0c561564ce6
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-controller-rhel8@sha256:2b8b052aa9d5281e033220cecbe1e41198d3f81d38d8ad863363104a64af793a
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:1203cf6bcb136aa1c9d2ef8fdae9c24f055df4b60fc96ab512712108d076100c
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/eventing-in-memory-channel-dispatcher-rhel8@sha256:1203cf6bcb136aa1c9d2ef8fdae9c24f055df4b60fc96ab512712108d076100c
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-istio-controller-rhel8@sha256:489bc48ea89de2ae891d12a5a2ff4a14fc737d9ab2039b4df5defbaf783a306b
+  name: IMAGE_eventing-istio-controller__eventing-istio-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-controller-rhel8@sha256:cd6f6210695039f6695668e8fbe9348d934d53d047f81f80aa2cd68da1d565cc
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:e629f016372a1549ed03e3f448c170fe8bd7aeeab9cacdaf7bf0b20c59e296d0
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:e629f016372a1549ed03e3f448c170fe8bd7aeeab9cacdaf7bf0b20c59e296d0
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8@sha256:e629f016372a1549ed03e3f448c170fe8bd7aeeab9cacdaf7bf0b20c59e296d0
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-post-install-rhel8@sha256:3bc7b79bfd0de429d111bbbbbf3f848b9469694ae2ad33d180a11dc12e875d67
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:f469fc6f82e9ed233481180da108d0b1ef480ac165d4ffce5e9402d8aa080ab8
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:f469fc6f82e9ed233481180da108d0b1ef480ac165d4ffce5e9402d8aa080ab8
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-receiver-rhel8@sha256:f469fc6f82e9ed233481180da108d0b1ef480ac165d4ffce5e9402d8aa080ab8
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/eventing-kafka-broker-webhook-rhel8@sha256:21b9a2e671cdc5c6d694b918d7fe794c0a91fa6487316240231b90827183a2ef
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-filter-rhel8@sha256:73bba4048d7185c5816d25be2bdcad1597dc9d2eb0e6714d8c3e58f4c77d0282
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtbroker-ingress-rhel8@sha256:09f668747852d8ffe8fc7cca51c4e414a046b41b1e3d777466d143636148f55a
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtchannel-broker-rhel8@sha256:aedb5d2b060292006ebbfbe1108c93af3c652decc240e19a6415083ddb2e7979
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/eventing-mtping-rhel8@sha256:b9bf89156a42a950ad188739806c9499084426acc0e19373f5c3832b668730d6
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:fbc93a6137779bc2b2f131765f2db66d3ad1aaab8cc420e2fb1390694b41411d
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-storage-version-migration-rhel8@sha256:fbc93a6137779bc2b2f131765f2db66d3ad1aaab8cc420e2fb1390694b41411d
+  name: IMAGE_storage-version-migration-eventing-__migrate
+- image: registry.redhat.io/openshift-serverless-1/eventing-webhook-rhel8@sha256:37dc0c92be81c86eb25e05fca87ce906bcf928c4a90042182d146ac3593f3a73
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/func-utils-rhel8@sha256:7b11f01ff32f7f41899c60d162389f46efccc3ec955b0bce1d993c47fd627db7
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/ingress-rhel8-operator@sha256:6c800066d3df98229ced683ff86e6ba66e73a01a2f32b1956952f3bffe556978
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8@sha256:7e36c484e5c005e291467bcdfbff2791ee6b4f52570b740035c453a67b957407
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/knative-rhel8-operator@sha256:8dcdc36aeb7c0c246095d32d7e1606a5219985278d25dcf29ee5f01dedd778aa
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/kourier-control-rhel8@sha256:737793adc6f8d570f0af45eed1fa9fa95afba68b6c3c3aa67f38892d9625452f
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:062c9c6a15a1feb37ceec917d45901b5eb2368bf0368a151782677a2eea097be
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:d53d0d5bb4fb114fd46a0de22d26ff1eefd9579ad556079e8d65d483b8b94d5a
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:82b9bfb8b83701db1a9b891d1ffc1e782d4b0f971fc9a53525942845c2602934
+  name: ""
+- image: registry.redhat.io/openshift-serverless-1/serverless-rhel8-operator@sha256:61b971cbb4a6585c916e956a7a0f4096e49794188eea56cb09c2c89eebedd7df
+  name: knative-operator
+- image: registry.redhat.io/openshift-serverless-1/serving-activator-rhel8@sha256:22e62a4ac77f6fcefb041c5d7d5f2fd289a6c8ee06f3de98f6837ad0e876fadc
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-hpa-rhel8@sha256:7b7a3107853e467128952012c8647e0dcf3c40a2c81aca3aec90478dc160aab9
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/serving-autoscaler-rhel8@sha256:74d578ddd1fb1b4a7b696ab2ba0dc59616fe7c730bc94cb2cdd93d6e53f15c69
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/serving-controller-rhel8@sha256:f5d69ffded16f5008c2f936a3eb03488ba554dc004aa0fc24995242251ac6d5b
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serving-queue-rhel8@sha256:629183a90335e9159284f641103234e79a49e48785c59f3c800f74acea2faa64
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/serving-storage-version-migration-rhel8@sha256:620794a4937ea20858cee3ea8566286575dfa8e03ca5a2972a70da22748be127
+  name: IMAGE_storage-version-migration-serving-__migrate
+- image: registry.redhat.io/openshift-serverless-1/serving-webhook-rhel8@sha256:e2b0a4336567ca54f17d4ab48266cad9f0505b4b34a99e1ce39a57afb5d808be
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8@sha256:c7ea3d26e4220fcfde67b840b1cdb135bd9774ff84eb2e4673de81c9f3696d11
+  name: IMAGE_MUST_GATHER
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:02b834fd74da71ec37f6a5c0d10aac9a679d1a0f4e510c4f77723ef2367e858a
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:e34f912158985525f6efb3c4b675f20854fc677c867d12fe3cd2e971309428dc
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:3d505d9c0f5d4cd5a4ec03b8d038656c6cdbdf5191e00ce6388f7e0e4d2f1b74
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+- image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+- image: registry.redhat.io/ubi8/nodejs-20-minimal@sha256:1a493f45b1621f3f9de81d0c41f2e614803d4b6fe5c3233d0467063d5baf165d
+  name: IMAGE_KN_PLUGIN_FUNC_NODEJS_20_MINIMAL
+- image: registry.redhat.io/ubi8/openjdk-21@sha256:e8e2b2525e1ba56ec2e2cc582a4fba7c95210cb2e073f6744172cf5d41ff309b
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_21
+- image: registry.redhat.io/ubi8/python-39@sha256:59a97ad8ec36453d8f6503f41a06585536b000611827183309fdc4dbb8cf9c27
+  name: IMAGE_KN_PLUGIN_FUNC_PYTHON_39
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:7328625a0368cb770eb291e7b3f3f67a01ac463b6418058a43d49c719dd88bf4
+name: serverless-operator.v1.35.0
+package: serverless-operator
+properties:
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeEventing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.knative.dev
+    kind: KnativeServing
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: operator.serverless.openshift.io
+    kind: KnativeKafka
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: serverless-operator
+    version: 1.35.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeServing",
+            "metadata": {
+              "name": "knative-serving"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.knative.dev/v1beta1",
+            "kind": "KnativeEventing",
+            "metadata": {
+              "name": "knative-eventing"
+            },
+            "spec": {
+            }
+          },
+          {
+            "apiVersion": "operator.serverless.openshift.io/v1alpha1",
+            "kind": "KnativeKafka",
+            "metadata": {
+              "name": "knative-kafka"
+            },
+            "spec": {
+              "broker": {
+                "enabled": false,
+                "defaultConfig": {
+                  "numPartitions": 10,
+                  "replicationFactor": 3,
+                  "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+                }
+              },
+              "source": {
+                "enabled": false
+              },
+              "sink": {
+                "enabled": false
+              },
+              "channel": {
+                "enabled": false,
+                "bootstrapServers": "REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS"
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+      certified: "false"
+      createdAt: "2020-04-20T17:00:00Z"
+      description: Deploy and manage event-driven serverless applications and functions
+        using Knative.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.34.0 <1.35.0'
+      operatorframework.io/suggested-namespace: openshift-serverless
+      operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
+      operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8@sha256:79dcd58e4aae42fa0f437fe43387d08c8be9f2e0a5460894a33b41e9151fb45e
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      repository: https://github.com/openshift-knative/serverless-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: A platform for streamlined application deployment, traffic-based
+          auto-scaling from zero to N, and traffic-split rollouts
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Serving installed
+          displayName: Version
+          path: version
+        - description: Conditions of Knative Serving installed
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1beta1
+      - description: An event-driven application platform that leverages CloudEvents
+          with a simple HTTP interface
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.operator.knative.dev
+        statusDescriptors:
+        - description: The version of Knative Eventing installed
+          displayName: Version
+          path: version
+        version: v1beta1
+      - description: An extension to Knative Eventing, merging HTTP accessibility
+          with Apache Kafka's proven efficiency and reliability
+        displayName: Knative Kafka
+        kind: KnativeKafka
+        name: knativekafkas.operator.serverless.openshift.io
+        version: v1alpha1
+    description: |-
+      The Red Hat OpenShift Serverless operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+
+      # Prerequisites
+      Knative Serving (and Knative Eventing respectively) can only be installed into the
+      `knative-serving` (`knative-eventing`) namespace. These namespaces will be
+      automatically created when installing the operator.
+
+      The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+      OpenShift Container Platform. For more information, see the documentation on [Getting started
+      with OpenShift Serverless](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.35/html/serving/getting-started-with-knative-serving#serverless-applications).
+
+      # Supported Features
+      - **Easy to get started:** Provides a simplified developer experience to deploy
+        and run cloud native applications on Kubernetes, providing powerful
+        abstractions.
+      - **Immutable Revisions:** Deploy new features performing canary, A/B or
+        blue-green testing with gradual traffic rollout following best practices.
+      - **Use any programming language or runtime of choice:** From Java, Python, Go
+        and JavaScript to Quarkus, SpringBoot or Node.js.
+      - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+        or idling behavior. Applications automatically scale to zero when not in use,
+        or scale up to meet demand, with built in reliability and fault tolerance.
+      - **Event Driven Applications:** You can build loosely coupled, distributed applications
+        that can be connected to a variety of either built in or third party event sources,
+        powered by operators.
+      - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+        that can run anywhere OpenShift Container Platform runs. You can leverage data
+        locality and SaaS as you need it.
+
+      # Components & APIs
+      This operator provides the following components:
+
+      ## Knative Serving
+      Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers.
+      Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting.
+      Other features include:
+      - Simplified deployment of serverless containers
+      - Traffic-based auto-scaling, including scale-to-zero
+      - Routing and network programming
+      - Point-in-time application snapshots and their configurations
+
+      ## Knative Eventing
+      Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and
+      event consumers.
+      Knative Eventing supports the following architectural cloud-native concepts:
+
+      - Services are loosely coupled during development and deployed independently to production
+      - A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+      - Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+      ## Knative Functions
+      Knative Functions allows developers to write functions that let them focus on business logic.
+      These functions are deployed as Knative Services and take advantage of Knative Serving and Eventing.
+      Knative Functions bring greater efficiency, more scalability and faster development to facilitate rapid go-to-market.
+
+      Other features include:
+      - Build strategies including Source-to-Image (S2I) and Buildpacks
+      - Multiple runtimes, including Node.js, Quarkus and Go
+      - Local developer experience through the kn CLI
+      - Project templates
+      - Support for receiving CloudEvents and plain HTTP requests
+
+      ## Knative CLI `kn`
+      The Knative client `kn` allows you to create Knative resources from the command line or from within
+      Shell scripts.
+      With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas.
+
+      `kn` offers you:
+      - Full support for managing all features of Knative Serving: Services, Revisions and Routes
+      - Support for managing Knative Eventing entities: Sources, Brokers, Triggers, Channels and Subscriptions
+      - A kubectl-like plugin architecture to extend the built-in functionality
+      - Easy integration of Knative into Tekton pipelines by using `kn` in a Tekton task
+      - Create, build and deploy Knative Functions for multiple runtimes, including Node.js, Quarkus, and Go
+
+      # Further Information
+      For documentation on OpenShift Serverless, see:
+      - [Installation
+      Guide](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.35/html/installing_openshift_serverless/index)
+      - [Develop Serverless Applications](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.35/html/serving/getting-started-with-knative-serving#serverless-applications)
+    displayName: Red Hat OpenShift Serverless
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+    - eventing
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Documentation
+      url: https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.35/html/installing_openshift_serverless/index
+    - name: Source Repository
+      url: https://github.com/openshift-knative/serverless-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Serverless Team
+    maturity: stable
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/openshift-serverless-1/serverless-operator-bundle@sha256:7328625a0368cb770eb291e7b3f3f67a01ac463b6418058a43d49c719dd88bf4
+  name: ""
+- image: registry.access.redhat.com/ubi8/nodejs-20-minimal@sha256:a2a7e399aaf09a48c28f40820da16709b62aee6f2bc703116b9345fab5830861
+  name: IMAGE_KN_PLUGIN_FUNC_NODEJS_20_MINIMAL
+- image: registry.access.redhat.com/ubi8/openjdk-21@sha256:441897a1f691c7d4b3a67bb3e0fea83e18352214264cb383fd057bbbd5ed863c
+  name: IMAGE_KN_PLUGIN_FUNC_OPENJDK_21
+- image: registry.access.redhat.com/ubi8/python-39@sha256:27e795fd6b1b77de70d1dc73a65e4c790650748a9cfda138fdbd194b3d6eea3d
+  name: IMAGE_KN_PLUGIN_FUNC_PYTHON_39
+- image: registry.redhat.io/openshift-serverless-1/kn-backstage-plugins-eventmesh-rhel8@sha256:7a538702cfb775d18bee4a17f47104c62a1b0ac747aab851895e079093a73aaa
+  name: IMAGE_eventmesh-backend__controller
+- image: registry.redhat.io/openshift-serverless-1/kn-client-cli-artifacts-rhel8@sha256:82a41eaae2cd8b6004dcb663a2cd359c09fecf646bf5beaec330463abea0ea90
+  name: IMAGE_KN_CLIENT_CLI_ARTIFACTS
+- image: registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:2e24f1085ed369597713dc6416e454d62add751c8c22a0531210e727f35b6502
+  name: IMAGE_KN_CLIENT
+- image: registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:a67b1b1dcfef0f1e470db79dc74f636f9cfe47b747c958e9e5b175ea628d3a52
+  name: KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:a67b1b1dcfef0f1e470db79dc74f636f9cfe47b747c958e9e5b175ea628d3a52
+  name: KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:a67b1b1dcfef0f1e470db79dc74f636f9cfe47b747c958e9e5b175ea628d3a52
+  name: KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher
+- image: registry.redhat.io/openshift-serverless-1/kn-ekb-kafka-controller-rhel8@sha256:7c84244d62e8f4a3e3ab5c27b050b0cfb2c94c82b86f9af1c815048ddce43939
+  name: KAFKA_IMAGE_kafka-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/kn-ekb-post-install-rhel8@sha256:ce3725ddf469a677b939f7b2b613eafb987c788518f070e52d1ce61cd9c85829
+  name: KAFKA_IMAGE_kafka-controller-post-install__post-install
+- image: registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:7fb3155f7b5292b784891fca026912ce64540104e3a27523976aa2054f72a8ee
+  name: KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver
+- image: registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:7fb3155f7b5292b784891fca026912ce64540104e3a27523976aa2054f72a8ee
+  name: KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver
+- image: registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:7fb3155f7b5292b784891fca026912ce64540104e3a27523976aa2054f72a8ee
+  name: KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver
+- image: registry.redhat.io/openshift-serverless-1/kn-ekb-webhook-kafka-rhel8@sha256:0e0801ac8fe263d7926ab70afccb321d71b7ad7a153881e0f64151211386028e
+  name: KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-apiserver-receive-adapter-rhel8@sha256:a71070562b68c01f1e6e7e951032c25ea49da1a54d017df872c82112ef26f7e6
+  name: IMAGE_APISERVER_RA_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-channel-controller-rhel8@sha256:7b1b1ecaa030c5ecfc116ed2f0278f1fca99f9746fd1563c14d58c69726922e0
+  name: IMAGE_imc-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-channel-dispatcher-rhel8@sha256:8e5d63fbe2d8fd9f1aa30fd6224ecd3718b3b16f97cbe90614c759b7192972a6
+  name: IMAGE_DISPATCHER_IMAGE
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-channel-dispatcher-rhel8@sha256:8e5d63fbe2d8fd9f1aa30fd6224ecd3718b3b16f97cbe90614c759b7192972a6
+  name: IMAGE_imc-dispatcher__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-controller-rhel8@sha256:8f289d849927d90b429da58746273c7bfed65c14351e1797b9c9c148646a6aab
+  name: IMAGE_eventing-controller__eventing-controller
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-filter-rhel8@sha256:c4237b716bed3901f4b745a96edf4f81b227dd0306e8611690616f3b20da2f24
+  name: IMAGE_mt-broker-filter__filter
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-ingress-rhel8@sha256:3d6d20ee72cca047033939640f9769bf2f373f137090e235cb2e6367221580d2
+  name: IMAGE_mt-broker-ingress__ingress
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-istio-controller-rhel8@sha256:799f987b024f3125796e902e027ee8ec5b5b25a3179dad116a98e349c4cb6454
+  name: IMAGE_eventing-istio-controller__eventing-istio-controller
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-jobsink-rhel8@sha256:394787c5ea1b4f63412be92bbf38f17f03cba61805ee758c26121b682863340d
+  name: IMAGE_job-sink__job-sink
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-migrate-rhel8@sha256:16628700b0b4ac8a079cc46750aefd829dc278e538a9f0d41473392f3896eaf2
+  name: IMAGE_storage-version-migration-eventing-__migrate
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-migrate-rhel8@sha256:16628700b0b4ac8a079cc46750aefd829dc278e538a9f0d41473392f3896eaf2
+  name: KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-mtchannel-broker-rhel8@sha256:345a91dde91ddb2fa53f11d2e92e8b60b8c6f7c7689e2c21a4253de4044f07cd
+  name: IMAGE_mt-broker-controller__mt-broker-controller
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-mtping-rhel8@sha256:b5dad74e320f3956a6c2cc70694d13a88c6544e4c0e81a54ae8747cbd537a55f
+  name: IMAGE_pingsource-mt-adapter__dispatcher
+- image: registry.redhat.io/openshift-serverless-1/kn-eventing-webhook-rhel8@sha256:0813cd0fe3706b861272075ed88038a5e9cdbd75a7be065f70dd5e44dce4579e
+  name: IMAGE_eventing-webhook__eventing-webhook
+- image: registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@sha256:443162d16adcb0dbc5ddbff4de172b2e7e80cc17928e0d9bf0e723cb0e99ebaf
+  name: IMAGE_KN_PLUGIN_EVENT_SENDER
+- image: registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:da3263b8d1961358ef384d35f152eb43260052bc0788f5f85cb101a492934117
+  name: IMAGE_KN_PLUGIN_FUNC_UTIL
+- image: registry.redhat.io/openshift-serverless-1/kn-serving-activator-rhel8@sha256:a4904b390e63f24e43345323d61c40fcbc759dea2d5fd7963f54873b45a5d40d
+  name: IMAGE_activator
+- image: registry.redhat.io/openshift-serverless-1/kn-serving-autoscaler-hpa-rhel8@sha256:31c6974e6a2902c0a51a18a243c7eecd56c2abb35699b4f6b8afb69a68cd603e
+  name: IMAGE_autoscaler-hpa
+- image: registry.redhat.io/openshift-serverless-1/kn-serving-autoscaler-rhel8@sha256:5376a42e2da3ec656a4dfc96ae877d2d94e89afd76cc53e4716ec397e9cde845
+  name: IMAGE_autoscaler
+- image: registry.redhat.io/openshift-serverless-1/kn-serving-controller-rhel8@sha256:254b06a028a47e534ca7f8aa6b894e9a869f28b3a0674cb70f32f3044b3f8e6e
+  name: IMAGE_controller__controller
+- image: registry.redhat.io/openshift-serverless-1/kn-serving-queue-rhel8@sha256:f6f9208f8da20ea331d1d0062814d332931d059a8e7e811b6bc3b82d96ebb498
+  name: IMAGE_queue-proxy
+- image: registry.redhat.io/openshift-serverless-1/kn-serving-storage-version-migration-rhel8@sha256:b1b7cb020c83fb72d4eb4dbd07f48dfec014d4f4b602ae9daa0e32bd0cf342d7
+  name: IMAGE_storage-version-migration-serving-__migrate
+- image: registry.redhat.io/openshift-serverless-1/kn-serving-webhook-rhel8@sha256:bd4533268e1610a56400a1d2daf65a650d4e05dbd811d243995bb840c4e161b2
+  name: IMAGE_webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/net-istio-controller-rhel8@sha256:3a69adc9fddcd245b90c2e9ce4d17a385c8f5556e807b0e28e99b5cee28c8461
+  name: IMAGE_net-istio-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/net-istio-webhook-rhel8@sha256:aef829f6b62186f3bd7f8bf97d8ecba08207a4e9e279188d664c5a687500aa8e
+  name: IMAGE_net-istio-webhook__webhook
+- image: registry.redhat.io/openshift-serverless-1/net-kourier-kourier-rhel8@sha256:8e5a05f21f38f3a33ee96dd3ef6743e32ff16fc8fd6258f9d8aab7e9253ecb84
+  name: IMAGE_net-kourier-controller__controller
+- image: registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8@sha256:04f97b8594c2dfea4de468650c7771b1c7f42f27060ed34987502ee0ac87be33
+  name: knative-openshift-ingress
+- image: registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8@sha256:9dadd3f0fe123d77cf4e759e445fe5bf67153de58bd322bfa9ad47cd5d476d7e
+  name: knative-openshift
+- image: registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8@sha256:79dcd58e4aae42fa0f437fe43387d08c8be9f2e0a5460894a33b41e9151fb45e
+  name: IMAGE_MUST_GATHER
+- image: registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator@sha256:f77fb20bf90f0f1c3eb28934551f3a3ee5e4076ba9ef204afc3e20d951cb97e3
+  name: knative-operator
+- image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:02b834fd74da71ec37f6a5c0d10aac9a679d1a0f4e510c4f77723ef2367e858a
+  name: IMAGE_kourier-gateway
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:42be2d5bb4d09f4fa31602f8521af07b0c1f27f47379d1529b769bc7bd61abc9
+  name: IMAGE_KUBE_RBAC_PROXY
+- image: registry.redhat.io/rhel8/buildah@sha256:3d505d9c0f5d4cd5a4ec03b8d038656c6cdbdf5191e00ce6388f7e0e4d2f1b74
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_BUILDAH
+- image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
+  name: IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I
+schema: olm.bundle

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -31,6 +31,8 @@ requirements:
     min: '4.14'
     max: '4.18'
     label: 'v4.14'
+    # OCP stream for kube-rbac-proxy image.
+    kube-rbac-proxy: "4.17"
 dependencies:
   serving: knative-v1.15
   # serving midstream branch name


### PR DESCRIPTION
The kube-rbac-proxy image for the latest version in the list might not be available yet (like 4.18 at the moment). We need to be able to specify the stream.

Also, add catalog for 4.18. This would be normally generated by Github action later but the Application/Component for thie catalog already exist in Konflux so without the catalog, the build for FBC 4.18 would be failing on this PR.

Fixes error such as this one from [Validate](https://github.com/openshift-knative/serverless-operator/actions/runs/11838336246/job/32987229808):
```
time="2024-11-14T13:47:35Z" level=fatal msg="Error parsing image name \"docker://registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.18\": reading manifest v4.18 in registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9: manifest unknown"
./hack/generate/../lib/ui.bash: line 39: ERROR_HANDLERS: unbound variable
./hack/generate/../lib/ui.bash: line 39: ERROR_HANDLERS: unbound variable
./hack/generate/../lib/ui.bash: line 39: ERROR_HANDLERS: unbound variable
13:47:35.185 ERROR:   🚨 Error (code: 1) occurred at ./hack/generate/catalog.sh:164, with command: image=$(latest_konflux_image_sha "${image}" "v${image_stream}")
```

[Slack discussion](https://redhat-internal.slack.com/archives/CKR568L8G/p1731595939626919)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
