### PR TITLE
Create index image out of bundle images from Konflux

### DIFF
--- a/hack/generate/dockerfile.sh
+++ b/hack/generate/dockerfile.sh
@@ -42,7 +42,6 @@ if [[ "$template" =~ index.Dockerfile ]]; then
   # One is already added in template
   num_csvs=$(( INDEX_IMAGE_NUM_CSVS-1 ))
 
-  # TODO gradually migrate other bundle images to Konflux-based ones as we build more minor versions with Konflux
   # Generate additional entries
   for i in $(seq $num_csvs); do
     current_minor=$(( minor-i ))
@@ -53,7 +52,7 @@ if [[ "$template" =~ index.Dockerfile ]]; then
     fi
     current_version="${major}.${current_minor}.0"
 
-    sed --in-place "/opm render/a registry.ci.openshift.org/knative/release-${current_version}:serverless-bundle \\\\" "$target"
+    sed --in-place "/opm render/a quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-${major}${current_minor}/serverless-bundle:${current_version} \\\\" "$target"
   done
 
 elif [[ "$template" =~ catalog.Dockerfile ]]; then

--- a/olm-catalog/serverless-operator-index/Dockerfile
+++ b/olm-catalog/serverless-operator-index/Dockerfile
@@ -9,9 +9,9 @@ COPY olm-catalog/serverless-operator-index/configs /configs
 
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml \
-registry.ci.openshift.org/knative/release-1.35.0:serverless-bundle \
-registry.ci.openshift.org/knative/release-1.36.0:serverless-bundle \
-      quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-137/serverless-bundle@sha256:242d44dea37458606231e3d886c748801f70921eb38d7e326dc55916841afb30 >> /configs/index.yaml
+quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle:1.35.0 \
+quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/serverless-bundle:1.36.0 \
+      quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-137/serverless-bundle@sha256:c1ef1f98e9594a6d82f08c4db8c347a08e03bb30bde3be75ddfbdb7b24f65f14 >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe


### PR DESCRIPTION
Currently the index for CI is generated from the bundles built in Prow. As we built all bundles now in Konflux, we can switch to using them.