### PR TITLE
[release-1.35] Bump patch version for 1.35 to 1.35.1

### DIFF
--- a/.tekton/serverless-bundle-135-push.yaml
+++ b/.tekton/serverless-bundle-135-push.yaml
@@ -38,7 +38,7 @@ spec:
     - name: additional-tags
       value:
         - $(context.pipelineRun.uid)-{{revision}}
-        - 1.35.0
+        - 1.35.1
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/.tekton/serverless-index-135-fbc-414-push.yaml
+++ b/.tekton/serverless-index-135-fbc-414-push.yaml
@@ -40,7 +40,7 @@ spec:
     - name: additional-tags
       value:
         - $(context.pipelineRun.uid)-{{revision}}
-        - 1.35.0
+        - 1.35.1
         - latest
   pipelineRef:
     name: fbc-builder

--- a/.tekton/serverless-index-135-fbc-415-push.yaml
+++ b/.tekton/serverless-index-135-fbc-415-push.yaml
@@ -40,7 +40,7 @@ spec:
     - name: additional-tags
       value:
         - $(context.pipelineRun.uid)-{{revision}}
-        - 1.35.0
+        - 1.35.1
         - latest
   pipelineRef:
     name: fbc-builder

--- a/.tekton/serverless-index-135-fbc-416-push.yaml
+++ b/.tekton/serverless-index-135-fbc-416-push.yaml
@@ -40,7 +40,7 @@ spec:
     - name: additional-tags
       value:
         - $(context.pipelineRun.uid)-{{revision}}
-        - 1.35.0
+        - 1.35.1
         - latest
   pipelineRef:
     name: fbc-builder

--- a/.tekton/serverless-index-135-fbc-417-push.yaml
+++ b/.tekton/serverless-index-135-fbc-417-push.yaml
@@ -40,7 +40,7 @@ spec:
     - name: additional-tags
       value:
         - $(context.pipelineRun.uid)-{{revision}}
-        - 1.35.0
+        - 1.35.1
         - latest
   pipelineRef:
     name: fbc-builder

--- a/.tekton/serverless-index-135-fbc-418-push.yaml
+++ b/.tekton/serverless-index-135-fbc-418-push.yaml
@@ -40,7 +40,7 @@ spec:
     - name: additional-tags
       value:
         - $(context.pipelineRun.uid)-{{revision}}
-        - 1.35.0
+        - 1.35.1
         - latest
   pipelineRef:
     name: fbc-builder

--- a/.tekton/serverless-ingress-135-push.yaml
+++ b/.tekton/serverless-ingress-135-push.yaml
@@ -38,7 +38,7 @@ spec:
     - name: additional-tags
       value:
         - $(context.pipelineRun.uid)-{{revision}}
-        - 1.35.0
+        - 1.35.1
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/.tekton/serverless-kn-operator-135-push.yaml
+++ b/.tekton/serverless-kn-operator-135-push.yaml
@@ -38,7 +38,7 @@ spec:
     - name: additional-tags
       value:
         - $(context.pipelineRun.uid)-{{revision}}
-        - 1.35.0
+        - 1.35.1
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/.tekton/serverless-metadata-webhook-135-push.yaml
+++ b/.tekton/serverless-metadata-webhook-135-push.yaml
@@ -38,7 +38,7 @@ spec:
     - name: additional-tags
       value:
         - $(context.pipelineRun.uid)-{{revision}}
-        - 1.35.0
+        - 1.35.1
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/.tekton/serverless-must-gather-135-push.yaml
+++ b/.tekton/serverless-must-gather-135-push.yaml
@@ -38,7 +38,7 @@ spec:
     - name: additional-tags
       value:
         - $(context.pipelineRun.uid)-{{revision}}
-        - 1.35.0
+        - 1.35.1
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/.tekton/serverless-openshift-kn-operator-135-push.yaml
+++ b/.tekton/serverless-openshift-kn-operator-135-push.yaml
@@ -38,7 +38,7 @@ spec:
     - name: additional-tags
       value:
         - $(context.pipelineRun.uid)-{{revision}}
-        - 1.35.0
+        - 1.35.1
         - latest
     - name: prefetch-input
       value: '[{"type":"rpm"}]'

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -24,7 +24,7 @@ USER 65532
 LABEL \
       com.redhat.component="openshift-serverless-1-must-gather-rhel8-container" \
       name="openshift-serverless-1/svls-must-gather-rhel8" \
-      version=1.35.0 \
+      version=1.35.1 \
       summary="Red Hat OpenShift Serverless 1 Must Gather" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Must Gather" \

--- a/olm-catalog/serverless-operator-index/Dockerfile
+++ b/olm-catalog/serverless-operator-index/Dockerfile
@@ -9,8 +9,8 @@ COPY olm-catalog/serverless-operator-index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml \
-registry.ci.openshift.org/knative/release-1.33.0:serverless-bundle \
 registry.ci.openshift.org/knative/release-1.34.0:serverless-bundle \
+registry.ci.openshift.org/knative/release-1.35.0:serverless-bundle \
       quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle@sha256:93b945eb2361b07bc86d67a9a7d77a0301a0bad876c83a9a64af2cfb86c83bff >> /configs/index.yaml
 
 # The base image is expected to contain

--- a/olm-catalog/serverless-operator-index/configs/index.yaml
+++ b/olm-catalog/serverless-operator-index/configs/index.yaml
@@ -3,22 +3,22 @@ schema: olm.channel
 name: stable
 package: serverless-operator
 entries:
