### PR TITLE
Add branch label to generated override snapshots

### DIFF
--- a/.konflux-release/override-snapshot-fbc-414.yaml
+++ b/.konflux-release/override-snapshot-fbc-414.yaml
@@ -1,17 +1,18 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-fbc-414-override-snapshot-
+  name: serverless-operator-135-fbc-414-override-snapshot-f4807552
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135-fbc-414
+    branch: release-1.35
 spec:
   application: serverless-operator-135-fbc-414
   components:
     - name: "serverless-index-135-fbc-414"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-414/serverless-index-135-fbc-414@sha256:1eca53d1077ba78ef175c518abba1a3917020c4870fcf31d4ad16ee03fae0db5"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-414/serverless-index-135-fbc-414@sha256:27732fe264a60a940cc4b10e836b71cdf8c974edf90f4b1f4a0db4aadfedb344"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "7292e49bfa1322237b2fdf455adabe4b7ef9256f"
+          revision: "1600c9cc088b326e4d8d9b0c51c34b08274be6b6"
           dockerfileUrl: "Dockerfile"

--- a/.konflux-release/override-snapshot-fbc-415.yaml
+++ b/.konflux-release/override-snapshot-fbc-415.yaml
@@ -1,17 +1,18 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-fbc-415-override-snapshot-
+  name: serverless-operator-135-fbc-415-override-snapshot-dd334ba9
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135-fbc-415
+    branch: release-1.35
 spec:
   application: serverless-operator-135-fbc-415
   components:
     - name: "serverless-index-135-fbc-415"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-415/serverless-index-135-fbc-415@sha256:dfefd75369c83137585dedeed89972737824755c2e199ff1014aafe4eec9c598"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-415/serverless-index-135-fbc-415@sha256:84f3f3b126257edd544c3302fa84b057bea4e8c7d98a58bc045c4abf2832d199"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "7292e49bfa1322237b2fdf455adabe4b7ef9256f"
+          revision: "1600c9cc088b326e4d8d9b0c51c34b08274be6b6"
           dockerfileUrl: "Dockerfile"

--- a/.konflux-release/override-snapshot-fbc-416.yaml
+++ b/.konflux-release/override-snapshot-fbc-416.yaml
@@ -1,17 +1,18 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-fbc-416-override-snapshot-
+  name: serverless-operator-135-fbc-416-override-snapshot-b74aa782
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135-fbc-416
+    branch: release-1.35
 spec:
   application: serverless-operator-135-fbc-416
   components:
     - name: "serverless-index-135-fbc-416"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-416/serverless-index-135-fbc-416@sha256:e6664357b687115ce9ee8c93551d46ea58b29065f17492e331580606274a3dcf"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-416/serverless-index-135-fbc-416@sha256:fc9996d17e36c2a509021776fce9bdd7b7244ea021a8e5a3a1efbbea98eabbd8"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "7292e49bfa1322237b2fdf455adabe4b7ef9256f"
+          revision: "1600c9cc088b326e4d8d9b0c51c34b08274be6b6"
           dockerfileUrl: "Dockerfile"

--- a/.konflux-release/override-snapshot-fbc-417.yaml
+++ b/.konflux-release/override-snapshot-fbc-417.yaml
@@ -1,17 +1,18 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-fbc-417-override-snapshot-
+  name: serverless-operator-135-fbc-417-override-snapshot-bab82166
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135-fbc-417
+    branch: release-1.35
 spec:
   application: serverless-operator-135-fbc-417
   components:
     - name: "serverless-index-135-fbc-417"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-417/serverless-index-135-fbc-417@sha256:9c2dc323302806c927159f081b993929ce4b404f98f2ac7783f4ec31de1278bd"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-417/serverless-index-135-fbc-417@sha256:779183ca033520b7b92c41d54fa0413ee7f04990671877d58b3d34dc6c4a9eab"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "7292e49bfa1322237b2fdf455adabe4b7ef9256f"
+          revision: "1600c9cc088b326e4d8d9b0c51c34b08274be6b6"
           dockerfileUrl: "Dockerfile"

