### PR TITLE
Fix lint - remove unused glob parameter in upgrade tests

### DIFF
--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -1,11 +1,9 @@
 package upgrade
 
 import (
-	pkgupgrade "knative.dev/pkg/test/upgrade"
-	"knative.dev/reconciler-test/pkg/environment"
-
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/upgrade/installation"
+	pkgupgrade "knative.dev/pkg/test/upgrade"
 )
 
 func ServerlessUpgradeOperations(ctx *test.Context) []pkgupgrade.Operation {
@@ -18,7 +16,7 @@ func ServerlessUpgradeOperations(ctx *test.Context) []pkgupgrade.Operation {
 	}
 }
 
-func ServerlessDowngradeOperations(ctx *test.Context, glob environment.GlobalEnvironment) []pkgupgrade.Operation {
+func ServerlessDowngradeOperations(ctx *test.Context) []pkgupgrade.Operation {
 	return []pkgupgrade.Operation{
 		pkgupgrade.NewOperation("DowngradeServerless", func(c pkgupgrade.Context) {
 			if err := installation.DowngradeServerless(ctx); err != nil {

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -75,7 +75,7 @@ func TestServerlessUpgradePrePost(t *testing.T) {
 		},
 		Installations: pkgupgrade.Installations{
 			UpgradeWith:   upgrade.ServerlessUpgradeOperations(ctx),
-			DowngradeWith: upgrade.ServerlessDowngradeOperations(ctx, global),
+			DowngradeWith: upgrade.ServerlessDowngradeOperations(ctx),
 		},
 	}
 	suite.Execute(pkgupgrade.Configuration{T: t})
@@ -97,7 +97,7 @@ func TestServerlessUpgradeContinual(t *testing.T) {
 		},
 		Installations: pkgupgrade.Installations{
 			UpgradeWith:   upgrade.ServerlessUpgradeOperations(ctx),
-			DowngradeWith: upgrade.ServerlessDowngradeOperations(ctx, global),
+			DowngradeWith: upgrade.ServerlessDowngradeOperations(ctx),
 		},
 	}
 	suite.Execute(pkgupgrade.Configuration{T: t})


### PR DESCRIPTION
Fixes failures such as this one: https://github.com/openshift-knative/serverless-operator/actions/runs/13007672227/job/36280248664?pr=3362

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