+  - name: "serverless-operator.v1.35.1"
+    replaces: "serverless-operator.v1.35.0"
+    skipRange: ">=1.35.0 <1.35.1"
   - name: "serverless-operator.v1.35.0"
     replaces: "serverless-operator.v1.34.0"
     skipRange: ">=1.34.0 <1.35.0"
-  - name: "serverless-operator.v1.34.0"
-    replaces: "serverless-operator.v1.33.0"
-    skipRange: ">=1.33.0 <1.34.0"
-  - name: serverless-operator.v1.33.0
+  - name: serverless-operator.v1.34.0
 ---
 schema: olm.channel
 name: stable-1.35
 package: serverless-operator
 entries:
+  - name: "serverless-operator.v1.35.1"
+    replaces: "serverless-operator.v1.35.0"
+    skipRange: ">=1.35.0 <1.35.1"
   - name: "serverless-operator.v1.35.0"
     replaces: "serverless-operator.v1.34.0"
     skipRange: ">=1.34.0 <1.35.0"
-  - name: "serverless-operator.v1.34.0"
-    replaces: "serverless-operator.v1.33.0"
-    skipRange: ">=1.33.0 <1.34.0"
-  - name: serverless-operator.v1.33.0
+  - name: serverless-operator.v1.34.0

--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -18,7 +18,7 @@ LABEL operators.operatorframework.io.bundle.channels.v1="stable,stable-1.35"
 LABEL \
       com.redhat.component="openshift-serverless-1-serverless-operator-bundle-container" \
       name="openshift-serverless-1/serverless-operator-bundle" \
-      version="1.35.0" \
+      version="1.35.1" \
       summary="Red Hat OpenShift Serverless Bundle" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless Bundle" \
@@ -29,6 +29,6 @@ LABEL \
       com.redhat.delivery.backport=false \
       distribution-scope="authoritative-source-only" \
       url="https://catalog.redhat.com/software/container-stacks/detail/5ec53fcb110f56bd24f2ddc5" \
-      release="1.35.0" \
+      release="1.35.1" \
       io.openshift.tags="bundle" \
       vendor="Red Hat, Inc."

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -71,14 +71,14 @@ metadata:
       Deploy and manage event-driven serverless applications and functions using Knative.
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
-    olm.skipRange: '>=1.34.0 <1.35.0'
+    olm.skipRange: '>=1.35.0 <1.35.1'
     operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8@sha256:119fbc185f167f3866dbb5b135efc4ee787728c2e47dd1d2d66b76dc5c43609e
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.arm64: supported
-  name: serverless-operator.v1.35.0
+  name: serverless-operator.v1.35.1
   namespace: placeholder
 spec:
   # User-facing metadata
@@ -951,7 +951,7 @@ spec:
                       - name: "IMAGE_KN_PLUGIN_FUNC_PYTHON_39"
                         value: "registry.access.redhat.com/ubi8/python-39@sha256:27e795fd6b1b77de70d1dc73a65e4c790650748a9cfda138fdbd194b3d6eea3d"
                       - name: "CURRENT_VERSION"
-                        value: "1.35.0"
+                        value: "1.35.1"
                       - name: "KNATIVE_SERVING_VERSION"
                         value: "1.15"
                       - name: "KNATIVE_EVENTING_VERSION"
@@ -1145,7 +1145,7 @@ spec:
                       - name: "KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate"
                         value: "registry.redhat.io/openshift-serverless-1/kn-eventing-migrate-rhel8@sha256:e408db39c541a46ebf7ff1162fe6f81f6df1fe4eeed4461165d4cb1979c63d27"
                       - name: "CURRENT_VERSION"
-                        value: "1.35.0"
+                        value: "1.35.1"
                       - name: "KNATIVE_SERVING_VERSION"
                         value: "1.15"
                       - name: "KNATIVE_EVENTING_VERSION"
@@ -1425,5 +1425,5 @@ spec:
       image: "registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel8@sha256:119fbc185f167f3866dbb5b135efc4ee787728c2e47dd1d2d66b76dc5c43609e"
     - name: "IMAGE_KN_CLIENT_CLI_ARTIFACTS"
       image: "registry.redhat.io/openshift-serverless-1/kn-client-cli-artifacts-rhel8@sha256:f983be49897be59dba1275f36bdd83f648663ee904e4f242599e9269fc354fd7"
-  replaces: serverless-operator.v1.34.0
-  version: 1.35.0
+  replaces: serverless-operator.v1.35.0
+  version: 1.35.1

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -4,10 +4,10 @@ project:
   # all components in `dependencies.previous` to the same versions as `dependencies` in the same PR.
   # Otherwise, the upgrade tests will not pass, as we have a different SO version with the same bundle contents.
   # Also make sure to update values under `olm.previous` by copying from `olm.replaces` and `olm.skipRange`.
-  version: 1.35.0
+  version: 1.35.1
 olm:
-  replaces: 1.34.0
-  skipRange: '>=1.34.0 <1.35.0'
+  replaces: 1.35.0
+  skipRange: '>=1.35.0 <1.35.1'
   channels:
     default: stable
     list:

--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -71,8 +71,8 @@ dependencies:
   operator: 1.15.4
   # Previous versions required for downgrade testing
   previous:
-    serving: knative-v1.14
-    eventing: knative-v1.14
-    eventing_kafka_broker: knative-v1.14
+    serving: knative-v1.15
+    eventing: knative-v1.15
+    eventing_kafka_broker: knative-v1.15
   mustgather:
     image: quay.io/openshift-knative/must-gather


### PR DESCRIPTION
SO 1.35.0 was released. So we can bump the patch version of 1.35 to get everything prepared for a patch release.

PR to update the tag in openshift/release: https://github.com/openshift/release/pull/61140