### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for serverless-openshift-kn-operator-136

### DIFF
--- a/openshift-knative-operator/Dockerfile
+++ b/openshift-knative-operator/Dockerfile
@@ -26,8 +26,9 @@ USER 65532
 
 LABEL \
       com.redhat.component="openshift-serverless-1-openshift-knative-operator-rhel8-container" \
-      name="openshift-serverless-1/openshift-knative-operator-rhel8" \
+      name="openshift-serverless-1/serverless-openshift-kn-rhel8-operator" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_serverless:1.36::el8" \
       summary="Red Hat OpenShift Serverless 1 Openshift Knative Operator" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Openshift Knative Operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
