### PR TITLE
WIP: Disable the controllers for KafkaNamespaced Broker/Trigger controllers to avoid issues.

### DIFF
--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller.go
@@ -645,7 +645,7 @@ func configureEventingKafka(spec serverlessoperatorv1alpha1.KnativeKafkaSpec) mf
 		if u.GetKind() == "Deployment" && u.GetName() == "kafka-controller" {
 
 			var disabledKafkaControllers = common.StringMap{
-				brokerController:  "broker-controller,trigger-controller,namespaced-broker-controller,namespaced-trigger-controller",
+				brokerController:  "broker-controller,trigger-controller",
 				sinkController:    "sink-controller",
 				sourceController:  "source-controller",
 				channelController: "channel-controller",

--- a/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
+++ b/knative-operator/pkg/controller/knativekafka/knativekafka_controller_test.go
@@ -607,7 +607,7 @@ func TestDisabledControllers(t *testing.T) {
 				Enabled: true,
 			},
 		},
-		expectedDisabledControllers: []string{"broker-controller", "trigger-controller", "namespaced-broker-controller", "namespaced-trigger-controller", "source-controller"},
+		expectedDisabledControllers: []string{"broker-controller", "trigger-controller", "source-controller"},
 	}, {
 		name: "broker and sink",
 		knativeKafka: v1alpha1.KnativeKafkaSpec{
@@ -629,7 +629,7 @@ func TestDisabledControllers(t *testing.T) {
 				Enabled: false,
 			},
 		},
-		expectedDisabledControllers: []string{"broker-controller", "trigger-controller", "namespaced-broker-controller", "namespaced-trigger-controller", "sink-controller", "source-controller"},
+		expectedDisabledControllers: []string{"broker-controller", "trigger-controller", "sink-controller", "source-controller"},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Will be disabled on OCP, but will stay upstream for longer

requires https://github.com/openshift-knative/eventing-kafka-broker/pull/1804

Fixes JIRA #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-
