### PR TITLE
Move override-snapshot generation into separate Makefile target

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -81,6 +81,10 @@ jobs:
           REGISTRY_REDHAT_IO_PASSWORD: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}
         run: make generate-catalog
 
+      - name: Regenerate override-snapshot
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: make generate-override-snapshot
+
       # Optional:
       #   Since we're generating files based on a floating branch in midstream,
       #   we need to reconcile those files periodically.

--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,10 @@ generate-catalog:
 	./hack/generate/catalog.sh
 .PHONY: generate-catalog
 
+generate-override-snapshot:
+	./hack/generate/override-snapshot.sh .konflux-release/
+.PHONY: generate-override-snapshot
+
 # Generates all files that are templated with release metadata.
 release-files: install-tools
 	./hack/generate/csv.sh \
@@ -322,8 +326,6 @@ release-files: install-tools
 	./hack/generate/mesh-auth-policies.sh \
   	tenant-1,tenant-2,serving-tests,serverless-tests,eventing-e2e0,eventing-e2e1,eventing-e2e2,eventing-e2e3,eventing-e2e4
 	./hack/generate/metadata-webhook.sh
-	./hack/generate/override-snapshot.sh \
-  	.konflux-release/
 
 generate-dockerfiles: install-tool-generate
 	GOFLAGS='' go install github.com/openshift-knative/hack/cmd/generate@latest


### PR DESCRIPTION
Currently seeing issues like the following in midstream repos
```
Error: no attestations associated with quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-istio-controller@sha256:43d18806e8d10c9a9269a1925554765442289fda0387d9e9e413cecce6e2332a
main.go:62: error during command execution: no attestations associated with quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-istio-controller@sha256:43d18806e8d10c9a9269a1925554765442289fda0387d9e9e413cecce6e2332a
...
18:09:51.109 ERROR:   🚨 Error (code: 1) occurred at ./hack/generate/override-snapshot.sh:13, with command: parameters="$(cosign download attestation "${image_ref}" | jq -r '.payload' | base64 -d | jq -c '.predicate.invocation.parameters')"
...
```

So moving the override-snapshot generation into separate Makefile target and run only in validate workflow.

