### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for serverless-must-gather-135

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -23,7 +23,8 @@ USER 65532
 
 LABEL \
       com.redhat.component="openshift-serverless-1-must-gather-rhel8-container" \
-      name="openshift-serverless-1/svls-must-gather-rhel8" \
+      name="openshift-serverless-1/serverless-must-gather-rhel8" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.35::el8" \
       version=1.35.2 \
       summary="Red Hat OpenShift Serverless 1 Must Gather" \
       maintainer="serverless-support@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
