### PR TITLE
Fix SO index

### DIFF
--- a/olm-catalog/serverless-operator-index/Dockerfile
+++ b/olm-catalog/serverless-operator-index/Dockerfile
@@ -11,10 +11,6 @@ RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> 
 RUN /bin/opm render --skip-tls-verify -o yaml \
 registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
 registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
-      registry.ci.openshift.org/knative/release-1.35.0:serverless-bundle >> /configs/index.yaml || \
-    /bin/opm render --skip-tls-verify -o yaml \
-registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
-registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
       quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle@sha256:0d5feb3c9f59246d16db1c687e3c1085fcc8a360cd51974197a878944df06b1d >> /configs/index.yaml
 
 # The base image is expected to contain

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -9,8 +9,6 @@ COPY olm-catalog/serverless-operator-index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=__DEFAULT_CHANNEL__ --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml \
-      registry.ci.openshift.org/knative/release-__VERSION__:serverless-bundle >> /configs/index.yaml || \
-    /bin/opm render --skip-tls-verify -o yaml \
       __BUNDLE__ >> /configs/index.yaml
 
 # The base image is expected to contain


### PR DESCRIPTION
Our Dockerfile for Index image is now pulling
`registry.ci.openshift.org/knative/release-1.35.0:serverless-bundle` on line 14 as the bundle now exists.

It doesn't pull the the previously built
`image-registry.openshift-image-registry.svc:5000/openshift-marketplace/serverless-bundle:latest` and the release-1.35.0 bundle references images at `registry.redhat.io` which are not pullable yet.

Originally reported here: https://github.com/openshift-knative/serverless-operator/pull/3054#issuecomment-2503220449