--- a/.konflux-release/override-snapshot-fbc-418.yaml
+++ b/.konflux-release/override-snapshot-fbc-418.yaml
@@ -1,17 +1,18 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-fbc-418-override-snapshot-
+  name: serverless-operator-135-fbc-418-override-snapshot-811b3ed8
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135-fbc-418
+    branch: release-1.35
 spec:
   application: serverless-operator-135-fbc-418
   components:
     - name: "serverless-index-135-fbc-418"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-418/serverless-index-135-fbc-418@sha256:93cc61097d21c728a7d22b266a873a530d7e7dbe5bd7f2a0f67b7364744aee7e"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135-fbc-418/serverless-index-135-fbc-418@sha256:ff097bacdfc302a234b3fde60d82d222cabeb00d249a301c990c431f592ed1b0"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "7292e49bfa1322237b2fdf455adabe4b7ef9256f"
+          revision: "1600c9cc088b326e4d8d9b0c51c34b08274be6b6"
           dockerfileUrl: "Dockerfile"

--- a/.konflux-release/override-snapshot.yaml
+++ b/.konflux-release/override-snapshot.yaml
@@ -1,269 +1,270 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  generateName: serverless-operator-135-override-snapshot-
+  name: serverless-operator-135-override-snapshot-e6fb2b36
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-135
+    branch: release-1.35
 spec:
   application: serverless-operator-135
   components:
     - name: "kn-backstage-plugins-eventmesh-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-backstage-plugins-eventmesh@sha256:b91e759e75a9c15b17cc1ea66dc26f24d6f0d78f0fe1adb2812635623639fc83"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-backstage-plugins-eventmesh@sha256:77665d8683230256122e60c3ec0496e80543675f39944c70415266ee5cffd080"
       source:
         git:
           url: "https://github.com/openshift-knative/backstage-plugins"
-          revision: "fcd453a02ad60384faa8fe2f591dfb998338c3c8"
+          revision: "bc5d1f3874cf1524bc5ff91859b17204bc172eb5"
           dockerfileUrl: "openshift/ci-operator/knative-images/eventmesh/Dockerfile"
     - name: "kn-client-cli-artifacts-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-client-cli-artifacts@sha256:a6efd3434fd6a3e0de35a3015110c2c06583ab3629b14a656dfc5f847b2079b1"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-client-cli-artifacts@sha256:f983be49897be59dba1275f36bdd83f648663ee904e4f242599e9269fc354fd7"
       source:
         git:
           url: "https://github.com/openshift-knative/client"
-          revision: "f5b5ad7bf25f262b7989130d6f3ab02fdc008b53"
+          revision: "790599447950c7905b306cfbb660c355e15e7f1e"
           dockerfileUrl: "openshift/ci-operator/knative-images/cli-artifacts/Dockerfile"
     - name: "kn-client-kn-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-client-kn@sha256:525dddc0faac56bd7848c73b1a37a58770ca1c1a1404f7342f39734a75ab27cd"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-client-kn@sha256:d21cc7e094aa46ba7f6ea717a3d7927da489024a46a6c1224c0b3c5834dcb7a6"
       source:
         git:
           url: "https://github.com/openshift-knative/client"
-          revision: "f5b5ad7bf25f262b7989130d6f3ab02fdc008b53"
+          revision: "790599447950c7905b306cfbb660c355e15e7f1e"
           dockerfileUrl: "openshift/ci-operator/knative-images/kn/Dockerfile"
     - name: "kn-ekb-dispatcher-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-dispatcher@sha256:67cae04c8992a390d5c8afa59a3950e12fc20987d270b8a62cd586f06b574bdb"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-dispatcher@sha256:9cab1c37aae66e949a5d65614258394f566f2066dd20b5de5a8ebc3a4dd17e4c"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing-kafka-broker"
-          revision: "52c61d80da7601f896a6516dad16a87989db18dd"
+          revision: "94e3b0ed47b4fd3be0f6a49eee47e0012f0314c4"
           dockerfileUrl: "openshift/ci-operator/static-images/dispatcher/hermetic/Dockerfile"
     - name: "kn-ekb-kafka-controller-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-kafka-controller@sha256:8e98bbd0e7d0e89fc293c57f4ef5ad23fcffb00585efda5e1ff05fda658656c7"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-kafka-controller@sha256:e7dbf060ee40b252f884283d80fe63655ded5229e821f7af9e940582e969fc01"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing-kafka-broker"
