### PR TITLE
fix grafana-dash-knative-eventing-channel query for kafkachannels

### DIFF
--- a/knative-operator/deploy/resources/dashboards/eventing/grafana-dash-knative-eventing-channel.yaml
+++ b/knative-operator/deploy/resources/dashboards/eventing/grafana-dash-knative-eventing-channel.yaml
@@ -1025,7 +1025,7 @@ data:
             "multi": false,
             "name": "namespace",
             "options": [],
-            "query": "label_values((kn_eventing_dispatch_latency_ms_count{job=\"kafka-channel-receiver-sm-service\", kn_kafkachannel_namespace!=\"unknown\"} OR kn_eventing_dispatch_duration_seconds_count{job=\"imc-dispatcher-sm-service\", }), kn_channel_namespace)",
+            "query": "label_values((label_replace(kn_eventing_dispatch_latency_ms_count{job=\"kafka-channel-receiver-sm-service\", kn_kafkachannel_namespace!=\"unknown\"}, \"kn_channel_namespace\", \"$1\", \"kn_kafkachannel_namespace\", \"(.*)\") OR kn_eventing_dispatch_duration_seconds_count{job=\"imc-dispatcher-sm-service\"}), kn_channel_namespace)",
             "refresh": 2,
             "regex": "",
             "sort": 1,


### PR DESCRIPTION
kn_eventing_dispatch_latency_ms_count has `kn_kafkachannel_namespace` , 
kn_eventing_dispatch_duration_seconds_count has `kn_channel_namespace`

So when using just `kn_channel_namespace` labels, we don't see the kafkachannel namespaces.

Use label_replace to rename the `kn_kafkachannel_namespace` labels to `kn_channel_namespace` for the namespace query.

- :broom: fix grafana-dash-knative-eventing-channel query for kafkachannels