### PR TITLE
fix: make images install-all works on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
+# Target architecture and OS for image builds
+# Defaults to amd64/linux for OpenShift clusters, but can be overridden for local development
+TARGET_ARCH ?= amd64
+TARGET_OS ?= linux
+
 # Useful for local development
 dev:
 	./hack/dev.sh
 
 # General purpose targets
 images:
-	./hack/images.sh $(DOCKER_REPO_OVERRIDE)
+	TARGET_ARCH=$(TARGET_ARCH) TARGET_OS=$(TARGET_OS) ./hack/images.sh $(DOCKER_REPO_OVERRIDE)
 
 install: install-tools
 	./hack/install.sh
@@ -18,7 +23,7 @@ install-all: install-tools
 	SCALE_UP=4 INSTALL_KAFKA="true" ENABLE_TRACING=true ./hack/install.sh
 
 install-release-next: install-tools generated-files-release-next
-	ON_CLUSTER_BUILDS=true ./hack/images.sh image-registry.openshift-image-registry.svc:5000/openshift-marketplace
+	ON_CLUSTER_BUILDS=true TARGET_ARCH=$(TARGET_ARCH) TARGET_OS=$(TARGET_OS) ./hack/images.sh image-registry.openshift-image-registry.svc:5000/openshift-marketplace
 	USE_RELEASE_NEXT=true DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace ./hack/install.sh
 
 install-tracing:

--- a/hack/images.sh
+++ b/hack/images.sh
@@ -17,8 +17,13 @@ fi
 
 repo=$1
 
+# Set default target architecture and OS if not provided
+TARGET_ARCH=${TARGET_ARCH:-amd64}
+TARGET_OS=${TARGET_OS:-linux}
+
 on_cluster_builds=${ON_CLUSTER_BUILDS:-false}
 echo "On cluster builds: ${on_cluster_builds}"
+echo "Target platform: ${TARGET_OS}/${TARGET_ARCH}"
 
 if [[ $on_cluster_builds = true ]]; then
   #  image-registry.openshift-image-registry.svc:5000/openshift-marketplace/openshift-knative-operator:latest
@@ -32,14 +37,14 @@ if [[ $on_cluster_builds = true ]]; then
 
 else
   tmp_dockerfile=$(replace_images openshift-knative-operator/Dockerfile)
-  podman build -t "$repo/serverless-openshift-knative-operator" -f "${tmp_dockerfile}" .
+  podman build --platform="${TARGET_OS}/${TARGET_ARCH}" -t "$repo/serverless-openshift-knative-operator" -f "${tmp_dockerfile}" .
   podman push "$repo/serverless-openshift-knative-operator"
 
   tmp_dockerfile=$(replace_images knative-operator/Dockerfile)
-  podman build -t "$repo/serverless-knative-operator" -f "${tmp_dockerfile}" .
+  podman build --platform="${TARGET_OS}/${TARGET_ARCH}" -t "$repo/serverless-knative-operator" -f "${tmp_dockerfile}" .
   podman push "$repo/serverless-knative-operator"
 
   tmp_dockerfile=$(replace_images serving/ingress/Dockerfile)
-  podman build -t "$repo/serverless-ingress" -f "${tmp_dockerfile}" .
+  podman build --platform="${TARGET_OS}/${TARGET_ARCH}" -t "$repo/serverless-ingress" -f "${tmp_dockerfile}" .
   podman push "$repo/serverless-ingress"
 fi

--- a/hack/lib/images.bash
+++ b/hack/lib/images.bash
@@ -407,8 +407,12 @@ function image_with_sha {
   image=${1:?"Provide image"}
   return_input_on_empty=${2:-"false"}
 
+  # Use TARGET_OS and TARGET_ARCH if set, otherwise default to linux/amd64
+  target_os=${TARGET_OS:-linux}
+  target_arch=${TARGET_ARCH:-amd64}
+
   # shellcheck disable=SC2086
-  digest=$(skopeo inspect --retry-times=10 --no-tags=true ${SKOPEO_EXTRA_FLAGS} "docker://${image}" | jq -r '.Digest' || echo "")
+  digest=$(skopeo inspect --retry-times=10 --override-os "${target_os}" --override-arch "${target_arch}" --no-tags=true ${SKOPEO_EXTRA_FLAGS} "docker://${image}" | jq -r '.Digest' || echo "")
   if [ "${digest}" = "" ]; then
     if [ "${return_input_on_empty}" = "true" ]; then
       echo "${image}"
@@ -425,7 +429,12 @@ function image_with_sha {
 
 function bundle_image_version {
   image=${1:?"Provide image"}
-  version=$(skopeo inspect --no-tags=true "docker://${image}" | jq -r '.Labels.version')
+
+  # Use TARGET_OS and TARGET_ARCH if set, otherwise default to linux/amd64
+  target_os=${TARGET_OS:-linux}
+  target_arch=${TARGET_ARCH:-amd64}
+
+  version=$(skopeo inspect --no-tags=true --override-os "${target_os}" --override-arch "${target_arch}" "docker://${image}" | jq -r '.Labels.version')
   echo "${version}"
 }
 


### PR DESCRIPTION
This fixes some build issues I ran into when trying to run `make images install-all` from a macbook on `release-1.35`.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add `TARGET_ARCH` and `TARGET_OS` flags to the makefile and scripts
