### PR TITLE
Update override-snapshot names to reflect latest applied snapshots

### DIFF
--- a/.konflux-release/override-snapshot-fbc-414.yaml
+++ b/.konflux-release/override-snapshot-fbc-414.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-fbc-414-override-snapshot-
+  name: serverless-operator-135-fbc-414-override-snapshot-7r7h6
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135-fbc-414

--- a/.konflux-release/override-snapshot-fbc-415.yaml
+++ b/.konflux-release/override-snapshot-fbc-415.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-fbc-415-override-snapshot-
+  name: serverless-operator-135-fbc-415-override-snapshot-cr6th
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135-fbc-415

--- a/.konflux-release/override-snapshot-fbc-416.yaml
+++ b/.konflux-release/override-snapshot-fbc-416.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-fbc-416-override-snapshot-
+  name: serverless-operator-135-fbc-416-override-snapshot-4hxk6
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135-fbc-416

--- a/.konflux-release/override-snapshot-fbc-417.yaml
+++ b/.konflux-release/override-snapshot-fbc-417.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-fbc-417-override-snapshot-
+  name: serverless-operator-135-fbc-417-override-snapshot-wqfg6
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135-fbc-417

--- a/.konflux-release/override-snapshot-fbc-418.yaml
+++ b/.konflux-release/override-snapshot-fbc-418.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-fbc-418-override-snapshot-
+  name: serverless-operator-135-fbc-418-override-snapshot-v4m6n
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135-fbc-418

--- a/.konflux-release/override-snapshot.yaml
+++ b/.konflux-release/override-snapshot.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-override-snapshot-
+  name: serverless-operator-135-override-snapshot-zg96j
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135


### PR DESCRIPTION
Setting the latest override-snapshots name to reflect what is in the cluster (as we applied them via generatedName), and as we have https://github.com/openshift-knative/serverless-operator/pull/3348 to make the names deterministic.

