### PR TITLE
[SRVCOM-3428] remove workaround installing cert-manager from upstream instead of OperatorHub on OCP 4.18

### DIFF
--- a/hack/lib/certmanager.bash
+++ b/hack/lib/certmanager.bash
@@ -17,14 +17,7 @@ function deploy_certmanager_operator {
 
   deployment_namespace="cert-manager"
 
-  ocp_version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}')
-  # Workaround for cert-manager not being available in 4.18 yet.
-  # https://issues.redhat.com/browse/SRVCOM-3428
-  if versions.ge "$(versions.major_minor "$ocp_version")" "4.18"; then
-    oc apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml
-  else
-    oc apply -f "${certmanager_resources_dir}"/subscription.yaml || return $?
-  fi
+  oc apply -f "${certmanager_resources_dir}"/subscription.yaml || return $?
 
   logger.info "Waiting until cert manager operator is available"
 


### PR DESCRIPTION
This removes the workaround added in 4dba7ea308e77b12a48a10295fe882869103ebe9.

Fixes https://issues.redhat.com/browse/SRVCOM-3428

## Proposed Changes

- :broom: remove workaround installing cert-manager from upstream instead of OperatorHub on OCP 4.18
