### PR TITLE
[release-1.37] fix(upgrades-tests): longer customizable timeout for cluster upgrade

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -566,7 +566,7 @@ EOF
     # Make sure the cluster upgrade is run with latest version of Serverless as
     # the Serverless upgrade tests leave the product at the previous version (after downgrade).
     approve_csv "$CURRENT_CSV" "$OLM_UPGRADE_CHANNEL"
-    go_test_e2e -run=TestClusterUpgrade -timeout=220m "${common_opts[@]}" \
+    go_test_e2e -run=TestClusterUpgrade -timeout="${CLUSTER_UPGRADE_TIMEOUT:-300m}" "${common_opts[@]}" \
       --openshiftimage="${UPGRADE_OCP_IMAGE}" \
       --upgradeopenshift
   fi


### PR DESCRIPTION
Fixes JIRA https://issues.redhat.com/browse/SRVCOM-4021

- :bug: longer customizable timeout for cluster upgrade
