### PR TITLE
[SRVCOM-4102] add OLMv1 support to upgrade tests

### DIFF
--- a/hack/lib/olmv1_catalog.bash
+++ b/hack/lib/olmv1_catalog.bash
@@ -158,20 +158,12 @@ function wait_for_clusterextension_ready {
 
   logger.info "Wait for ClusterExtension to be ready"
 
-  # Wait for Progressing condition with Succeeded reason
-  if ! timeout 600 "[[ \$(oc get clusterextension ${OLMV1_CLUSTEREXTENSION_NAME} -o jsonpath='{.status.conditions[?(@.type==\"Progressing\")].reason}') != Succeeded ]]" ; then
+  # Loop while either version doesn't match OR Progressing reason isn't Succeeded.
+  # timeout stops when the expression returns non-zero (i.e. both conditions are met).
+  if ! timeout 600 "[[ \$(oc get clusterextension ${OLMV1_CLUSTEREXTENSION_NAME} -o jsonpath='{.status.install.bundle.version}') != ${version} || \$(oc get clusterextension ${OLMV1_CLUSTEREXTENSION_NAME} -o jsonpath='{.status.conditions[?(@.type==\"Progressing\")].reason}') != Succeeded ]]"; then
     oc get clusterextension "${OLMV1_CLUSTEREXTENSION_NAME}" -o yaml || true
-    logger.error "ClusterExtension failed to become ready"
+    logger.error "ClusterExtension failed to reach version ${version}"
     return 105
-  fi
-
-  # Verify installed bundle version matches requested version
-  local installed_version
-  installed_version=$(oc get clusterextension "${OLMV1_CLUSTEREXTENSION_NAME}" -o jsonpath='{.status.install.bundle.version}')
-
-  if [[ "$installed_version" != "$version" ]]; then
-    logger.error "Installed version ($installed_version) does not match requested version ($version)"
-    return 106
   fi
 
   logger.success "ClusterExtension is ready with version ${version}"

--- a/hack/lib/serverless.bash
+++ b/hack/lib/serverless.bash
@@ -124,6 +124,14 @@ function delete_catalog {
   fi
 }
 
+function ensure_serverless_version {
+  if [[ "${OLM_VERSION}" == "v1" ]]; then
+    upgrade_serverless_olmv1 "$1"
+  else
+    approve_csv "$@"
+  fi
+}
+
 function install_knative_resources {
   local serverless_version
   serverless_version=${1:?Pass serverless version as arg[1]}

--- a/test/clusterextension.go
+++ b/test/clusterextension.go
@@ -1,0 +1,92 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var clusterExtensionGVR = schema.GroupVersionResource{
+	Group:    "olm.operatorframework.io",
+	Version:  "v1",
+	Resource: "clusterextensions",
+}
+
+const ClusterExtensionName = "serverless-operator"
+
+func PatchClusterExtensionVersion(ctx *Context, name, version string) error {
+	patch := []byte(fmt.Sprintf(`{"spec":{"source":{"catalog":{"version":"%s"}}}}`, version))
+	_, err := ctx.Clients.Dynamic.Resource(clusterExtensionGVR).Patch(
+		context.Background(), name, types.MergePatchType, patch, metav1.PatchOptions{})
+	return err
+}
+
+func PatchClusterExtensionVersionWithPolicy(ctx *Context, name, version, policy string) error {
+	patch := []byte(fmt.Sprintf(
+		`{"spec":{"source":{"catalog":{"version":"%s","upgradeConstraintPolicy":"%s"}}}}`,
+		version, policy))
+	_, err := ctx.Clients.Dynamic.Resource(clusterExtensionGVR).Patch(
+		context.Background(), name, types.MergePatchType, patch, metav1.PatchOptions{})
+	return err
+}
+
+func WaitForClusterExtensionReady(ctx *Context, name, version string, timeout time.Duration) error {
+	if err := wait.PollUntilContextTimeout(context.Background(), Interval, timeout, true, func(_ context.Context) (bool, error) {
+		ce, err := ctx.Clients.Dynamic.Resource(clusterExtensionGVR).Get(
+			context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		// Check installed version matches requested version.
+		installed, found, err := unstructured.NestedString(ce.Object, "status", "install", "bundle", "version")
+		if err != nil || !found || installed != version {
+			return false, nil
+		}
+
+		// Check Progressing condition indicates success.
+		conditions, found, err := unstructured.NestedSlice(ce.Object, "status", "conditions")
+		if err != nil || !found {
+			return false, nil
+		}
+
+		for _, c := range conditions {
+			cond, ok := c.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			condType, _, _ := unstructured.NestedString(cond, "type")
+			reason, _, _ := unstructured.NestedString(cond, "reason")
+			if condType == "Progressing" && reason == "Succeeded" {
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("ClusterExtension %s did not reach version %s: %w", name, version, err)
+	}
+	return nil
+}
+
+func GetClusterExtensionInstalledVersion(ctx *Context, name string) (string, error) {
+	ce, err := ctx.Clients.Dynamic.Resource(clusterExtensionGVR).Get(
+		context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	version, found, err := unstructured.NestedString(ce.Object, "status", "install", "bundle", "version")
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("version not found in ClusterExtension %s status", name)
+	}
+	return version, nil
+}

--- a/test/flags.go
+++ b/test/flags.go
@@ -36,6 +36,7 @@ type FlagsStruct struct {
 	OpenShiftImage          string // Target OpenShift image for upgrades
 	UpgradeOpenShift        bool   // Whether to upgrade the OpenShift cluster
 	SkipServingPreUpgrade   bool   // Whether to skip Serving pre-upgrade tests
+	OLMVersion              string // OLM version: "v0" or "v1"
 }
 
 func initializeFlags() *FlagsStruct {
@@ -77,6 +78,8 @@ func initializeFlags() *FlagsStruct {
 		"Whether to upgrade OpenShift cluster during upgrade tests.")
 	flag.BoolVar(&f.SkipServingPreUpgrade, "skipservingpreupgrade", false,
 		"Whether to skip Serving pre-upgrade tests during upgrade tests.")
+	flag.StringVar(&f.OLMVersion, "olmversion", "v0",
+		"OLM version to use for upgrade tests: \"v0\" or \"v1\".")
 
 	return &f
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -543,6 +543,7 @@ EOF
     "--upgradechannel=${OLM_UPGRADE_CHANNEL}" \
     "--csv=${CURRENT_CSV}" \
     "--csvprevious=${PREVIOUS_CSV}" \
+    "--olmversion=${OLM_VERSION}" \
     "--servingversion=${KNATIVE_SERVING_VERSION/knative-v/}" \
     "--eventingversion=${KNATIVE_EVENTING_VERSION/knative-v/}" \
     "--kafkaversion=${KNATIVE_EVENTING_KAFKA_BROKER_VERSION/knative-v/}" \
@@ -580,7 +581,7 @@ EOF
     oc create namespace serving-tests
     # Make sure the cluster upgrade is run with latest version of Serverless as
     # the Serverless upgrade tests leave the product at the previous version (after downgrade).
-    approve_csv "$CURRENT_CSV" "$OLM_UPGRADE_CHANNEL"
+    ensure_serverless_version "$CURRENT_CSV" "$OLM_UPGRADE_CHANNEL"
     go_test_e2e -run=TestClusterUpgrade -timeout="${CLUSTER_UPGRADE_TIMEOUT:-300m}" "${common_opts[@]}" \
       --openshiftimage="${UPGRADE_OCP_IMAGE}" \
       --upgradeopenshift
@@ -643,7 +644,8 @@ function kitchensink_upgrade_tests {
      --images.producer.file="${images_file}" \
      --imagetemplate="${IMAGE_TEMPLATE}" \
      --csv="$(kitchensink_csvs)" \
-     --upgradechannel="${OLM_UPGRADE_CHANNEL}"
+     --upgradechannel="${OLM_UPGRADE_CHANNEL}" \
+     --olmversion="${OLM_VERSION}"
 
   logger.success 'Kitchensink upgrade tests passed'
 }
@@ -665,6 +667,7 @@ function kitchensink_upgrade_stress_tests {
      --catalogsource="${OLM_SOURCE}" \
      --upgradechannel="${OLM_UPGRADE_CHANNEL}" \
      --csv="${CURRENT_CSV}" \
+     --olmversion="${OLM_VERSION}" \
      --servingversion="${KNATIVE_SERVING_VERSION/knative-v/}" \
      --eventingversion="${KNATIVE_EVENTING_VERSION/knative-v/}" \
      --kafkaversion="${KNATIVE_EVENTING_KAFKA_BROKER_VERSION/knative-v/}"

--- a/test/upgrade/installation/serverless.go
+++ b/test/upgrade/installation/serverless.go
@@ -8,164 +8,60 @@ import (
 	"github.com/openshift-knative/serverless-operator/test"
 	"github.com/openshift-knative/serverless-operator/test/v1alpha1"
 	"github.com/openshift-knative/serverless-operator/test/v1beta1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
 	DefaultInstallPlanTimeout = 15 * time.Minute
 )
 
-func UpgradeServerlessTo(ctx *test.Context, csv, source string, timeout time.Duration) error {
-	if _, err := test.UpdateSubscriptionChannelSource(ctx, test.Flags.Subscription, test.Flags.UpgradeChannel, source); err != nil {
-		return err
-	}
+type ServerlessLifecycle interface {
+	Upgrade(ctx *test.Context) error
+	UpgradeTo(ctx *test.Context, version string, timeout time.Duration) error
+	Downgrade(ctx *test.Context) error
+}
 
-	installPlan, err := test.WaitForInstallPlan(ctx, test.OperatorsNamespace, csv, source, timeout)
-	if err != nil {
-		if !wait.Interrupted(err) {
-			return err
-		}
-		if source != test.ServerlessOperatorPackage {
-			// InstallPlan not found in the original catalog source, try the one that was just built.
-			if _, err := test.UpdateSubscriptionChannelSource(ctx,
-				test.Flags.Subscription, test.Flags.UpgradeChannel, test.ServerlessOperatorPackage); err != nil {
-				return err
-			}
-			installPlan, err = test.WaitForInstallPlan(ctx,
-				test.OperatorsNamespace, csv, test.ServerlessOperatorPackage, timeout)
-		}
-		if err != nil {
-			return err
-		}
+func NewServerlessLifecycle(olmVersion string) ServerlessLifecycle {
+	if olmVersion == "v1" {
+		return &clusterExtensionLifecycle{}
 	}
+	return &subscriptionLifecycle{}
+}
 
-	if err := test.ApproveInstallPlan(ctx, installPlan.Name); err != nil {
-		return err
-	}
-	if _, err := test.WaitForClusterServiceVersionState(ctx, csv, test.OperatorsNamespace, test.IsCSVSucceeded); err != nil {
-		return err
-	}
-
-	servingInStateFunc := v1beta1.IsKnativeServingWithVersionReady(strings.TrimPrefix(test.Flags.ServingVersion, "v"))
-	if len(test.Flags.ServingVersion) == 0 {
+func WaitForKnativeComponentsReady(ctx *test.Context, servingVersion, eventingVersion, kafkaVersion string) error {
+	servingInStateFunc := v1beta1.IsKnativeServingWithVersionReady(strings.TrimPrefix(servingVersion, "v"))
+	if len(servingVersion) == 0 {
 		servingInStateFunc = v1beta1.IsKnativeServingReady
 	}
-	knativeServing := test.ServingNamespace
 	if _, err := v1beta1.WaitForKnativeServingState(ctx,
-		knativeServing,
-		knativeServing,
-		servingInStateFunc,
-	); err != nil {
-		return fmt.Errorf("serving upgrade failed: %w", err)
-	}
-
-	eventingInStateFunc := v1beta1.IsKnativeEventingWithVersionReady(strings.TrimPrefix(test.Flags.EventingVersion, "v"))
-	if len(test.Flags.EventingVersion) == 0 {
-		eventingInStateFunc = v1beta1.IsKnativeEventingReady
-	}
-	knativeEventing := test.EventingNamespace
-	if _, err := v1beta1.WaitForKnativeEventingState(ctx,
-		knativeEventing,
-		knativeEventing,
-		eventingInStateFunc,
-	); err != nil {
-		return fmt.Errorf("eventing upgrade failed: %w", err)
-	}
-
-	kafkaInStateFunc := v1alpha1.IsKnativeKafkaWithVersionReady(strings.TrimPrefix(test.Flags.KafkaVersion, "v"))
-	if len(test.Flags.KafkaVersion) == 0 {
-		kafkaInStateFunc = v1alpha1.IsKnativeKafkaReady
-	}
-	if _, err := v1alpha1.WaitForKnativeKafkaState(ctx,
-		"knative-kafka",
-		knativeEventing,
-		kafkaInStateFunc,
-	); err != nil {
-		return fmt.Errorf("knative kafka upgrade failed: %w", err)
-	}
-
-	return nil
-}
-
-func UpgradeServerless(ctx *test.Context) error {
-	return UpgradeServerlessTo(ctx, test.Flags.CSV, test.Flags.CatalogSource, DefaultInstallPlanTimeout)
-}
-
-func DowngradeServerless(ctx *test.Context) error {
-	const subscription = "serverless-operator"
-
-	if err := test.DeleteSubscription(ctx, subscription, test.OperatorsNamespace); err != nil {
-		return err
-	}
-
-	if err := test.DeleteClusterServiceVersion(ctx, test.Flags.CSV, test.OperatorsNamespace); err != nil {
-		return err
-	}
-
-	if err := test.WaitForServerlessOperatorsDeleted(ctx); err != nil {
-		return err
-	}
-
-	// Ensure complete clean up to prevent https://issues.redhat.com/browse/SRVCOM-2203
-	if err := test.DeleteNamespace(ctx, test.OperatorsNamespace); err != nil {
-		return err
-	}
-
-	if _, err := test.CreateNamespace(ctx, test.OperatorsNamespace); err != nil {
-		return err
-	}
-
-	if _, err := test.CreateOperatorGroup(ctx, "serverless", test.OperatorsNamespace); err != nil {
-		return err
-	}
-
-	if _, err := test.CreateSubscription(ctx, subscription, test.Flags.CSVPrevious); err != nil {
-		return err
-	}
-
-	installPlan, err := test.WaitForInstallPlan(ctx, test.OperatorsNamespace, test.Flags.CSVPrevious, test.Flags.CatalogSource, DefaultInstallPlanTimeout)
-	if err != nil {
-		return err
-	}
-
-	if err := test.ApproveInstallPlan(ctx, installPlan.Name); err != nil {
-		return err
-	}
-
-	if _, err := test.WaitForClusterServiceVersionState(ctx, test.Flags.CSVPrevious, test.OperatorsNamespace, test.IsCSVSucceeded); err != nil {
-		return err
-	}
-
-	knativeServing := test.ServingNamespace
-	servingVersion := strings.TrimPrefix(test.Flags.ServingVersionPrevious, "v")
-	servingInStateFunc := v1beta1.IsKnativeServingWithVersionReady(servingVersion)
-	if _, err := v1beta1.WaitForKnativeServingState(ctx,
-		knativeServing,
-		knativeServing,
+		test.ServingNamespace,
+		test.ServingNamespace,
 		servingInStateFunc,
 	); err != nil {
 		return fmt.Errorf("expected ready KnativeServing at version %s: %w", servingVersion, err)
 	}
 
-	knativeEventing := test.EventingNamespace
-	eventingVersion := strings.TrimPrefix(test.Flags.EventingVersionPrevious, "v")
-	eventingInStateFunc := v1beta1.IsKnativeEventingWithVersionReady(eventingVersion)
+	eventingInStateFunc := v1beta1.IsKnativeEventingWithVersionReady(strings.TrimPrefix(eventingVersion, "v"))
+	if len(eventingVersion) == 0 {
+		eventingInStateFunc = v1beta1.IsKnativeEventingReady
+	}
 	if _, err := v1beta1.WaitForKnativeEventingState(ctx,
-		knativeEventing,
-		knativeEventing,
+		test.EventingNamespace,
+		test.EventingNamespace,
 		eventingInStateFunc,
 	); err != nil {
 		return fmt.Errorf("expected ready KnativeEventing at version %s: %w", eventingVersion, err)
 	}
 
-	knativeKafkaVersion := strings.TrimPrefix(test.Flags.KafkaVersionPrevious, "v")
-	kafkaInStateFunc := v1alpha1.IsKnativeKafkaWithVersionReady(knativeKafkaVersion)
+	kafkaInStateFunc := v1alpha1.IsKnativeKafkaWithVersionReady(strings.TrimPrefix(kafkaVersion, "v"))
+	if len(kafkaVersion) == 0 {
+		kafkaInStateFunc = v1alpha1.IsKnativeKafkaReady
+	}
 	if _, err := v1alpha1.WaitForKnativeKafkaState(ctx,
 		"knative-kafka",
-		knativeEventing,
+		test.EventingNamespace,
 		kafkaInStateFunc,
 	); err != nil {
-		return fmt.Errorf("expected ready KnativeKafka at version %s: %w", knativeKafkaVersion, err)
+		return fmt.Errorf("expected ready KnativeKafka at version %s: %w", kafkaVersion, err)
 	}
 
 	return nil

--- a/test/upgrade/installation/serverless_olmv0.go
+++ b/test/upgrade/installation/serverless_olmv0.go
@@ -1,0 +1,100 @@
+package installation
+
+import (
+	"time"
+
+	"github.com/openshift-knative/serverless-operator/test"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type subscriptionLifecycle struct{}
+
+func (l *subscriptionLifecycle) UpgradeTo(ctx *test.Context, version string, timeout time.Duration) error {
+	source := test.Flags.CatalogSource
+
+	if _, err := test.UpdateSubscriptionChannelSource(ctx, test.Flags.Subscription, test.Flags.UpgradeChannel, source); err != nil {
+		return err
+	}
+
+	installPlan, err := test.WaitForInstallPlan(ctx, test.OperatorsNamespace, version, source, timeout)
+	if err != nil {
+		if !wait.Interrupted(err) {
+			return err
+		}
+		if source != test.ServerlessOperatorPackage {
+			// InstallPlan not found in the original catalog source, try the one that was just built.
+			if _, err := test.UpdateSubscriptionChannelSource(ctx,
+				test.Flags.Subscription, test.Flags.UpgradeChannel, test.ServerlessOperatorPackage); err != nil {
+				return err
+			}
+			installPlan, err = test.WaitForInstallPlan(ctx,
+				test.OperatorsNamespace, version, test.ServerlessOperatorPackage, timeout)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := test.ApproveInstallPlan(ctx, installPlan.Name); err != nil {
+		return err
+	}
+	if _, err := test.WaitForClusterServiceVersionState(ctx, version, test.OperatorsNamespace, test.IsCSVSucceeded); err != nil {
+		return err
+	}
+
+	return WaitForKnativeComponentsReady(ctx,
+		test.Flags.ServingVersion, test.Flags.EventingVersion, test.Flags.KafkaVersion)
+}
+
+func (l *subscriptionLifecycle) Upgrade(ctx *test.Context) error {
+	return l.UpgradeTo(ctx, test.Flags.CSV, DefaultInstallPlanTimeout)
+}
+
+func (l *subscriptionLifecycle) Downgrade(ctx *test.Context) error {
+	const subscription = "serverless-operator"
+
+	if err := test.DeleteSubscription(ctx, subscription, test.OperatorsNamespace); err != nil {
+		return err
+	}
+
+	if err := test.DeleteClusterServiceVersion(ctx, test.Flags.CSV, test.OperatorsNamespace); err != nil {
+		return err
+	}
+
+	if err := test.WaitForServerlessOperatorsDeleted(ctx); err != nil {
+		return err
+	}
+
+	// Ensure complete clean up to prevent https://issues.redhat.com/browse/SRVCOM-2203
+	if err := test.DeleteNamespace(ctx, test.OperatorsNamespace); err != nil {
+		return err
+	}
+
+	if _, err := test.CreateNamespace(ctx, test.OperatorsNamespace); err != nil {
+		return err
+	}
+
+	if _, err := test.CreateOperatorGroup(ctx, "serverless", test.OperatorsNamespace); err != nil {
+		return err
+	}
+
+	if _, err := test.CreateSubscription(ctx, subscription, test.Flags.CSVPrevious); err != nil {
+		return err
+	}
+
+	installPlan, err := test.WaitForInstallPlan(ctx, test.OperatorsNamespace, test.Flags.CSVPrevious, test.Flags.CatalogSource, DefaultInstallPlanTimeout)
+	if err != nil {
+		return err
+	}
+
+	if err := test.ApproveInstallPlan(ctx, installPlan.Name); err != nil {
+		return err
+	}
+
+	if _, err := test.WaitForClusterServiceVersionState(ctx, test.Flags.CSVPrevious, test.OperatorsNamespace, test.IsCSVSucceeded); err != nil {
+		return err
+	}
+
+	return WaitForKnativeComponentsReady(ctx,
+		test.Flags.ServingVersionPrevious, test.Flags.EventingVersionPrevious, test.Flags.KafkaVersionPrevious)
+}

--- a/test/upgrade/installation/serverless_olmv1.go
+++ b/test/upgrade/installation/serverless_olmv1.go
@@ -1,0 +1,45 @@
+package installation
+
+import (
+	"strings"
+	"time"
+
+	"github.com/openshift-knative/serverless-operator/test"
+)
+
+type clusterExtensionLifecycle struct{}
+
+func (l *clusterExtensionLifecycle) UpgradeTo(ctx *test.Context, version string, timeout time.Duration) error {
+	semver := strings.TrimPrefix(version, "serverless-operator.v")
+
+	if err := test.PatchClusterExtensionVersion(ctx, test.ClusterExtensionName, semver); err != nil {
+		return err
+	}
+
+	if err := test.WaitForClusterExtensionReady(ctx, test.ClusterExtensionName, semver, timeout); err != nil {
+		return err
+	}
+
+	return WaitForKnativeComponentsReady(ctx,
+		test.Flags.ServingVersion, test.Flags.EventingVersion, test.Flags.KafkaVersion)
+}
+
+func (l *clusterExtensionLifecycle) Upgrade(ctx *test.Context) error {
+	return l.UpgradeTo(ctx, test.Flags.CSV, DefaultInstallPlanTimeout)
+}
+
+func (l *clusterExtensionLifecycle) Downgrade(ctx *test.Context) error {
+	version := strings.TrimPrefix(test.Flags.CSVPrevious, "serverless-operator.v")
+
+	if err := test.PatchClusterExtensionVersionWithPolicy(
+		ctx, test.ClusterExtensionName, version, "SelfCertified"); err != nil {
+		return err
+	}
+
+	if err := test.WaitForClusterExtensionReady(ctx, test.ClusterExtensionName, version, DefaultInstallPlanTimeout); err != nil {
+		return err
+	}
+
+	return WaitForKnativeComponentsReady(ctx,
+		test.Flags.ServingVersionPrevious, test.Flags.EventingVersionPrevious, test.Flags.KafkaVersionPrevious)
+}

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -137,7 +137,8 @@ func TestKitchensink(t *testing.T) {
 				Installations: pkgupgrade.Installations{
 					UpgradeWith: []pkgupgrade.Operation{
 						pkgupgrade.NewOperation("UpgradeServerless", func(c pkgupgrade.Context) {
-							if err := installation.UpgradeServerlessTo(ctx, csv, test.Flags.CatalogSource, installation.DefaultInstallPlanTimeout); err != nil {
+							lifecycle := installation.NewServerlessLifecycle(test.Flags.OLMVersion)
+							if err := lifecycle.UpgradeTo(ctx, csv, installation.DefaultInstallPlanTimeout); err != nil {
 								c.T.Error("Serverless upgrade failed:", err)
 							}
 						}),

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -8,9 +8,10 @@ import (
 )
 
 func ServerlessUpgradeOperations(ctx *test.Context) []pkgupgrade.Operation {
+	lifecycle := installation.NewServerlessLifecycle(test.Flags.OLMVersion)
 	return []pkgupgrade.Operation{
 		pkgupgrade.NewOperation("UpgradeServerless", func(c pkgupgrade.Context) {
-			if err := installation.UpgradeServerless(ctx); err != nil {
+			if err := lifecycle.Upgrade(ctx); err != nil {
 				c.T.Error("Serverless upgrade failed:", err)
 			}
 		}),
@@ -18,9 +19,10 @@ func ServerlessUpgradeOperations(ctx *test.Context) []pkgupgrade.Operation {
 }
 
 func ServerlessDowngradeOperations(ctx *test.Context) []pkgupgrade.Operation {
+	lifecycle := installation.NewServerlessLifecycle(test.Flags.OLMVersion)
 	return []pkgupgrade.Operation{
 		pkgupgrade.NewOperation("DowngradeServerless", func(c pkgupgrade.Context) {
-			if err := installation.DowngradeServerless(ctx); err != nil {
+			if err := lifecycle.Downgrade(ctx); err != nil {
 				c.T.Error("Serverless downgrade failed:", err)
 			}
 		}),


### PR DESCRIPTION
Fixes JIRA [SRVCOM-4102](https://redhat.atlassian.net/browse/SRVCOM-4102)

## Proposed Changes

- :gift: Implement ServerlessLifecycle interface dispatching upgrade/downgrade operations to OLMv0 or OLMv1 based on --olmversion flag. Add ClusterExtension helpers and ensure_serverless_version bash dispatcher.

OLMv1 upgrade tests pass in our Jenkins job. OpenShift CI job will follow. 
