### PR TITLE
Add target to apply override-snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,10 @@ generate-override-snapshot: install-tools
   	.konflux-release/
 .PHONY: generate-override-snapshot
 
+apply-override-snapshot:
+	kubectl apply -f .konflux-release/
+.PHONY: apply-override-snapshot
+
 # Generates all files that are templated with release metadata.
 release-files: install-tools
 	./hack/generate/csv.sh \


### PR DESCRIPTION
Makes later the workflow to apply the snapshots independent from location of override-snapshots and how they are getting applied