### PR TITLE
Separate installing cert manager operator and certificates

### DIFF
--- a/hack/lib/certmanager.bash
+++ b/hack/lib/certmanager.bash
@@ -5,6 +5,7 @@ certmanager_resources_dir="$(dirname "${BASH_SOURCE[0]}")/certmanager_resources"
 function install_certmanager {
   ensure_catalog_pods_running
   deploy_certmanager_operator
+  deploy_certificates
 }
 
 function uninstall_certmanager {
@@ -31,6 +32,12 @@ function deploy_certmanager_operator {
   timeout 600 "[[ \$(oc get deploy -n ${deployment_namespace} cert-manager-webhook --no-headers | wc -l) != 1 ]]" || return 1
   oc wait deployments -n ${deployment_namespace} cert-manager-webhook --for condition=available --timeout=600s
   oc wait deployments -n ${deployment_namespace} cert-manager --for condition=available --timeout=600s
+}
+
+function deploy_certificates {
+  logger.info "Installing certificates"
+
+  deployment_namespace="cert-manager"
 
   # serving resources
   oc apply -f "${certmanager_resources_dir}"/serving-selfsigned-issuer.yaml || return $?


### PR DESCRIPTION
Allows for testing proper CA setup downstream instead of self-signed certificates and still re-using the installation function for certmanager operator.

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
