### PR TITLE
Added CRDs to must gather collection for easier use for analyze tools

### DIFF
--- a/must-gather/bin/gather_knative
+++ b/must-gather/bin/gather_knative
@@ -69,3 +69,6 @@ done
 
 NAMESPACE=$(${BIN} get pods --all-namespaces -l name=knative-openshift -o jsonpath="{.items[0].metadata.namespace}")
 ${BIN} adm inspect namespace ${NAMESPACE} --dest-dir=${LOGS_DIR}
+
+# Collect CRDs for use with omc
+${BIN} adm inspect customresourcedefinition.apiextensions.k8s.io --dest-dir=${LOGS_DIR}


### PR DESCRIPTION
Adding CRDs to must gather so when support get a must gather archive we can use omc with it instead of manually looking at the files

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
Add CRDs to must gather

- :gift: Add new feature

