### PR TITLE
[WIP] Manually bump to 1.36.0

### DIFF
--- a/.tekton/serverless-bundle-135-push.yaml
+++ b/.tekton/serverless-bundle-135-push.yaml
@@ -36,7 +36,7 @@ spec:
       value: '{{revision}}'
     - name: additional-tags
       value:
-        - 1.35.0
+        - 1.36.0
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/.tekton/serverless-index-135-fbc-414-push.yaml
+++ b/.tekton/serverless-index-135-fbc-414-push.yaml
@@ -39,7 +39,7 @@ spec:
       value: '{{revision}}'
     - name: additional-tags
       value:
-        - 1.35.0
+        - 1.36.0
         - latest
   pipelineRef:
     name: fbc-builder

--- a/.tekton/serverless-index-135-fbc-415-push.yaml
+++ b/.tekton/serverless-index-135-fbc-415-push.yaml
@@ -39,7 +39,7 @@ spec:
       value: '{{revision}}'
     - name: additional-tags
       value:
-        - 1.35.0
+        - 1.36.0
         - latest
   pipelineRef:
     name: fbc-builder

--- a/.tekton/serverless-index-135-fbc-416-push.yaml
+++ b/.tekton/serverless-index-135-fbc-416-push.yaml
@@ -39,7 +39,7 @@ spec:
       value: '{{revision}}'
     - name: additional-tags
       value:
-        - 1.35.0
+        - 1.36.0
         - latest
   pipelineRef:
     name: fbc-builder

--- a/.tekton/serverless-index-135-fbc-417-push.yaml
+++ b/.tekton/serverless-index-135-fbc-417-push.yaml
@@ -39,7 +39,7 @@ spec:
       value: '{{revision}}'
     - name: additional-tags
       value:
-        - 1.35.0
+        - 1.36.0
         - latest
   pipelineRef:
     name: fbc-builder

--- a/.tekton/serverless-index-135-fbc-418-push.yaml
+++ b/.tekton/serverless-index-135-fbc-418-push.yaml
@@ -39,7 +39,7 @@ spec:
       value: '{{revision}}'
     - name: additional-tags
       value:
-        - 1.35.0
+        - 1.36.0
         - latest
   pipelineRef:
     name: fbc-builder

--- a/.tekton/serverless-ingress-135-push.yaml
+++ b/.tekton/serverless-ingress-135-push.yaml
@@ -36,7 +36,7 @@ spec:
       value: '{{revision}}'
     - name: additional-tags
       value:
-        - 1.35.0
+        - 1.36.0
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/.tekton/serverless-kn-operator-135-push.yaml
+++ b/.tekton/serverless-kn-operator-135-push.yaml
@@ -36,7 +36,7 @@ spec:
       value: '{{revision}}'
     - name: additional-tags
       value:
-        - 1.35.0
+        - 1.36.0
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/.tekton/serverless-metadata-webhook-135-push.yaml
+++ b/.tekton/serverless-metadata-webhook-135-push.yaml
@@ -36,7 +36,7 @@ spec:
       value: '{{revision}}'
     - name: additional-tags
       value:
-        - 1.35.0
+        - 1.36.0
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/.tekton/serverless-must-gather-135-push.yaml
+++ b/.tekton/serverless-must-gather-135-push.yaml
@@ -36,7 +36,7 @@ spec:
       value: '{{revision}}'
     - name: additional-tags
       value:
-        - 1.35.0
+        - 1.36.0
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/.tekton/serverless-openshift-kn-operator-135-push.yaml
+++ b/.tekton/serverless-openshift-kn-operator-135-push.yaml
@@ -36,7 +36,7 @@ spec:
       value: '{{revision}}'
     - name: additional-tags
       value:
-        - 1.35.0
+        - 1.36.0
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -2,6 +2,8 @@
 
 set -Eeuo pipefail
 
+set -x
+
 template="${1:?Provide template file as arg[1]}"
 target="${2:?Provide a target CSV file as arg[2]}"
 

--- a/hack/generate/dockerfile.sh
+++ b/hack/generate/dockerfile.sh
@@ -56,13 +56,6 @@ if [[ "$template" =~ index.Dockerfile ]]; then
     sed --in-place "/opm render/a registry.ci.openshift.org/knative/release-${current_version}:serverless-bundle \\\\" "$target"
   done
 
