### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for serverless-ingress-135

### DIFF
--- a/serving/ingress/Dockerfile
+++ b/serving/ingress/Dockerfile
@@ -23,13 +23,14 @@ USER 65532
 
 LABEL \
       com.redhat.component="openshift-serverless-1-ingress-rhel8-container" \
-      name="openshift-serverless-1/ingress-rhel8" \
+      name="openshift-serverless-1/serverless-ingress-rhel8" \
       version=$VERSION \
       summary="Red Hat OpenShift Serverless 1 Ingress" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Ingress" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Ingress" \
       io.k8s.description="Red Hat OpenShift Serverless Ingress" \
-      io.openshift.tags="ingress"
+      io.openshift.tags="ingress" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.35::el8"
 
 ENTRYPOINT ["/usr/bin/ingress"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
