### PR TITLE
[release-1.37] patch the version of gotestsum

### DIFF
--- a/hack/patches/024-gotestsum-version.patch
+++ b/hack/patches/024-gotestsum-version.patch
@@ -1,0 +1,12 @@
+diff --git a/vendor/knative.dev/hack/library.sh b/vendor/knative.dev/hack/library.sh
+--- a/vendor/knative.dev/hack/library.sh
++++ b/vendor/knative.dev/hack/library.sh
+@@ -588,7 +588,7 @@
+   logfile="${logfile/.xml/.jsonl}"
+   echo "Running go test with args: ${go_test_args[*]}"
+   local gotest_retcode=0
+-  go_run gotest.tools/gotestsum@v1.11.0 \
++  go_run gotest.tools/gotestsum@v1.13.0 \
+     --format "${GO_TEST_VERBOSITY:-testname}" \
+     --junitfile "${xml}" \
+     --junitfile-testsuite-name relative \

--- a/test/eventing-kafka.bash
+++ b/test/eventing-kafka.bash
@@ -26,6 +26,9 @@ function upstream_knative_eventing_kafka_broker_e2e {
 
   cd "$KNATIVE_EVENTING_KAFKA_BROKER_HOME"
 
+  # TODO: Try to hack gotestsum version until we fix it in midstream EKB
+  patch -p1 < "${root_dir}/hack/patches/024-gotestsum-version.patch" || true
+
   export FIRST_EVENT_DELAY_ENABLED=false # Disable very slow test since it's already running in ekb CI
 
   export TEST_IMAGE_TEMPLATE="registry.ci.openshift.org/openshift/knative-eventing-kafka-broker-test-{{.Name}}:${KNATIVE_EVENTING_KAFKA_BROKER_VERSION}"

--- a/test/eventing.bash
+++ b/test/eventing.bash
@@ -32,6 +32,11 @@ function upstream_knative_eventing_e2e {
 function upstream_knative_eventing_e2e_mesh() {
   pushd "${KNATIVE_EVENTING_ISTIO_HOME}" || return $?
 
+  # TODO: Try to hack gotestsum version until we fix it in midstream EKB
+  local root_dir
+  root_dir="$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"
+  patch -p1 < "${root_dir}/hack/patches/024-gotestsum-version.patch" || true
+
   ./openshift/e2e-tests.sh || return $?
 
   popd || return $?

--- a/vendor/knative.dev/hack/library.sh
+++ b/vendor/knative.dev/hack/library.sh
@@ -588,7 +588,7 @@ function report_go_test() {
   logfile="${logfile/.xml/.jsonl}"
   echo "Running go test with args: ${go_test_args[*]}"
   local gotest_retcode=0
-  go_run gotest.tools/gotestsum@v1.11.0 \
+  go_run gotest.tools/gotestsum@v1.13.0 \
     --format "${GO_TEST_VERBOSITY:-testname}" \
     --junitfile "${xml}" \
     --junitfile-testsuite-name relative \


### PR DESCRIPTION
- :broom: Patch gotestsum to a version compatible with go 1.25