### PR TITLE
Add workflow for CSV revision alignment check

### DIFF
--- a/.github/workflows/csv-revision-check.yaml
+++ b/.github/workflows/csv-revision-check.yaml
@@ -1,0 +1,30 @@
+name: CSV revision check
+
+on:
+  pull_request:
+    paths:
+      - 'olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml'
+    branches:
+      - 'main'
+      - 'release-*'
+
+jobs:
+  csv-revision-check:
+    name: CSV component revision alignment check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Golang
+        uses: openshift-knative/hack/actions/setup-go@main
+
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install yq
+        run: |
+          go install github.com/mikefarah/yq/v3@latest
+
+      - name: Revision check
+        run: make verify-csv-revisions


### PR DESCRIPTION
Add a workflow to run the CSV alignment check from #3338.
The alternative would be to run this as an optional check in Prow (discussion: https://redhat-internal.slack.com/archives/CKR568L8G/p1737047279212559)