### PR TITLE
use floats for "le"

### DIFF
--- a/test/monitoringe2e/helpers.go
+++ b/test/monitoringe2e/helpers.go
@@ -62,7 +62,7 @@ var (
 	}
 
 	KafkaControllerQueries = []string{
-		"sum(rate(kafka_broker_controller_reconcile_latency_bucket{le=\"100.0\", job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}[5m])) / sum(rate(kafka_broker_controller_reconcile_latency_count{job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}[5m]))",
+		"sum(rate(kafka_broker_controller_reconcile_latency_bucket{le=~\"100(.0)?\", job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}[5m])) / sum(rate(kafka_broker_controller_reconcile_latency_count{job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}[5m]))",
 		"sum(kafka_broker_controller_workqueue_depth{job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}) by (name)",
 	}
 

--- a/test/monitoringe2e/helpers.go
+++ b/test/monitoringe2e/helpers.go
@@ -62,7 +62,7 @@ var (
 	}
 
 	KafkaControllerQueries = []string{
-		"sum(rate(kafka_broker_controller_reconcile_latency_bucket{le=\"100\", job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}[5m])) / sum(rate(kafka_broker_controller_reconcile_latency_count{job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}[5m]))",
+		"sum(rate(kafka_broker_controller_reconcile_latency_bucket{le=\"100.0\", job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}[5m])) / sum(rate(kafka_broker_controller_reconcile_latency_count{job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}[5m]))",
 		"sum(kafka_broker_controller_workqueue_depth{job=\"kafka-controller-sm-service\", namespace=\"knative-eventing\"}) by (name)",
 	}
 


### PR DESCRIPTION
In OpenShift 4.19 

```
With Prometheus v3, the classic histogram's "le" and summary's "quantile" labels values will be floats.
```

per https://issues.redhat.com/browse/MON-4129

- :broom: Use floats in "le" label prometheus query