### PR TITLE
Add mirrors in ImageContentSourcePolicy and ImageMirrorSet for next SO version too

### DIFF
--- a/hack/generate/catalog.sh
+++ b/hack/generate/catalog.sh
@@ -197,4 +197,4 @@ logger.info "Generating ImageContextSourcePolicy"
 
 default_serverless_operator_images
 # shellcheck disable=SC2154
-create_image_content_source_policy "${INDEX_IMAGE}" "$registry_redhat_io" "$registry_quay" "$registry_quay_previous" "olm-catalog/serverless-operator-index/image_content_source_policy.yaml" ".tekton/images-mirror-set.yaml"
+create_image_content_source_policy "${INDEX_IMAGE}" "$registry_redhat_io" "$registry_quay" "$registry_quay_previous" "$registry_quay_next" "olm-catalog/serverless-operator-index/image_content_source_policy.yaml" ".tekton/images-mirror-set.yaml"

--- a/hack/lib/images.bash
+++ b/hack/lib/images.bash
@@ -18,8 +18,13 @@ quay_registry_app_version=${quay_registry_app_version%.*} # 136.0 -> 136
 quay_registry_app_version_previous=${PREVIOUS_VERSION/./} # 1.35.0 -> 135.0
 quay_registry_app_version_previous=${quay_registry_app_version_previous%.*} # 135.0 -> 135
 
+quay_registry_app_version_next=${CURRENT_VERSION/./} # 1.36.0 -> 136.0
+quay_registry_app_version_next=${quay_registry_app_version_next%.*} # 136.0 -> 136
+quay_registry_app_version_next="$((quay_registry_app_version_next + 1))" # 136 -> 137
+
 export registry_quay="${registry_prefix_quay}${quay_registry_app_version}"
 export registry_quay_previous="${registry_prefix_quay}${quay_registry_app_version_previous}"
+export registry_quay_next="${registry_prefix_quay}${quay_registry_app_version_next}"
 export registry_redhat_io="registry.redhat.io/openshift-serverless-1"
 
 export FORCE_USE_QUAY_IMAGES=${FORCE_USE_QUAY_IMAGES:-"false"}


### PR DESCRIPTION
Currently the ImageContentSourcePolicy and ImageMirrorSet only contains a mirror configuration for the current and previous SO registry.
This can lead to issues, when the branch gets cut late. E.g. ATM we have SO main config with the 1.37 release (thus mirror configs for SO repos 1.36 and 1.37). Anyhow EKB 1.18 (which would require SO 1.38 which does not exist yet) uses the SO main branch too. But SO main does not contain the mirror for SO 1.38 repos.

This PR addresses it and adds the repo for the next SO release to the mirror configs too. This should not be a big issue IIUC, as in the CSV we have the image SHAs, which only exists in one of those repos.