### PR TITLE
[RELEASE-1.35] [SRVKS-1307] Fix nil check in Serving reconciler

### DIFF
--- a/hack/patches/022-serving-ingress-ns-filter.patch
+++ b/hack/patches/022-serving-ingress-ns-filter.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
-index 4b8eca0b0..0398dfbf9 100644
+index 4b8eca0b0..ccf9f2f67 100644
 --- a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
 +++ b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
 @@ -19,14 +19,15 @@ package knativeserving
@@ -20,21 +20,20 @@ index 4b8eca0b0..0398dfbf9 100644
  	"knative.dev/operator/pkg/apis/operator/base"
  	"knative.dev/operator/pkg/apis/operator/v1beta1"
  	clientset "knative.dev/operator/pkg/client/clientset/versioned"
-@@ -86,7 +87,12 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1beta1.Knative
- 		logger.Error("Unable to fetch installed manifest; no cluster-scoped resources will be finalized", err)
+@@ -90,6 +91,12 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1beta1.Knative
+ 	if manifest == nil {
  		return nil
  	}
--
 +	// we need this to apply the correct namespace to the resources otherwise it defaults to knative-serving
 +	*manifest, err = manifest.Transform(overrideKourierNamespace(original))
 +	if err != nil {
 +		logger.Error("Unable to apply kourier namespace transform", err)
 +		return nil
 +	}
- 	if manifest == nil {
- 		return nil
- 	}
-@@ -97,6 +103,20 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1beta1.Knative
+
+ 	if err := common.Uninstall(manifest); err != nil {
+ 		logger.Error("Failed to finalize platform resources", err)
+@@ -97,6 +104,20 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1beta1.Knative
  	return nil
  }
 
@@ -55,7 +54,7 @@ index 4b8eca0b0..0398dfbf9 100644
  // ReconcileKind compares the actual state with the desired, and attempts to
  // converge the two.
  func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServing) pkgreconciler.Event {
-@@ -117,6 +137,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServi
+@@ -117,6 +138,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServi
  		security.AppendTargetSecurity,
  		common.AppendAdditionalManifests,
  		r.appendExtensionManifests,

--- a/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
+++ b/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go
@@ -87,13 +87,14 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1beta1.Knative
 		logger.Error("Unable to fetch installed manifest; no cluster-scoped resources will be finalized", err)
 		return nil
 	}
+
+	if manifest == nil {
+		return nil
+	}
 	// we need this to apply the correct namespace to the resources otherwise it defaults to knative-serving
 	*manifest, err = manifest.Transform(overrideKourierNamespace(original))
 	if err != nil {
 		logger.Error("Unable to apply kourier namespace transform", err)
-		return nil
-	}
-	if manifest == nil {
 		return nil
 	}
 


### PR DESCRIPTION
Fixes JIRA #SRVKS-1307

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- I haven't reproduced this yet but the nil check should move a few lines above anyway.
- Log posted in the ticket:
```
2025-02-21T13:26:06.399854219Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1927953]
2025-02-21T13:26:06.399873619Z 
2025-02-21T13:26:06.399873619Z goroutine 225 [running]:
2025-02-21T13:26:06.399884419Z knative.dev/operator/pkg/reconciler/knativeserving.(*Reconciler).FinalizeKind(0xc0001645b0, {0x23e63e8, 0xc0045e0750}, 0xc000468dc8)
2025-02-21T13:26:06.399893119Z 	/workspace/vendor/knative.dev/operator/pkg/reconciler/knativeserving/knativeserving.go:91 +0x493
```
This comes from `*manifest, err = manifest.Transform(overrideKourierNamespace(original))`.

In general manifests in our case should not be nil as this is retrieved based on the status in the Serving CR which has:
```
                "manifests": [
                    "/var/run/ko/knative-serving/latest",
                    "/var/run/ko/ingress/latest/kourier"
                ],
```
Unless this is wiped out at some point manifest should not be nil. 
`overrideKourierNamespace(original)` does not seem to be an issue and `manifest.Transform` can handle nil values passed to it.