-          revision: "52c61d80da7601f896a6516dad16a87989db18dd"
+          revision: "94e3b0ed47b4fd3be0f6a49eee47e0012f0314c4"
           dockerfileUrl: "openshift/ci-operator/knative-images/kafka-controller/Dockerfile"
     - name: "kn-ekb-post-install-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-post-install@sha256:4cf45945c38e31e3768db64365fb63b48ca704178db3fec90787d5814c809a14"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-post-install@sha256:097e7891a85779880b3e64edb2cb1579f17bc902a17d2aa0c1ef91aeb088f5f1"
       source:
         git:
-          url: "https://github.com/openshift-knative/eventing-kafka-broker.git"
-          revision: "52c61d80da7601f896a6516dad16a87989db18dd"
+          url: "https://github.com/openshift-knative/eventing-kafka-broker"
+          revision: "94e3b0ed47b4fd3be0f6a49eee47e0012f0314c4"
           dockerfileUrl: "openshift/ci-operator/knative-images/post-install/Dockerfile"
     - name: "kn-ekb-receiver-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-receiver@sha256:8bbeb7f506b64780af4967996c795337947a32d4e7e97fb1a72e916b49263a8b"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-receiver@sha256:207a1c3d7bf18a56ab8fd69255beeac6581a97576665e8b79f93df74da911285"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing-kafka-broker"
-          revision: "52c61d80da7601f896a6516dad16a87989db18dd"
+          revision: "94e3b0ed47b4fd3be0f6a49eee47e0012f0314c4"
           dockerfileUrl: "openshift/ci-operator/static-images/receiver/hermetic/Dockerfile"
     - name: "kn-ekb-webhook-kafka-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-webhook-kafka@sha256:e5a5a36a9855dfad3a0f9f216d029a1ebbb98d82150f1c8aa134e5f6c75c7679"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-ekb-webhook-kafka@sha256:cafb9dcc4059b3bc740180cd8fb171bdad44b4d72365708d31f86327a29b9ec5"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing-kafka-broker"
-          revision: "52c61d80da7601f896a6516dad16a87989db18dd"
+          revision: "94e3b0ed47b4fd3be0f6a49eee47e0012f0314c4"
           dockerfileUrl: "openshift/ci-operator/knative-images/webhook-kafka/Dockerfile"
     - name: "kn-eventing-apiserver-receive-adapter-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-apiserver-receive-adapter@sha256:8c394d2b05cfbeacfb7800f1c555676542ba44e6f9746830cc58e5a964ac8874"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-apiserver-receive-adapter@sha256:ec3c038d2baf7ff915a2c5ee90c41fb065a9310ccee473f0a39d55de632293e3"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing"
-          revision: "efacbc466fb74b59c2fde6430508882f6f8e287f"
+          revision: "ea25be40fbc64a93590c06936fe512caed50b08e"
           dockerfileUrl: "openshift/ci-operator/knative-images/apiserver_receive_adapter/Dockerfile"
     - name: "kn-eventing-channel-controller-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-channel-controller@sha256:7248baba1f9e6c1bfbf43bea08fd3272f87a5aee41390888ddd37eb2dbc1a451"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-channel-controller@sha256:2c2912c0ba2499b0ba193fcc33360145696f6cfe9bf576afc1eac1180f50b08d"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing"
-          revision: "efacbc466fb74b59c2fde6430508882f6f8e287f"
+          revision: "ea25be40fbc64a93590c06936fe512caed50b08e"
           dockerfileUrl: "openshift/ci-operator/knative-images/channel_controller/Dockerfile"
     - name: "kn-eventing-channel-dispatcher-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-channel-dispatcher@sha256:491ed4ffc15adb12459e15cbb0a92b9572637a6b7164587b08bc4b452caabd47"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-channel-dispatcher@sha256:4d7ecfae62161eff86b02d1285ca9896983727ec318b0d29f0b749c4eba31226"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing"
