### PR TITLE
run make generate-override-snapshot manually create override-snapshot

### DIFF
--- a/.konflux-release/override-snapshot-fbc-414.yaml
+++ b/.konflux-release/override-snapshot-fbc-414.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  name: serverless-operator-136-fbc-414-override-snapshot-82a2dcd2
+  name: serverless-operator-136-fbc-414-override-snapshot-3193b301
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-136-fbc-414
@@ -10,9 +10,9 @@ spec:
   application: serverless-operator-136-fbc-414
   components:
     - name: "serverless-index-136-fbc-414"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-414/serverless-index-136-fbc-414@sha256:0592db73d0fcd9741cda6d947b2e67ea9efaec96012b8363b8d95d6c32a1630b"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-414/serverless-index-136-fbc-414@sha256:4256c9af49027a13ff2ee6b484f062e68a1a51ded3e95bfb65eb3e001f75531d"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "068caff95bd290556a98e889854e4f7215b6c483"
+          revision: "7f58c5170bb87f5063534dde905bdb3caea6e977"
           dockerfileUrl: "Dockerfile"

--- a/.konflux-release/override-snapshot-fbc-415.yaml
+++ b/.konflux-release/override-snapshot-fbc-415.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  name: serverless-operator-136-fbc-415-override-snapshot-5a8620cb
+  name: serverless-operator-136-fbc-415-override-snapshot-3bbe1771
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-136-fbc-415
@@ -10,9 +10,9 @@ spec:
   application: serverless-operator-136-fbc-415
   components:
     - name: "serverless-index-136-fbc-415"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-415/serverless-index-136-fbc-415@sha256:2c40d14f05dc1fec5c40e24ca2207eadc72915826adf72263e64990c73b15985"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-415/serverless-index-136-fbc-415@sha256:1148ad861a00ad055be806097ae0c13f5e1c66c33a44e3a56f4c459fad7dda1c"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "068caff95bd290556a98e889854e4f7215b6c483"
+          revision: "7f58c5170bb87f5063534dde905bdb3caea6e977"
           dockerfileUrl: "Dockerfile"

--- a/.konflux-release/override-snapshot-fbc-416.yaml
+++ b/.konflux-release/override-snapshot-fbc-416.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  name: serverless-operator-136-fbc-416-override-snapshot-6ce4bdbc
+  name: serverless-operator-136-fbc-416-override-snapshot-5178755f
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-136-fbc-416
@@ -10,9 +10,9 @@ spec:
   application: serverless-operator-136-fbc-416
   components:
     - name: "serverless-index-136-fbc-416"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-416/serverless-index-136-fbc-416@sha256:608d2bc252ec05af845e7905e4095ac69fe2b02384783c81f22f4d8df4f8b73a"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-416/serverless-index-136-fbc-416@sha256:b25776dfaf325a58703d02603fc372fbb5250cbb303f6a871b5dc03c4106d89a"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "068caff95bd290556a98e889854e4f7215b6c483"
+          revision: "7f58c5170bb87f5063534dde905bdb3caea6e977"
           dockerfileUrl: "Dockerfile"

--- a/.konflux-release/override-snapshot-fbc-417.yaml
+++ b/.konflux-release/override-snapshot-fbc-417.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  name: serverless-operator-136-fbc-417-override-snapshot-d82c9e49
+  name: serverless-operator-136-fbc-417-override-snapshot-27443e1c
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-136-fbc-417
@@ -10,9 +10,9 @@ spec:
   application: serverless-operator-136-fbc-417
   components:
     - name: "serverless-index-136-fbc-417"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-417/serverless-index-136-fbc-417@sha256:d68b90a6ccbb5cefec7086b9ebfc9c92c09de6bf84544e3adcbccb8a5a01675d"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-417/serverless-index-136-fbc-417@sha256:fa32604b036ca8228825c6f1b126afd9d1f17a6903c244eca17bc7ab3cd7a9fb"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "068caff95bd290556a98e889854e4f7215b6c483"
+          revision: "7f58c5170bb87f5063534dde905bdb3caea6e977"
           dockerfileUrl: "Dockerfile"

--- a/.konflux-release/override-snapshot-fbc-418.yaml
+++ b/.konflux-release/override-snapshot-fbc-418.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  name: serverless-operator-136-fbc-418-override-snapshot-129601ad
+  name: serverless-operator-136-fbc-418-override-snapshot-05c1eaf0
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-136-fbc-418
@@ -10,9 +10,9 @@ spec:
   application: serverless-operator-136-fbc-418
   components:
     - name: "serverless-index-136-fbc-418"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-418/serverless-index-136-fbc-418@sha256:fec90d37479e9f9a9e4e24ef1d3d69e77a2e47ad84b89731c1c64aa937f03c12"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-418/serverless-index-136-fbc-418@sha256:b21bcf3ce42c181962eeecdb7819dcd5590e983f3bb251831c00a7dd3b34a4c9"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "068caff95bd290556a98e889854e4f7215b6c483"
