### PR TITLE
Update build Dockerfile to Golang 1.23

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/


### PR DESCRIPTION
Update the build dockerfile to Golang 1.23 too, as this was missed in #3590.
I'll update the automation for this as a follow up, as this changes currently a lot and I want to test this separately, so we get unblocked on main first