### PR TITLE
kitchensink-upgrade, skip features only available in newer versions

### DIFF
--- a/olm-catalog/serverless-operator-index/Dockerfile
+++ b/olm-catalog/serverless-operator-index/Dockerfile
@@ -16,7 +16,7 @@ COPY olm-catalog/serverless-operator-index/index-bundles.yaml /index-bundles.yam
 RUN /bin/opm init serverless-operator --default-channel=stable --output yaml >> /configs/index.yaml
 RUN cat /index-bundles.yaml >> /configs/index.yaml
 RUN /bin/opm render --skip-tls-verify -o yaml \
-      quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-138/serverless-bundle@sha256:4259c65eebfbe03585639d73c3239f443c4dc16c598663f47d1ed544aa5eefef >> /configs/index.yaml
+      quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-138/serverless-bundle@sha256:b1657a3acdec74007b0d6693ea7d52fa9cd4662a77dc3beaa31984361b00bca8 >> /configs/index.yaml
 
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe

--- a/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
+++ b/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
@@ -72,13 +72,13 @@ metadata:
     capabilities: Full Lifecycle
     categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
     certified: "false"
-    createdAt: "2026-06-12T11:53:39Z"
+    createdAt: "2026-07-14T14:33:00Z"
     description: |-
       Deploy and manage event-driven serverless applications and functions using Knative.
     repository: https://github.com/openshift-knative/serverless-operator
     support: Red Hat
     olm.skipRange: '>1.37.1 <1.38.0'
-    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel9@sha256:a9f5c07d761909208a98abc3511e6ce7457a705d26f413222b068a2254b1d88e
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel9@sha256:db1ae782b76cefd4669973e01b44e77f5212fd0a900b17c35e43c8732d5d9779
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
@@ -838,7 +838,7 @@ spec:
                 serviceAccountName: knative-operator
                 containers:
                   - name: knative-operator
-                    image: registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel9-operator@sha256:0a61bc1a63e078b602e28ec9570caf208e819ea24b19a995465a14ea84414299
+                    image: registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel9-operator@sha256:2da67018c0976a246e4776f78cbbe89f0bb66a6a90980e4d60ed4ae6c8d649d3
                     readinessProbe:
                       periodSeconds: 1
                       httpGet:
@@ -1023,7 +1023,7 @@ spec:
                           - ALL
                 containers:
                   - name: knative-openshift
-                    image: registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel9@sha256:f078ea8b88d16be6ad6c8e322ae6b42e320cc5d4172d66d591f1122dcf98adb0
+                    image: registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel9@sha256:9c5750656a98ca95b5fa5ecbf53f6bc6b22dd13d555140b7aecf032eb327c036
                     imagePullPolicy: Always
                     readinessProbe:
                       httpGet:
@@ -1225,7 +1225,7 @@ spec:
                 serviceAccountName: knative-openshift-ingress
                 containers:
                   - name: knative-openshift-ingress
-                    image: registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel9@sha256:08bdcefc7dac163b7c2d943ed3253eae6001daac7059a580126e4af6d63b169e
+                    image: registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel9@sha256:dbabd8a985d2866e4d17135da3fdbdf92e91fa69a9ca523bedf124f572ebc3b4
                     imagePullPolicy: Always
                     ports:
                       - containerPort: 9090
@@ -1376,11 +1376,11 @@ spec:
         - knativeeventings.operator.knative.dev
   relatedImages:
     - name: "knative-operator"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel9-operator@sha256:0a61bc1a63e078b602e28ec9570caf208e819ea24b19a995465a14ea84414299"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-rhel9-operator@sha256:2da67018c0976a246e4776f78cbbe89f0bb66a6a90980e4d60ed4ae6c8d649d3"
     - name: "knative-openshift"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel9@sha256:f078ea8b88d16be6ad6c8e322ae6b42e320cc5d4172d66d591f1122dcf98adb0"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-kn-operator-rhel9@sha256:9c5750656a98ca95b5fa5ecbf53f6bc6b22dd13d555140b7aecf032eb327c036"
     - name: "knative-openshift-ingress"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel9@sha256:08bdcefc7dac163b7c2d943ed3253eae6001daac7059a580126e4af6d63b169e"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-ingress-rhel9@sha256:dbabd8a985d2866e4d17135da3fdbdf92e91fa69a9ca523bedf124f572ebc3b4"
     - name: "IMAGE_queue-proxy"
       image: "registry.redhat.io/openshift-serverless-1/kn-serving-queue-rhel9@sha256:d6aa8e4bb1bef2e41f19804af2c54ad2da9df274f1be5238101ebcf71e698373"
     - name: "IMAGE_activator"
@@ -1490,7 +1490,7 @@ spec:
     - name: "KAFKA_IMAGE_knative-kafka-storage-version-migrator__migrate"
       image: "registry.redhat.io/openshift-serverless-1/kn-eventing-migrate-rhel9@sha256:f067b7c14f89197d392334c95463130e1fa2cdf2c7a9c45d0344f7c166a90b0a"
     - name: "IMAGE_MUST_GATHER"
-      image: "registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel9@sha256:a9f5c07d761909208a98abc3511e6ce7457a705d26f413222b068a2254b1d88e"
+      image: "registry.redhat.io/openshift-serverless-1/serverless-must-gather-rhel9@sha256:db1ae782b76cefd4669973e01b44e77f5212fd0a900b17c35e43c8732d5d9779"
     - name: "IMAGE_KN_CLIENT_CLI_ARTIFACTS"
       image: "registry.redhat.io/openshift-serverless-1/kn-client-cli-artifacts-rhel9@sha256:82a3b18a4510978e23727266a122dada384abc5bf7eaebd606676941693bf140"
   replaces: serverless-operator.v1.37.1

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -11,13 +11,13 @@ arches:
     name: socat
     evr: 1.7.4.1-8.el9
     sourcerpm: socat-1.7.4.1-8.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rsync-3.2.5-7.el9_8.aarch64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rsync-3.2.5-7.el9_8.2.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 420142
