### PR TITLE
Resolve quay repo correctly on knative-nightly tag

### DIFF
--- a/hack/lib/images.bash
+++ b/hack/lib/images.bash
@@ -375,11 +375,16 @@ function image_with_sha {
 
 function get_app_version_from_tag() {
   local tag app_version
-  tag=${1:?"Provide tag for Serving images"}
+  tag=${1:?"Provide tag for images"}
 
-  app_version=$(sobranch --upstream-version "${tag/knative-v/}") # -> release-1.34
-  app_version=${app_version/release-/}                   # -> 1.34
-  app_version=${app_version/./}                          # -> 134
+  if [[ "$tag" == "knative-nightly" ]]; then
+    app_version=$quay_registry_app_version
+  else
+    app_version=$(sobranch --upstream-version "${tag/knative-v/}") # -> release-1.34
+    app_version=${app_version/release-/}                   # -> 1.34
+    app_version=${app_version/./}                          # -> 134
+  fi
+
   echo "${app_version}"
 }
 


### PR DESCRIPTION
Currently we see the quay repo not being resolved correctly, on release-next builds (when tag is knative-nightly), e.g. [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing-kafka-broker/1358/pull-ci-openshift-knative-eventing-kafka-broker-release-next-417-test-e2e/1886216516643328000)
```
time="2025-02-03T02:32:05Z" level=fatal msg="Error parsing image name \"docker://quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-/kn-eventing-controller:latest\": invalid reference format"
```

This PR addresses it and checks in `get_app_version_from_tag` for this corner case and returns the current version of SO as app version 