### PR TITLE
Update to Golang 1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,6 @@ generate-dockerfiles: install-tool-generate
 	GOFLAGS='' go install github.com/openshift-knative/hack/cmd/generate@latest
 	$(shell go env GOPATH)/bin/generate \
 		--generators dockerfile \
-		--dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17"  \
 		--includes knative-operator \
 		--includes openshift-knative-operator \
 		--includes serving/ingress \

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift-knative/serverless-operator
 
-go 1.22.0
-
-toolchain go1.22.7
+go 1.23.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/knative-operator/Dockerfile
+++ b/knative-operator/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for knative-operator/cmd/knative-operator.
-ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder

--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for openshift-knative-operator/cmd/openshift-knative-operator.
-ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder

--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for serving/ingress/cmd/ingress.
-ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder

--- a/serving/metadata-webhook/Dockerfile
+++ b/serving/metadata-webhook/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for serving/metadata-webhook/cmd/webhook.
-ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder


### PR DESCRIPTION
Updating to Golang 1.23, as some "downstream" projects require go 1.23 (`go: go.mod requires go >= 1.23.0 (running go 1.22.9; GOTOOLCHAIN=local)`, e.g. [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_serverless-operator/3589/pull-ci-openshift-knative-serverless-operator-main-417-upstream-e2e/1909861411991851008)