### PR TITLE
Improve CSV generation by dynamically updating createdAt timestamp

### DIFF
--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -262,7 +262,10 @@ for name in "${!yaml_keys[@]}"; do
   yq write --inplace "$target" "$name" "${yaml_keys[$name]}"
 done
 
+yq write --inplace --style=double "$target" "metadata.annotations.createdAt" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
 for name in "${!vars[@]}"; do
   echo "Value: ${name} -> ${vars[$name]}"
   sed --in-place "s/__${name}__/${vars[${name}]}/" "$target"
 done
+echo "CSV generated successfully"


### PR DESCRIPTION
## Summary

This PR updates the CSV generation logic to dynamically set the `metadata.annotations.createdAt` field during CSV generation instead of relying on the static template value.

Additionally, the timestamp is written using double-quote YAML style to preserve the expected CSV formatting.

This is also needed due to recent Konflux changes where FIPS scanning exemption logic now evaluates bundle createdAt timestamps.
## Changes

* Generate `createdAt` timestamp dynamically using UTC time
* Ensure YAML output format remains:

  ```yaml
  createdAt: "2026-05-19T11:41:07Z"
  ```
* Keep existing CSV generation behavior unchanged

## Context

Recent Konflux changes introduced logic to exempt pre-cutoff bundles from FIPS scanning checks:

Exempts pre-cutoff (before 2025-01-31) bundles with qualifying Red Hat subscriptions from FIPS scanning.

Having an up-to-date createdAt timestamp ensures newly generated bundles are evaluated correctly by the updated validation logic.

## Example

Before: Fixed value

```yaml
createdAt: "2020-04-20T17:00:00Z"
```

After:

```yaml
createdAt: "2026-05-19T11:41:07Z"
```
more info- https://github.com/konflux-ci/build-definitions/pull/3407 and  https://redhat.atlassian.net/browse/EC-1694
cc @dsimansk 