This is what we have in the cluster:
```
$ k get snapshot --sort-by=.metadata.creationTimestamp -l test.appstudio.openshift.io/type=override -o yaml
apiVersion: v1
items:
- apiVersion: appstudio.redhat.com/v1alpha1
  kind: Snapshot
  metadata:
    annotations:
      test.appstudio.openshift.io/status: '[{"scenario":"serverless-operator-135-fbc-414-ec-override-snapshot","status":"TestPassed","lastUpdateTime":"2025-01-16T17:43:09.548194434Z","details":"Integration
        test passed","startTime":"2025-01-16T17:40:52.764551448Z","completionTime":"2025-01-16T17:43:09.548194434Z","testPipelineRunName":"serverless-operator-135-fbc-414-ec-override-snapshot-4rv49"},{"scenario":"serverless-operator-135-fbc-414-ec","status":"TestPassed","lastUpdateTime":"2025-01-16T17:43:00.469679431Z","details":"Integration
        test passed","startTime":"2025-01-16T17:40:52.751790616Z","completionTime":"2025-01-16T17:43:00.469679431Z","testPipelineRunName":"serverless-operator-135-fbc-414-ec-276ph"}]'
    creationTimestamp: "2025-01-16T17:40:52Z"
    generateName: serverless-operator-135-fbc-414-override-snapshot-
    generation: 1
    labels:
      application: serverless-operator-135-fbc-414
      test.appstudio.openshift.io/type: override
    name: serverless-operator-135-fbc-414-override-snapshot-7r7h6
    namespace: ocp-serverless-tenant
    ownerReferences:
    - apiVersion: appstudio.redhat.com/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: Application
      name: serverless-operator-135-fbc-414
      uid: 16c088b3-5c11-49ee-94de-cf1c0ccf45ab
    resourceVersion: "3015601698"
    uid: 27341e1f-a2a1-4024-9c27-23d113f281d8
  spec:
    application: serverless-operator-135-fbc-414
    components:
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-414/serverless-index-135-fbc-414@sha256:27732fe264a60a940cc4b10e836b71cdf8c974edf90f4b1f4a0db4aadfedb344
      name: serverless-index-135-fbc-414
      source:
        git:
          dockerfileUrl: Dockerfile
          revision: 1600c9cc088b326e4d8d9b0c51c34b08274be6b6
          url: https://github.com/openshift-knative/serverless-operator
  status:
    conditions:
    - lastTransitionTime: "2025-01-16T17:40:52Z"
      message: The Snapshot's component(s) was/were added to the global candidate
        list
      reason: Added
      status: "True"
      type: AddedToGlobalCandidateList
    - lastTransitionTime: "2025-01-16T17:43:09Z"
      message: Snapshot integration status condition is finished since all testing
        pipelines completed
      reason: Finished
      status: "True"
      type: AppStudioIntegrationStatus
    - lastTransitionTime: "2025-01-16T17:43:09Z"
      message: All Integration Pipeline tests passed
      reason: Passed
      status: "True"
      type: AppStudioTestSucceeded
    - lastTransitionTime: "2025-01-16T17:43:09Z"
      message: The Snapshot was auto-released
      reason: AutoReleased
      status: "True"
      type: AutoReleased
- apiVersion: appstudio.redhat.com/v1alpha1
  kind: Snapshot
  metadata:
    annotations:
      test.appstudio.openshift.io/status: '[{"scenario":"serverless-operator-135-fbc-415-ec","status":"TestPassed","lastUpdateTime":"2025-01-16T17:42:54.887463054Z","details":"Integration
        test passed","startTime":"2025-01-16T17:40:52.932710214Z","completionTime":"2025-01-16T17:42:54.887463054Z","testPipelineRunName":"serverless-operator-135-fbc-415-ec-n5pmf"},{"scenario":"serverless-operator-135-fbc-415-ec-override-snapshot","status":"TestPassed","lastUpdateTime":"2025-01-16T17:43:05.208342432Z","details":"Integration
        test passed","startTime":"2025-01-16T17:40:52.943168289Z","completionTime":"2025-01-16T17:43:05.208342432Z","testPipelineRunName":"serverless-operator-135-fbc-415-ec-override-snapshot-c59hb"}]'
    creationTimestamp: "2025-01-16T17:40:52Z"
    generateName: serverless-operator-135-fbc-415-override-snapshot-
    generation: 1
    labels:
      application: serverless-operator-135-fbc-415
      test.appstudio.openshift.io/type: override
    name: serverless-operator-135-fbc-415-override-snapshot-cr6th
    namespace: ocp-serverless-tenant
    ownerReferences:
    - apiVersion: appstudio.redhat.com/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: Application
      name: serverless-operator-135-fbc-415
      uid: 73c3f9e4-0ffd-4f71-b4c7-4ef8e593de3f
    resourceVersion: "3015600786"
    uid: be439902-09fe-4a85-8c6b-8aab943b5c76
  spec:
    application: serverless-operator-135-fbc-415
    components:
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-415/serverless-index-135-fbc-415@sha256:84f3f3b126257edd544c3302fa84b057bea4e8c7d98a58bc045c4abf2832d199
      name: serverless-index-135-fbc-415
      source:
        git:
          dockerfileUrl: Dockerfile
          revision: 1600c9cc088b326e4d8d9b0c51c34b08274be6b6
          url: https://github.com/openshift-knative/serverless-operator
  status:
    conditions:
    - lastTransitionTime: "2025-01-16T17:40:52Z"
      message: The Snapshot's component(s) was/were added to the global candidate
        list
      reason: Added
      status: "True"
      type: AddedToGlobalCandidateList
    - lastTransitionTime: "2025-01-16T17:43:05Z"
      message: Snapshot integration status condition is finished since all testing
        pipelines completed
      reason: Finished
      status: "True"
      type: AppStudioIntegrationStatus
    - lastTransitionTime: "2025-01-16T17:43:05Z"
      message: All Integration Pipeline tests passed
      reason: Passed
      status: "True"
      type: AppStudioTestSucceeded
    - lastTransitionTime: "2025-01-16T17:43:05Z"
      message: The Snapshot was auto-released
      reason: AutoReleased
      status: "True"
      type: AutoReleased
- apiVersion: appstudio.redhat.com/v1alpha1
  kind: Snapshot
  metadata:
    annotations:
      test.appstudio.openshift.io/status: '[{"scenario":"serverless-operator-135-fbc-416-ec","status":"TestPassed","lastUpdateTime":"2025-01-16T17:42:53.321236925Z","details":"Integration
        test passed","startTime":"2025-01-16T17:40:53.116686791Z","completionTime":"2025-01-16T17:42:53.321236925Z","testPipelineRunName":"serverless-operator-135-fbc-416-ec-p2m6r"},{"scenario":"serverless-operator-135-fbc-416-ec-override-snapshot","status":"TestPassed","lastUpdateTime":"2025-01-16T17:43:28.999203086Z","details":"Integration
        test passed","startTime":"2025-01-16T17:40:53.131401469Z","completionTime":"2025-01-16T17:43:28.999203086Z","testPipelineRunName":"serverless-operator-135-fbc-416-ec-override-snapshot-wftdz"}]'
    creationTimestamp: "2025-01-16T17:40:53Z"
    generateName: serverless-operator-135-fbc-416-override-snapshot-
    generation: 1
    labels:
      application: serverless-operator-135-fbc-416
      test.appstudio.openshift.io/type: override
    name: serverless-operator-135-fbc-416-override-snapshot-4hxk6
    namespace: ocp-serverless-tenant
    ownerReferences:
    - apiVersion: appstudio.redhat.com/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: Application
      name: serverless-operator-135-fbc-416
      uid: b70f8b96-c7de-4ac3-a8b5-c409f3c3841b
    resourceVersion: "3015605342"
    uid: cde4ba98-7c9c-4bdc-90f8-62ebdb61e0e9
  spec:
    application: serverless-operator-135-fbc-416
    components:
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-416/serverless-index-135-fbc-416@sha256:fc9996d17e36c2a509021776fce9bdd7b7244ea021a8e5a3a1efbbea98eabbd8
      name: serverless-index-135-fbc-416
      source:
        git:
          dockerfileUrl: Dockerfile
          revision: 1600c9cc088b326e4d8d9b0c51c34b08274be6b6
          url: https://github.com/openshift-knative/serverless-operator
  status:
    conditions:
    - lastTransitionTime: "2025-01-16T17:40:53Z"
      message: The Snapshot's component(s) was/were added to the global candidate
        list
      reason: Added
      status: "True"
      type: AddedToGlobalCandidateList
    - lastTransitionTime: "2025-01-16T17:43:29Z"
      message: Snapshot integration status condition is finished since all testing
        pipelines completed
      reason: Finished
      status: "True"
      type: AppStudioIntegrationStatus
    - lastTransitionTime: "2025-01-16T17:43:29Z"
      message: All Integration Pipeline tests passed
      reason: Passed
      status: "True"
      type: AppStudioTestSucceeded
    - lastTransitionTime: "2025-01-16T17:43:29Z"
      message: The Snapshot was auto-released
      reason: AutoReleased
      status: "True"
      type: AutoReleased
- apiVersion: appstudio.redhat.com/v1alpha1
  kind: Snapshot
  metadata:
    annotations:
      test.appstudio.openshift.io/status: '[{"scenario":"serverless-operator-135-fbc-417-ec-override-snapshot","status":"TestPassed","lastUpdateTime":"2025-01-16T17:43:21.80288389Z","details":"Integration
        test passed","startTime":"2025-01-16T17:40:53.302925644Z","completionTime":"2025-01-16T17:43:21.80288389Z","testPipelineRunName":"serverless-operator-135-fbc-417-ec-override-snapshot-vb9m7"},{"scenario":"serverless-operator-135-fbc-417-ec","status":"TestPassed","lastUpdateTime":"2025-01-16T17:42:49.019526895Z","details":"Integration
        test passed","startTime":"2025-01-16T17:40:53.318678703Z","completionTime":"2025-01-16T17:42:49.019526895Z","testPipelineRunName":"serverless-operator-135-fbc-417-ec-tcpzl"}]'
    creationTimestamp: "2025-01-16T17:40:53Z"
    generateName: serverless-operator-135-fbc-417-override-snapshot-
    generation: 1
    labels:
      application: serverless-operator-135-fbc-417
      test.appstudio.openshift.io/type: override
    name: serverless-operator-135-fbc-417-override-snapshot-wqfg6
    namespace: ocp-serverless-tenant
    ownerReferences:
    - apiVersion: appstudio.redhat.com/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: Application
      name: serverless-operator-135-fbc-417
      uid: 094aad71-ab9c-4ba6-b808-f30683143c1d
    resourceVersion: "3015603799"
    uid: 387727a5-263e-4b1c-b04e-e64970a57773
  spec:
    application: serverless-operator-135-fbc-417
    components:
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-417/serverless-index-135-fbc-417@sha256:779183ca033520b7b92c41d54fa0413ee7f04990671877d58b3d34dc6c4a9eab
      name: serverless-index-135-fbc-417
      source:
        git:
          dockerfileUrl: Dockerfile
          revision: 1600c9cc088b326e4d8d9b0c51c34b08274be6b6
          url: https://github.com/openshift-knative/serverless-operator
  status:
    conditions:
    - lastTransitionTime: "2025-01-16T17:40:53Z"
      message: The Snapshot's component(s) was/were added to the global candidate
        list
      reason: Added
      status: "True"
      type: AddedToGlobalCandidateList
    - lastTransitionTime: "2025-01-16T17:43:21Z"
      message: Snapshot integration status condition is finished since all testing
        pipelines completed
      reason: Finished
      status: "True"
      type: AppStudioIntegrationStatus
    - lastTransitionTime: "2025-01-16T17:43:21Z"
      message: All Integration Pipeline tests passed
      reason: Passed
      status: "True"
      type: AppStudioTestSucceeded
    - lastTransitionTime: "2025-01-16T17:43:21Z"
      message: The Snapshot was auto-released
      reason: AutoReleased
      status: "True"
      type: AutoReleased
- apiVersion: appstudio.redhat.com/v1alpha1
  kind: Snapshot
  metadata:
    annotations:
      test.appstudio.openshift.io/status: '[{"scenario":"serverless-operator-135-fbc-418-ec","status":"TestPassed","lastUpdateTime":"2025-01-16T17:42:58.275576736Z","details":"Integration
        test passed","startTime":"2025-01-16T17:40:53.480104483Z","completionTime":"2025-01-16T17:42:58.275576736Z","testPipelineRunName":"serverless-operator-135-fbc-418-ec-rh9b7"},{"scenario":"serverless-operator-135-fbc-418-ec-override-snapshot","status":"TestPassed","lastUpdateTime":"2025-01-16T17:42:56.253386532Z","details":"Integration
        test passed","startTime":"2025-01-16T17:40:53.497492559Z","completionTime":"2025-01-16T17:42:56.253386532Z","testPipelineRunName":"serverless-operator-135-fbc-418-ec-override-snapshot-w8rh8"}]'
    creationTimestamp: "2025-01-16T17:40:53Z"
    generateName: serverless-operator-135-fbc-418-override-snapshot-
    generation: 1
    labels:
      application: serverless-operator-135-fbc-418
      test.appstudio.openshift.io/type: override
    name: serverless-operator-135-fbc-418-override-snapshot-v4m6n
    namespace: ocp-serverless-tenant
    ownerReferences:
    - apiVersion: appstudio.redhat.com/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: Application
      name: serverless-operator-135-fbc-418
      uid: 8fc4a978-c180-449c-8f56-ade1952af760
    resourceVersion: "3015599460"
    uid: 69eac2e7-4fac-4d03-bb83-235ea9471271
  spec:
    application: serverless-operator-135-fbc-418
    components:
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-418/serverless-index-135-fbc-418@sha256:ff097bacdfc302a234b3fde60d82d222cabeb00d249a301c990c431f592ed1b0
      name: serverless-index-135-fbc-418
      source:
        git:
          dockerfileUrl: Dockerfile
          revision: 1600c9cc088b326e4d8d9b0c51c34b08274be6b6
          url: https://github.com/openshift-knative/serverless-operator
  status:
    conditions:
    - lastTransitionTime: "2025-01-16T17:40:53Z"
      message: The Snapshot's component(s) was/were added to the global candidate
        list
      reason: Added
      status: "True"
      type: AddedToGlobalCandidateList
    - lastTransitionTime: "2025-01-16T17:42:58Z"
      message: Snapshot integration status condition is finished since all testing
        pipelines completed
      reason: Finished
      status: "True"
      type: AppStudioIntegrationStatus
    - lastTransitionTime: "2025-01-16T17:42:58Z"
      message: All Integration Pipeline tests passed
      reason: Passed
      status: "True"
      type: AppStudioTestSucceeded
    - lastTransitionTime: "2025-01-16T17:42:58Z"
      message: The Snapshot was auto-released
      reason: AutoReleased
      status: "True"
      type: AutoReleased
- apiVersion: appstudio.redhat.com/v1alpha1
  kind: Snapshot
  metadata:
    annotations:
      test.appstudio.openshift.io/status: '[{"scenario":"serverless-operator-135-ec","status":"TestPassed","lastUpdateTime":"2025-01-16T18:41:23.892267752Z","details":"Integration
        test passed","startTime":"2025-01-16T17:40:54.3688108Z","completionTime":"2025-01-16T18:41:23.892267752Z","testPipelineRunName":"serverless-operator-135-ec-dt75b"},{"scenario":"serverless-operator-135-ec-override-snapshot","status":"TestPassed","lastUpdateTime":"2025-01-17T15:47:13.669200712Z","details":"Integration
        test passed","startTime":"2025-01-17T14:49:29.250064546Z","completionTime":"2025-01-17T15:47:13.669200712Z","testPipelineRunName":"serverless-operator-135-ec-override-snapshot-k5s9w"}]'
    creationTimestamp: "2025-01-16T17:40:53Z"
    generateName: serverless-operator-135-override-snapshot-
    generation: 1
    labels:
      application: serverless-operator-135
      test.appstudio.openshift.io/type: override
    name: serverless-operator-135-override-snapshot-zg96j
    namespace: ocp-serverless-tenant
    ownerReferences:
    - apiVersion: appstudio.redhat.com/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: Application
      name: serverless-operator-135
      uid: 8f3a4d3b-d687-43bc-a681-19ac3b3e9da7
    resourceVersion: "3021729045"
    uid: 24533d30-09b8-426d-a8f6-152e70895492
  spec:
    application: serverless-operator-135
    components:
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-backstage-plugins-eventmesh@sha256:77665d8683230256122e60c3ec0496e80543675f39944c70415266ee5cffd080
      name: kn-backstage-plugins-eventmesh-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/eventmesh/Dockerfile
          revision: bc5d1f3874cf1524bc5ff91859b17204bc172eb5
          url: https://github.com/openshift-knative/backstage-plugins
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-client-cli-artifacts@sha256:f983be49897be59dba1275f36bdd83f648663ee904e4f242599e9269fc354fd7
      name: kn-client-cli-artifacts-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
          revision: 790599447950c7905b306cfbb660c355e15e7f1e
          url: https://github.com/openshift-knative/client
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-client-kn@sha256:d21cc7e094aa46ba7f6ea717a3d7927da489024a46a6c1224c0b3c5834dcb7a6
      name: kn-client-kn-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/kn/Dockerfile
          revision: 790599447950c7905b306cfbb660c355e15e7f1e
          url: https://github.com/openshift-knative/client
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-dispatcher@sha256:9cab1c37aae66e949a5d65614258394f566f2066dd20b5de5a8ebc3a4dd17e4c
      name: kn-ekb-dispatcher-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/static-images/dispatcher/hermetic/Dockerfile
          revision: 94e3b0ed47b4fd3be0f6a49eee47e0012f0314c4
          url: https://github.com/openshift-knative/eventing-kafka-broker
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-kafka-controller@sha256:e7dbf060ee40b252f884283d80fe63655ded5229e821f7af9e940582e969fc01
      name: kn-ekb-kafka-controller-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/kafka-controller/Dockerfile
          revision: 94e3b0ed47b4fd3be0f6a49eee47e0012f0314c4
          url: https://github.com/openshift-knative/eventing-kafka-broker
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-post-install@sha256:097e7891a85779880b3e64edb2cb1579f17bc902a17d2aa0c1ef91aeb088f5f1
      name: kn-ekb-post-install-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/post-install/Dockerfile
          revision: 94e3b0ed47b4fd3be0f6a49eee47e0012f0314c4
          url: https://github.com/openshift-knative/eventing-kafka-broker
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-receiver@sha256:207a1c3d7bf18a56ab8fd69255beeac6581a97576665e8b79f93df74da911285
      name: kn-ekb-receiver-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/static-images/receiver/hermetic/Dockerfile
          revision: 94e3b0ed47b4fd3be0f6a49eee47e0012f0314c4
          url: https://github.com/openshift-knative/eventing-kafka-broker
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-webhook-kafka@sha256:cafb9dcc4059b3bc740180cd8fb171bdad44b4d72365708d31f86327a29b9ec5
      name: kn-ekb-webhook-kafka-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/webhook-kafka/Dockerfile
          revision: 94e3b0ed47b4fd3be0f6a49eee47e0012f0314c4
          url: https://github.com/openshift-knative/eventing-kafka-broker
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-apiserver-receive-adapter@sha256:ec3c038d2baf7ff915a2c5ee90c41fb065a9310ccee473f0a39d55de632293e3
      name: kn-eventing-apiserver-receive-adapter-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/apiserver_receive_adapter/Dockerfile
          revision: ea25be40fbc64a93590c06936fe512caed50b08e
          url: https://github.com/openshift-knative/eventing
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-channel-controller@sha256:2c2912c0ba2499b0ba193fcc33360145696f6cfe9bf576afc1eac1180f50b08d
      name: kn-eventing-channel-controller-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/channel_controller/Dockerfile
          revision: ea25be40fbc64a93590c06936fe512caed50b08e
          url: https://github.com/openshift-knative/eventing
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-channel-dispatcher@sha256:4d7ecfae62161eff86b02d1285ca9896983727ec318b0d29f0b749c4eba31226
      name: kn-eventing-channel-dispatcher-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/channel_dispatcher/Dockerfile
          revision: ea25be40fbc64a93590c06936fe512caed50b08e
          url: https://github.com/openshift-knative/eventing
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-controller@sha256:1b4856760983e14f50028ab3d361bb6cd0120f0be6c76b586f2b42f5507c3f63
      name: kn-eventing-controller-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/controller/Dockerfile
          revision: ea25be40fbc64a93590c06936fe512caed50b08e
          url: https://github.com/openshift-knative/eventing
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-filter@sha256:cec64e69a3a1c10bc2b48b06a5dd6a0ddd8b993840bbf1ac7881d79fc854bc91
      name: kn-eventing-filter-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/filter/Dockerfile
          revision: ea25be40fbc64a93590c06936fe512caed50b08e
          url: https://github.com/openshift-knative/eventing
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-ingress@sha256:7e6049da45969fa3f766d2a542960b170097b2087cad15f5bba7345d8cdc0dad
      name: kn-eventing-ingress-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/ingress/Dockerfile
          revision: ea25be40fbc64a93590c06936fe512caed50b08e
          url: https://github.com/openshift-knative/eventing
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-istio-controller@sha256:d14fd8abf4e8640dbde210f567dd36866fe5f0f814a768a181edcb56a8e7f35b
      name: kn-eventing-istio-controller-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/controller/Dockerfile
          revision: 0fac4c94ec762551abcea3b582eb6df6be737ca7
          url: https://github.com/openshift-knative/eventing-istio
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-jobsink@sha256:8ecea4b6af28fe8c7f8bfcc433c007555deb8b7def7c326867b04833c524565d
      name: kn-eventing-jobsink-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/jobsink/Dockerfile
          revision: ea25be40fbc64a93590c06936fe512caed50b08e
          url: https://github.com/openshift-knative/eventing
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-migrate@sha256:e408db39c541a46ebf7ff1162fe6f81f6df1fe4eeed4461165d4cb1979c63d27
      name: kn-eventing-migrate-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/migrate/Dockerfile
          revision: ea25be40fbc64a93590c06936fe512caed50b08e
          url: https://github.com/openshift-knative/eventing
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-mtchannel-broker@sha256:2685917be6a6843c0d82bddf19f9368c39c107dae1fd1d4cb2e69d1aa87588ec
      name: kn-eventing-mtchannel-broker-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/mtchannel_broker/Dockerfile
          revision: ea25be40fbc64a93590c06936fe512caed50b08e
          url: https://github.com/openshift-knative/eventing
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-mtping@sha256:c5a5b6bc4fdb861133fd106f324cc4a904c6c6a32cabc6203efc578d8f46bbf4
      name: kn-eventing-mtping-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/mtping/Dockerfile
          revision: ea25be40fbc64a93590c06936fe512caed50b08e
          url: https://github.com/openshift-knative/eventing
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-webhook@sha256:efe2d60e777918df9271f5512e4722f8cf667fe1a59ee937e093224f66bc8cbf
      name: kn-eventing-webhook-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/webhook/Dockerfile
          revision: ea25be40fbc64a93590c06936fe512caed50b08e
          url: https://github.com/openshift-knative/eventing
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-plugin-event-sender@sha256:08f0b4151edd6d777e2944c6364612a5599e5a775e5150a76676a45f753c2e23
      name: kn-plugin-event-sender-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/images/kn-event-sender/Dockerfile
          revision: 726991e8ad3d146ef4a8483349f73ceea73d81a7
          url: https://github.com/openshift-knative/kn-plugin-event
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-plugin-func-func-util@sha256:01e0ab5c8203ef0ca39b4e9df8fd1a8c2769ef84fce7fecefc8e8858315e71ca
      name: kn-plugin-func-func-util-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/func-util/Dockerfile
          revision: af1715fbd2b2f3160c4fc83ed276980f07d33604
          url: https://github.com/openshift-knative/kn-plugin-func
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-activator@sha256:3892eadbaa6aba6d79d6fe2a88662c851650f7c7be81797b2fc91d0593a763d1
      name: kn-serving-activator-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/activator/Dockerfile
          revision: e273006127447ceb369f13867d1fefc94dbd7a15
          url: https://github.com/openshift-knative/serving
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-autoscaler-hpa@sha256:6b30d3f6d77a6e74d4df5a9d2c1b057cdc7ebbbf810213bc0a97590e741bae1c
      name: kn-serving-autoscaler-hpa-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
          revision: e273006127447ceb369f13867d1fefc94dbd7a15
          url: https://github.com/openshift-knative/serving
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-autoscaler@sha256:00777fa53883f25061ebe171b0d47025d27acd39582a619565e9167288321952
      name: kn-serving-autoscaler-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/autoscaler/Dockerfile
          revision: e273006127447ceb369f13867d1fefc94dbd7a15
          url: https://github.com/openshift-knative/serving
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-controller@sha256:41a21fdc683183422ebb29707d81eca96d7ca119d01f369b9defbaea94c09939
      name: kn-serving-controller-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/controller/Dockerfile
          revision: e273006127447ceb369f13867d1fefc94dbd7a15
          url: https://github.com/openshift-knative/serving
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-queue@sha256:bd464d68e283ce6c48ae904010991b491b738ada5a419f044bf71fd48326005b
      name: kn-serving-queue-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/queue/Dockerfile
          revision: e273006127447ceb369f13867d1fefc94dbd7a15
          url: https://github.com/openshift-knative/serving
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-storage-version-migration@sha256:de87597265ee5ac26db4458a251d00a5ec1b5cd0bfff4854284070fdadddb7ab
      name: kn-serving-storage-version-migration-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/migrate/Dockerfile
          revision: e273006127447ceb369f13867d1fefc94dbd7a15
          url: https://github.com/openshift-knative/serving
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-webhook@sha256:eb33e874b5a7c051db91cd6a63223aabd987988558ad34b34477bee592ceb3ab
      name: kn-serving-webhook-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/webhook/Dockerfile
          revision: e273006127447ceb369f13867d1fefc94dbd7a15
          url: https://github.com/openshift-knative/serving
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-istio-controller@sha256:ec77d44271ba3d86af6cbbeb70f20a720d30d1b75e93ac5e1024790448edf1dd
      name: net-istio-controller-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/controller/Dockerfile
          revision: 6da2a7679b1c104b3098b7f7060dd9ed3215b72d
          url: https://github.com/openshift-knative/net-istio
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-istio-webhook@sha256:07074f52b5fb1f2eb302854dce1ed5b81c665ed843f9453fc35a5ebcb1a36696
      name: net-istio-webhook-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/webhook/Dockerfile
          revision: 6da2a7679b1c104b3098b7f7060dd9ed3215b72d
          url: https://github.com/openshift-knative/net-istio
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-kourier-kourier@sha256:e5f1111791ffff7978fe175f3e3af61a431c08d8eea4457363c66d66596364d8
      name: net-kourier-kourier-115
      source:
        git:
          dockerfileUrl: openshift/ci-operator/knative-images/kourier/Dockerfile
          revision: 0a84f902fee158d27ef0749364942c9155425f64
          url: https://github.com/openshift-knative/net-kourier
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-ingress@sha256:3d1ab23c9ce119144536dd9a9b80c12bf2bb8e5f308d9c9c6c5b48c41f4aa89e
      name: serverless-ingress-135
      source:
        git:
          dockerfileUrl: serving/ingress/Dockerfile
          revision: 437a9023370f5dbd2b0371a3345ca28ad88c00d3
          url: https://github.com/openshift-knative/serverless-operator
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-kn-operator@sha256:78cb34062730b3926a465f0665475f0172a683d7204423ec89d32289f5ee329d
      name: serverless-kn-operator-135
      source:
        git:
          dockerfileUrl: knative-operator/Dockerfile
          revision: 437a9023370f5dbd2b0371a3345ca28ad88c00d3
          url: https://github.com/openshift-knative/serverless-operator
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-must-gather@sha256:119fbc185f167f3866dbb5b135efc4ee787728c2e47dd1d2d66b76dc5c43609e
      name: serverless-must-gather-135
      source:
        git:
          dockerfileUrl: must-gather/Dockerfile
          revision: 437a9023370f5dbd2b0371a3345ca28ad88c00d3
          url: https://github.com/openshift-knative/serverless-operator
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-openshift-kn-operator@sha256:0f763b740cc1b614cf354c40f3dc17050e849b4cbf3a35cdb0537c2897d44c95
      name: serverless-openshift-kn-operator-135
      source:
        git:
          dockerfileUrl: openshift-knative-operator/Dockerfile
          revision: 437a9023370f5dbd2b0371a3345ca28ad88c00d3
          url: https://github.com/openshift-knative/serverless-operator
    - containerImage: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle@sha256:93b945eb2361b07bc86d67a9a7d77a0301a0bad876c83a9a64af2cfb86c83bff
      name: serverless-bundle-135
      source:
        git:
          dockerfileUrl: olm-catalog/serverless-operator/Dockerfile
          revision: 3e828fc372388acb902862b45e8204133c9b7d0a
          url: https://github.com/openshift-knative/serverless-operator
  status:
    conditions:
    - lastTransitionTime: "2025-01-16T17:40:54Z"
      message: The Snapshot's component(s) was/were added to the global candidate
        list
      reason: Added
      status: "True"
      type: AddedToGlobalCandidateList
    - lastTransitionTime: "2025-01-17T15:47:13Z"
      message: Snapshot integration status condition is finished since all testing
        pipelines completed
      reason: Finished
      status: "True"
      type: AppStudioIntegrationStatus
    - lastTransitionTime: "2025-01-17T15:47:13Z"
      message: All Integration Pipeline tests passed
      reason: Passed
      status: "True"
      type: AppStudioTestSucceeded
    - lastTransitionTime: "2025-01-17T15:47:13Z"
      message: The Snapshot was auto-released
      reason: AutoReleased
      status: "True"
      type: AutoReleased
kind: List
metadata:
  resourceVersion: ""
```