### PR TITLE
Inject Istio sidecars in job-sink deployment for tests

### DIFF
--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -265,6 +265,12 @@ spec:
       sidecar.istio.io/logLevel: "debug"
       sidecar.istio.io/rewriteAppHTTPProbers: "true"
     name: imc-dispatcher
+  - labels:
+      sidecar.istio.io/inject: "true"
+    annotations:
+      sidecar.istio.io/logLevel: "debug"
+      sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    name: job-sink
 EOF
 
   yq merge --inplace --arrays append "$custom_resource" "$istio_patch"


### PR DESCRIPTION
This periodic job is failing: [https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-[…]erverless-operator-main-417-mesh-e2e-c/1871023958090846208](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-417-mesh-e2e-c/1871023958090846208)
Injecting the sidecars should help.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
