### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for serverless-bundle-136

### DIFF
--- a/olm-catalog/serverless-operator/Dockerfile
+++ b/olm-catalog/serverless-operator/Dockerfile
@@ -31,4 +31,5 @@ LABEL \
       url="https://catalog.redhat.com/software/container-stacks/detail/5ec53fcb110f56bd24f2ddc5" \
       release="1.36.1" \
       io.openshift.tags="bundle" \
-      vendor="Red Hat, Inc."
+      vendor="Red Hat, Inc." \
+      cpe="cpe:/a:redhat:openshift_serverless:1.36::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
