### PR TITLE
Run testselect directly

### DIFF
--- a/hack/lib/testselect.bash
+++ b/hack/lib/testselect.bash
@@ -3,9 +3,6 @@
 function run_testselect {
   if [[ -n "${ARTIFACT_DIR:-}" && -n "${CLONEREFS_OPTIONS:-}" ]]; then
     local clonedir rootdir
-
-    GOFLAGS="" go install github.com/openshift-knative/hack/cmd/testselect
-
     clonedir=$(mktemp -d)
 
     # CLONEREFS_OPTIONS var is set in CI
@@ -17,7 +14,7 @@ function run_testselect {
 
     # The testselect clones a repository. Make sure it's cloned into a temp dir.
     pushd "$clonedir" || return $?
-    "$(go env GOPATH)/bin/testselect" --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
+    go run github.com/openshift-knative/hack/cmd/testselect@latest --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
     popd || return $?
 
     logger.info 'Tests to be run:'

--- a/hack/lib/testselect.bash
+++ b/hack/lib/testselect.bash
@@ -2,14 +2,9 @@
 
 function run_testselect {
   if [[ -n "${ARTIFACT_DIR:-}" && -n "${CLONEREFS_OPTIONS:-}" ]]; then
-    local clonedir rootdir hack_tmp_dir
+    local clonedir rootdir
 
-    hack_tmp_dir=$(mktemp -d)
-    git clone --branch main https://github.com/openshift-knative/hack "$hack_tmp_dir"
-    pushd "$hack_tmp_dir" || return $?
-    go install github.com/openshift-knative/hack/cmd/testselect
-    popd || return $?
-    rm -rf "$hack_tmp_dir"
+    GOFLAGS="" go install github.com/openshift-knative/hack/cmd/testselect
 
     clonedir=$(mktemp -d)
 


### PR DESCRIPTION
We're running into 
```
Cloning into '/tmp/knative.D3EjJ6RQ/tmp.bAwqelmbkP'...
/tmp/knative.D3EjJ6RQ/tmp.bAwqelmbkP /go/src/github.com/openshift-knative/serverless-operator
go: inconsistent vendoring in /tmp/knative.D3EjJ6RQ/tmp.bAwqelmbkP:
	github.com/blang/semver/v4@v4.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/coreos/go-semver@v0.3.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        ...
	To ignore the vendor directory, use -mod=readonly or -mod=mod.
	To sync the vendor directory, run:
		go mod vendor
12:32:11.730 ERROR:   🚨 Error (code: 1) occurred at /go/src/github.com/openshift-knative/serverless-operator/hack/lib/testselect.bash:10, with command: go install github.com/openshift-knative/hack/cmd/testselect
```
E.g. [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_serverless-operator/3386/pull-ci-openshift-knative-serverless-operator-release-1.35-417-test-upgrade-aws-417/1890344162276937728)

We don't need to clone hack repo anymore to install the tools, so run it directly