### PR TITLE
[release-1.35] Run testselect directly

### DIFF
--- a/hack/lib/testselect.bash
+++ b/hack/lib/testselect.bash
@@ -14,7 +14,7 @@ function run_testselect {
 
     # The testselect clones a repository. Make sure it's cloned into a temp dir.
     pushd "$clonedir" || return $?
-    go run github.com/openshift-knative/hack/cmd/testselect@latest --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
+    GOFLAGS="" go run github.com/openshift-knative/hack/cmd/testselect@latest --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
     popd || return $?
 
     logger.info 'Tests to be run:'

--- a/hack/lib/testselect.bash
+++ b/hack/lib/testselect.bash
@@ -2,15 +2,7 @@
 
 function run_testselect {
   if [[ -n "${ARTIFACT_DIR:-}" && -n "${CLONEREFS_OPTIONS:-}" ]]; then
-    local clonedir rootdir hack_tmp_dir
-
-    hack_tmp_dir=$(mktemp -d)
-    git clone --branch main https://github.com/openshift-knative/hack "$hack_tmp_dir"
-    pushd "$hack_tmp_dir" || return $?
-    go install github.com/openshift-knative/hack/cmd/testselect
-    popd || return $?
-    rm -rf "$hack_tmp_dir"
-
+    local clonedir rootdir
     clonedir=$(mktemp -d)
 
     # CLONEREFS_OPTIONS var is set in CI
@@ -22,7 +14,7 @@ function run_testselect {
 
     # The testselect clones a repository. Make sure it's cloned into a temp dir.
     pushd "$clonedir" || return $?
-    "$(go env GOPATH)/bin/testselect" --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
+    go run github.com/openshift-knative/hack/cmd/testselect@latest --testsuites="${rootdir}/test/testsuites.yaml" --clonerefs="${ARTIFACT_DIR}/clonerefs.json" --output="${ARTIFACT_DIR}/tests.txt"
     popd || return $?
 
     logger.info 'Tests to be run:'


### PR DESCRIPTION
Manual backport of https://github.com/openshift-knative/serverless-operator/pull/3387/commits/95f52d538addf1251316d358e4a4edd39de6bfde