### PR TITLE
Increase scaling worker nodes to 6 for upgrade tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,14 +196,14 @@ test-upstream-upgrade-testonly:
 test-upgrade: install-tools
 	TRACING_BACKEND=zipkin ZIPKIN_DEDICATED_NODE=true ./hack/tracing.sh
 	UNINSTALL_STRIMZI=false ./hack/strimzi.sh
-	INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=5 ./hack/install.sh
+	INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=6 ./hack/install.sh
 	TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
 mesh-upgrade: install-tools
 	UNINSTALL_MESH=false ./hack/mesh.sh
 	TRACING_BACKEND=zipkin ./hack/tracing.sh
 	UNINSTALL_STRIMZI=false ./hack/strimzi.sh
-	MESH=true INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=5 ./hack/install.sh
+	MESH=true INSTALL_PREVIOUS_VERSION=true INSTALL_KAFKA=true TRACING_BACKEND=zipkin ENABLE_TRACING=true SCALE_UP=6 ./hack/install.sh
 	MESH=true TEST_KNATIVE_KAFKA=true TEST_KNATIVE_E2E=false TEST_KNATIVE_UPGRADE=true ./test/upstream-e2e-tests.sh
 
 test-upgrade-with-mesh: mesh-upgrade


### PR DESCRIPTION
Resource consumption increased with eventing-kafka-broker since 1.15, because we switched to StatefulSets for some resources:

* 1.14: https://github.com/openshift-knative/eventing-kafka-broker/blob/af5fd33caa51e17ce0ed8ecdc42e06c2a95872da/data-plane/config/channel/500-dispatcher.yaml#L124
* 1.15: https://github.com/openshift-knative/eventing-kafka-broker/blob/1cd61d8ce31a33e8e4e5f8be2164065efd807ac8/data-plane/config/channel/500-dispatcher.yaml#L128

/cherry-pick release-1.35