### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for serverless-must-gather-136

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -23,13 +23,14 @@ USER 65532
 
 LABEL \
       com.redhat.component="openshift-serverless-1-must-gather-rhel8-container" \
-      name="openshift-serverless-1/svls-must-gather-rhel8" \
+      name="openshift-serverless-1/serverless-must-gather-rhel8" \
       version=1.36.1 \
       summary="Red Hat OpenShift Serverless 1 Must Gather" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Must Gather" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Must Gather" \
       io.k8s.description="Red Hat OpenShift Serverless Must Gather" \
-      io.openshift.tags="must-gather"
+      io.openshift.tags="must-gather" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.36::el8"
 
 ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
