### PR TITLE
Bump to Strimzi 0.46.1 operator and clean kafka cfg

### DIFF
--- a/hack/lib/strimzi.bash
+++ b/hack/lib/strimzi.bash
@@ -31,6 +31,7 @@ metadata:
 spec:
   kafka:
     version: 3.9.0
+    metadataVersion: 3.9-IV0
     replicas: 3
     listeners:
       # PLAINTEXT
@@ -74,7 +75,6 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      inter.broker.protocol.version: "3.9"
       auto.create.topics.enable: "false"
   entityOperator:
     topicOperator: {}

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -12,7 +12,7 @@ fi
 source "$(dirname "${BASH_SOURCE[0]}")/../../vendor/knative.dev/hack/e2e-tests.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/images.bash"
 
-export STRIMZI_VERSION=0.45.1
+export STRIMZI_VERSION=0.46.1
 
 # Adjust these when upgrading the knative versions.
 export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-$(metadata.get dependencies.serving)}"


### PR DESCRIPTION
As per title, latest of Strimz that is supporting 3.9.0 kafka 