### PR TITLE
[main] update docs-default `max` OCP version to 4.19

### DIFF
--- a/olm-catalog/serverless-operator/project.yaml
+++ b/olm-catalog/serverless-operator/project.yaml
@@ -28,8 +28,10 @@ requirements:
       - "4.16"
       - "4.17"
       - "4.18"
+      - "4.19"
+      - "4.20"
     min: '4.14'
-    max: '4.18'
+    max: '4.19'
     label: 'v4.14'
     # OCP stream for kube-rbac-proxy image.
     kube-rbac-proxy: "4.17"


### PR DESCRIPTION
- :broom: Add OCP 4.19 and 4.20
- :broom: Make the current OCP `max` the version to use in docs links (4.19)