### PR TITLE
don't scale down, allow skipping spot instances

### DIFF
--- a/hack/lib/scaleup.bash
+++ b/hack/lib/scaleup.bash
@@ -26,8 +26,8 @@ function scale_up_workers {
 
   logger.debug "ready machine count: ${current_total}, number of available zones: ${az_total}"
 
-  if [[ "${SCALE_UP}" == "${current_total}" ]]; then
-    logger.success "Cluster is already scaled up to ${SCALE_UP} replicas"
+  if [[ "${current_total}" -ge "${SCALE_UP}" ]]; then
+    logger.success "Cluster already has ${current_total} replicas (requested ${SCALE_UP}), no scaling needed"
     return 0
   fi
 
@@ -68,6 +68,11 @@ function cluster_scalable {
 
 # Convert existing machinesets to spot instances
 function use_spot_instances {
+  if [[ "${SKIP_SPOT_INSTANCES}" == "true" ]]; then
+    logger.info 'Skipping spot instances, SKIP_SPOT_INSTANCES is set to true.'
+    return
+  fi
+
   if ! cluster_scalable; then
     logger.info 'Skipping spot instances, the cluster is not scalable.'
     return

--- a/hack/lib/vars.bash
+++ b/hack/lib/vars.bash
@@ -46,6 +46,7 @@ export KUBECONFIG="${KUBECONFIG:-$(realpath ~/.kube/config)}"
 export OPENSHIFT_CI="${OPENSHIFT_CI:-}"
 export OPERATOR="${OPERATOR:-serverless-operator}"
 export SCALE_UP="${SCALE_UP:--1}"
+export SKIP_SPOT_INSTANCES="${SKIP_SPOT_INSTANCES:-false}"
 
 export OLM_NAMESPACE="${OLM_NAMESPACE:-openshift-marketplace}"
 export ON_CLUSTER_BUILDS_NAMESPACE="${ON_CLUSTER_BUILDS_NAMESPACE:-openshift-serverless-builds}"


### PR DESCRIPTION
- :gift: Add SKIP_SPOT_INSTANCES to skip the spottification
- :broom: Don't scale down if SCALE_UP is lower that the current cluster

Investigating current CI failures in our periodic runs, scaling and re-creation of the machinesets disrupts the cluster in ways that make it difficult to determine if it's OK to run the tests (e.g. Prometheus might take time to recover, while the tests using it are already running.

In Prow, we should not need any scale up or spot instance re-creation during the test runtime, they should instead configure the installer to create the cluster with the appropriate size and types.

For now at least disable scaling down (so that the job can configure enough workers in the install phase), and allow skipping the spottification explicitly. 
