### PR TITLE
Increase tempo stack memory limits further

### DIFF
--- a/hack/lib/tracing.bash
+++ b/hack/lib/tracing.bash
@@ -233,7 +233,7 @@ spec:
   resources:
     total:
       limits:
-        memory: 4Gi
+        memory: 16Gi
         cpu: 2000m
   template:
     queryFrontend:


### PR DESCRIPTION
Still getting OOMKilled in tempo on tracing tests