+          revision: "7f58c5170bb87f5063534dde905bdb3caea6e977"
           dockerfileUrl: "Dockerfile"

--- a/.konflux-release/override-snapshot-fbc-419.yaml
+++ b/.konflux-release/override-snapshot-fbc-419.yaml
@@ -1,0 +1,18 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: serverless-operator-136-fbc-419-override-snapshot-f803b607
+  labels:
+    test.appstudio.openshift.io/type: override
+    application: serverless-operator-136-fbc-419
+    branch: release-1.36
+spec:
+  application: serverless-operator-136-fbc-419
+  components:
+    - name: "serverless-index-136-fbc-419"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136-fbc-419/serverless-index-136-fbc-419@sha256:380f43f6bba727b93cb8e8a9caa33bc8d4eb8943b785222eb48a068bceb2505a"
+      source:
+        git:
+          url: "https://github.com/openshift-knative/serverless-operator"
+          revision: "7f58c5170bb87f5063534dde905bdb3caea6e977"
+          dockerfileUrl: "Dockerfile"

--- a/.konflux-release/override-snapshot.yaml
+++ b/.konflux-release/override-snapshot.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Snapshot
 metadata:
-  name: serverless-operator-136-override-snapshot-cca62089
+  name: serverless-operator-136-override-snapshot-a4b1920c
   labels:
     test.appstudio.openshift.io/type: override
     application: serverless-operator-136
@@ -297,37 +297,37 @@ spec:
           revision: "b7f7b5f989cd1a1e87afc5ae5b10d09d33e4d55c"
           dockerfileUrl: "openshift/ci-operator/knative-images/kourier/Dockerfile"
     - name: "serverless-ingress-136"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/serverless-ingress@sha256:4fe46e37bec06d471fca0fcd10c982bd93ea19566d26eb071a4db71394dfe907"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/serverless-ingress@sha256:fbeb930b3a6964c22efa6b975a5cc56127e902d2860f3484a86b4322a31d2649"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "300ca1f9459ec047cac92596f152ca3e3cf9b658"
+          revision: "c2385138a9eca080ee3e818b66995f717299b638"
           dockerfileUrl: "serving/ingress/Dockerfile"
     - name: "serverless-kn-operator-136"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/serverless-kn-operator@sha256:7145262118d684f83826134cbef22da80c33c9bb5aa2b5066a021bf740c2e30f"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/serverless-kn-operator@sha256:34c9fbb247fd922d58db785e24d6486073bed30465b6f7d22ea54c5bddc8335a"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "300ca1f9459ec047cac92596f152ca3e3cf9b658"
+          revision: "c2385138a9eca080ee3e818b66995f717299b638"
           dockerfileUrl: "knative-operator/Dockerfile"
     - name: "serverless-must-gather-136"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/serverless-must-gather@sha256:6a6afcadc65a3f536576139170f1910627ae2372237c4a3567e4e344140c0ed1"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/serverless-must-gather@sha256:e6d6957e0a60923b17b32baeb0b46b45f50bf19e8663ca982cf9d92e7105d8a0"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "300ca1f9459ec047cac92596f152ca3e3cf9b658"
+          revision: "c2385138a9eca080ee3e818b66995f717299b638"
           dockerfileUrl: "must-gather/Dockerfile"
     - name: "serverless-openshift-kn-operator-136"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/serverless-openshift-kn-operator@sha256:7f94a713df362c9eb683a497cab2795bc164a15eca1061251e6d69000abd074d"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/serverless-openshift-kn-operator@sha256:30030c31149955ab14ae8c5fc144e54012b25ed4e3b93e0f3be6bf6fbbdc793b"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "300ca1f9459ec047cac92596f152ca3e3cf9b658"
+          revision: "c2385138a9eca080ee3e818b66995f717299b638"
           dockerfileUrl: "openshift-knative-operator/Dockerfile"
     - name: "serverless-bundle-136"
-      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/serverless-bundle@sha256:4a7323dda6a3419cef4ee58fd51daf9af9e65beafb0216fc0be3619c321ab19c"
+      containerImage: "quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/serverless-bundle@sha256:6f7063a82dba5a4808240c7fdb42dc1d1bd7612680f5e3ea9019d59bb371f1f4"
       source:
         git:
           url: "https://github.com/openshift-knative/serverless-operator"
-          revision: "788c8e7903e26063d216c90888632745f731ca08"
+          revision: "9cad2ee3c097e9e0312d4ef9d1f0699cfefc78de"
           dockerfileUrl: "olm-catalog/serverless-operator/Dockerfile"


### PR DESCRIPTION
Manually create an override snapshot, due to the non-presence of 1.35 and 1.36 on 4.19, validate action create catalog.yaml with suspicious values. 