### PR TITLE
fix: correct input condition for override snapshot

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -88,7 +88,7 @@ jobs:
         run: make generate-catalog
 
       - name: Regenerate override-snapshot
-        if: ( github.event_name == 'workflow_dispatch' && inputs.skip-override-snapshot-gen == 'false' ) || github.event_name == 'schedule' || ( github.event_name == 'push' && !contains(github.ref_name, 'dependabot/') )
+        if: ( github.event_name == 'workflow_dispatch' && github.event.inputs.skip-override-snapshot-gen == 'false' ) || github.event_name == 'schedule' || ( github.event_name == 'push' && !contains(github.ref_name, 'dependabot/') )
         working-directory: ./src/github.com/${{ github.repository }}
         run: make generate-override-snapshot
 


### PR DESCRIPTION
Fixes incorrect usage of `inputs.skip-override-snapshot-gen` in workflow_dispatch.
Now uses `github.event.inputs.skip-override-snapshot-gen` to properly evaluate the input.
