### PR TITLE
Test long running requests in Serving

### DIFF
--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -94,6 +94,7 @@ DEFAULT_IMAGE_TEMPLATE=$(
   cat <<-EOF
 {{- with .Name }}
 {{- if eq . "httpproxy" }}${QUAY_REGISTRY}/serving/{{.}}:${KNATIVE_SERVING_VERSION#knative-}
+{{- else if eq . "autoscale" }}${QUAY_REGISTRY}/serving/{{.}}:${KNATIVE_SERVING_VERSION#knative-}
 {{- else if eq . "recordevents" }}${QUAY_REGISTRY}/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
 {{- else if eq . "wathola-forwarder" }}${QUAY_REGISTRY}/eventing/{{.}}:${KNATIVE_EVENTING_VERSION#knative-}
 {{- else if eq . "kafka" }}quay.io/strimzi/kafka:latest-kafka-3.4.0

--- a/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
+++ b/serving/ingress/pkg/reconciler/ingress/resources/route_test.go
@@ -416,10 +416,8 @@ func TestMakeRoute(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if test.timeout != "" {
 				t.Setenv(HAProxyTimeoutEnv, test.timeout)
-				DefaultTimeout = getDefaultHAProxyTimeout()
 				defer func() {
 					t.Setenv(HAProxyTimeoutEnv, "")
-					DefaultTimeout = getDefaultHAProxyTimeout()
 				}()
 			}
 			routes, err := MakeRoutes(test.ingress)

--- a/test/images.go
+++ b/test/images.go
@@ -8,4 +8,5 @@ const (
 	RecordEventsImg     = "recordevents"
 	WatholaForwarderImg = "wathola-forwarder"
 	KafkaImg            = "kafka"
+	AutoscaleImg        = "autoscale"
 )

--- a/test/servinge2e/servicemesh/longrunning/timeout_test.go
+++ b/test/servinge2e/servicemesh/longrunning/timeout_test.go
@@ -1,0 +1,48 @@
+package longrunning
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openshift-knative/serverless-operator/serving/ingress/pkg/reconciler/ingress/resources"
+	"github.com/openshift-knative/serverless-operator/test"
+	"github.com/openshift-knative/serverless-operator/test/servinge2e/servicemesh"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
+	servingTest "knative.dev/serving/test"
+)
+
+const (
+	routeTimeout = "800"
+	sleepTime    = 630000
+)
+
+func TestTimeoutForLongRunningRequests(t *testing.T) {
+	ctx := test.SetupClusterAdmin(t)
+	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, ctx) })
+	defer test.CleanupAll(t, ctx)
+
+	service := test.Service("longrunning", test.Namespace, pkgTest.ImagePath(test.AutoscaleImg), map[string]string{
+		servicemesh.ServingEnablePassthroughKey: "true",
+		resources.SetRouteTimeoutAnnotation:     routeTimeout,
+	}, nil)
+	service = test.WithServiceReadyOrFail(ctx, service)
+	serviceURL := service.Status.URL.URL()
+	serviceURL.RawQuery = fmt.Sprintf("sleep=%d", sleepTime)
+
+	if _, err := pkgTest.WaitForEndpointStateWithTimeout(
+		context.Background(),
+		ctx.Clients.Kube,
+		t.Logf,
+		serviceURL,
+		spoof.MatchesBody("Slept"),
+		"CheckResponse",
+		true,
+		time.Second*900,
+		servingTest.AddRootCAtoTransport(context.Background(), t.Logf, &servingTest.Clients{KubeClient: ctx.Clients.Kube}, true),
+	); err != nil {
+		t.Fatalf("Unexpected state for %s :%v", serviceURL, err)
+	}
+}


### PR DESCRIPTION
Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Test for #3017 #3016 
- Introduces  the `serving.knative.openshift.io/setRouteTimeout` ksvc annotation, so that the user can set the timeout per route.  This is aligned with the fact that a ksvc can set a timeout per revision. We don't use the haproxy annotation directly since it might change in the future and in an upgrade scenario we don't want to update the ksvc annotations.
- Using mesh mode since RHAI uses that. Also we avoid running the test with every PR since it takes > 10minutes.
- Tested with Kourier locally:
```
go test -v -failfast -timeout=30m -parallel=1 ./test/servinge2e/servicemesh/longrunning --kubeconfigs=...
=== RUN   TestTimeoutForLongRunningRequests
time="2024-11-19T23:34:32+02:00" level=info msg="Loading kube client config from path \"/.....\""
W1119 23:34:33.007228  193306 warnings.go:70] Kubernetes default value is insecure, Knative may default this to secure in a future release: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation, spec.template.spec.containers[0].securityContext.capabilities, spec.template.spec.containers[0].securityContext.runAsNonRoot, spec.template.spec.containers[0].securityContext.seccompProfile
   spoof.go:111: Spoofing longrunning-serverless-tests.apps.ci-ln-glppxsb-76ef8.aws-2.ci.openshift.org -> longrunning-serverless-tests.apps.ci-ln-glppxsb-76ef8.aws-2.ci.openshift.org
   service.go:61: Cleaning up Knative Service 'serverless-tests/longrunning'
--- PASS: TestTimeoutForLongRunningRequests (642.17s)
PASS
ok  	github.com/openshift-knative/serverless-operator/test/servinge2e/servicemesh/longrunning	642.195s

```