### PR TITLE
Fix SO version in override snapshot generation

### DIFF
--- a/hack/generate/override-snapshot.sh
+++ b/hack/generate/override-snapshot.sh
@@ -30,7 +30,7 @@ EOF
 }
 
 function create_component_snapshot {
-  local snapshot_file so_branch so_version so_semversion serving_tag serving_version_dotted serving_version tmp_catalog_dir max_ocp_version latest_index_image
+  local snapshot_file so_short_version so_version so_semversion serving_tag serving_version_dotted serving_version tmp_catalog_dir max_ocp_version latest_index_image
   snapshot_file="${1}/override-snapshot.yaml"
 
   serving_tag="$(metadata.get dependencies.serving)"
@@ -39,24 +39,26 @@ function create_component_snapshot {
   so_branch="$(sobranch --upstream-version "${serving_version_dotted}")"
   so_version="$(get_app_version_from_tag "${serving_tag}")"
   so_semversion="$(metadata.get project.version)"
+  so_short_version=${so_semversion/./} # 1.36.0 -> 136.0
+  so_short_version=${so_short_version%.*} # 136.0 -> 136
 
   cat > "${snapshot_file}" <<EOF
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  name: serverless-operator-${so_version}-override-snapshot
+  name: serverless-operator-${so_short_version}-override-snapshot
   labels:
     test.appstudio.openshift.io/type: override
-    application: serverless-operator-${so_version}
+    application: serverless-operator-${so_short_version}
     branch: ${so_branch}
 spec:
-  application: serverless-operator-${so_version}
+  application: serverless-operator-${so_short_version}
 EOF
 
   tmp_catalog_dir=$(mktemp -d)
   max_ocp_version="$(metadata.get requirements.ocpVersion.max)"
   max_ocp_version=${max_ocp_version/./}
-  latest_index_image="${registry_quay}-fbc-${max_ocp_version}/serverless-index-${so_version}-fbc-${max_ocp_version}:latest"
+  latest_index_image="${registry_quay}-fbc-${max_ocp_version}/serverless-index-${so_short_version}-fbc-${max_ocp_version}:latest"
 
   # get catalog from latest index, so we can get the referenced images from there
   opm migrate "${latest_index_image}" "${tmp_catalog_dir}" -o json
@@ -75,10 +77,10 @@ EOF
       if [[ $image == "serverless-operator-bundle" ]]; then
         # bundle component is named in konflux serverless-bundle-<version>
 
-        component_name="serverless-bundle-${so_version}"
+        component_name="serverless-bundle-${so_short_version}"
         component_image_ref="${registry_quay}/serverless-bundle@${image_sha}"
       elif [[ $image =~ serverless ]]; then
-        component_name="${image}-${so_version}"
+        component_name="${image}-${so_short_version}"
       else
         component_name="${image}-${serving_version}"
       fi
@@ -95,13 +97,15 @@ EOF
 }
 
 function create_fbc_snapshots {
-  local rootdir snapshot_dir so_version so_branch serving_tag
+  local rootdir snapshot_dir so_short_version so_branch serving_tag
   rootdir="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")")"
   snapshot_dir="${1}"
 
   serving_tag="$(metadata.get dependencies.serving)"
   so_branch="$(sobranch --upstream-version "${serving_tag/knative-v/}")"
-  so_version=$(get_app_version_from_tag "${serving_tag}")
+  so_short_version="$(metadata.get project.version)"
+  so_short_version=${so_short_version/./} # 1.36.0 -> 136.0
+  so_short_version=${so_short_version%.*} # 136.0 -> 136
 
   while IFS= read -r ocp_version; do
     ocp_version=${ocp_version/./}
@@ -111,18 +115,18 @@ function create_fbc_snapshots {
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  name: serverless-operator-${so_version}-fbc-${ocp_version}-override-snapshot
+  name: serverless-operator-${so_short_version}-fbc-${ocp_version}-override-snapshot
   labels:
     test.appstudio.openshift.io/type: override
-    application: serverless-operator-${so_version}-fbc-${ocp_version}
+    application: serverless-operator-${so_short_version}-fbc-${ocp_version}
     branch: ${so_branch}
 spec:
-  application: serverless-operator-${so_version}-fbc-${ocp_version}
+  application: serverless-operator-${so_short_version}-fbc-${ocp_version}
 EOF
 
-  index_image="${registry_quay}-fbc-${ocp_version}/serverless-index-${so_version}-fbc-${ocp_version}"
+  index_image="${registry_quay}-fbc-${ocp_version}/serverless-index-${so_short_version}-fbc-${ocp_version}"
   index_image_digest="$(skopeo inspect --retry-times=10 --no-tags docker://"${index_image}:latest" | jq -r .Digest)"
-  add_component "${snapshot_file}" "serverless-index-${so_version}-fbc-${ocp_version}" "${index_image}@${index_image_digest}"
+  add_component "${snapshot_file}" "serverless-index-${so_short_version}-fbc-${ocp_version}" "${index_image}@${index_image_digest}"
 
   append_hash_to_snapshot_name "${snapshot_file}"
 


### PR DESCRIPTION
Using the correct SO version in the image references to prevent `error resolving name for image ref quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-418/serverless-index-135-fbc-418:latest` like [here](https://github.com/openshift-knative/serverless-operator/actions/runs/12985285072/job/36209834038)