### PR TITLE
follow up on moving the on-cluster-builds to a separate namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ install-all: install-tools
 	SCALE_UP=4 INSTALL_KAFKA="true" ENABLE_TRACING=true ./hack/install.sh
 
 install-release-next: install-tools generated-files-release-next
-	ON_CLUSTER_BUILDS=true TARGET_ARCH=$(TARGET_ARCH) TARGET_OS=$(TARGET_OS) ./hack/images.sh image-registry.openshift-image-registry.svc:5000/openshift-marketplace
-	USE_RELEASE_NEXT=true DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace ./hack/install.sh
+	ON_CLUSTER_BUILDS=true TARGET_ARCH=$(TARGET_ARCH) TARGET_OS=$(TARGET_OS) ./hack/images.sh image-registry.openshift-image-registry.svc:5000/openshift-serverless-builds
+	USE_RELEASE_NEXT=true DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-serverless-builds ./hack/install.sh
 
 install-tracing:
 	./hack/tracing.sh

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ pushed to your docker repository.
 `make images` requires docker or podman to build images, by setting
 `ON_CLUSTER_BUILDS=true` env variable, `make images` will build images
 using OpenShift Build and they will be available at the in-cluster
-registry `image-registry.openshift-image-registry.svc:5000/openshift-marketplace/<image_name>`.
+registry `image-registry.openshift-image-registry.svc:5000/openshift-serverless-builds/<image_name>`.
 
 To install the system using those images, use
-`DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace`
+`DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-serverless-builds`
 
 ### Installing the system
 
@@ -227,7 +227,7 @@ changed usually are `project.version`, `olm.replaces` and `olm.skipRange`.
 Next, add the now outdated version of serverless-operator to the CatalogSource deployment
 in [catalogsource.bash](./hack/lib/catalogsource.bash). The image to be added usually has
 the following format: `registry.ci.openshift.org/openshift/openshift-serverless-$OLD_VERSION:serverless-bundle`.
-Add it before the "current" image, which is `image-registry.openshift-image-registry.svc:5000/$OLM_NAMESPACE/serverless-bundle`.
+Add it before the "current" image, which is `image-registry.openshift-image-registry.svc:5000/openshift-serverless-builds/serverless-bundle`.
 
 After the changes are done, commit them and run `make generated-files`. All manifests
 will now be updated accordingly. It's encouraged to commit the generated changes

--- a/docs/gitops/README.md
+++ b/docs/gitops/README.md
@@ -30,7 +30,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
 spec:
   displayName: Serverless Operator
-  image: image-registry.openshift-image-registry.svc:5000/openshift-marketplace/serverless-index:latest
+  image: image-registry.openshift-image-registry.svc:5000/openshift-serverless-builds/serverless-index:latest
   publisher: Red Hat
   sourceType: grpc
  ---

--- a/hack/images.sh
+++ b/hack/images.sh
@@ -26,6 +26,7 @@ echo "On cluster builds: ${on_cluster_builds}"
 echo "Target platform: ${TARGET_OS}/${TARGET_ARCH}"
 
 if [[ $on_cluster_builds = true ]]; then
+  ensure_namespace "${ON_CLUSTER_BUILDS_NAMESPACE}"
   #  image-registry.openshift-image-registry.svc:5000/openshift-serverless-builds/openshift-knative-operator:latest
   build_image "serverless-openshift-knative-operator" "${root_dir}" "openshift-knative-operator/Dockerfile" || exit 1
   #  image-registry.openshift-image-registry.svc:5000/openshift-serverless-builds/knative-operator:latest


### PR DESCRIPTION
Fixes `make images` if run first (make sure the ON_CLUSTER_BUILDS_NAMESPACE exist)

Update references to the on-cluster-built images wrt the namespace change.

- :bug: Fix `make images` missing ON_CLUSTER_BUILDS_NAMESPACE