-          revision: "efacbc466fb74b59c2fde6430508882f6f8e287f"
+          revision: "ea25be40fbc64a93590c06936fe512caed50b08e"
           dockerfileUrl: "openshift/ci-operator/knative-images/channel_dispatcher/Dockerfile"
     - name: "kn-eventing-controller-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-controller@sha256:a10c5d1137b6000ab82b7f3a6ec1d382470a995e09c2f53f8b9a977e97cdefd2"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-controller@sha256:1b4856760983e14f50028ab3d361bb6cd0120f0be6c76b586f2b42f5507c3f63"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing"
-          revision: "efacbc466fb74b59c2fde6430508882f6f8e287f"
+          revision: "ea25be40fbc64a93590c06936fe512caed50b08e"
           dockerfileUrl: "openshift/ci-operator/knative-images/controller/Dockerfile"
     - name: "kn-eventing-filter-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-filter@sha256:be5f4c4063c2495af323d995cc91a42ed2eeed6554d32cfb88e63b4cf9c5e9a7"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-filter@sha256:cec64e69a3a1c10bc2b48b06a5dd6a0ddd8b993840bbf1ac7881d79fc854bc91"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing"
-          revision: "efacbc466fb74b59c2fde6430508882f6f8e287f"
+          revision: "ea25be40fbc64a93590c06936fe512caed50b08e"
           dockerfileUrl: "openshift/ci-operator/knative-images/filter/Dockerfile"
     - name: "kn-eventing-ingress-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-ingress@sha256:d7bc8a045878aad8385e2959a46d0fc41b1c8af5a32b5fb49141ff53111d9a95"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-ingress@sha256:7e6049da45969fa3f766d2a542960b170097b2087cad15f5bba7345d8cdc0dad"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing"
-          revision: "efacbc466fb74b59c2fde6430508882f6f8e287f"
+          revision: "ea25be40fbc64a93590c06936fe512caed50b08e"
           dockerfileUrl: "openshift/ci-operator/knative-images/ingress/Dockerfile"
     - name: "kn-eventing-istio-controller-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-istio-controller@sha256:d99049813c202b2fb6ba893627665f1f682e3e05db9fff246a4ea1df1b641a07"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-istio-controller@sha256:d14fd8abf4e8640dbde210f567dd36866fe5f0f814a768a181edcb56a8e7f35b"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing-istio"
-          revision: "de212d908861b7a89b9cfdf5c110426256872c7d"
+          revision: "0fac4c94ec762551abcea3b582eb6df6be737ca7"
           dockerfileUrl: "openshift/ci-operator/knative-images/controller/Dockerfile"
     - name: "kn-eventing-jobsink-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-jobsink@sha256:36a0bd6c217418ab855f24b917e43f325152e5a712830288f328585c0f6323b6"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-jobsink@sha256:8ecea4b6af28fe8c7f8bfcc433c007555deb8b7def7c326867b04833c524565d"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing"
-          revision: "efacbc466fb74b59c2fde6430508882f6f8e287f"
+          revision: "ea25be40fbc64a93590c06936fe512caed50b08e"
           dockerfileUrl: "openshift/ci-operator/knative-images/jobsink/Dockerfile"
     - name: "kn-eventing-migrate-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-migrate@sha256:4d51a880f0f230911c3b8834a67dacddd3d6414c65e7f1eae6d0c05641008de1"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-migrate@sha256:e408db39c541a46ebf7ff1162fe6f81f6df1fe4eeed4461165d4cb1979c63d27"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing"
-          revision: "efacbc466fb74b59c2fde6430508882f6f8e287f"
+          revision: "ea25be40fbc64a93590c06936fe512caed50b08e"
           dockerfileUrl: "openshift/ci-operator/knative-images/migrate/Dockerfile"
     - name: "kn-eventing-mtchannel-broker-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-mtchannel-broker@sha256:04cbb57b37c57e53d4d37a1f54b91bf7eee0666fb8101510897e5ead9afd7d17"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-mtchannel-broker@sha256:2685917be6a6843c0d82bddf19f9368c39c107dae1fd1d4cb2e69d1aa87588ec"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing"