-  # Hacks. Should gradually go away with next versions.
-  # Workaround for https://issues.redhat.com/browse/SRVCOM-3207
-  # Use a manually built image for 1.32.0.
-  # TODO: Remove this when 1.32.0 is not included in index. This is a problem only for 1.32.0.
-  sed --in-place "s|registry.ci.openshift.org/knative/release-1.32.0:serverless-bundle|quay.io/openshift-knative/serverless-bundle:release-1.32.0|" "$target"
-  # Replace the old format for 1.31.0 and older.
-  sed --in-place "s|registry.ci.openshift.org/knative/release-1.31.0:serverless-bundle|registry.ci.openshift.org/knative/openshift-serverless-v1.31.0:serverless-bundle|" "$target"
 elif [[ "$template" =~ catalog.Dockerfile ]]; then
   while IFS=$'\n' read -r ocp_version; do
     values[OCP_VERSION]="${ocp_version}"

--- a/hack/generate/images-rekt.sh
+++ b/hack/generate/images-rekt.sh
@@ -9,12 +9,5 @@ target="${2:?Provide a target file as arg[2]}"
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/images.bash"
 
 default_knative_eventing_images
-default_knative_eventing_istio_images
-default_knative_eventing_kafka_broker_images
-default_knative_backstage_plugins_images
-default_knative_serving_images
-default_knative_ingress_images
-default_knative_kn_plugin_func_images
-default_knative_client_images
 
 envsubst < "$template" > "$target"

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -24,7 +24,7 @@ USER 65532
 LABEL \
       com.redhat.component="openshift-serverless-1-must-gather-rhel8-container" \
       name="openshift-serverless-1/svls-must-gather-rhel8" \
-      version=1.35.0 \
+      version=1.36.0 \
       summary="Red Hat OpenShift Serverless 1 Must Gather" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Must Gather" \

--- a/olm-catalog/serverless-operator-index/Dockerfile
+++ b/olm-catalog/serverless-operator-index/Dockerfile
@@ -9,13 +9,9 @@ COPY olm-catalog/serverless-operator-index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml \
-registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
 registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
-      registry.ci.openshift.org/knative/release-1.35.0:serverless-bundle >> /configs/index.yaml || \
-    /bin/opm render --skip-tls-verify -o yaml \
-registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
-registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
-      quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle@sha256:0d5feb3c9f59246d16db1c687e3c1085fcc8a360cd51974197a878944df06b1d >> /configs/index.yaml
+registry.ci.openshift.org/knative/release-1.35.0:serverless-bundle \
+       >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe

--- a/olm-catalog/serverless-operator-index/configs/index.yaml
+++ b/olm-catalog/serverless-operator-index/configs/index.yaml
@@ -3,22 +3,22 @@ schema: olm.channel
 name: stable
 package: serverless-operator
 entries:
+  - name: "serverless-operator.v1.36.0"
+    replaces: "serverless-operator.v1.35.0"
+    skipRange: ">=1.35.0 <1.36.0"
   - name: "serverless-operator.v1.35.0"
     replaces: "serverless-operator.v1.34.0"
     skipRange: ">=1.34.0 <1.35.0"
-  - name: "serverless-operator.v1.34.0"
-    replaces: "serverless-operator.v1.33.0"
-    skipRange: ">=1.33.0 <1.34.0"
-  - name: serverless-operator.v1.33.0
+  - name: serverless-operator.v1.34.0
 ---
 schema: olm.channel
-name: stable-1.35
+name: stable-1.36
 package: serverless-operator
 entries:
+  - name: "serverless-operator.v1.36.0"
+    replaces: "serverless-operator.v1.35.0"
+    skipRange: ">=1.35.0 <1.36.0"
   - name: "serverless-operator.v1.35.0"
     replaces: "serverless-operator.v1.34.0"
     skipRange: ">=1.34.0 <1.35.0"
-  - name: "serverless-operator.v1.34.0"
-    replaces: "serverless-operator.v1.33.0"
-    skipRange: ">=1.33.0 <1.34.0"
-  - name: serverless-operator.v1.33.0
+  - name: serverless-operator.v1.34.0

--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -13,12 +13,12 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=serverless-operator
 LABEL operators.operatorframework.io.bundle.channel.default.v1="stable"
-LABEL operators.operatorframework.io.bundle.channels.v1="stable,stable-1.35"
+LABEL operators.operatorframework.io.bundle.channels.v1="stable,stable-1.36"
 
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
       name="openshift-serverless-1/serverless-operator-bundle" \
-      version="1.35.0" \
+      version="1.36.0" \
       summary="Red Hat OpenShift Serverless Bundle" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \
@@ -29,6 +29,6 @@ LABEL \
       com.redhat.delivery.backport=false \
       distribution-scope="authoritative-source-only" \
       url="https://catalog.redhat.com/software/container-stacks/detail/5ec53fcb110f56bd24f2ddc5" \
