### PR TITLE
Create the `Run make generated-files` PRs as Serverless-QE robot

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -95,6 +95,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || ( github.event_name == 'push' && !contains(github.ref_name, 'dependabot/') )
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.SERVERLESS_QE_ROBOT }}
           path: ./src/github.com/${{ github.repository }}
           branch: auto/update-generated-files-${{ github.ref_name }}
           title: "[${{ github.ref_name }}] Run make generated-files"


### PR DESCRIPTION
Currently no GH workflows are triggered on the `Run make generated-files` PRs. For example we're missing the csv-revision-check run in #3401.
This is because PRs created with the `GITHUB_TOKEN`, do not trigger workflows: see [automatic-token-authentication#using-the-github_token-in-a-workflow](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.

Or [here](https://github.com/marketplace/actions/create-pull-request#token)

Therefor we switch to the Serverless-QE robot user in the validate workflow to allow triggering workflows on the created PRs.