-          revision: "efacbc466fb74b59c2fde6430508882f6f8e287f"
+          revision: "ea25be40fbc64a93590c06936fe512caed50b08e"
           dockerfileUrl: "openshift/ci-operator/knative-images/mtchannel_broker/Dockerfile"
     - name: "kn-eventing-mtping-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-mtping@sha256:8270bde9e7fa7f82cc7d23a88323f9ef4de46bade3f0ac767a4d84169a9f4e4a"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-mtping@sha256:c5a5b6bc4fdb861133fd106f324cc4a904c6c6a32cabc6203efc578d8f46bbf4"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing"
-          revision: "efacbc466fb74b59c2fde6430508882f6f8e287f"
+          revision: "ea25be40fbc64a93590c06936fe512caed50b08e"
           dockerfileUrl: "openshift/ci-operator/knative-images/mtping/Dockerfile"
     - name: "kn-eventing-webhook-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-webhook@sha256:21a9ae1a661da2e14f9454cd367d376579dbec3a117eac94ccb484d6e9bd4354"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-webhook@sha256:efe2d60e777918df9271f5512e4722f8cf667fe1a59ee937e093224f66bc8cbf"
       source:
         git:
           url: "https://github.com/openshift-knative/eventing"
-          revision: "efacbc466fb74b59c2fde6430508882f6f8e287f"
+          revision: "ea25be40fbc64a93590c06936fe512caed50b08e"
           dockerfileUrl: "openshift/ci-operator/knative-images/webhook/Dockerfile"
     - name: "kn-plugin-event-sender-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-plugin-event-sender@sha256:1d2a8b786bd09301530d37440ce6501527cfd511ba78d97da5eda952a6558ebe"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-plugin-event-sender@sha256:08f0b4151edd6d777e2944c6364612a5599e5a775e5150a76676a45f753c2e23"
       source:
         git:
           url: "https://github.com/openshift-knative/kn-plugin-event"
-          revision: "db3a977daffc948331d4245149ddf02642be5c37"
+          revision: "726991e8ad3d146ef4a8483349f73ceea73d81a7"
           dockerfileUrl: "openshift/ci-operator/images/kn-event-sender/Dockerfile"
     - name: "kn-plugin-func-func-util-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-plugin-func-func-util@sha256:63fbd304ffb93e5883b987ac90a476cd9ff9946f164ca8acb9c1a95fee84bcb3"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-plugin-func-func-util@sha256:01e0ab5c8203ef0ca39b4e9df8fd1a8c2769ef84fce7fecefc8e8858315e71ca"
       source:
         git:
           url: "https://github.com/openshift-knative/kn-plugin-func"
-          revision: "52a2d08610a5ad7210b66904f947c4f3ed5e422f"
+          revision: "af1715fbd2b2f3160c4fc83ed276980f07d33604"
           dockerfileUrl: "openshift/ci-operator/knative-images/func-util/Dockerfile"
     - name: "kn-serving-activator-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-activator@sha256:eacffba1b6ae9910726890953bca8af72eef1f23b67de87731c20b03f84eb64e"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-activator@sha256:3892eadbaa6aba6d79d6fe2a88662c851650f7c7be81797b2fc91d0593a763d1"
       source:
         git:
           url: "https://github.com/openshift-knative/serving"
-          revision: "fd62d96a5194b806a0ebfef3cc8bdc4b8fd3cf00"
+          revision: "e273006127447ceb369f13867d1fefc94dbd7a15"
           dockerfileUrl: "openshift/ci-operator/knative-images/activator/Dockerfile"
     - name: "kn-serving-autoscaler-hpa-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-autoscaler-hpa@sha256:bbed471d612c38ce66b5f87fac69c3ef4388114ce993b6ec926beed51c41815b"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-autoscaler-hpa@sha256:6b30d3f6d77a6e74d4df5a9d2c1b057cdc7ebbbf810213bc0a97590e741bae1c"
       source:
         git:
           url: "https://github.com/openshift-knative/serving"