-      release="1.35.0" \
+      release="1.36.0" \
       io.openshift.tags="bundle" \
       vendor="Red Hat, Inc."

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -71,14 +71,14 @@ metadata:
       Deploy and manage event-driven serverless applications and functions using Knative.
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
-    olm.skipRange: '>=1.34.0 <1.35.0'
-    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8@sha256:cf172b93a447fedc1de4a1c38e33e992105747119642ae0606a4d26d3e1abf33
+    olm.skipRange: '>=1.35.0 <1.36.0'
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8:latest
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.arm64: supported
-  name: serverless-operator.v1.35.0
+  name: serverless-operator.v1.36.0
   namespace: placeholder
 spec:
   # User-facing metadata
@@ -98,7 +98,7 @@ spec:
 
     The components provided with the OpenShift Serverless operator require minimum cluster sizes on
     OpenShift Container Platform. For more information, see the documentation on [Getting started
-    with OpenShift Serverless](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.35/html/serving/getting-started-with-knative-serving#serverless-applications).
+    with OpenShift Serverless](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.36/html/serving/getting-started-with-knative-serving#serverless-applications).
 
     # Supported Features
     - **Easy to get started:** Provides a simplified developer experience to deploy
@@ -166,8 +166,8 @@ spec:
     # Further Information
     For documentation on OpenShift Serverless, see:
     - [Installation
-    Guide](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.35/html/installing_openshift_serverless/index)
-    - [Develop Serverless Applications](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.35/html/serving/getting-started-with-knative-serving#serverless-applications)
+    Guide](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.36/html/installing_openshift_serverless/index)
+    - [Develop Serverless Applications](https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.36/html/serving/getting-started-with-knative-serving#serverless-applications)
   icon:
     - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij48ZGVmcz48c3R5bGU+LmF7ZmlsbDojZmZmO30uYntmaWxsOiNlMDA7fTwvc3R5bGU+PC9kZWZzPjxwYXRoIGNsYXNzPSJhIiBkPSJNMjgsMUgxMGE5LDksMCwwLDAtOSw5VjI4YTksOSwwLDAsMCw5LDlIMjhhOSw5LDAsMCwwLDktOVYxMGE5LDksMCwwLDAtOS05WiIvPjxwYXRoIGQ9Ik0yOCwyLjI1QTcuNzU4Nyw3Ljc1ODcsMCwwLDEsMzUuNzUsMTBWMjhBNy43NTg3LDcuNzU4NywwLDAsMSwyOCwzNS43NUgxMEE3Ljc1ODcsNy43NTg3LDAsMCwxLDIuMjUsMjhWMTBBNy43NTg3LDcuNzU4NywwLDAsMSwxMCwyLjI1SDI4TTI4LDFIMTBhOSw5LDAsMCwwLTksOVYyOGE5LDksMCwwLDAsOSw5SDI4YTksOSwwLDAsMCw5LTlWMTBhOSw5LDAsMCwwLTktOVoiLz48cGF0aCBjbGFzcz0iYiIgZD0iTTE0LDIzLjQ3NjZIMTBhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwxNCwyMy40NzY2Wm0tMy4zNzUtMS4yNWgyLjc1di0yLjc1aC0yLjc1WiIvPjxwYXRoIGNsYXNzPSJiIiBkPSJNMjEsMjMuNDc2NkgxN2EuNjI1My42MjUzLDAsMCwxLS42MjUtLjYyNXYtNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUtLjYyNWg0YS42MjUyLjYyNTIsMCwwLDEsLjYyNS42MjV2NEEuNjI1My42MjUzLDAsMCwxLDIxLDIzLjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0xNy41LDE2LjQ3NjZoLTRhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwxNy41LDE2LjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0yNC41LDE2LjQ3NjZoLTRhLjYyNTMuNjI1MywwLDAsMS0uNjI1LS42MjV2LTRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LS42MjVoNGEuNjI1Mi42MjUyLDAsMCwxLC42MjUuNjI1djRBLjYyNTMuNjI1MywwLDAsMSwyNC41LDE2LjQ3NjZabS0zLjM3NS0xLjI1aDIuNzV2LTIuNzVoLTIuNzVaIi8+PHBhdGggY2xhc3M9ImIiIGQ9Ik0yOCwyMy40NzY2SDI0YS42MjUzLjYyNTMsMCwwLDEtLjYyNS0uNjI1di00YS42MjUyLjYyNTIsMCwwLDEsLjYyNS0uNjI1aDRhLjYyNTIuNjI1MiwwLDAsMSwuNjI1LjYyNXY0QS42MjUzLjYyNTMsMCwwLDEsMjgsMjMuNDc2NlptLTMuMzc1LTEuMjVoMi43NXYtMi43NWgtMi43NVoiLz48cGF0aCBkPSJNMjksMjYuNDc2Nkg5YS42MjUuNjI1LDAsMCwxLDAtMS4yNUgyOWEuNjI1LjYyNSwwLDAsMSwwLDEuMjVaIi8+PC9zdmc+
       mediatype: image/svg+xml
@@ -191,7 +191,7 @@ spec:
     - kafka
   links:
     - name: Documentation
-      url: https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.35/html/installing_openshift_serverless/index
+      url: https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.36/html/installing_openshift_serverless/index
     - name: Source Repository
       url: https://github.com/openshift-knative/serverless-operator
   maintainers:
@@ -830,7 +830,7 @@ spec:
                 serviceAccountName: knative-operator
                 containers:
                   - name: knative-operator
-                    image: registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator@sha256:6d025e7be6e96249827985a8329e54bed93c3b0a08795fd31ca9502b9e664da1
+                    image: registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator:latest
                     readinessProbe:
                       periodSeconds: 1
                       httpGet:
@@ -937,7 +937,7 @@ spec:
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
                         value: "registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@sha256:1d2a8b786bd09301530d37440ce6501527cfd511ba78d97da5eda952a6558ebe"
                       - name: "IMAGE_KN_CLIENT"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:4be5297b86aaf82e8faeecb178bcc71772658403d46912b59f7d096aac48eef7"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:96b9b74ef35c0f8fb32ec3b743e585fb7402fa3da35608ae870f9119ba8a0cef"
                       - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
                         value: "registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:63fbd304ffb93e5883b987ac90a476cd9ff9946f164ca8acb9c1a95fee84bcb3"
                       - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"
@@ -951,7 +951,7 @@ spec:
                       - name: "IMAGE_KN_PLUGIN_FUNC_PYTHON_39"
                         value: "registry.access.redhat.com/ubi8/python-39@sha256:27e795fd6b1b77de70d1dc73a65e4c790650748a9cfda138fdbd194b3d6eea3d"
                       - name: "CURRENT_VERSION"
-                        value: "1.35.0"
+                        value: "1.36.0"
                       - name: "KNATIVE_SERVING_VERSION"
                         value: "1.15"
                       - name: "KNATIVE_EVENTING_VERSION"
@@ -981,7 +981,7 @@ spec:
                 serviceAccountName: knative-openshift
                 initContainers:
                   - name: cli-artifacts
-                    image: registry.redhat.io/openshift-serverless-1/kn-client-cli-artifacts-rhel8@sha256:c710808404e4c2fb2d3131b5dfbb0939263a2cf49e0dc64b5ad5a99c19cf2e50
+                    image: registry.redhat.io/openshift-serverless-1/kn-client-cli-artifacts-rhel8@sha256:dddc3115f29066f9b9224de3bd147a3285ea86e25de2dba60e056408096ff185
                     imagePullPolicy: Always
                     command: ["sh", "-c", "rm -rf /cli-artifacts/* && cp /usr/share/kn/**/* /cli-artifacts && chmod 444 /cli-artifacts/*"]
                     volumeMounts:
@@ -995,7 +995,7 @@ spec:
                           - ALL
                 containers:
                   - name: knative-openshift
-                    image: registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8@sha256:05a301408a6c687900aa605161e280da3c6ccfdcea7df1f1b95b5879b794f23d
+                    image: registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8:latest
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -1111,7 +1111,7 @@ spec:
                       - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
                         value: "registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@sha256:1d2a8b786bd09301530d37440ce6501527cfd511ba78d97da5eda952a6558ebe"
                       - name: "IMAGE_KN_CLIENT"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:4be5297b86aaf82e8faeecb178bcc71772658403d46912b59f7d096aac48eef7"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:96b9b74ef35c0f8fb32ec3b743e585fb7402fa3da35608ae870f9119ba8a0cef"
                       - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
                         value: "registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:63fbd304ffb93e5883b987ac90a476cd9ff9946f164ca8acb9c1a95fee84bcb3"
                       - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"
@@ -1125,27 +1125,27 @@ spec:
                       - name: "IMAGE_KN_PLUGIN_FUNC_PYTHON_39"
                         value: "registry.access.redhat.com/ubi8/python-39@sha256:27e795fd6b1b77de70d1dc73a65e4c790650748a9cfda138fdbd194b3d6eea3d"
                       - name: "KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:7fb3155f7b5292b784891fca026912ce64540104e3a27523976aa2054f72a8ee"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:d9df8909fca703a67048f5ad12b1715753b69cd6230125995b8f5ab07c209465"
                       - name: "KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:b48f6e01fd3ce82aaa8bbd13e6c141bf03283da8779108f0b74f630ea11c668d"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:5e89e55f6b1d76171f3898829fed12942b47d32fae1ecb6e5b5fc5e93f7a34b8"
                       - name: "KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:7fb3155f7b5292b784891fca026912ce64540104e3a27523976aa2054f72a8ee"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:d9df8909fca703a67048f5ad12b1715753b69cd6230125995b8f5ab07c209465"
                       - name: "KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:b48f6e01fd3ce82aaa8bbd13e6c141bf03283da8779108f0b74f630ea11c668d"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:5e89e55f6b1d76171f3898829fed12942b47d32fae1ecb6e5b5fc5e93f7a34b8"
                       - name: "KAFKA_IMAGE_kafka-controller__controller"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-kafka-controller-rhel8@sha256:ee500884177c5f3aea315aa3dba089fe0293c4687a15a7f223d65e0c4d5ee0e4"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-kafka-controller-rhel8@sha256:723138a27374fffa3f2ed19821c9c62c7a58793b1b2fc8fa524b64f53d8ea92c"
                       - name: "KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:7fb3155f7b5292b784891fca026912ce64540104e3a27523976aa2054f72a8ee"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:d9df8909fca703a67048f5ad12b1715753b69cd6230125995b8f5ab07c209465"
                       - name: "KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:b48f6e01fd3ce82aaa8bbd13e6c141bf03283da8779108f0b74f630ea11c668d"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:5e89e55f6b1d76171f3898829fed12942b47d32fae1ecb6e5b5fc5e93f7a34b8"
                       - name: "KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-webhook-kafka-rhel8@sha256:afa54f0a233fb241b41c72a410d8cc342790759f6cb60d2756711953df59ceac"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-webhook-kafka-rhel8@sha256:90daffb2617e708be1f74050549e94ef952909342d8668098bcf2a6cd0186aa3"
                       - name: "KAFKA_IMAGE_kafka-controller-post-install__post-install"
-                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-post-install-rhel8@sha256:f6fe641a3fd0ac3065eccbc116b859d700a009a4c1f5d86e4ea694cfeab49265"
+                        value: "registry.redhat.io/openshift-serverless-1/kn-ekb-post-install-rhel8@sha256:145fd7462c399ccca2e3fadb1de79eb48696b27497ac6f788ab8a3f8a759f695"
                       - name: "KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate"
                         value: "registry.redhat.io/openshift-serverless-1/kn-eventing-migrate-rhel8@sha256:4d51a880f0f230911c3b8834a67dacddd3d6414c65e7f1eae6d0c05641008de1"
                       - name: "CURRENT_VERSION"
-                        value: "1.35.0"
+                        value: "1.36.0"
                       - name: "KNATIVE_SERVING_VERSION"
                         value: "1.15"
                       - name: "KNATIVE_EVENTING_VERSION"
@@ -1177,7 +1177,7 @@ spec:
                 serviceAccountName: knative-openshift-ingress
                 containers:
                   - name: knative-openshift-ingress
-                    image: registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8@sha256:f2c1dd4b83833413611c3056578db13889d8cee9026fbc739890465506f0aa9c
+                    image: registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8:latest
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -1328,11 +1328,11 @@ spec:
         - knativeeventings.operator.knative.dev
   relatedImages:
     - name: "knative-operator"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator@sha256:6d025e7be6e96249827985a8329e54bed93c3b0a08795fd31ca9502b9e664da1"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel8-operator:latest"
     - name: "knative-openshift"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8@sha256:05a301408a6c687900aa605161e280da3c6ccfdcea7df1f1b95b5879b794f23d"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel8:latest"
     - name: "knative-openshift-ingress"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8@sha256:f2c1dd4b83833413611c3056578db13889d8cee9026fbc739890465506f0aa9c"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel8:latest"
     - name: "IMAGE_queue-proxy"
       image: "registry.redhat.io/openshift-serverless-1/kn-serving-queue-rhel8@sha256:723c4d19370575cb4ce79d4a60cb68f64ae419f2cce6b9f611dce4201def7eac"
     - name: "IMAGE_activator"
@@ -1388,7 +1388,7 @@ spec:
     - name: "IMAGE_KN_PLUGIN_EVENT_SENDER"
       image: "registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@sha256:1d2a8b786bd09301530d37440ce6501527cfd511ba78d97da5eda952a6558ebe"
     - name: "IMAGE_KN_CLIENT"
-      image: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:4be5297b86aaf82e8faeecb178bcc71772658403d46912b59f7d096aac48eef7"
+      image: "registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8@sha256:96b9b74ef35c0f8fb32ec3b743e585fb7402fa3da35608ae870f9119ba8a0cef"
     - name: "IMAGE_KN_PLUGIN_FUNC_UTIL"
       image: "registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:63fbd304ffb93e5883b987ac90a476cd9ff9946f164ca8acb9c1a95fee84bcb3"
     - name: "IMAGE_KN_PLUGIN_FUNC_TEKTON_S2I"
@@ -1402,28 +1402,28 @@ spec:
     - name: "IMAGE_KN_PLUGIN_FUNC_PYTHON_39"
       image: "registry.access.redhat.com/ubi8/python-39@sha256:27e795fd6b1b77de70d1dc73a65e4c790650748a9cfda138fdbd194b3d6eea3d"
     - name: "KAFKA_IMAGE_kafka-broker-receiver__kafka-broker-receiver"
-      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:7fb3155f7b5292b784891fca026912ce64540104e3a27523976aa2054f72a8ee"
+      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:d9df8909fca703a67048f5ad12b1715753b69cd6230125995b8f5ab07c209465"
     - name: "KAFKA_IMAGE_kafka-broker-dispatcher__kafka-broker-dispatcher"
-      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:b48f6e01fd3ce82aaa8bbd13e6c141bf03283da8779108f0b74f630ea11c668d"
+      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:5e89e55f6b1d76171f3898829fed12942b47d32fae1ecb6e5b5fc5e93f7a34b8"
     - name: "KAFKA_IMAGE_kafka-channel-receiver__kafka-channel-receiver"
-      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:7fb3155f7b5292b784891fca026912ce64540104e3a27523976aa2054f72a8ee"
+      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:d9df8909fca703a67048f5ad12b1715753b69cd6230125995b8f5ab07c209465"
     - name: "KAFKA_IMAGE_kafka-channel-dispatcher__kafka-channel-dispatcher"
-      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:b48f6e01fd3ce82aaa8bbd13e6c141bf03283da8779108f0b74f630ea11c668d"
+      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:5e89e55f6b1d76171f3898829fed12942b47d32fae1ecb6e5b5fc5e93f7a34b8"
     - name: "KAFKA_IMAGE_kafka-controller__controller"
-      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-kafka-controller-rhel8@sha256:ee500884177c5f3aea315aa3dba089fe0293c4687a15a7f223d65e0c4d5ee0e4"
+      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-kafka-controller-rhel8@sha256:723138a27374fffa3f2ed19821c9c62c7a58793b1b2fc8fa524b64f53d8ea92c"
     - name: "KAFKA_IMAGE_kafka-sink-receiver__kafka-sink-receiver"
-      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:7fb3155f7b5292b784891fca026912ce64540104e3a27523976aa2054f72a8ee"
+      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-receiver-rhel8@sha256:d9df8909fca703a67048f5ad12b1715753b69cd6230125995b8f5ab07c209465"
     - name: "KAFKA_IMAGE_kafka-source-dispatcher__kafka-source-dispatcher"
-      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:b48f6e01fd3ce82aaa8bbd13e6c141bf03283da8779108f0b74f630ea11c668d"
+      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-dispatcher-rhel8@sha256:5e89e55f6b1d76171f3898829fed12942b47d32fae1ecb6e5b5fc5e93f7a34b8"
     - name: "KAFKA_IMAGE_kafka-webhook-eventing__kafka-webhook-eventing"
-      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-webhook-kafka-rhel8@sha256:afa54f0a233fb241b41c72a410d8cc342790759f6cb60d2756711953df59ceac"
+      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-webhook-kafka-rhel8@sha256:90daffb2617e708be1f74050549e94ef952909342d8668098bcf2a6cd0186aa3"
     - name: "KAFKA_IMAGE_kafka-controller-post-install__post-install"
-      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-post-install-rhel8@sha256:f6fe641a3fd0ac3065eccbc116b859d700a009a4c1f5d86e4ea694cfeab49265"
+      image: "registry.redhat.io/openshift-serverless-1/kn-ekb-post-install-rhel8@sha256:145fd7462c399ccca2e3fadb1de79eb48696b27497ac6f788ab8a3f8a759f695"
     - name: "KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate"
       image: "registry.redhat.io/openshift-serverless-1/kn-eventing-migrate-rhel8@sha256:4d51a880f0f230911c3b8834a67dacddd3d6414c65e7f1eae6d0c05641008de1"
     - name: "IMAGE_MUST_GATHER"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8@sha256:cf172b93a447fedc1de4a1c38e33e992105747119642ae0606a4d26d3e1abf33"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8:latest"
     - name: "IMAGE_KN_CLIENT_CLI_ARTIFACTS"
-      image: "registry.redhat.io/openshift-serverless-1/kn-client-cli-artifacts-rhel8@sha256:c710808404e4c2fb2d3131b5dfbb0939263a2cf49e0dc64b5ad5a99c19cf2e50"
-  replaces: serverless-operator.v1.34.0
-  version: 1.35.0
+      image: "registry.redhat.io/openshift-serverless-1/kn-client-cli-artifacts-rhel8@sha256:dddc3115f29066f9b9224de3bd147a3285ea86e25de2dba60e056408096ff185"
+  replaces: serverless-operator.v1.35.0
+  version: 1.36.0

--- a/olm-catalog/serverless-operator/metadata/annotations.yaml
+++ b/olm-catalog/serverless-operator/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable,stable-1.35
+  operators.operatorframework.io.bundle.channels.v1: stable,stable-1.36
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -1,78 +1,78 @@
 project:
-  name: serverless-operator
-  # When bumping the Operator to a new version (major and minor), make sure to also update
-  # all components in `dependencies.previous` to the same versions as `dependencies` in the same PR.
-  # Otherwise, the upgrade tests will not pass, as we have a different SO version with the same bundle contents.
-  # Also make sure to update values under `olm.previous` by copying from `olm.replaces` and `olm.skipRange`.
-  version: 1.35.0
+    name: serverless-operator
+    # When bumping the Operator to a new version (major and minor), make sure to also update
+    # all components in `dependencies.previous` to the same versions as `dependencies` in the same PR.
+    # Otherwise, the upgrade tests will not pass, as we have a different SO version with the same bundle contents.
+    # Also make sure to update values under `olm.previous` by copying from `olm.replaces` and `olm.skipRange`.
+    version: 1.36.0
 olm:
-  replaces: 1.34.0
-  skipRange: '>=1.34.0 <1.35.0'
-  channels:
-    default: stable
-    list:
-      - stable
-      - stable-1.35
+    replaces: 1.35.0
+    skipRange: '>=1.35.0 <1.36.0'
+    channels:
+        default: stable
+        list:
+            - stable
+            - stable-1.36
 requirements:
-  kube:
-    # The min version validation in `vendor/knative.dev/pkg/version/version.go`
-    # is ignored as it is overridden by fake version via KUBERNETES_MIN_VERSION.
-    # This value is used for CSV's min version validation.
-    minVersion: 1.25.0
-  golang: '1.22'
-  nodejs: 20.x
-  ocpVersion:
-    list:
-      - "4.14"
-      - "4.15"
-      - "4.16"
-      - "4.17"
-      - "4.18"
-    min: '4.14'
-    max: '4.18'
-    label: 'v4.14'
-    # OCP stream for kube-rbac-proxy image.
-    kube-rbac-proxy: "4.17"
+    kube:
+        # The min version validation in `vendor/knative.dev/pkg/version/version.go`
+        # is ignored as it is overridden by fake version via KUBERNETES_MIN_VERSION.
+        # This value is used for CSV's min version validation.
+        minVersion: 1.25.0
+    golang: '1.22'
+    nodejs: 20.x
+    ocpVersion:
+        list:
+            - "4.14"
+            - "4.15"
+            - "4.16"
+            - "4.17"
+            - "4.18"
+        min: '4.14'
+        max: '4.18'
+        label: 'v4.14'
+        # OCP stream for kube-rbac-proxy image.
+        kube-rbac-proxy: "4.17"
 dependencies:
-  serving: knative-v1.15
-  # serving midstream branch name
-  serving_artifacts_branch: release-v1.15
-  # versions for networking components
-  kourier: knative-v1.15
-  net_kourier_artifacts_branch: release-v1.15
-  net_istio: knative-v1.15
-  net_istio_artifacts_branch: release-v1.15
-  redhat-knative-istio-authz-chart: 1.35.0
-  service_mesh_proxy: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:61a705509328e56d50a1eb9a7f5eb90512f69cc1040ef34c0adb86dd6b05429f
-  eventing: knative-v1.15
-  # eventing core midstream branch name
-  eventing_artifacts_branch: release-v1.15
-  # eventing-kafka-broker promotion tag
-  eventing_kafka_broker: knative-v1.15
-  # eventing-kafka-broker midstream branch or commit
-  eventing_kafka_broker_artifacts_branch: release-v1.15
-  # eventing-istio promotion tag
-  eventing_istio: knative-v1.15
-  # eventing-istio midstream branch or commit
-  eventing_istio_artifacts_branch: release-v1.15
-  # backstage-plugins promotion tag
-  backstage_plugins: knative-v1.15
-  # backstage-plugins midstream branch or commit
-  backstage_plugins_artifacts_branch: release-v1.15
-  cli: knative-v1.15
-  kube_rbac_proxy: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:3fa22124916523b958c67af8ad652e73a2c3d68bb5579da1cba1ade537f3b7ae
-  func:
-    promotion_tag: knative-v1.15
-    tekton_s2i: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
-    tekton_buildah: registry.redhat.io/rhel8/buildah@sha256:3d505d9c0f5d4cd5a4ec03b8d038656c6cdbdf5191e00ce6388f7e0e4d2f1b74
-    nodejs_20_minimal: registry.access.redhat.com/ubi8/nodejs-20-minimal@sha256:a2a7e399aaf09a48c28f40820da16709b62aee6f2bc703116b9345fab5830861
-    openjdk_21: registry.access.redhat.com/ubi8/openjdk-21@sha256:441897a1f691c7d4b3a67bb3e0fea83e18352214264cb383fd057bbbd5ed863c
-    python-39: registry.access.redhat.com/ubi8/python-39@sha256:27e795fd6b1b77de70d1dc73a65e4c790650748a9cfda138fdbd194b3d6eea3d
-  operator: 1.15.4
-  # Previous versions required for downgrade testing
-  previous:
-    serving: knative-v1.14
-    eventing: knative-v1.14
-    eventing_kafka_broker: knative-v1.14
-  mustgather:
-    image: quay.io/openshift-knative/must-gather
+    serving: knative-v1.15
+    # serving midstream branch name
+    serving_artifacts_branch: release-v1.15
+    # versions for networking components
+    kourier: knative-v1.15
+    net_kourier_artifacts_branch: release-v1.15
+    net_istio: knative-v1.15
+    net_istio_artifacts_branch: release-v1.15
+    redhat-knative-istio-authz-chart: 1.36.0
+    service_mesh_proxy: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:61a705509328e56d50a1eb9a7f5eb90512f69cc1040ef34c0adb86dd6b05429f
+    eventing: knative-v1.15
+    # eventing core midstream branch name
+    eventing_artifacts_branch: release-v1.15
+    # eventing-kafka-broker promotion tag
+    eventing_kafka_broker: knative-v1.15
+    # eventing-kafka-broker midstream branch or commit
+    eventing_kafka_broker_artifacts_branch: release-v1.15
+    # eventing-istio promotion tag
+    eventing_istio: knative-v1.15
+    # eventing-istio midstream branch or commit
+    eventing_istio_artifacts_branch: release-v1.15
+    # backstage-plugins promotion tag
+    backstage_plugins: knative-v1.15
+    # backstage-plugins midstream branch or commit
+    backstage_plugins_artifacts_branch: release-v1.15
+    cli: knative-v1.15
+    kube_rbac_proxy: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:3fa22124916523b958c67af8ad652e73a2c3d68bb5579da1cba1ade537f3b7ae
+    func:
+        promotion_tag: knative-v1.15
+        tekton_s2i: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
+        tekton_buildah: registry.redhat.io/rhel8/buildah@sha256:3d505d9c0f5d4cd5a4ec03b8d038656c6cdbdf5191e00ce6388f7e0e4d2f1b74
+        nodejs_20_minimal: registry.access.redhat.com/ubi8/nodejs-20-minimal@sha256:a2a7e399aaf09a48c28f40820da16709b62aee6f2bc703116b9345fab5830861
+        openjdk_21: registry.access.redhat.com/ubi8/openjdk-21@sha256:441897a1f691c7d4b3a67bb3e0fea83e18352214264cb383fd057bbbd5ed863c
+        python-39: registry.access.redhat.com/ubi8/python-39@sha256:27e795fd6b1b77de70d1dc73a65e4c790650748a9cfda138fdbd194b3d6eea3d
+    operator: 1.15.4
+    # Previous versions required for downgrade testing
+    previous:
+        serving: knative-v1.15
+        eventing: knative-v1.15
+        eventing_kafka_broker: knative-v1.15
+    mustgather:
+        image: quay.io/openshift-knative/must-gather

--- a/templates/index.Dockerfile
+++ b/templates/index.Dockerfile
@@ -9,8 +9,6 @@ COPY olm-catalog/serverless-operator-index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=__DEFAULT_CHANNEL__ --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml \
-      registry.ci.openshift.org/knative/release-__VERSION__:serverless-bundle >> /configs/index.yaml || \
-    /bin/opm render --skip-tls-verify -o yaml \
       __BUNDLE__ >> /configs/index.yaml
 
 # The base image is expected to contain


### PR DESCRIPTION
When we bump the metadata for a major version, images are not yet available for SO components on
the Konflux registry, so we use the `:latest` tag temporarily by passing "true" as argument to
various `latest_*` functions.

Eventually, once images are available, SHAs will be replaced/used.