-    checksum: sha256:39ba71d3677854505524df265ed828c7e00f026ecfe83df6ba86c7586588cae7
+    size: 425538
+    checksum: sha256:1e1fa89a9a4b843862fb9436295f187c55d314a9eb23d4bb8d6b07b2f41ba067
     name: rsync
-    evr: 3.2.5-7.el9_8
-    sourcerpm: rsync-3.2.5-7.el9_8.src.rpm
+    evr: 3.2.5-7.el9_8.2
+    sourcerpm: rsync-3.2.5-7.el9_8.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tar-1.34-11.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 904777
@@ -53,12 +53,12 @@ arches:
     checksum: sha256:4d83732bbf754e00d15133e15673230f41fbdae4a1cc27fba1cfb84744d0bf83
     name: socat
     evr: 1.7.4.1-8.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/r/rsync-3.2.5-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/r/rsync-3.2.5-7.el9_8.2.src.rpm
     repoid: ubi-9-for-aarch64-baseos-source-rpms
-    size: 1317820
-    checksum: sha256:881675c5bba9391d19536569a133069ffe0dd132468a04b3ea52fb697ebf926f
+    size: 1358189
+    checksum: sha256:37d0ee99d570df9eadf8244580dc078258ae4c9833ca3458cb6dc5851a7c37ca
     name: rsync
-    evr: 3.2.5-7.el9_8
+    evr: 3.2.5-7.el9_8.2
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/t/tar-1.34-11.el9.src.rpm
     repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 2294162
@@ -93,13 +93,13 @@ arches:
     name: socat
     evr: 1.7.4.1-8.el9
     sourcerpm: socat-1.7.4.1-8.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/r/rsync-3.2.5-7.el9_8.ppc64le.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/r/rsync-3.2.5-7.el9_8.2.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 453342
-    checksum: sha256:0570a89b350ada78d86d87afa90b101a7dc9791e5868b6f33fba00727440cd74
+    size: 459875
+    checksum: sha256:5e75716946f15a560fffc57967390adfdfc812d6b85997b9d712f041657cfd1f
     name: rsync
-    evr: 3.2.5-7.el9_8
-    sourcerpm: rsync-3.2.5-7.el9_8.src.rpm
+    evr: 3.2.5-7.el9_8.2
+    sourcerpm: rsync-3.2.5-7.el9_8.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/t/tar-1.34-11.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 945887
@@ -135,12 +135,12 @@ arches:
     checksum: sha256:4d83732bbf754e00d15133e15673230f41fbdae4a1cc27fba1cfb84744d0bf83
     name: socat
     evr: 1.7.4.1-8.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/r/rsync-3.2.5-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/r/rsync-3.2.5-7.el9_8.2.src.rpm
     repoid: ubi-9-for-ppc64le-baseos-source-rpms
-    size: 1317820
-    checksum: sha256:881675c5bba9391d19536569a133069ffe0dd132468a04b3ea52fb697ebf926f
+    size: 1358189
+    checksum: sha256:37d0ee99d570df9eadf8244580dc078258ae4c9833ca3458cb6dc5851a7c37ca
     name: rsync
-    evr: 3.2.5-7.el9_8
+    evr: 3.2.5-7.el9_8.2
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/t/tar-1.34-11.el9.src.rpm
     repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 2294162
@@ -175,13 +175,13 @@ arches:
     name: socat
     evr: 1.7.4.1-8.el9
     sourcerpm: socat-1.7.4.1-8.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/r/rsync-3.2.5-7.el9_8.s390x.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/r/rsync-3.2.5-7.el9_8.2.s390x.rpm
     repoid: ubi-9-for-s390x-baseos-rpms
-    size: 422461
-    checksum: sha256:e937047c63e4f5501bc08aeada17ec184254cdc2d5cd6a1a9e39b6477bf2bb72
+    size: 427539
+    checksum: sha256:d85d04511788214c554ff3068632f9e0edb39c8e7544f0610927f79d76677182
     name: rsync
-    evr: 3.2.5-7.el9_8
-    sourcerpm: rsync-3.2.5-7.el9_8.src.rpm
+    evr: 3.2.5-7.el9_8.2
+    sourcerpm: rsync-3.2.5-7.el9_8.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/t/tar-1.34-11.el9.s390x.rpm
     repoid: ubi-9-for-s390x-baseos-rpms
     size: 907745
@@ -217,12 +217,12 @@ arches:
     checksum: sha256:4d83732bbf754e00d15133e15673230f41fbdae4a1cc27fba1cfb84744d0bf83
     name: socat
     evr: 1.7.4.1-8.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/r/rsync-3.2.5-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/r/rsync-3.2.5-7.el9_8.2.src.rpm
     repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 1317820
-    checksum: sha256:881675c5bba9391d19536569a133069ffe0dd132468a04b3ea52fb697ebf926f
+    size: 1358189
+    checksum: sha256:37d0ee99d570df9eadf8244580dc078258ae4c9833ca3458cb6dc5851a7c37ca
     name: rsync
