### PR TITLE
raise tempo memory limits

### DIFF
--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -233,7 +233,7 @@ spec:
   resources:
     total:
       limits:
-        memory: 2Gi
+        memory: 4Gi
         cpu: 2000m
   template:
     queryFrontend:


### PR DESCRIPTION
- :broom: Raise tempo memory limits

seeing OOMKilled in the tempo container, e.g. https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_serverless-operator/3156/pull-ci-openshift-knative-serverless-operator-release-1.35-417-operator-e2e-aws-417/1866938775821619200 