### PR TITLE
[release-1.35] Use Konflux image in yaml for metadata-webhook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,7 @@ release-files: install-tools
   	tenant-1,tenant-2,serving-tests,serverless-tests,eventing-e2e0,eventing-e2e1,eventing-e2e2,eventing-e2e3,eventing-e2e4
 	./hack/generate/override-snapshot.sh \
   	.konflux-release/
+	./hack/generate/metadata-webhook.sh
 
 generate-dockerfiles: install-tool-generate
 	GOFLAGS='' go install github.com/openshift-knative/hack/cmd/generate@latest

--- a/hack/generate/metadata-webhook.sh
+++ b/hack/generate/metadata-webhook.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/__sources__.bash"
+
+function update_webhook_image {
+  local image="${registry_quay}/serverless-metadata-webhook:latest"
+  yq w --inplace serving/metadata-webhook/config/webhook.yaml 'spec.template.spec.containers(name==webhook).image' "${image}"
+}
+
+logger.info "Updating metadata-webhook image"
+update_webhook_image

--- a/serving/metadata-webhook/config/webhook.yaml
+++ b/serving/metadata-webhook/config/webhook.yaml
@@ -22,56 +22,52 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: webhook
-              topologyKey: kubernetes.io/hostname
-            weight: 100
-
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: webhook
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       serviceAccountName: controller
       containers:
-      - name: webhook
-        image: registry.ci.openshift.org/knative/serverless-metadata-webhook:knative-main
-        resources:
-          requests:
-            cpu: 20m
-            memory: 20Mi
-          limits:
-            cpu: 200m
-            memory: 200Mi
-        env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: KUBERNETES_MIN_VERSION
-          value: v1.0.0
-        - name: CONFIG_LOGGING_NAME
-          value: config-logging
-        - name: METRICS_DOMAIN
-          value: knative.dev/samples
-        - name: WEBHOOK_NAME
-          value: webhook
-
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          capabilities:
-            drop:
-            - all
-
-        readinessProbe: &probe
-          periodSeconds: 1
-          httpGet:
-            scheme: HTTPS
-            port: 8443
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: "webhook"
-        livenessProbe: *probe
-
+        - name: webhook
+          image: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-metadata-webhook:latest
+          resources:
+            requests:
+              cpu: 20m
+              memory: 20Mi
+            limits:
+              cpu: 200m
+              memory: 200Mi
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBERNETES_MIN_VERSION
+              value: v1.0.0
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: METRICS_DOMAIN
+              value: knative.dev/samples
+            - name: WEBHOOK_NAME
+              value: webhook
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - all
+          readinessProbe: &probe
+            periodSeconds: 1
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              httpHeaders:
+                - name: k-kubelet-probe
+                  value: "webhook"
+          livenessProbe: *probe
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
       # high value that we respect whatever value it has configured for the lame duck grace period.
       terminationGracePeriodSeconds: 300


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift-knative/serverless-operator/pull/3069

The image is multiarch and might be specific for each branch. The Makefile had a conflict (adding override-snapshot in the same place)

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
