### PR TITLE
Allow to skip override-snapshot creation in manual workflow run

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -15,6 +15,12 @@ on:
   schedule:
     - cron: "0 6 * * *" # Daily at 06:00.
   workflow_dispatch: # Manual workflow trigger
+    inputs:
+      skip-override-snapshot-gen:
+        type: boolean
+        default: false
+        required: false
+        description: "Skip override-snapshot creation"
 
 jobs:
   generated-files-committed:
@@ -82,7 +88,7 @@ jobs:
         run: make generate-catalog
 
       - name: Regenerate override-snapshot
-        if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || ( github.event_name == 'push' && !contains(github.ref_name, 'dependabot/') )
+        if: ( github.event_name == 'workflow_dispatch' && inputs.skip-override-snapshot-gen == 'false' ) || github.event_name == 'schedule' || ( github.event_name == 'push' && !contains(github.ref_name, 'dependabot/') )
         working-directory: ./src/github.com/${{ github.repository }}
         run: make generate-override-snapshot
 


### PR DESCRIPTION
Sometimes we can run into having a catalog containing components which do not have the attestation information, which does not allow us to update the override-snapshot YAML (see e.g. https://github.com/openshift-knative/serverless-operator/actions/runs/14965418444/job/42034411265). Those "broken catalogs" can for example happen when a component build fails and we ignore the `Validate / Generated files are committed (pull_request)` test run (e.g. on branch cuts).

This results then in some chicken-egg problems, as the override-snapshot gen is part of the [validate action](https://github.com/openshift-knative/serverless-operator/actions/workflows/validate.yaml), which fails in the workflow and thus we don't get an updated bundle/catalog.

As we don't have a fix for the attestation information yet, we can also add an option to skip the override-snapshot update, when we trigger the workflow manually, which then allows us to still create a PR which updates the bundle and catalog.