### PR TITLE
SRVCOM-4302: Set default metrics-protocol to prometheus

### DIFF
--- a/openshift-knative-operator/pkg/eventing/extension_test.go
+++ b/openshift-knative-operator/pkg/eventing/extension_test.go
@@ -425,6 +425,11 @@ func ke(mods ...func(*operatorv1beta1.KnativeEventing)) *operatorv1beta1.Knative
 		Spec: operatorv1beta1.KnativeEventingSpec{
 			SinkBindingSelectionMode: "inclusion",
 			CommonSpec: base.CommonSpec{
+				Config: base.ConfigMapData{
+					monitoring.ObservabilityCMName: {
+						monitoring.ObservabilityBackendKey: "prometheus",
+					},
+				},
 				HighAvailability: &base.HighAvailability{
 					Replicas: ptr.To(int32(2)),
 				},

--- a/openshift-knative-operator/pkg/monitoring/helpers.go
+++ b/openshift-knative-operator/pkg/monitoring/helpers.go
@@ -65,6 +65,9 @@ func injectNamespaceWithSubject(resourceNamespace string, subjectNamespace strin
 
 func reconcileMonitoring(ctx context.Context, api kubernetes.Interface, spec *base.CommonSpec, ns string) error {
 	if ShouldEnableMonitoring(spec.GetConfig()) {
+		// Set default metrics protocol to prometheus for backward compatibility with pre-OTEL Knative
+		common.ConfigureIfUnset(spec, ObservabilityCMName, ObservabilityBackendKey, "prometheus")
+
 		if err := reconcileMonitoringLabelOnNamespace(ctx, ns, api, true); err != nil {
 			return fmt.Errorf("failed to enable monitoring %w ", err)
 		}

--- a/openshift-knative-operator/pkg/serving/extension.go
+++ b/openshift-knative-operator/pkg/serving/extension.go
@@ -179,6 +179,9 @@ func (e *extension) Reconcile(ctx context.Context, comp base.KComponent) error {
 	// independent from upstream default changes.
 	common.ConfigureIfUnset(&ks.Spec.CommonSpec, "network", "autocreateClusterDomainClaims", "true")
 
+	// Set default request-metrics-protocol to prometheus for backward compatibility with pre-OTEL Knative
+	common.ConfigureIfUnset(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, "request-metrics-protocol", "prometheus")
+
 	// Temporary fix for SRVKS-743
 	if ks.Spec.Ingress.Istio.Enabled {
 		common.ConfigureIfUnset(&ks.Spec.CommonSpec, monitoring.ObservabilityCMName, monitoring.ObservabilityBackendKey, "none")

--- a/openshift-knative-operator/pkg/serving/extension_test.go
+++ b/openshift-knative-operator/pkg/serving/extension_test.go
@@ -558,6 +558,10 @@ func ks(mods ...func(*operatorv1beta1.KnativeServing)) *operatorv1beta1.KnativeS
 						"autocreateClusterDomainClaims": "true",
 						"defaultExternalScheme":         "https",
 					},
+					monitoring.ObservabilityCMName: {
+						monitoring.ObservabilityBackendKey: "prometheus",
+						"request-metrics-protocol":         "prometheus",
+					},
 				},
 				Registry: base.Registry{
 					Default: "bar2",


### PR DESCRIPTION
After the Knative 1.21 OTEL migration, the upstream default for metrics-protocol changed from implicitly enabled to 'none'. This caused ServiceMonitors to be created but metrics endpoints to be unreachable, triggering monitoring alerts.

This change sets sensible defaults when users have an empty KnativeServing or KnativeEventing .spec.config, maintaining backward compatibility with pre-1.21 behavior while still allowing users to explicitly configure the protocol.

Fixes JIRA #SRVCOM-4302