### PR TITLE
[main] Improve generated file validation logic in verify-diff.sh

### DIFF
--- a/hack/verify-diff.sh
+++ b/hack/verify-diff.sh
@@ -1,71 +1,117 @@
 #!/usr/bin/env bash
 
-# Define the files to exclude
-readonly EXCLUDE_FILES=(
+set -euo pipefail
+
+# Generated Files that are allowed to change.
+# Changes are still validated against allowed diff patterns below.
+readonly -a EXCLUDE_FILES=(
   'olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml'
   'olm-catalog/serverless-operator-index/Dockerfile'
   'test/images-rekt.yaml'
-  '.konflux-release/*'
-)
-# Define the patterns to exclude
-readonly EXCLUDE_PATTERNS=(
-  '*sha256:*'
-  '*revision: *'
-  'url: \"https://github.com/openshift-knative/.*(\.git)?\"' # some repos in the override-snapshot have the .git suffix, some not ¯\_(ツ)_/¯
-  'name: serverless-operator-.*-override-snapshot-.*'
 )
 
-# Function to check if a file should be excluded
-function should_exclude() {
-  local file="$1"
+# Directories allowed to change
+readonly -a EXCLUDE_DIRS=(
+  '.konflux-release/'
+)
 
-  diff="$(git --no-pager -c color.ui=never diff --unified=0 "$file" | grep '^[+-][\ a-z]')"
-  while IFS= read -r line; do
-    line_matched_pattern=false
-    for pattern in "${EXCLUDE_PATTERNS[@]}"; do
-      # shellcheck disable=SC2053
-      if  [[ $line == $pattern || $line =~ $pattern ]]; then
-        echo "Excluding line $line since it matches pattern $pattern"
-        line_matched_pattern=true
-        break
-      fi
-    done
+# Allowed diff patterns inside excluded files.
+readonly -a EXCLUDE_PATTERNS=(
+  '^[+-].*sha256:'
+  '^[+-].*revision: '
+  '^[+-].*createdAt: '
+  '^[+-].*url: "https://github.com/openshift-knative/.*(\.git)?"'
+  '^[+-].*name: serverless-operator-.*-override-snapshot-.*'
+)
 
-    if [[ "$line_matched_pattern" == "false" ]]; then
-      echo "line '$line' doesn't match any of the patterns. Failing the exclude check"
-      return 1
-    fi
-
-  done <<< "$diff"
-
-  return 0
-}
-
-# shellcheck disable=SC2016
 function debug_log_fail() {
   echo '::debug::Running `git status`'
   git -c color.status=always status
+
   echo '::debug::Running `git diff`'
   git --no-pager -c color.ui=always diff
+
   echo '::error::Not all generated files are committed. Run `make generated-files` and commit files.'
   echo '::warning::`make generated-files` needs to be run on GOPATH due to https://github.com/knative/pkg/issues/1287'
 }
 
-# shellcheck disable=SC2143
-if [ -n "$(git status --porcelain | grep -v -E "$(IFS=\|; echo "${EXCLUDE_FILES[*]}")")" ]; then
-  debug_log_fail
-  exit 33
-fi
+function is_excluded_file() {
+  local file="$1"
 
-# shellcheck disable=SC2143
-if [ -n "$(git status --porcelain | grep -E "$(IFS=\|; echo "${EXCLUDE_FILES[*]}")")" ]; then
-  echo 'Excluded files are different'
+  # Exact file matches
+  for excluded in "${EXCLUDE_FILES[@]}"; do
+    if [[ "$file" == "$excluded" ]]; then
+      return 0
+    fi
+  done
 
-  git diff --name-only | while read -r file; do
-    if ! should_exclude "$file"; then
-      git --no-pager -c color.ui=always diff "$file"
+  # Directory prefix matches
+  for dir in "${EXCLUDE_DIRS[@]}"; do
+    if [[ "$file" == "$dir"* ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+function validate_excluded_file_diff() {
+  local file="$1"
+
+  local diff_lines
+
+  diff_lines=$(
+    git --no-pager diff --unified=0 -- "$file" \
+      | grep -E '^[+-]' \
+      | grep -vE '^(\+\+\+|---|@@)' || true
+  )
+
+  # No relevant diff lines
+  [[ -z "$diff_lines" ]] && return 0
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    local matched=false
+
+    for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+      if [[ "$line" =~ $pattern ]]; then
+        matched=true
+        break
+      fi
+    done
+
+    if [[ "$matched" == "false" ]]; then
+      echo "line '$line' doesn't match any allowed patterns"
+      return 1
+    fi
+
+  done <<< "$diff_lines"
+
+  return 0
+}
+# Exit early when there are no changes
+git diff --quiet && exit 0
+
+# Collect changed files safely
+mapfile -t changed_files < <(git diff --name-only)
+
+# Fail if unexpected files changed
+for file in "${changed_files[@]}"; do
+  if ! is_excluded_file "$file"; then
+    echo "Unexpected modified file: $file"
+    debug_log_fail
+    exit 33
+  fi
+done
+
+# Validate allowed diffs in excluded files
+for file in "${changed_files[@]}"; do
+  if is_excluded_file "$file"; then
+    if ! validate_excluded_file_diff "$file"; then
+      git --no-pager -c color.ui=always diff -- "$file"
       debug_log_fail
       exit 33
     fi
-  done
-fi
+  fi
+done


### PR DESCRIPTION
## Summary

This PR refactors and hardens `hack/verify-diff.sh` used for generated file validation in CI.

The previous implementation had several correctness and reliability issues around diff handling, exclusion matching, and shell behavior. This update improves the validation logic while keeping the original intent of allowing expected generated artifact drift.

## Changes

### Fixed incorrect subshell exit behavior

The previous implementation used:

```bash
git diff --name-only | while read -r file; do
```

Because the loop executed in a subshell, `exit 33` only exited the subshell instead of the main script in some cases.

The new implementation avoids pipe-based loops and uses safer iteration logic.

---

### Added support for `createdAt` changes

Generated CSV manifests can update the `createdAt` field during regeneration, which previously caused CI failures.

Allowed diff patterns now include:

* `createdAt`
* `sha256` image digest updates
* `revision`
* override snapshot names
* expected openshift-knative repository URL updates

---

### Replaced fragile grep-based exclusion matching

The previous script dynamically constructed regex expressions from file paths using `grep -E`, which was error-prone and difficult to maintain.

The new implementation uses explicit Bash-based file matching for:

* exact file matches
* directory prefix matches

This improves correctness and readability.

---

### Improved diff validation logic

The previous implementation mixed glob matching and regex matching:

```bash
[[ $line == $pattern || $line =~ $pattern ]]
```

This was inconsistent and difficult to reason about.

The updated implementation uses regex-only matching with explicit allowed diff patterns.

---

### Reduced noisy CI logging

Removed unnecessary success/debug output while preserving detailed logs during failures.

Successful runs now stay mostly silent while failures still provide:

* `git status`
* full `git diff`
* actionable error messages

---

while preserving the original validation intent for generated artifacts.

cc @dsimansk 