-    evr: 3.2.5-7.el9_8
+    evr: 3.2.5-7.el9_8.2
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/t/tar-1.34-11.el9.src.rpm
     repoid: ubi-9-for-s390x-baseos-source-rpms
     size: 2294162
@@ -257,13 +257,13 @@ arches:
     name: socat
     evr: 1.7.4.1-8.el9
     sourcerpm: socat-1.7.4.1-8.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rsync-3.2.5-7.el9_8.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rsync-3.2.5-7.el9_8.2.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 424707
-    checksum: sha256:6c1d064c38e4a3f4bcb756cb9ea0382cccf7a262433c286db45931d114074ff3
+    size: 430699
+    checksum: sha256:73c95e6404602b407a3cced5f1ae769a2c32b5b4ce9d646fc42617941863082c
     name: rsync
-    evr: 3.2.5-7.el9_8
-    sourcerpm: rsync-3.2.5-7.el9_8.src.rpm
+    evr: 3.2.5-7.el9_8.2
+    sourcerpm: rsync-3.2.5-7.el9_8.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tar-1.34-11.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 913256
@@ -299,12 +299,12 @@ arches:
     checksum: sha256:4d83732bbf754e00d15133e15673230f41fbdae4a1cc27fba1cfb84744d0bf83
     name: socat
     evr: 1.7.4.1-8.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/r/rsync-3.2.5-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/r/rsync-3.2.5-7.el9_8.2.src.rpm
     repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 1317820
-    checksum: sha256:881675c5bba9391d19536569a133069ffe0dd132468a04b3ea52fb697ebf926f
+    size: 1358189
+    checksum: sha256:37d0ee99d570df9eadf8244580dc078258ae4c9833ca3458cb6dc5851a7c37ca
     name: rsync
-    evr: 3.2.5-7.el9_8
+    evr: 3.2.5-7.el9_8.2
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/t/tar-1.34-11.el9.src.rpm
     repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 2294162