-          revision: "fd62d96a5194b806a0ebfef3cc8bdc4b8fd3cf00"
+          revision: "e273006127447ceb369f13867d1fefc94dbd7a15"
           dockerfileUrl: "openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile"
     - name: "kn-serving-autoscaler-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-autoscaler@sha256:636da647e5ce879e7b5c80df4c22f5f5a416ef4db96ffb4cada7f533fb5dd714"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-autoscaler@sha256:00777fa53883f25061ebe171b0d47025d27acd39582a619565e9167288321952"
       source:
         git:
           url: "https://github.com/openshift-knative/serving"
-          revision: "fd62d96a5194b806a0ebfef3cc8bdc4b8fd3cf00"
+          revision: "e273006127447ceb369f13867d1fefc94dbd7a15"
           dockerfileUrl: "openshift/ci-operator/knative-images/autoscaler/Dockerfile"
     - name: "kn-serving-controller-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-controller@sha256:579ce1e0648f965f7fa625bfdc5099d440e1a690e40566f9b2b7a67964a264ec"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-controller@sha256:41a21fdc683183422ebb29707d81eca96d7ca119d01f369b9defbaea94c09939"
       source:
         git:
           url: "https://github.com/openshift-knative/serving"
-          revision: "fd62d96a5194b806a0ebfef3cc8bdc4b8fd3cf00"
+          revision: "e273006127447ceb369f13867d1fefc94dbd7a15"
           dockerfileUrl: "openshift/ci-operator/knative-images/controller/Dockerfile"
     - name: "kn-serving-queue-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-queue@sha256:723c4d19370575cb4ce79d4a60cb68f64ae419f2cce6b9f611dce4201def7eac"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-queue@sha256:bd464d68e283ce6c48ae904010991b491b738ada5a419f044bf71fd48326005b"
       source:
         git:
           url: "https://github.com/openshift-knative/serving"
-          revision: "fd62d96a5194b806a0ebfef3cc8bdc4b8fd3cf00"
+          revision: "e273006127447ceb369f13867d1fefc94dbd7a15"
           dockerfileUrl: "openshift/ci-operator/knative-images/queue/Dockerfile"
     - name: "kn-serving-storage-version-migration-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-storage-version-migration@sha256:45409f1c04ceef5e398f419cfd403d16ee37f987e8cd3070d00323b82af45d70"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-storage-version-migration@sha256:de87597265ee5ac26db4458a251d00a5ec1b5cd0bfff4854284070fdadddb7ab"
       source:
         git:
           url: "https://github.com/openshift-knative/serving"
-          revision: "fd62d96a5194b806a0ebfef3cc8bdc4b8fd3cf00"
+          revision: "e273006127447ceb369f13867d1fefc94dbd7a15"
           dockerfileUrl: "openshift/ci-operator/knative-images/migrate/Dockerfile"
     - name: "kn-serving-webhook-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-webhook@sha256:dbde2b08a6fd2399312fb8da0b028853b9933c0f72189346bfc8bd60cd70aefa"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-serving-webhook@sha256:eb33e874b5a7c051db91cd6a63223aabd987988558ad34b34477bee592ceb3ab"
       source:
         git:
           url: "https://github.com/openshift-knative/serving"
-          revision: "fd62d96a5194b806a0ebfef3cc8bdc4b8fd3cf00"
+          revision: "e273006127447ceb369f13867d1fefc94dbd7a15"
           dockerfileUrl: "openshift/ci-operator/knative-images/webhook/Dockerfile"
     - name: "net-istio-controller-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-istio-controller@sha256:23d2b4f48506f3ddf4f91636563d20e7cc05b56d90e538791e7cf6f927227195"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-istio-controller@sha256:ec77d44271ba3d86af6cbbeb70f20a720d30d1b75e93ac5e1024790448edf1dd"
       source:
         git:
           url: "https://github.com/openshift-knative/net-istio"
-          revision: "fb4ed9cb6417825a2dc6463bf48b8580e7f0e249"
+          revision: "6da2a7679b1c104b3098b7f7060dd9ed3215b72d"
           dockerfileUrl: "openshift/ci-operator/knative-images/controller/Dockerfile"
     - name: "net-istio-webhook-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-istio-webhook@sha256:785725db4bbd2709613c270f65fd0adeb0969772c2f55475b987b51ec4201654"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-istio-webhook@sha256:07074f52b5fb1f2eb302854dce1ed5b81c665ed843f9453fc35a5ebcb1a36696"
       source:
         git:
           url: "https://github.com/openshift-knative/net-istio"
