### PR TITLE
Copy logs to SHARED_DIR on exit

### DIFF
--- a/hack/lib/ui.bash
+++ b/hack/lib/ui.bash
@@ -54,9 +54,11 @@ function stacktrace {
 }
 
 function debugging.setup {
-  local debuglog debugdir
-  debugdir="${ARTIFACTS:-/tmp}"
-  debuglog="${debugdir}/debuglog-$(basename "$0").log"
+  local debuglog logdir stdoutlog stderrlog
+  logdir="${ARTIFACTS:-/tmp}"
+  debuglog="${logdir}/debuglog-$(basename "$0").log"
+  stdoutlog="${logdir}/stdout-$(basename "$0").log"
+  stderrlog="${logdir}/stderr-$(basename "$0").log"
   logger.debug "Debug log (set -x) is written to: ${debuglog}"
   # ref: https://serverfault.com/a/579078
   # Use FD 19 to capture the debug stream caused by "set -x":
@@ -68,6 +70,10 @@ function debugging.setup {
 
   # Register finish of debugging at exit
   trap debugging.finish EXIT
+
+  # Send stdout and stderr also to log files.
+  # shellcheck disable=SC2093
+  exec 1> >(tee "${stdoutlog}" >&1) 2> >(tee "${stderrlog}" >&2)
   set -x
 }
 
@@ -75,6 +81,10 @@ function debugging.finish {
   # Close the output:
   set +x
   exec 19>&-
+
+  if [[ -n "${SHARED_DIR:-}" ]]; then
+    cp -v "${ARTIFACTS}"/debuglog-*.log "${ARTIFACTS}"/stdout-*.log "${ARTIFACTS}"/stderr-*.log "${SHARED_DIR}" || true
+  fi
 }
 
 function logger.debug {

--- a/hack/lib/ui.bash
+++ b/hack/lib/ui.bash
@@ -82,8 +82,8 @@ function debugging.finish {
   set +x
   exec 19>&-
 
-  if [[ -n "${SHARED_DIR:-}" ]]; then
-    cp -v "${ARTIFACTS}"/debuglog-*.log "${ARTIFACTS}"/stdout-*.log "${ARTIFACTS}"/stderr-*.log "${SHARED_DIR}" || true
+  if [ -n "${SHARED_DIR:-}" ] && [ -n "${JOB_NAME_SAFE:-}" ]; then
+    tar -czvf "${SHARED_DIR}/${JOB_NAME_SAFE}-testlog.tar.gz" "${ARTIFACTS}"/debuglog-*.log "${ARTIFACTS}"/stdout-*.log "${ARTIFACTS}"/stderr-*.log || true
   fi
 }
 


### PR DESCRIPTION
When a test container in CI is interrupted due to timeout or infrastructure failures the test log is lost. This change will copy debug logs to the shared dir so that they can be collected by "gather" steps that run after test container.
The gather step will look like this in a follow-up PR against openshift/release:
```
    post:
    - as: test-logs-gather
      best_effort: true
      cli: latest
      commands: cp -v ${SHARED_DIR}/*-testlog.tar.gz "${ARTIFACT_DIR}/" || true
      from: serverless-source-image
      optional_on_success: true
      resources:
        requests:
          cpu: 100m
      timeout: 1m0s
```
Or we could extract it like: `tar xvz -C ${ARTIFACT_DIR} -f *-testlog.tar.gz || true`

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