--- a/test/kitchensinke2e/broker_test.go
+++ b/test/kitchensinke2e/broker_test.go
@@ -11,11 +11,11 @@ import (
 const groupSize = 8
 
 func TestBrokerReadinessBrokerDLS(t *testing.T) {
-	testFeatureSet(t, features.BrokerFeatureSetWithBrokerDLS())
+	testFeatureSet(t, features.BrokerFeatureSetWithBrokerDLS(""))
 }
 
 func TestBrokerReadinessTriggerDLS(t *testing.T) {
-	testFeatureSet(t, features.BrokerFeatureSetWithTriggerDLS())
+	testFeatureSet(t, features.BrokerFeatureSetWithTriggerDLS(""))
 }
 
 func split(featureSet feature.FeatureSet, groupSize int) []feature.FeatureSet {

--- a/test/kitchensinke2e/channel_test.go
+++ b/test/kitchensinke2e/channel_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestChannelReadiness(t *testing.T) {
-	testFeatureSet(t, features.ChannelFeatureSet())
+	testFeatureSet(t, features.ChannelFeatureSet(""))
 }

--- a/test/kitchensinke2e/eventtransform_test.go
+++ b/test/kitchensinke2e/eventtransform_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestEventTransformReadiness(t *testing.T) {
-	testFeatureSet(t, features.EventTransformFeatureSet())
+	testFeatureSet(t, features.EventTransformFeatureSet(""))
 }

--- a/test/kitchensinke2e/features/broker.go
+++ b/test/kitchensinke2e/features/broker.go
@@ -104,29 +104,32 @@ func BrokerReadiness(index int, broker component, brokerDls component, triggers 
 	return f
 }
 
-func BrokerFeatureSetWithBrokerDLS() feature.FeatureSet {
-	return brokerFeatureSetWithBrokerDLS(false, 1)
+func BrokerFeatureSetWithBrokerDLS(version string) feature.FeatureSet {
+	return brokerFeatureSetWithBrokerDLS(false, 1, version)
 }
 
-func BrokerFeatureSetWithBrokerDLSShort() feature.FeatureSet {
-	return brokerFeatureSetWithBrokerDLS(true, 1)
+func BrokerFeatureSetWithBrokerDLSShort(version string) feature.FeatureSet {
+	return brokerFeatureSetWithBrokerDLS(true, 1, version)
 }
 
-func BrokerFeatureSetWithBrokerDLSStress() feature.FeatureSet {
-	return brokerFeatureSetWithBrokerDLS(true, NumDeployments)
+func BrokerFeatureSetWithBrokerDLSStress(version string) feature.FeatureSet {
+	return brokerFeatureSetWithBrokerDLS(true, NumDeployments, version)
 }
 
 // BrokerFeatureSetWithBrokerDLS returns all combinations of Broker X DeadLetterSinks,
 // each broker with all possible Triggers with the DeadLetterSink set on the Broker.
-func brokerFeatureSetWithBrokerDLS(short bool, times int) feature.FeatureSet {
+func brokerFeatureSetWithBrokerDLS(short bool, times int, version string) feature.FeatureSet {
 	dls := deadLetterSinks
 	trgs := triggers
 	if short {
 		dls = deadLetterSinksShort
 		trgs = triggersShort
 	}
-	features := make([]*feature.Feature, 0, len(brokers)*len(dls))
-	for _, broker := range brokers {
+	brks := filterByVersion(brokers, version)
+	dls = filterByVersion(dls, version)
+	trgs = filterByVersion(trgs, version)
+	features := make([]*feature.Feature, 0, len(brks)*len(dls))
+	for _, broker := range brks {
 		for _, deadLetterSink := range dls {
 			for i := 0; i < times; i++ {
 				features = append(features, BrokerReadiness(i, broker, deadLetterSink, trgs, nil))
@@ -139,29 +142,32 @@ func brokerFeatureSetWithBrokerDLS(short bool, times int) feature.FeatureSet {
 	}
 }
 
-func BrokerFeatureSetWithTriggerDLS() feature.FeatureSet {
-	return brokerFeatureSetWithTriggerDLS(false, 1)
+func BrokerFeatureSetWithTriggerDLS(version string) feature.FeatureSet {
+	return brokerFeatureSetWithTriggerDLS(false, 1, version)
 }
 
-func BrokerFeatureSetWithTriggerDLSShort() feature.FeatureSet {
-	return brokerFeatureSetWithTriggerDLS(true, 1)
+func BrokerFeatureSetWithTriggerDLSShort(version string) feature.FeatureSet {
+	return brokerFeatureSetWithTriggerDLS(true, 1, version)
 }
 
-func BrokerFeatureSetWithTriggerDLSStress() feature.FeatureSet {
-	return brokerFeatureSetWithTriggerDLS(true, NumDeployments)
+func BrokerFeatureSetWithTriggerDLSStress(version string) feature.FeatureSet {
+	return brokerFeatureSetWithTriggerDLS(true, NumDeployments, version)
 }
 
 // BrokerFeatureSetWithTriggerDLS returns all combinations of Broker X DeadLetterSinks,
 // each broker with all possible Triggers with the DeadLetterSink set on the Trigger.
-func brokerFeatureSetWithTriggerDLS(short bool, times int) feature.FeatureSet {
+func brokerFeatureSetWithTriggerDLS(short bool, times int, version string) feature.FeatureSet {
 	dls := deadLetterSinks
 	trgs := triggers
 	if short {
 		dls = deadLetterSinksShort
 		trgs = triggersShort
 	}
-	features := make([]*feature.Feature, 0, len(brokers)*len(dls))
-	for _, broker := range brokers {
+	brks := filterByVersion(brokers, version)
+	dls = filterByVersion(dls, version)
+	trgs = filterByVersion(trgs, version)
+	features := make([]*feature.Feature, 0, len(brks)*len(dls))
+	for _, broker := range brks {
 		for _, deadLetterSink := range dls {
 			for i := 0; i < times; i++ {
 				features = append(features, BrokerReadiness(i, broker, nil, trgs, deadLetterSink))

--- a/test/kitchensinke2e/features/channel.go
+++ b/test/kitchensinke2e/features/channel.go
@@ -66,19 +66,19 @@ func ChannelReadiness(index int, channel component, subscriber, reply, dls compo
 	return f
 }
 
-func ChannelFeatureSet() feature.FeatureSet {
-	return channelFeatureSet(false, 1)
+func ChannelFeatureSet(version string) feature.FeatureSet {
+	return channelFeatureSet(false, 1, version)
 }
 
-func ChannelFeatureSetShort() feature.FeatureSet {
-	return channelFeatureSet(true, 1)
+func ChannelFeatureSetShort(version string) feature.FeatureSet {
+	return channelFeatureSet(true, 1, version)
 }
 
-func ChannelFeatureSetStress() feature.FeatureSet {
-	return channelFeatureSet(true, NumDeployments)
+func ChannelFeatureSetStress(version string) feature.FeatureSet {
+	return channelFeatureSet(true, NumDeployments, version)
 }
 
-func channelFeatureSet(short bool, times int) feature.FeatureSet {
+func channelFeatureSet(short bool, times int, version string) feature.FeatureSet {
 	dls := deadLetterSinks
 	rep := replies
 	subscr := subscribers
@@ -87,6 +87,10 @@ func channelFeatureSet(short bool, times int) feature.FeatureSet {
 		rep = repliesShort
 		subscr = subscribersShort
 	}
+	chs := filterByVersion(channels, version)
+	dls = filterByVersion(dls, version)
+	rep = filterByVersion(rep, version)
+	subscr = filterByVersion(subscr, version)
 
 	type testCombination struct {
 		channel        component
@@ -98,21 +102,21 @@ func channelFeatureSet(short bool, times int) feature.FeatureSet {
 	testCombinations := make([]testCombination, 0)
 
 	// Test all combinations of Channel X Subscriber, with no replies or DLS
-	for _, channel := range channels {
+	for _, channel := range chs {
 		for _, subscriber := range subscr {
 			testCombinations = append(testCombinations, testCombination{channel: channel, subscriber: subscriber})
 		}
 	}
 
 	// Test all combinations of Channel X Reply, with any subscriber (we'll use the same subscriber Kind as the reply)
-	for _, channel := range channels {
+	for _, channel := range chs {
 		for _, reply := range rep {
 			testCombinations = append(testCombinations, testCombination{channel, reply, reply, nil})
 		}
 	}
 
 	// Test all combinations of Channel X DLS, with any subscriber (we'll use the same subscriber Kind as the DLS)
-	for _, channel := range channels {
+	for _, channel := range chs {
 		for _, deadLetterSink := range dls {
 			testCombinations = append(testCombinations, testCombination{channel, deadLetterSink, nil, deadLetterSink})
 		}

--- a/test/kitchensinke2e/features/components.go
+++ b/test/kitchensinke2e/features/components.go
@@ -301,10 +301,11 @@ var jobSink = genericComponent{
 }
 
 var eventTransformSink = genericComponent{
-	shortLabel: "evtr",
-	label:      "EventTransform",
-	kind:       "EventTransform",
-	gvr:        eventtransform.GVR(),
+	shortLabel:   "evtr",
+	label:        "EventTransform",
+	kind:         "EventTransform",
+	gvr:          eventtransform.GVR(),
+	sinceVersion: "1.36.0",
 	install: func(name string, _ ...manifest.CfgFn) feature.StepFn {
 		return func(ctx context.Context, t feature.T) {
 			eventtransform.Install(name,
@@ -316,10 +317,11 @@ var eventTransformSink = genericComponent{
 }
 
 var eventTransformGeneric = genericComponent{
-	shortLabel: "gevtr",
-	label:      "EventTransform",
-	kind:       "EventTransform",
-	gvr:        eventtransform.GVR(),
+	shortLabel:   "gevtr",
+	label:        "EventTransform",
+	kind:         "EventTransform",
+	gvr:          eventtransform.GVR(),
+	sinceVersion: "1.36.0",
 	install: func(name string, opts ...manifest.CfgFn) feature.StepFn {
 		return func(ctx context.Context, t feature.T) {
 			eventtransform.Install(name,

--- a/test/kitchensinke2e/features/eventtransform.go
+++ b/test/kitchensinke2e/features/eventtransform.go
@@ -59,12 +59,12 @@ func EventTransformTriggerReadiness(index int, eventTr component, sink component
 	return f
 }
 
-func EventTransformFeatureSet() feature.FeatureSet {
-	return eventTransformFeatureSet(false, 1)
+func EventTransformFeatureSet(version string) feature.FeatureSet {
+	return eventTransformFeatureSet(false, 1, version)
 }
 
 // eventTransformFeatureSet return combinations of eventTransform (with and without reply) for each sink
-func eventTransformFeatureSet(short bool, times int) feature.FeatureSet {
+func eventTransformFeatureSet(short bool, times int, version string) feature.FeatureSet {
 
 	sinks := sinksAll
 	if short {
@@ -73,8 +73,10 @@ func eventTransformFeatureSet(short bool, times int) feature.FeatureSet {
 	if times > 1 {
 		sinks = sinksLight
 	}
-	features := make([]*feature.Feature, 0, len(eventTransformers)*len(sinks)*times*2)
-	for _, eventTr := range eventTransformers {
+	evtrs := filterByVersion(eventTransformers, version)
+	sinks = filterByVersion(sinks, version)
+	features := make([]*feature.Feature, 0, len(evtrs)*len(sinks)*times*2)
+	for _, eventTr := range evtrs {
 		for _, sink := range sinks {
 			for i := 0; i < times; i++ {
 				features = append(features, EventTransformTriggerReadiness(i, eventTr, sink, true))

--- a/test/kitchensinke2e/features/flow.go
+++ b/test/kitchensinke2e/features/flow.go
@@ -171,25 +171,26 @@ func ParallelReadiness(testLabel string, flowTestConfiguration flowTestConfigura
 	return f
 }
 
-func SequenceNoReplyFeatureSet() feature.FeatureSet {
-	return sequenceNoReplyFeatureSet(false, 1)
+func SequenceNoReplyFeatureSet(version string) feature.FeatureSet {
+	return sequenceNoReplyFeatureSet(false, 1, version)
 }
 
-func SequenceNoReplyFeatureSetShort() feature.FeatureSet {
-	return sequenceNoReplyFeatureSet(true, 1)
+func SequenceNoReplyFeatureSetShort(version string) feature.FeatureSet {
+	return sequenceNoReplyFeatureSet(true, 1, version)
 }
 
-func SequenceNoReplyFeatureSetStress() feature.FeatureSet {
-	return sequenceNoReplyFeatureSet(true, NumDeployments)
+func SequenceNoReplyFeatureSetStress(version string) feature.FeatureSet {
+	return sequenceNoReplyFeatureSet(true, NumDeployments, version)
 }
 
 // SequenceNoReplyFeatureSet returns sequences with all possible Kinds as steps, with no reply
-func sequenceNoReplyFeatureSet(short bool, times int) feature.FeatureSet {
+func sequenceNoReplyFeatureSet(short bool, times int, version string) feature.FeatureSet {
 	features := make([]*feature.Feature, 0, len(flowTestConfigurations))
 	steps := sinksAll
 	if short {
 		steps = sinksShort
 	}
+	steps = filterByVersion(steps, version)
 	for _, flowTestConfiguration := range flowTestConfigurations {
 		for i := 0; i < times; i++ {
 			features = append(features, SequenceReadiness(
@@ -203,16 +204,16 @@ func sequenceNoReplyFeatureSet(short bool, times int) feature.FeatureSet {
 	}
 }
 
-func ParallelNoReplyFeatureSet() feature.FeatureSet {
-	return parallelNoReplyFeatureSet(false, 1)
+func ParallelNoReplyFeatureSet(version string) feature.FeatureSet {
+	return parallelNoReplyFeatureSet(false, 1, version)
 }
 
-func ParallelNoReplyFeatureSetShort() feature.FeatureSet {
-	return parallelNoReplyFeatureSet(true, 1)
+func ParallelNoReplyFeatureSetShort(version string) feature.FeatureSet {
+	return parallelNoReplyFeatureSet(true, 1, version)
 }
 
-func ParallelNoReplyFeatureSetStress() feature.FeatureSet {
-	return parallelNoReplyFeatureSet(true, NumDeployments)
+func ParallelNoReplyFeatureSetStress(version string) feature.FeatureSet {
+	return parallelNoReplyFeatureSet(true, NumDeployments, version)
 }
 
 // ParallelNoReplyFeatureSet returns parallels with
@@ -220,7 +221,7 @@ func ParallelNoReplyFeatureSetStress() feature.FeatureSet {
 // * all possible kinds of replies (with a random subscriber each)
 // * all possible kind of filters (with a random subscriber each)
 // with no global reply
-func parallelNoReplyFeatureSet(short bool, times int) feature.FeatureSet {
+func parallelNoReplyFeatureSet(short bool, times int, version string) feature.FeatureSet {
 	fltrs := filters
 	rpls := replies
 	subscr := subscribers
@@ -229,6 +230,9 @@ func parallelNoReplyFeatureSet(short bool, times int) feature.FeatureSet {
 		rpls = repliesShort
 		subscr = subscribersShort
 	}
+	fltrs = filterByVersion(fltrs, version)
+	rpls = filterByVersion(rpls, version)
+	subscr = filterByVersion(subscr, version)
 	features := make([]*feature.Feature, 0, len(flowTestConfigurations))
 	for _, flowTestConfiguration := range flowTestConfigurations {
 		for i := 0; i < times; i++ {
@@ -243,29 +247,30 @@ func parallelNoReplyFeatureSet(short bool, times int) feature.FeatureSet {
 	}
 }
 
-func SequenceGlobalReplyFeatureSet() feature.FeatureSet {
-	return sequenceGlobalReplyFeatureSet(false, 1)
+func SequenceGlobalReplyFeatureSet(version string) feature.FeatureSet {
+	return sequenceGlobalReplyFeatureSet(false, 1, version)
 }
 
-func SequenceGlobalReplyFeatureSetShort() feature.FeatureSet {
-	return sequenceGlobalReplyFeatureSet(true, 1)
+func SequenceGlobalReplyFeatureSetShort(version string) feature.FeatureSet {
+	return sequenceGlobalReplyFeatureSet(true, 1, version)
 }
 
-func SequenceGlobalReplyFeatureSetStress() feature.FeatureSet {
-	return sequenceGlobalReplyFeatureSet(true, NumDeployments)
+func SequenceGlobalReplyFeatureSetStress(version string) feature.FeatureSet {
+	return sequenceGlobalReplyFeatureSet(true, NumDeployments, version)
 }
 
 // SequenceGlobalReplyFeatureSet returns sequences with a global reply (with a single random Step)
-func sequenceGlobalReplyFeatureSet(short bool, times int) feature.FeatureSet {
+func sequenceGlobalReplyFeatureSet(short bool, times int, version string) feature.FeatureSet {
 	rpls := replies
 	if short {
 		rpls = repliesShort
 	}
+	rpls = filterByVersion(rpls, version)
+	steps := filterByVersion(sinksAll, version)
 	// We're using random to choose a random subscriber for a given reply Kind
 	source := rand.NewSource(time.Now().UnixNano())
 	rnd := rand.New(source)
 	features := make([]*feature.Feature, 0, len(flowTestConfigurations)*len(rpls))
-	steps := sinksAll
 	for _, flowTestConfiguration := range flowTestConfigurations {
 		for _, reply := range rpls {
 			// We've already tested all possible step kinds above,
@@ -282,24 +287,26 @@ func sequenceGlobalReplyFeatureSet(short bool, times int) feature.FeatureSet {
 	}
 }
 
-func ParallelGlobalReplyFeatureSet() feature.FeatureSet {
-	return parallelGlobalReplyFeatureSet(false, 1)
+func ParallelGlobalReplyFeatureSet(version string) feature.FeatureSet {
+	return parallelGlobalReplyFeatureSet(false, 1, version)
 }
 
-func ParallelGlobalReplyFeatureSetShort() feature.FeatureSet {
-	return parallelGlobalReplyFeatureSet(true, 1)
+func ParallelGlobalReplyFeatureSetShort(version string) feature.FeatureSet {
+	return parallelGlobalReplyFeatureSet(true, 1, version)
 }
 
-func ParallelGlobalReplyFeatureSetStress() feature.FeatureSet {
-	return parallelGlobalReplyFeatureSet(true, NumDeployments)
+func ParallelGlobalReplyFeatureSetStress(version string) feature.FeatureSet {
+	return parallelGlobalReplyFeatureSet(true, NumDeployments, version)
 }
 
 // ParallelGlobalReplyFeatureSet returns parallels with a global reply (with a single Branch of a random subscriber)
-func parallelGlobalReplyFeatureSet(short bool, times int) feature.FeatureSet {
+func parallelGlobalReplyFeatureSet(short bool, times int, version string) feature.FeatureSet {
 	rpls := replies
 	if short {
 		rpls = repliesShort
 	}
+	rpls = filterByVersion(rpls, version)
+	subscr := filterByVersion(subscribers, version)
 	// We're using random to choose a random subscriber for a given reply Kind
 	source := rand.NewSource(time.Now().UnixNano())
 	rnd := rand.New(source)
@@ -310,7 +317,7 @@ func parallelGlobalReplyFeatureSet(short bool, times int) feature.FeatureSet {
 				label := fmt.Sprintf("%s-par-%s-rep-%d", flowTestConfiguration.shortLabel, shortLabel(reply), i)
 				// We've already tested all possible branches kinds above,
 				// so just use a single branch (with a random subscriber) in the sequence for the "with-reply" test
-				features = append(features, ParallelReadiness(label, flowTestConfiguration, []component{subscribers[rnd.Intn(len(subscribers))]}, []component{}, []component{}, reply))
+				features = append(features, ParallelReadiness(label, flowTestConfiguration, []component{subscr[rnd.Intn(len(subscr))]}, []component{}, []component{}, reply))
 			}
 		}
 	}

--- a/test/kitchensinke2e/features/source.go
+++ b/test/kitchensinke2e/features/source.go
@@ -36,20 +36,20 @@ func SourceReadiness(index int, source component, sink component) *feature.Featu
 	return f
 }
 
-func SourceFeatureSet() feature.FeatureSet {
-	return sourceFeatureSet(false, 1)
+func SourceFeatureSet(version string) feature.FeatureSet {
+	return sourceFeatureSet(false, 1, version)
 }
 
-func SourceFeatureSetShort() feature.FeatureSet {
-	return sourceFeatureSet(true, 1)
+func SourceFeatureSetShort(version string) feature.FeatureSet {
+	return sourceFeatureSet(true, 1, version)
 }
 
-func SourceFeatureSetStress() feature.FeatureSet {
-	return sourceFeatureSet(true, 50)
+func SourceFeatureSetStress(version string) feature.FeatureSet {
+	return sourceFeatureSet(true, 50, version)
 }
 
 // sourceFeatureSet returns all combinations of Source x Sinks.
-func sourceFeatureSet(short bool, times int) feature.FeatureSet {
+func sourceFeatureSet(short bool, times int, version string) feature.FeatureSet {
 	sinks := sinksAll
 	if short {
 		sinks = sinksShort
@@ -57,8 +57,10 @@ func sourceFeatureSet(short bool, times int) feature.FeatureSet {
 	if times > 1 {
 		sinks = sinksLight
 	}
-	features := make([]*feature.Feature, 0, len(sources)*len(sinks))
-	for _, source := range sources {
+	srcs := filterByVersion(sources, version)
+	sinks = filterByVersion(sinks, version)
+	features := make([]*feature.Feature, 0, len(srcs)*len(sinks))
+	for _, source := range srcs {
 		for _, sink := range sinks {
 			for i := 0; i < times; i++ {
 				features = append(features, SourceReadiness(i, source, sink))

--- a/test/kitchensinke2e/features/types.go
+++ b/test/kitchensinke2e/features/types.go
@@ -28,6 +28,10 @@ type labelable interface {
 	Label() string
 }
 
+type sinceVersionable interface {
+	SinceVersion() string
+}
+
 type component interface {
 	installable
 	kreferencable
@@ -46,6 +50,14 @@ type genericComponent struct {
 
 	// label is used in test descriptions
 	label string
+
+	// sinceVersion is the version that the component first appeared in (e.g. "1.36.0").
+	// Empty string means the component has been available forever.
+	sinceVersion string
+}
+
+func (c genericComponent) SinceVersion() string {
+	return c.sinceVersion
 }
 
 func (c genericComponent) ShortLabel() string {

--- a/test/kitchensinke2e/features/version.go
+++ b/test/kitchensinke2e/features/version.go
@@ -1,0 +1,62 @@
+package features
+
+import (
+	"strconv"
+	"strings"
+)
+
+// filterByVersion returns only components available in the given version.
+// If version is empty, all components are returned (no filtering).
+func filterByVersion(components []component, version string) []component {
+	if version == "" {
+		return components
+	}
+	var filtered []component
+	for _, c := range components {
+		if sv, ok := c.(sinceVersionable); ok {
+			since := sv.SinceVersion()
+			if since != "" && compareVersions(version, since) < 0 {
+				continue
+			}
+		}
+		filtered = append(filtered, c)
+	}
+	return filtered
+}
+
+// compareVersions compares two semver-like version strings (e.g. "1.36.0").
+// Returns -1 if a < b, 0 if a == b, 1 if a > b.
+func compareVersions(a, b string) int {
+	aParts := parseVersion(a)
+	bParts := parseVersion(b)
+
+	for i := 0; i < 3; i++ {
+		if aParts[i] < bParts[i] {
+			return -1
+		}
+		if aParts[i] > bParts[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
+func parseVersion(v string) [3]int {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	var result [3]int
+	for i := 0; i < len(parts) && i < 3; i++ {
+		result[i], _ = strconv.Atoi(parts[i])
+	}
+	return result
+}
+
+// ParseVersionFromCSV extracts the version from a CSV name like
+// "serverless-operator.v1.36.0" -> "1.36.0".
+func ParseVersionFromCSV(csv string) string {
+	_, after, ok := strings.Cut(csv, ".v")
+	if !ok {
+		return ""
+	}
+	return after
+}

--- a/test/kitchensinke2e/features/version.go
+++ b/test/kitchensinke2e/features/version.go
@@ -50,13 +50,3 @@ func parseVersion(v string) [3]int {
 	}
 	return result
 }
-
-// ParseVersionFromCSV extracts the version from a CSV name like
-// "serverless-operator.v1.36.0" -> "1.36.0".
-func ParseVersionFromCSV(csv string) string {
-	_, after, ok := strings.Cut(csv, ".v")
-	if !ok {
-		return ""
-	}
-	return after
-}

--- a/test/kitchensinke2e/flow_test.go
+++ b/test/kitchensinke2e/flow_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestFlowReadiness(t *testing.T) {
 	featureSets := []feature.FeatureSet{
-		features.SequenceNoReplyFeatureSet(),
-		features.ParallelNoReplyFeatureSet(),
-		features.SequenceGlobalReplyFeatureSet(),
-		features.ParallelGlobalReplyFeatureSet(),
+		features.SequenceNoReplyFeatureSet(""),
+		features.ParallelNoReplyFeatureSet(""),
+		features.SequenceGlobalReplyFeatureSet(""),
+		features.ParallelGlobalReplyFeatureSet(""),
 	}
 
 	for _, fs := range featureSets {

--- a/test/kitchensinke2e/source_test.go
+++ b/test/kitchensinke2e/source_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestSourceReadiness(t *testing.T) {
-	testFeatureSet(t, features.SourceFeatureSet())
+	testFeatureSet(t, features.SourceFeatureSet(""))
 }

--- a/test/lib.bash
+++ b/test/lib.bash
@@ -609,8 +609,6 @@ function kitchensink_csvs {
   csvs=( $(yq read --doc 0 "$rootdir/olm-catalog/serverless-operator-index/configs/index.yaml" 'entries[*].name') )
 
   array.reverse csvs csvs_rev
-  # Remove first CSV as this is already installed.
-  unset 'csvs_rev[0]'
 
   # Filter out .micro releases between .0 and the last .x, as they would be skipped due to skipVersion
   declare -a csvs_filtered

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -61,6 +61,16 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// ParseVersionFromCSV extracts the version from a CSV name like
+// "serverless-operator.v1.36.0" -> "1.36.0".
+func ParseVersionFromCSV(csv string) string {
+	_, after, ok := strings.Cut(csv, ".v")
+	if !ok {
+		return ""
+	}
+	return after
+}
+
 // TestKitchensink tests as many Knative resources as possible during upgrades.
 // It does a series of upgrades according to CSVs passed via test flags. For each
 // upgrade it takes a random subset of features from the whole group, installs them
@@ -73,16 +83,19 @@ func TestKitchensink(t *testing.T) {
 	ctx := test.SetupClusterAdmin(t)
 	test.CleanupOnInterrupt(t, func() { test.CleanupAll(t, ctx) })
 
+	csvs := strings.Split(strings.Trim(test.Flags.CSV, ","), ",")
+	oldestVersion := ParseVersionFromCSV(csvs[0])
+
 	// Add feature sets to be tested during upgrades.
 	featureSets := []feature.FeatureSet{
-		features.BrokerFeatureSetWithBrokerDLSShort(),
-		features.BrokerFeatureSetWithTriggerDLSShort(),
-		features.ChannelFeatureSetShort(),
-		features.SequenceNoReplyFeatureSetShort(),
-		features.SequenceGlobalReplyFeatureSetShort(),
-		features.ParallelNoReplyFeatureSetShort(),
-		features.ParallelGlobalReplyFeatureSetShort(),
-		features.SourceFeatureSetShort(),
+		features.BrokerFeatureSetWithBrokerDLSShort(oldestVersion),
+		features.BrokerFeatureSetWithTriggerDLSShort(oldestVersion),
+		features.ChannelFeatureSetShort(oldestVersion),
+		features.SequenceNoReplyFeatureSetShort(oldestVersion),
+		features.SequenceGlobalReplyFeatureSetShort(oldestVersion),
+		features.ParallelNoReplyFeatureSetShort(oldestVersion),
+		features.ParallelGlobalReplyFeatureSetShort(oldestVersion),
+		features.SourceFeatureSetShort(oldestVersion),
 	}
 
 	var featureGroup FeatureWithEnvironmentGroup
@@ -98,8 +111,6 @@ func TestKitchensink(t *testing.T) {
 	source := rand.NewSource(time.Now().UnixNano())
 	rnd := rand.New(source)
 	rnd.Shuffle(len(featureGroup), func(i, j int) { featureGroup[i], featureGroup[j] = featureGroup[j], featureGroup[i] })
-
-	csvs := strings.Split(strings.Trim(test.Flags.CSV, ","), ",")
 
 	// Split features across upgrades.
 	groups := featureGroup.Split(len(csvs))
@@ -166,14 +177,14 @@ func TestUpgradeStress(t *testing.T) {
 
 	// Add feature sets to be tested during upgrades.
 	featureSets := []feature.FeatureSet{
-		features.BrokerFeatureSetWithBrokerDLSStress(),
-		features.BrokerFeatureSetWithTriggerDLSStress(),
-		features.ChannelFeatureSetStress(),
-		features.SequenceNoReplyFeatureSetStress(),
-		features.SequenceGlobalReplyFeatureSetStress(),
-		features.ParallelNoReplyFeatureSetStress(),
-		features.ParallelGlobalReplyFeatureSetStress(),
-		features.SourceFeatureSetStress(),
+		features.BrokerFeatureSetWithBrokerDLSStress(""),
+		features.BrokerFeatureSetWithTriggerDLSStress(""),
+		features.ChannelFeatureSetStress(""),
+		features.SequenceNoReplyFeatureSetStress(""),
+		features.SequenceGlobalReplyFeatureSetStress(""),
+		features.ParallelNoReplyFeatureSetStress(""),
+		features.ParallelGlobalReplyFeatureSetStress(""),
+		features.SourceFeatureSetStress(""),
 	}
 
 	var featureGroup FeatureWithEnvironmentGroup

--- a/test/upgrade/kitchensink/kitchensink_test.go
+++ b/test/upgrade/kitchensink/kitchensink_test.go
@@ -115,6 +115,9 @@ func TestKitchensink(t *testing.T) {
 	// Split features across upgrades.
 	groups := featureGroup.Split(len(csvs))
 
+	// The oldest version is already installed, skip it.
+	csvs = csvs[1:]
+
 	for i, csv := range csvs {
 		_, toVersion, _ := strings.Cut(csv, ".")
 


### PR DESCRIPTION
We do have random failures if a feature only avaiable since 1.36 (such as EventTransform) gets into the first set of features tested in kitchensink-upgrade while 1.35.0 is installed. 

This patch skips kitchensink components that are not available in the oldest version used in the kitchensink-upgrade run.

- :broom: kitchensink-upgrade, skip features only available in newer versions