-          revision: "fb4ed9cb6417825a2dc6463bf48b8580e7f0e249"
+          revision: "6da2a7679b1c104b3098b7f7060dd9ed3215b72d"
           dockerfileUrl: "openshift/ci-operator/knative-images/webhook/Dockerfile"
     - name: "net-kourier-kourier-115"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-kourier-kourier@sha256:d50e5d1877297d3975931aae6bbbc37e29d33bea0de13c18342b281686c5ed86"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/net-kourier-kourier@sha256:e5f1111791ffff7978fe175f3e3af61a431c08d8eea4457363c66d66596364d8"
       source:
         git:
           url: "https://github.com/openshift-knative/net-kourier"
-          revision: "ecc321f6ce091110031e321cad07ee18a2b06681"
+          revision: "0a84f902fee158d27ef0749364942c9155425f64"
           dockerfileUrl: "openshift/ci-operator/knative-images/kourier/Dockerfile"
     - name: "serverless-ingress-135"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-ingress@sha256:ce89da17d8587ab042bc22270f21c0d3e7b25faaa56768ad15b066d0ef9cc00e"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-ingress@sha256:3d1ab23c9ce119144536dd9a9b80c12bf2bb8e5f308d9c9c6c5b48c41f4aa89e"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "baf5e6a1ed226c25815c7ed53666fa6e131116bf"
+          revision: "437a9023370f5dbd2b0371a3345ca28ad88c00d3"
           dockerfileUrl: "serving/ingress/Dockerfile"
     - name: "serverless-kn-operator-135"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-kn-operator@sha256:a2241984de16848fb4a2b04c27ea3349c56b0473db55fd8a0c8b204b593a771a"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-kn-operator@sha256:78cb34062730b3926a465f0665475f0172a683d7204423ec89d32289f5ee329d"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "511168ab8c84d76504417e6a8ecdb77dafc4c0e0"
+          revision: "437a9023370f5dbd2b0371a3345ca28ad88c00d3"
           dockerfileUrl: "knative-operator/Dockerfile"
     - name: "serverless-must-gather-135"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-must-gather@sha256:6dcc21031bd95cbc48c44c3e52b178f4cc50a6ee78268d24612c4cfda54a2a35"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-must-gather@sha256:119fbc185f167f3866dbb5b135efc4ee787728c2e47dd1d2d66b76dc5c43609e"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "baf5e6a1ed226c25815c7ed53666fa6e131116bf"
+          revision: "437a9023370f5dbd2b0371a3345ca28ad88c00d3"
           dockerfileUrl: "must-gather/Dockerfile"
     - name: "serverless-openshift-kn-operator-135"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-openshift-kn-operator@sha256:9ded2b825b63833c7b9b2a3501f3e34f771c4a04dd8952bb10c948021f94a33c"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-openshift-kn-operator@sha256:0f763b740cc1b614cf354c40f3dc17050e849b4cbf3a35cdb0537c2897d44c95"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "baf5e6a1ed226c25815c7ed53666fa6e131116bf"
+          revision: "437a9023370f5dbd2b0371a3345ca28ad88c00d3"
           dockerfileUrl: "openshift-knative-operator/Dockerfile"
     - name: "serverless-bundle-135"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle@sha256:bac71a7e495b762a6b4eb13ab87ae68026165af0566a16a107cdb2bfe2053ced"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle@sha256:93b945eb2361b07bc86d67a9a7d77a0301a0bad876c83a9a64af2cfb86c83bff"
       source:
         git:
-          url: "https://github.com/openshift-knative/serverless-operator.git"
-          revision: "f4b7a48344747dc9d8fa544e82b4e4c7234a6d47"
+          url: "https://github.com/openshift-knative/serverless-operator"
+          revision: "3e828fc372388acb902862b45e8204133c9b7d0a"
           dockerfileUrl: "olm-catalog/serverless-operator/Dockerfile"


### PR DESCRIPTION
This helps with downstream automation. It needs to be clear for which branch/stream the override snapshot in Konflux is generated. Currently, we parse it from "labels.application" but it is error-prone.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
